### PR TITLE
docs(cicd): add CI/CD platform documentation to README, roadmap, and rules

### DIFF
--- a/.claude/rules/frank-infrastructure.md
+++ b/.claude/rules/frank-infrastructure.md
@@ -21,14 +21,14 @@
 | Infisical | 192.168.55.204 | Cilium L2 LoadBalancer |
 | LiteLLM Gateway | 192.168.55.206 | Cilium L2 LoadBalancer |
 | Sympozium Web UI | 192.168.55.207 | Cilium L2 LoadBalancer |
+| Gitea | 192.168.55.209 | Cilium L2 LoadBalancer (port 3000 HTTP, 2222 SSH) |
+| Zot OCI Registry | 192.168.55.210 | Cilium L2 LoadBalancer (port 5000 HTTPS) |
 | Authentik | 192.168.55.211 | Cilium L2 LoadBalancer (port 9000) |
 | Paperclip | 192.168.55.212 | Cilium L2 LoadBalancer (port 3100) |
 | ComfyUI | 192.168.55.213 | Cilium L2 LoadBalancer (port 8188) |
 | GPU Switcher | 192.168.55.214 | Cilium L2 LoadBalancer (port 8080) |
 | Secure Agent Pod (SSH) | 192.168.55.215 | Cilium L2 LoadBalancer (port 22/SSH) |
 | n8n-01 | 192.168.55.216 | Cilium L2 LoadBalancer (port 5678) |
-| Gitea | 192.168.55.209 | Cilium L2 LoadBalancer (port 3000 HTTP, 2222 SSH) |
-| Zot OCI Registry | 192.168.55.210 | Cilium L2 LoadBalancer (port 5000 HTTPS) |
 | Tekton Dashboard | 192.168.55.217 | Cilium L2 LoadBalancer (port 9097) |
 | Secure Agent Pod (VibeKanban) | 192.168.55.218 | Cilium L2 LoadBalancer (port 8081) |
 | Traefik Ingress | 192.168.55.220 | Cilium L2 LoadBalancer |

--- a/.claude/rules/frank-infrastructure.md
+++ b/.claude/rules/frank-infrastructure.md
@@ -27,6 +27,9 @@
 | GPU Switcher | 192.168.55.214 | Cilium L2 LoadBalancer (port 8080) |
 | Secure Agent Pod (SSH) | 192.168.55.215 | Cilium L2 LoadBalancer (port 22/SSH) |
 | n8n-01 | 192.168.55.216 | Cilium L2 LoadBalancer (port 5678) |
+| Gitea | 192.168.55.209 | Cilium L2 LoadBalancer (port 3000 HTTP, 2222 SSH) |
+| Zot OCI Registry | 192.168.55.210 | Cilium L2 LoadBalancer (port 5000 HTTPS) |
+| Tekton Dashboard | 192.168.55.217 | Cilium L2 LoadBalancer (port 9097) |
 | Secure Agent Pod (VibeKanban) | 192.168.55.218 | Cilium L2 LoadBalancer (port 8081) |
 | Traefik Ingress | 192.168.55.220 | Cilium L2 LoadBalancer |
 | Homepage | (via Traefik) | IngressRoute (master.cluster.derio.net) |

--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ The following UIs are exposed via Cilium L2 LoadBalancer with fixed IPs:
 | Infisical | http://192.168.55.204:8080 | 192.168.55.204 |
 | LiteLLM Gateway | http://192.168.55.206:4000 | 192.168.55.206 |
 | Sympozium Web UI | http://192.168.55.207:8080 | 192.168.55.207 |
+| Gitea | http://192.168.55.209:3000 | 192.168.55.209 |
+| Zot OCI Registry | https://192.168.55.210:5000 | 192.168.55.210 |
 | Authentik | http://192.168.55.211:9000 | 192.168.55.211 |
 | Paperclip | http://192.168.55.212:3100 | 192.168.55.212 |
 | ComfyUI | http://192.168.55.213:8188 | 192.168.55.213 |
 | GPU Switcher | http://192.168.55.214:8080 | 192.168.55.214 |
 | Secure Agent Pod (SSH) | ssh claude@192.168.55.215 | 192.168.55.215 |
 | n8n-01 | http://192.168.55.216:5678 | 192.168.55.216 |
-| Gitea | http://192.168.55.209:3000 | 192.168.55.209 |
-| Zot OCI Registry | https://192.168.55.210:5000 | 192.168.55.210 |
 | Tekton Dashboard | http://192.168.55.217:9097 | 192.168.55.217 |
 | Secure Agent Pod (VibeKanban) | http://192.168.55.218:8081 | 192.168.55.218 |
 | Traefik Ingress | https://*.cluster.derio.net | 192.168.55.220 |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Enterprise-grade Kubernetes cluster on Talos Linux across heterogeneous hardware
 | Workflow Automation | n8n | Per-user instances on gpu-1, Authentik forward-auth, dedicated PostgreSQL, Prometheus metrics |
 | Secure Agent Pod | Kali Linux + VibeKanban | Hardened non-root coding agent workstation on gpu-1, Cilium egress controls, ESO secrets, SSH + VibeKanban UI |
 | In-Cluster Ingress | Traefik v3 | Wildcard TLS (`*.cluster.derio.net`) via ACME + Cloudflare DNS-01, Authentik forward-auth, raspi edge nodes |
+| CI/CD Platform | Gitea + Tekton + Zot | Self-hosted git forge (GitHub mirror), K8s-native pipelines, OCI registry with cosign signing — all on pc-1 |
 | Cluster Dashboard | gethomepage.dev | Service catalog at `master.cluster.derio.net` with HTTP health indicators and custom bookmarks |
 
 ## Repository Structure
@@ -90,6 +91,8 @@ frank/
 │   ├── authentik/values.yaml + manifests/       # Authentik IdP + blueprints
 │   ├── authentik-extras/manifests/              # K8s RBAC bindings for OIDC groups
 │   ├── vclusters/                               # Per-vCluster Helm values
+│   │   ├── template/values.yaml                 # Base config (SQLite, policies, sync)
+│   │   └── experiments/values.yaml              # First sandbox instance
 │   ├── paperclip-db/values.yaml                 # Bitnami PostgreSQL for Paperclip
 │   ├── paperclip/manifests/                     # Paperclip Deployment, ExternalSecrets, PVC, LB Service
 │   ├── comfyui/manifests/                       # ComfyUI diffusion model server (time-shared GPU)
@@ -100,9 +103,15 @@ frank/
 │   ├── n8n-01-postgresql/values.yaml           # Bitnami PostgreSQL for n8n-01
 │   ├── secure-agent-pod/manifests/             # Secure coding agent pod (gpu-1, SSH + VibeKanban)
 │   ├── traefik/values.yaml + manifests/        # Traefik ingress (192.168.55.220), middlewares, IngressRoutes
-│   └── homepage/manifests/                     # gethomepage.dev dashboard (master.cluster.derio.net)
-│       ├── template/values.yaml                 # Base config (SQLite, policies, sync)
-│       └── experiments/values.yaml              # First sandbox instance
+│   ├── homepage/manifests/                     # gethomepage.dev dashboard (master.cluster.derio.net)
+│   ├── gitea/values.yaml + manifests/          # Gitea git forge (192.168.55.209), GitHub mirrors, Authentik OIDC
+│   ├── zot/values.yaml + manifests/            # Zot OCI registry (192.168.55.210), cert-manager TLS, cosign
+│   └── tekton/                                 # Tekton CI/CD platform on pc-1
+│       ├── vendor/                             # Vendored releases (Pipelines, Triggers, Dashboard)
+│       ├── tasks/                              # CI Tasks (git-clone, run-tests, build-push, cosign-sign, gitea-status)
+│       ├── pipelines/                          # gitea-ci Pipeline (clone → test → build → sign → report)
+│       ├── triggers/                           # EventListener, TriggerBinding, TriggerTemplate for Gitea webhooks
+│       └── manifests/                          # ExternalSecrets, RBAC, Dashboard LB Service
 ├── clusters/
 │   └── hop/                   # Hop edge cluster (Hetzner CX23, standalone talosctl)
 │       ├── apps/              # Hop ArgoCD App-of-Apps
@@ -166,6 +175,9 @@ The following UIs are exposed via Cilium L2 LoadBalancer with fixed IPs:
 | GPU Switcher | http://192.168.55.214:8080 | 192.168.55.214 |
 | Secure Agent Pod (SSH) | ssh claude@192.168.55.215 | 192.168.55.215 |
 | n8n-01 | http://192.168.55.216:5678 | 192.168.55.216 |
+| Gitea | http://192.168.55.209:3000 | 192.168.55.209 |
+| Zot OCI Registry | https://192.168.55.210:5000 | 192.168.55.210 |
+| Tekton Dashboard | http://192.168.55.217:9097 | 192.168.55.217 |
 | Secure Agent Pod (VibeKanban) | http://192.168.55.218:8081 | 192.168.55.218 |
 | Traefik Ingress | https://*.cluster.derio.net | 192.168.55.220 |
 | Homepage Dashboard | https://master.cluster.derio.net | (via Traefik) |
@@ -234,6 +246,15 @@ argocd app list
 | traefik | traefik-system | In-cluster ingress controller (192.168.55.220), ACME wildcard TLS for `*.cluster.derio.net` |
 | traefik-extras | traefik-system | Middleware CRDs (security headers, IP allowlist, Authentik forward-auth) + 16 IngressRoutes |
 | homepage | homepage | Cluster dashboard at `master.cluster.derio.net`, HTTP health indicators, service catalog |
+| gitea | gitea | Git forge with GitHub pull-mirror (192.168.55.209:3000), Authentik OIDC SSO |
+| gitea-extras | gitea | ExternalSecret for admin password, OIDC client secret, GitHub mirror token |
+| zot | zot | OCI container/artifact registry (192.168.55.210:5000), self-signed TLS via cert-manager |
+| zot-extras | zot | Certificate, ClusterIssuer, ExternalSecret for push password and OIDC |
+| tekton-pipelines | tekton-pipelines | Tekton Pipelines controller + webhook (vendored release) |
+| tekton-triggers | tekton-pipelines | Tekton Triggers controller + interceptors (vendored release) |
+| tekton-dashboard | tekton-pipelines | Tekton Dashboard (192.168.55.217:9097, vendored release) |
+| tekton-extras | tekton-pipelines | CI Tasks, gitea-ci Pipeline, Gitea EventListener, ExternalSecrets, RBAC |
+| longhorn-cicd | longhorn-system | Single-replica StorageClass for CI/CD workloads on pc-1 |
 
 ### Hop Cluster Applications
 

--- a/blog/content/building/00-overview/index.md
+++ b/blog/content/building/00-overview/index.md
@@ -54,6 +54,9 @@ This post is a **living document**: it gets updated as new technologies and capa
 | **Health Bridge** | Grafana alert → GitHub Project lifecycle state bridge — automatic degraded/dead/healthy transitions, issue comments, bug issue creation |
 | **Traefik (in-cluster)** | In-cluster ingress controller, wildcard TLS (`*.cluster.derio.net`), ACME via Cloudflare DNS-01, Authentik forward-auth for 12 services (`192.168.55.220`) |
 | **gethomepage.dev** | Cluster dashboard at `master.cluster.derio.net` — service catalog with HTTP health indicators, custom bookmarks |
+| **Gitea** | Self-hosted git forge with GitHub pull-mirror, Authentik OIDC SSO (`192.168.55.209`) |
+| **Tekton** | K8s-native CI/CD pipelines — webhook-driven clone, test, build, sign, report status on pc-1 |
+| **Zot** | OCI container/artifact registry with cert-manager TLS and cosign image signing (`192.168.55.210`) |
 
 ## Cluster State
 

--- a/blog/layouts/shortcodes/cluster-roadmap.html
+++ b/blog/layouts/shortcodes/cluster-roadmap.html
@@ -63,6 +63,9 @@
 .layer-auth { border-left-color: var(--rm-accent-4); }
 .layer-auth .layer-num { background: var(--rm-accent-4); }
 
+.layer-cicd { border-left-color: var(--rm-accent-2); }
+.layer-cicd .layer-num { background: var(--rm-accent-2); }
+
 .layer-upcoming {
   border-left-style: dashed;
   opacity: 0.55;
@@ -557,6 +560,24 @@
         <span class="tag">traefik</span>
         <span class="tag">acme</span>
         <span class="tag">192.168.55.220</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="roadmap-layer">
+    <div class="roadmap-card layer-cicd">
+      <div class="layer-title"><span class="layer-num">25</span> CI/CD Platform</div>
+      <div class="sub-items">
+        <span class="sub-item">Gitea (GitHub mirror forge)</span>
+        <span class="sub-item">Tekton Pipelines + Triggers</span>
+        <span class="sub-item">Zot OCI registry (cosign signed)</span>
+        <span class="sub-item">Webhook-driven CI on pc-1</span>
+      </div>
+      <div class="tags">
+        <span class="tag">gitea</span>
+        <span class="tag">tekton</span>
+        <span class="tag">zot</span>
+        <span class="tag">192.168.55.209</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Add Gitea (git forge), Zot (OCI registry), and Tekton (pipelines) to infrastructure rules, README, blog roadmap shortcode, and overview capability map
- Fix vclusters tree nesting in README repository structure
- All CI/CD infrastructure code was already committed on main — this PR adds the missing documentation updates from the Standard Layer Workflow

## Context
The CI/CD platform plan (`docs/superpowers/plans/2026-03-29--cicd--platform.md`) has status "semi-Deployed" — all 38 declarative infrastructure files (ArgoCD Applications, Helm values, ExternalSecrets, Tekton vendor releases, Tasks, Pipelines, Triggers) are committed. Remaining work is manual operations (Infisical secrets, Omni labels, webhook configuration, cosign keypair) and cluster testing.

## Test plan
- [ ] Verify README renders correctly on GitHub (tables, tree structure)
- [ ] Verify blog roadmap shortcode renders CI/CD layer with correct styling
- [ ] Verify blog overview capability map includes Gitea/Tekton/Zot entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)