### PR TITLE
style: banners use fixed width with black background

### DIFF
--- a/blog/layouts/partials/extend_head.html
+++ b/blog/layouts/partials/extend_head.html
@@ -20,11 +20,15 @@
     top: 0;
     z-index: 100;
     line-height: 0;
+    display: flex;
+    justify-content: center;
+    background-color: #000;
 }
 
 .site-banner-strip img {
     display: block;
     width: 100%;
+    max-width: 30em;
     height: auto;
 }
 </style>


### PR DESCRIPTION
Center banner images with max-width: 30em on a black background
instead of stretching full width across the viewport.

https://claude.ai/code/session_013mP34yD2VJLQNAozcaJNta