### PR TITLE
fix(cicd): harden Tekton CI pipeline (Phase 5)

### DIFF
--- a/apps/tekton/pipelines/gitea-ci.yaml
+++ b/apps/tekton/pipelines/gitea-ci.yaml
@@ -1,5 +1,5 @@
 # Main CI pipeline triggered by Gitea webhooks
-# Stage A: clone → test → report status
+# Stages: clone → test → build/push → cosign sign → report status
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
@@ -65,6 +65,8 @@ spec:
           workspace: shared-workspace
         - name: dockerconfig
           workspace: docker-credentials
+    # Sign by digest (not tag) to prevent TOCTOU — the digest is captured
+    # by Kaniko's --digest-file during the build-push step
     - name: sign
       runAfter: ["build-push"]
       when:
@@ -75,7 +77,7 @@ spec:
         name: cosign-sign
       params:
         - name: image
-          value: $(params.image)
+          value: "$(params.image)@$(tasks.build-push.results.IMAGE_DIGEST)"
   finally:
     - name: report-success
       when:

--- a/apps/tekton/tasks/build-push.yaml
+++ b/apps/tekton/tasks/build-push.yaml
@@ -16,6 +16,9 @@ spec:
     - name: context
       type: string
       default: "."
+  results:
+    - name: IMAGE_DIGEST
+      description: "Digest of the built image (e.g., sha256:abc123)"
   workspaces:
     - name: source
       description: "The git repo with Dockerfile"
@@ -23,11 +26,18 @@ spec:
       description: "Docker config.json for registry auth"
   steps:
     - name: build-and-push
-      image: gcr.io/kaniko-project/executor:latest
+      image: gcr.io/kaniko-project/executor:v1.23.2
+      resources:
+        requests:
+          cpu: 500m
+          memory: 512Mi
+        limits:
+          memory: 4Gi
       args:
         - "--dockerfile=$(params.dockerfile)"
         - "--context=$(workspaces.source.path)/$(params.context)"
         - "--destination=$(params.image)"
+        - "--digest-file=$(results.IMAGE_DIGEST.path)"
         - "--skip-tls-verify"
       env:
         - name: DOCKER_CONFIG

--- a/apps/tekton/tasks/cosign-sign.yaml
+++ b/apps/tekton/tasks/cosign-sign.yaml
@@ -8,10 +8,16 @@ spec:
   params:
     - name: image
       type: string
-      description: "Full image reference to sign"
+      description: "Full image reference to sign (preferably with digest)"
   steps:
     - name: sign
-      image: bitnami/cosign:latest
+      image: bitnami/cosign:2.4.1
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
       env:
         - name: COSIGN_PASSWORD
           value: ""

--- a/apps/tekton/tasks/git-clone.yaml
+++ b/apps/tekton/tasks/git-clone.yaml
@@ -44,6 +44,12 @@ spec:
   steps:
     - name: clone
       image: alpine/git:2.47.2
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
       securityContext:
         allowPrivilegeEscalation: false
         runAsNonRoot: true

--- a/apps/tekton/tasks/gitea-status.yaml
+++ b/apps/tekton/tasks/gitea-status.yaml
@@ -27,23 +27,44 @@ spec:
       default: "http://gitea-http.gitea.svc.cluster.local:3000"
   steps:
     - name: report
-      image: alpine:3
+      image: curlimages/curl:8.7.1
       env:
         - name: GITEA_TOKEN
           valueFrom:
             secretKeyRef:
               name: gitea-api-token
               key: token
-      script: |
-        #!/bin/sh
-        apk add --no-cache curl
-        STATUS_URL="$(params.gitea-url)/api/v1/repos/$(params.repo-full-name)/statuses/$(params.revision)"
-        curl -s -X POST "$STATUS_URL" \
-          -H "Authorization: token $GITEA_TOKEN" \
-          -H "Content-Type: application/json" \
-          -d "{
-            \"state\": \"$(params.state)\",
-            \"description\": \"$(params.description)\",
-            \"context\": \"$(params.context)\"
-          }"
-        echo "Reported status '$(params.state)' for $(params.revision)"
+        - name: REPO_FULL_NAME
+          value: $(params.repo-full-name)
+        - name: REVISION
+          value: $(params.revision)
+        - name: STATE
+          value: $(params.state)
+        - name: DESCRIPTION
+          value: $(params.description)
+        - name: CONTEXT
+          value: $(params.context)
+        - name: GITEA_URL
+          value: $(params.gitea-url)
+      resources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          memory: 128Mi
+      command: ["/bin/sh", "-e", "-c"]
+      args:
+        - |
+          STATUS_URL="${GITEA_URL}/api/v1/repos/${REPO_FULL_NAME}/statuses/${REVISION}"
+          # Escape values for safe JSON embedding
+          json_escape() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+          S=$(json_escape "$STATE")
+          D=$(json_escape "$DESCRIPTION")
+          C=$(json_escape "$CONTEXT")
+          PAYLOAD="{\"state\":\"${S}\",\"description\":\"${D}\",\"context\":\"${C}\"}"
+          HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$STATUS_URL" \
+            -H "Authorization: token $GITEA_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          echo "Reported status '${STATE}' for ${REVISION} (HTTP ${HTTP_CODE})"
+          [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]

--- a/apps/tekton/tasks/run-tests.yaml
+++ b/apps/tekton/tasks/run-tests.yaml
@@ -15,11 +15,20 @@ spec:
       description: "The git repo"
   steps:
     - name: test
-      image: alpine:3
+      image: alpine:3.20
       workingDir: $(workspaces.source.path)
-      script: |
-        #!/bin/sh
-        set -e
-        echo "Running tests..."
-        $(params.test-command)
-        echo "Tests passed."
+      env:
+        - name: TEST_CMD
+          value: $(params.test-command)
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+      command: ["/bin/sh", "-e", "-c"]
+      args:
+        - |
+          echo "Running tests..."
+          eval "$TEST_CMD"
+          echo "Tests passed."


### PR DESCRIPTION
## Summary

Code review fixes for the Phase 5 CI Pipeline implementation. Hardening changes for tasks, pipeline, and ArgoCD integration.

**Note:** C2 (ignoreDifferences) and I1 (git-clone v1 rewrite) were already merged via #46/#47. This PR carries the remaining fixes.

- **C1: JSON injection fix** — `gitea-status` task now passes params via env vars with proper JSON escaping and validates HTTP response codes
- **I2: Unpinned images** — Pinned all container images: Kaniko `v1.23.2`, cosign `2.4.1`, curl `8.7.1`, alpine `3.20`
- **I3: Repeated package install** — Replaced `alpine:3` + `apk add curl` with pre-built `curlimages/curl:8.7.1` in gitea-status task
- **I4: Tag-based signing** — Added `--digest-file` to Kaniko build-push task, pipeline now passes `image@digest` to cosign-sign (prevents TOCTOU)
- **I5: Resource limits** — Added `resources.requests` and `resources.limits` to all 5 task steps
- **S1: Shell injection surface** — Restructured `run-tests` task to use `command`/`args` arrays with env var passthrough

## Test plan

- [ ] Verify YAML validates (`kubectl apply --dry-run=client`)
- [ ] Run a test PipelineRun after Phase 4 infrastructure is deployed
- [ ] Verify `cosign verify` works with digest-signed images

> **Note:** Remaining unchecked plan steps (e2e testing, cosign keypair manual op) require deployed infrastructure. This PR addresses code quality only.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)