### PR TITLE
feat(cicd): Zot Registry config upgrade (Phase 4)

### DIFF
--- a/.claude/rules/frank-gotchas.md
+++ b/.claude/rules/frank-gotchas.md
@@ -45,3 +45,5 @@
 - Grafana Helm chart regenerates admin password Secret on re-render — PVC-backed database retains old password. Fix: `grafana cli admin reset-admin-password "$NEW_PASS"` inside the pod after re-deployment
 - VictoriaMetrics Helm chart `genCA` regenerates webhook caBundle on every render — must add `ignoreDifferences` on `ValidatingWebhookConfiguration` `.webhooks[].clientConfig.caBundle` in the ArgoCD Application to prevent ArgoCD from overwriting the operator-managed cert
 - Supercronic watches `~/.crontab` and auto-reloads on file change — no restart needed after updating crontab content
+- Zot Helm chart v0.1.0 is too minimal — no support for `mountConfig`, `mountSecret`, `persistence`, or `externalSecrets`. Use v0.1.60+ for TLS, htpasswd auth, and persistent storage
+- Zot htpasswd hash in `values.yaml` must be regenerated if `ZOT_PUSH_PASSWORD` changes in Infisical — the bcrypt hash and plaintext password are not kept in sync automatically

--- a/apps/root/templates/zot.yaml
+++ b/apps/root/templates/zot.yaml
@@ -10,7 +10,7 @@ spec:
   sources:
     - repoURL: https://zotregistry.dev/helm-charts/
       chart: zot
-      targetRevision: "0.1.0"
+      targetRevision: "0.1.60"
       helm:
         releaseName: zot
         valueFiles:

--- a/apps/zot/values.yaml
+++ b/apps/zot/values.yaml
@@ -8,10 +8,71 @@ service:
   annotations:
     lbipam.cilium.io/ips: "192.168.55.210"
 
-persistence:
-  enabled: true
+# TLS enabled — probes must use HTTPS
+httpGet:
+  scheme: HTTPS
+
+# Mount config.json from chart-managed ConfigMap at /etc/zot
+mountConfig: true
+
+configFiles:
+  config.json: |-
+    {
+      "storage": { "rootDirectory": "/var/lib/registry" },
+      "http": {
+        "address": "0.0.0.0",
+        "port": "5000",
+        "tls": {
+          "cert": "/secrets/tls/tls.crt",
+          "key": "/secrets/tls/tls.key"
+        },
+        "auth": {
+          "htpasswd": { "path": "/secret/htpasswd" }
+        },
+        "accessControl": {
+          "repositories": {
+            "**": {
+              "policies": [
+                {
+                  "users": ["tekton-push"],
+                  "actions": ["read", "create", "update"]
+                }
+              ],
+              "anonymousPolicy": ["read"],
+              "defaultPolicy": ["read"]
+            }
+          },
+          "adminPolicy": {
+            "users": ["tekton-push"],
+            "actions": ["read", "create", "update", "delete"]
+          }
+        }
+      },
+      "log": { "level": "info" }
+    }
+
+# Mount TLS cert from cert-manager Secret
+externalSecrets:
+  - secretName: zot-tls
+    mountPath: /secrets/tls
+
+# Mount htpasswd from chart-managed Secret at /secret
+mountSecret: true
+secretFiles:
+  htpasswd: |-
+    tekton-push:$2b$05$WpJc.HqAEf0d0/wiAJ7SCeCO2YdEgDeA/ERvDbq6/8pCafLM57Xfe
+
+# Persistent storage for registry blobs
+persistence: true
+pvc:
+  create: true
+  accessMode: ReadWriteOnce
+  storage: 50Gi
   storageClassName: longhorn-cicd
-  size: 50Gi
+
+# RWO PVC + single replica: must use Recreate to avoid mount deadlock
+strategy:
+  type: Recreate
 
 nodeSelector:
   kubernetes.io/hostname: pc-1

--- a/apps/zot/values.yaml
+++ b/apps/zot/values.yaml
@@ -2,6 +2,10 @@
 # Exposed at 192.168.55.210:5000 (HTTPS)
 # Runs on pc-1 with Longhorn-CICD storage (single replica)
 
+# Pin image to chart's default appVersion for visibility
+image:
+  tag: "v2.1.1"
+
 service:
   type: LoadBalancer
   port: 5000
@@ -12,13 +16,22 @@ service:
 httpGet:
   scheme: HTTPS
 
+# Uncomment if probes fail with 401 after enabling htpasswd auth.
+# Value is base64 of "tekton-push:<password>" (echo -n "tekton-push:pass" | base64)
+# authHeader: "<base64-encoded>"
+
 # Mount config.json from chart-managed ConfigMap at /etc/zot
 mountConfig: true
 
 configFiles:
   config.json: |-
     {
-      "storage": { "rootDirectory": "/var/lib/registry" },
+      "storage": {
+        "rootDirectory": "/var/lib/registry",
+        "dedupe": true,
+        "gc": true,
+        "gcDelay": "24h"
+      },
       "http": {
         "address": "0.0.0.0",
         "port": "5000",

--- a/docs/superpowers/plans/2026-03-29--cicd--platform.md
+++ b/docs/superpowers/plans/2026-03-29--cicd--platform.md
@@ -1257,7 +1257,9 @@ curl -sk https://192.168.55.210:5000/v2/
 # Expect: {} or {"repositories":[]}
 ```
 
-> **Deviation (2026-04-13):** Chart v0.1.0 was too minimal — no support for `mountConfig`, `mountSecret`, `persistence`, or `externalSecrets`. Upgraded to v0.1.60 which adds full config, secrets, PVC, and TLS support. Values rewritten with: `configFiles.config.json` (TLS + htpasswd auth + anonymous read), `externalSecrets` (cert-manager TLS), `mountSecret` (htpasswd), persistence via `pvc.create: true` with `longhorn-cicd`, and `strategy: Recreate` for RWO safety. Image upgrades from v1.4.1 to v2.1.1 (chart default). See PR from `vk/5b16-ffe-7-gh-43`.
+> **Deviation (2026-04-13):** Chart v0.1.0 was too minimal — no support for `mountConfig`, `mountSecret`, `persistence`, or `externalSecrets`. Upgraded to v0.1.60 which adds full config, secrets, PVC, and TLS support. Values rewritten with: `configFiles.config.json` (TLS + htpasswd auth + anonymous read + dedupe + GC), `externalSecrets` (cert-manager TLS), `mountSecret` (htpasswd), persistence via `pvc.create: true` with `longhorn-cicd`, and `strategy: Recreate` for RWO safety. Image pinned to v2.1.1 (chart default for 0.1.60). See PR from `vk/5b16-ffe-7-gh-43`.
+>
+> **Future cleanup:** The `zot-secrets` ExternalSecret in the `zot` namespace fetches `ZOT_PUSH_PASSWORD` and `ZOT_OIDC_CLIENT_SECRET` from Infisical but neither key is mounted into the Zot pod. The push password is only consumed by Tekton's `zot-push-creds` ExternalSecret in `tekton-pipelines`. Consider removing `zot-secrets` or repurposing it if OIDC is implemented.
 
 - [ ] **Step 10: Test image push/pull**
 

--- a/docs/superpowers/plans/2026-03-29--cicd--platform.md
+++ b/docs/superpowers/plans/2026-03-29--cicd--platform.md
@@ -1257,6 +1257,8 @@ curl -sk https://192.168.55.210:5000/v2/
 # Expect: {} or {"repositories":[]}
 ```
 
+> **Deviation (2026-04-13):** Chart v0.1.0 was too minimal — no support for `mountConfig`, `mountSecret`, `persistence`, or `externalSecrets`. Upgraded to v0.1.60 which adds full config, secrets, PVC, and TLS support. Values rewritten with: `configFiles.config.json` (TLS + htpasswd auth + anonymous read), `externalSecrets` (cert-manager TLS), `mountSecret` (htpasswd), persistence via `pvc.create: true` with `longhorn-cicd`, and `strategy: Recreate` for RWO safety. Image upgrades from v1.4.1 to v2.1.1 (chart default). See PR from `vk/5b16-ffe-7-gh-43`.
+
 - [ ] **Step 10: Test image push/pull**
 
 ```bash


### PR DESCRIPTION
## Summary

- Upgrade Zot Helm chart from v0.1.0 to v0.1.60 — v0.1.0 lacked support for `mountConfig`, `mountSecret`, `persistence`, and `externalSecrets`, resulting in a bare deployment with no TLS, no auth, no persistent storage, and no custom config
- Complete Zot configuration with TLS (cert-manager self-signed cert), htpasswd authentication (`tekton-push` user), anonymous read policy for image pulls, 50Gi Longhorn-CICD persistent storage, and Recreate strategy for RWO PVC safety
- Add deviation note to CI/CD platform plan documenting the chart upgrade rationale

Closes #43

## What changed

| File | Change |
|------|--------|
| `apps/root/templates/zot.yaml` | Chart version 0.1.0 → 0.1.60 |
| `apps/zot/values.yaml` | Complete rewrite with `configFiles.config.json`, TLS, htpasswd, persistence, access control |
| Plan file | Deviation note between Step 9 and Step 10 |

## Gotchas to add to `frank-gotchas.md`

- Zot Helm chart v0.1.0 is too minimal — no support for `mountConfig`, `mountSecret`, `persistence`, or `externalSecrets`. Use v0.1.60+ for TLS, htpasswd auth, and persistent storage
- Zot htpasswd hash in `values.yaml` must be regenerated if `ZOT_PUSH_PASSWORD` changes in Infisical — the bcrypt hash and plaintext password are not kept in sync automatically

## Post-merge verification

After merge, ArgoCD will sync the upgrade. Verify:

```bash
# Wait for new pod with volumes
kubectl get pods -n zot -w

# Check HTTPS works
curl -sk https://192.168.55.210:5000/v2/
# Expect: 200 OK (anonymous read)

# Check auth required for push
curl -sk -X POST https://192.168.55.210:5000/v2/test/blobs/uploads/
# Expect: 401 Unauthorized

# Check auth works
curl -sk -u tekton-push:<password> https://192.168.55.210:5000/v2/_catalog
# Expect: 200 OK

# Check PVC provisioned
kubectl get pvc -n zot
# Expect: zot-pvc Bound
```

Steps 10 (test image push/pull) and 11 (containerd mirror Talos patch) remain pending — they require post-merge deployment and manual Omni interaction respectively.

## Test plan

- [ ] ArgoCD syncs the upgraded chart without errors
- [ ] Zot pod starts with all volume mounts (config, TLS, htpasswd, PVC)
- [ ] HTTPS endpoint responds on `https://192.168.55.210:5000/v2/`
- [ ] Anonymous read works (no auth required for GET)
- [ ] Authenticated push works with `tekton-push` credentials
- [ ] PVC is provisioned on pc-1 via longhorn-cicd StorageClass

🤖 Generated with [Claude Code](https://claude.com/claude-code)