### PR TITLE
feat(edge): add arr.derio.net to Headscale split DNS

### DIFF
--- a/clusters/hop/apps/headscale/manifests/configmap.yaml
+++ b/clusters/hop/apps/headscale/manifests/configmap.yaml
@@ -51,6 +51,9 @@ data:
           frank.derio.net:
             - 192.168.10.11
             - 192.168.10.12
+          arr.derio.net:
+            - 192.168.10.11
+            - 192.168.10.12
       extra_records:
         - name: headplane.hop.derio.net
           type: A


### PR DESCRIPTION
Add arr.derio.net to the split DNS configuration so mesh clients
resolve arr.derio.net via home DNS servers (192.168.10.11/12),
matching the existing lab.derio.net and frank.derio.net entries.

https://claude.ai/code/session_01L9TXzPZi1treq5QVvBppKB