### PR TITLE
refactor: convert active plans to Phase format (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-03-20--repo--multi-cluster-restructure.md
+++ b/docs/superpowers/plans/2026-03-20--repo--multi-cluster-restructure.md
@@ -1,6 +1,8 @@
 # Multi-Cluster Monorepo Restructure — Implementation Plan
 
-> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For VK agents:** Use vk-execute to implement assigned phases.
+> **For local execution:** Use subagent-driven-development or executing-plans.
+> **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Goal:** Restructure the frank-cluster repo from a single-cluster layout (`apps/`, `patches/` at root) to a multi-cluster monorepo (`clusters/frank/apps/`, `clusters/frank/patches/`), matching the existing `clusters/hop/` structure.
 
@@ -27,7 +29,7 @@ This is a **high-blast-radius refactor** — it touches every ArgoCD Application
 
 ---
 
-## Chunk 1: Restructure
+## Phase 0: Restructure [agentic]
 
 ### Task 1: Move directories and update all path references
 
@@ -139,7 +141,7 @@ git commit -m "fix: correct remaining path references after repo restructure"
 
 ---
 
-## Chunk 2: Update References
+## Phase 1: Update References [agentic]
 
 ### Task 2: Update documentation and CI
 

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation.md
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation.md
@@ -1,6 +1,8 @@
 # Safe Update Automation Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For VK agents:** Use vk-execute to implement assigned phases.
+> **For local execution:** Use subagent-driven-development or executing-plans.
+> **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Goal:** Automate Helm chart update detection + pre-merge smoke testing (ArgoCD layer) and Talos/Kubernetes version tracking (Omni layer) for the Frank cluster.
 
@@ -36,7 +38,7 @@ renovate.json                          # Renovate config (regex manager, package
 
 ---
 
-## Chunk 1: ARC Self-Hosted Runner
+## Phase 0: ARC Self-Hosted Runner [agentic]
 
 ARC v2 uses two charts: `gha-runner-scale-set-controller` (cluster-scoped, sync-wave -1) and `gha-runner-scale-set` (namespaced runner pool). The runner needs a GitHub App installed on the repo and its credentials as a Kubernetes Secret before it can register.
 
@@ -318,6 +320,8 @@ git commit -m "feat(repo): add ARC runner set ArgoCD app with smoke-test RBAC"
 
 ---
 
+## Phase 1: ARC Bootstrap Secret [manual]
+
 ### Task 3: Bootstrap Secret (Manual Operation)
 
 The GitHub App credentials must exist as a Kubernetes Secret before the runner pod can register. This is a SOPS-encrypted bootstrap secret applied out-of-band.
@@ -388,7 +392,7 @@ kubectl get pod -n arc-system -o wide | grep runner
 
 ---
 
-## Chunk 2: Version Tracking
+## Phase 2: Version Tracking [agentic]
 
 ### Task 4: Create versions.yaml
 
@@ -577,7 +581,7 @@ git commit -m "feat(repo): add Talos/K8s version check workflow"
 
 ---
 
-## Chunk 3: Renovate Configuration
+## Phase 3: Renovate & Smoke Testing [agentic]
 
 ### Task 6: Renovate Configuration
 
@@ -726,8 +730,6 @@ status: pending
 Run the `gh api` command above (after Task 8 is complete and the workflow has run). Replace `:owner/:repo` with your actual values.
 
 ---
-
-## Chunk 4: Smoke Test Workflow
 
 ### Task 8: Smoke Test GitHub Actions Workflow
 
@@ -955,7 +957,7 @@ Once the workflow has run at least once successfully and `smoke-test/readiness` 
 
 ---
 
-## Chunk 5: Wire Up and Verify End-to-End
+## Phase 4: Branch Protection & End-to-End Verification [manual]
 
 ### Task 9: Verify Renovate Onboarding
 

--- a/docs/superpowers/plans/2026-03-29--cicd--platform.md
+++ b/docs/superpowers/plans/2026-03-29--cicd--platform.md
@@ -1,6 +1,8 @@
 # CI/CD Platform Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+> **For VK agents:** Use vk-execute to implement assigned phases.
+> **For local execution:** Use subagent-driven-development or executing-plans.
+> **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Goal:** Deploy a K8s-native CI/CD platform — Gitea (git forge mirroring GitHub), Tekton (pipeline engine), Zot (OCI registry) with cosign signing — all on pc-1.
 
@@ -9,7 +11,7 @@
 **Tech Stack:** ArgoCD, Helm, Longhorn, Cilium L2, Infisical + ExternalSecrets, Tekton Pipelines/Triggers/Dashboard, Gitea, Zot, cosign, cert-manager
 
 **Spec:** `docs/superpowers/specs/2026-03-29--cicd--platform-design.md`
-**Status:** semi-Deployed (pending: Infisical secrets, Gitea post-deploy config, webhook wiring, cosign keypair, containerd mirror patch)
+**Status:** In Progress (pending: Infisical secrets, Gitea post-deploy config, webhook wiring, cosign keypair, containerd mirror patch)
 
 ---
 
@@ -20,6 +22,8 @@
 - IPs `.209`, `.210`, `.217` are unallocated (verified 2026-03-29)
 
 ---
+
+## Phase 0: Infrastructure Prerequisites [agentic]
 
 ### Task 1: StorageClass and Node Labels
 
@@ -88,6 +92,8 @@ kubectl get node pc-1 --show-labels | grep role=cicd
 ```
 
 ---
+
+## Phase 1: Gitea Deployment [agentic]
 
 ### Task 2: Gitea Deployment
 
@@ -373,6 +379,8 @@ If OIDC fails, check:
 
 ---
 
+## Phase 2: Gitea Post-Deploy Configuration [manual]
+
 ### Task 3: Gitea Post-Deploy Configuration
 
 - [ ] **Step 1: Create service account and API token**
@@ -423,6 +431,8 @@ rm -rf /tmp/test-clone
 ```
 
 ---
+
+## Phase 3: Tekton Core & Triggers [agentic]
 
 ### Task 4: Tekton Core Deployment
 
@@ -990,6 +1000,8 @@ If no PipelineRun is created, debug:
 
 ---
 
+## Phase 4: Zot Registry [agentic]
+
 ### Task 6: Zot Registry Deployment
 
 **Files:**
@@ -1275,6 +1287,8 @@ status: pending
 ```
 
 ---
+
+## Phase 5: CI Pipeline [agentic]
 
 ### Task 7: Pipeline Stage A — Clone, Test, Report Status
 

--- a/docs/superpowers/plans/2026-04-09--repo--blog-media-infrastructure.md
+++ b/docs/superpowers/plans/2026-04-09--repo--blog-media-infrastructure.md
@@ -1,6 +1,8 @@
 # Blog Media Infrastructure Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For VK agents:** Use vk-execute to implement assigned phases.
+> **For local execution:** Use subagent-driven-development or executing-plans.
+> **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Goal:** Add media embedding infrastructure (asciinema player, screenshot shortcode, CSS) to the Hugo blog and insert media placeholders into ~23 posts.
 
@@ -12,6 +14,8 @@
 **Status:** Not Started
 
 ---
+
+## Phase 0: Media Infrastructure [agentic]
 
 ### Task 1: Create `screenshot` shortcode
 
@@ -284,6 +288,8 @@ Follow the pattern from `.claude/skills/blog-post/SKILL.md` for YAML frontmatter
 - [x] **Step 2: Commit** *(combined into single infrastructure commit)*
 
 ---
+
+## Phase 1: Verification [manual]
 
 ### Task 8: Verify and push
 

--- a/docs/superpowers/plans/2026-04-11--repo--vk-skills-harmonization.md
+++ b/docs/superpowers/plans/2026-04-11--repo--vk-skills-harmonization.md
@@ -409,14 +409,14 @@ Convert the 4 active plans from flat Task format to Phase > Task > Step format. 
 **Files:**
 - Modify: `docs/superpowers/plans/2026-03-20--repo--multi-cluster-restructure.md`
 
-- [ ] **Step 1: Read the current plan**
+- [x] **Step 1: Read the current plan**
 
 Read the full plan file. Identify the existing `### Task N:` sections and their natural phase boundaries. For a monorepo restructure, typical phases:
 - Phase 0: Pre-flight [manual] — disable auto-sync, take inventory (if present)
 - Phase 1: Restructure [agentic] — the bulk of the work
 - Phase 2: Post-restructure verification [agentic or manual]
 
-- [ ] **Step 2: Update the banner**
+- [x] **Step 2: Update the banner**
 
 Replace the existing "For agentic workers" banner with:
 
@@ -426,7 +426,7 @@ Replace the existing "For agentic workers" banner with:
 > **For dispatch:** Use vk-dispatch to create Issues from this plan.
 ```
 
-- [ ] **Step 3: Insert Phase headers**
+- [x] **Step 3: Insert Phase headers**
 
 Group existing `### Task N:` sections under `## Phase N: <name> [<type>]` headers. Rules:
 - Preserve all existing `### Task N:` headers and their content unchanged
@@ -434,13 +434,13 @@ Group existing `### Task N:` sections under `## Phase N: <name> [<type>]` header
 - Add `[manual]` or `[agentic]` tag to each new Phase header
 - Tasks must be h3 (`###`) — do NOT convert to h4
 
-- [ ] **Step 4: Validate**
+- [x] **Step 4: Validate**
 
 ```bash
 scripts/validate-plans.sh docs/superpowers/plans/2026-03-20--repo--multi-cluster-restructure.md && echo "PASS"
 ```
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add docs/superpowers/plans/2026-03-20--repo--multi-cluster-restructure.md
@@ -455,21 +455,21 @@ checkbox state and content. Updates banner to reference vk-execute."
 **Files:**
 - Modify: `docs/superpowers/plans/2026-03-25--repo--safe-update-automation.md`
 
-- [ ] **Step 1: Read the current plan**
+- [x] **Step 1: Read the current plan**
 
 Read the full plan. This plan has three pipeline tracks (Renovate, Talos version tracking, ARC v2). These map naturally to phases.
 
-- [ ] **Step 2: Apply the conversion procedure**
+- [x] **Step 2: Apply the conversion procedure**
 
 Same procedure as Task 1: update banner, wrap existing `### Task N:` sections under `## Phase N:` headers with appropriate phase names and types. Natural phase split: one phase per pipeline track. Preserve all checkbox state.
 
-- [ ] **Step 3: Validate**
+- [x] **Step 3: Validate**
 
 ```bash
 scripts/validate-plans.sh docs/superpowers/plans/2026-03-25--repo--safe-update-automation.md && echo "PASS"
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add docs/superpowers/plans/2026-03-25--repo--safe-update-automation.md
@@ -484,21 +484,21 @@ ARC v2). Preserves all checkbox state and content."
 **Files:**
 - Modify: `docs/superpowers/plans/2026-03-29--cicd--platform.md`
 
-- [ ] **Step 1: Read the current plan**
+- [x] **Step 1: Read the current plan**
 
 Read the full plan. This is a multi-component deployment (Gitea, Tekton, Zot). Status is `semi-Deployed` with pending items — **preserve the status value exactly**.
 
-- [ ] **Step 2: Apply the conversion procedure**
+- [x] **Step 2: Apply the conversion procedure**
 
 Same procedure. Natural phase split: one phase per component (or one phase for base infrastructure + one per component). The `semi-Deployed` status may fail validation against the profile's `status_values` — if so, update to `In Progress` with a note in the header explaining the pending items, or leave as `semi-Deployed` and add a `status_values` entry in the profile. **Preferred:** change to `In Progress` since `semi-Deployed` isn't in the profile.
 
-- [ ] **Step 3: Validate**
+- [x] **Step 3: Validate**
 
 ```bash
 scripts/validate-plans.sh docs/superpowers/plans/2026-03-29--cicd--platform.md && echo "PASS"
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add docs/superpowers/plans/2026-03-29--cicd--platform.md
@@ -514,23 +514,23 @@ not in profile status_values)."
 **Files:**
 - Modify: `docs/superpowers/plans/2026-04-09--repo--blog-media-infrastructure.md`
 
-- [ ] **Step 1: Read the current plan**
+- [x] **Step 1: Read the current plan**
 
 Read the full plan. This is a straightforward implementation plan — likely a single agentic phase with a post-deploy manual phase.
 
-- [ ] **Step 2: Apply the conversion procedure**
+- [x] **Step 2: Apply the conversion procedure**
 
 Same procedure. Likely split:
 - Phase 0: Implementation [agentic] — all existing tasks
 - Phase 1: Post-Deploy Checklist [manual] — if the plan already has one, preserve it
 
-- [ ] **Step 3: Validate**
+- [x] **Step 3: Validate**
 
 ```bash
 scripts/validate-plans.sh docs/superpowers/plans/2026-04-09--repo--blog-media-infrastructure.md && echo "PASS"
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add docs/superpowers/plans/2026-04-09--repo--blog-media-infrastructure.md


### PR DESCRIPTION
## Summary

- Convert 4 active plans from flat Task format to Phase > Task > Step format
- Update banners to reference vk-execute/vk-dispatch
- Normalize cicd-platform status from `semi-Deployed` to `In Progress` (profile-compliant)
- Preserve all existing checkbox state and content

### Plans converted:
- `multi-cluster-restructure` — 2 phases (Restructure, Update References)
- `safe-update-automation` — 5 phases (ARC runner, ARC bootstrap, Version Tracking, Renovate & Smoke Testing, Verification)
- `cicd-platform` — 6 phases (Infrastructure, Gitea, Gitea Post-Deploy, Tekton, Zot, CI Pipeline)
- `blog-media-infrastructure` — 2 phases (Media Infrastructure, Verification)

Closes #36

## Test plan

- [x] All 4 plans pass `scripts/validate-plans.sh`
- [x] Checkbox state preserved (verified via git diff — only additions are Phase headers and banner updates)
- [x] No content within Tasks was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)