### PR TITLE
feat(agents): VK relay deployment manifests (Phase 0)

### DIFF
--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: "0.0.0.0"
             - name: VK_SHARED_API_BASE
               value: "https://vk.cluster.derio.net"
+            - name: VK_SHARED_RELAY_API_BASE
+              value: "https://vk.cluster.derio.net"
           envFrom:
             - secretRef:
                 name: agent-secrets-tier1

--- a/apps/traefik/manifests/ingressroutes.yaml
+++ b/apps/traefik/manifests/ingressroutes.yaml
@@ -388,6 +388,15 @@ spec:
   entryPoints:
     - websecure
   routes:
+    - match: Host(`vk.cluster.derio.net`) && PathPrefix(`/v1/relay`)
+      kind: Rule
+      middlewares:
+        - name: ip-allowlist
+        - name: security-headers
+      services:
+        - name: vk-remote
+          namespace: agents
+          port: 8082
     - match: Host(`vk.cluster.derio.net`)
       kind: Rule
       middlewares:

--- a/apps/vk-remote/manifests/deployment.yaml
+++ b/apps/vk-remote/manifests/deployment.yaml
@@ -103,5 +103,9 @@ spec:
   selector:
     app: vk-remote
   ports:
-    - port: 8081
+    - name: http
+      port: 8081
       targetPort: 8081
+    - name: relay
+      port: 8082
+      targetPort: 8082

--- a/apps/vk-remote/manifests/deployment.yaml
+++ b/apps/vk-remote/manifests/deployment.yaml
@@ -83,15 +83,18 @@ spec:
             limits:
               cpu: 200m
               memory: 128Mi
+          startupProbe:
+            tcpSocket:
+              port: 8082
+            failureThreshold: 10
+            periodSeconds: 3
           readinessProbe:
             tcpSocket:
               port: 8082
-            initialDelaySeconds: 5
             periodSeconds: 15
           livenessProbe:
             tcpSocket:
               port: 8082
-            initialDelaySeconds: 10
             periodSeconds: 30
 ---
 apiVersion: v1

--- a/apps/vk-remote/manifests/deployment.yaml
+++ b/apps/vk-remote/manifests/deployment.yaml
@@ -55,6 +55,44 @@ spec:
             limits:
               cpu: 500m
               memory: 256Mi
+        - name: relay-server
+          image: ghcr.io/derio-net/vk-remote:edccfb1
+          command: ["/usr/local/bin/relay-server"]
+          ports:
+            - containerPort: 8082
+              protocol: TCP
+          env:
+            - name: RELAY_LISTEN_ADDR
+              value: "0.0.0.0:8082"
+            - name: VIBEKANBAN_REMOTE_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: vk-remote-secrets
+                  key: VIBEKANBAN_REMOTE_JWT_SECRET
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: vk-remote-secrets
+                  key: POSTGRES_PASSWORD
+            - name: SERVER_DATABASE_URL
+              value: "postgresql://remote:$(POSTGRES_PASSWORD)@postgres-vk:5432/remote?sslmode=disable"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          readinessProbe:
+            tcpSocket:
+              port: 8082
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          livenessProbe:
+            tcpSocket:
+              port: 8082
+            initialDelaySeconds: 10
+            periodSeconds: 30
 ---
 apiVersion: v1
 kind: Service

--- a/docs/superpowers/plans/2026-04-13--agents--vk-relay-deployment.md
+++ b/docs/superpowers/plans/2026-04-13--agents--vk-relay-deployment.md
@@ -5,7 +5,7 @@
 > **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Spec:** `docs/superpowers/specs/2026-04-13--agents--vk-relay-self-host-design.md`
-**Status:** Not Started
+**Status:** In Progress
 
 **Goal:** Deploy the VK relay server as a sidecar in the vk-remote pod and configure the secure-agent-pod to connect to it, enabling the remote web UI to proxy API calls to the local VK server.
 **Architecture:** Add relay sidecar to vk-remote deployment (same image, different entrypoint), split IngressRoute for relay paths, add `VK_SHARED_RELAY_API_BASE` to secure-agent-pod.

--- a/docs/superpowers/plans/2026-04-13--agents--vk-relay-deployment.md
+++ b/docs/superpowers/plans/2026-04-13--agents--vk-relay-deployment.md
@@ -32,7 +32,7 @@
 **Files:**
 - Modify: `apps/vk-remote/manifests/deployment.yaml`
 
-- [ ] **Step 1: Add relay-server container**
+- [x] **Step 1: Add relay-server container**
 
 Add a second container to the pod spec, after the existing `vk-remote` container:
 
@@ -79,7 +79,7 @@ Add a second container to the pod spec, after the existing `vk-remote` container
 
 Use the same image tag as the vk-remote container. Replace `<IMAGE_SHA>` with the SHA from the vibe-kanban plan's Phase 0 Task 3.
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add apps/vk-remote/manifests/deployment.yaml
@@ -91,7 +91,7 @@ git commit -m "feat(agents): add relay-server sidecar to vk-remote pod"
 **Files:**
 - Modify: `apps/vk-remote/manifests/deployment.yaml` (the Service is in the same file)
 
-- [ ] **Step 1: Add relay port to the existing Service**
+- [x] **Step 1: Add relay port to the existing Service**
 
 The Service definition is at the bottom of `deployment.yaml`. Add port 8082:
 
@@ -113,7 +113,7 @@ spec:
       targetPort: 8082
 ```
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add apps/vk-remote/manifests/deployment.yaml
@@ -125,7 +125,7 @@ git commit -m "feat(agents): add relay port to vk-remote service"
 **Files:**
 - Modify: `apps/traefik/manifests/ingressroutes.yaml`
 
-- [ ] **Step 1: Replace the existing vk-remote IngressRoute with two rules**
+- [x] **Step 1: Replace the existing vk-remote IngressRoute with two rules**
 
 Find the existing VK IngressRoute block:
 
@@ -166,7 +166,7 @@ Replace with two rules:
 
 The relay rule must come first — Traefik evaluates rules in order and the more specific PathPrefix match needs priority.
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add apps/traefik/manifests/ingressroutes.yaml
@@ -178,7 +178,7 @@ git commit -m "feat(agents): split vk IngressRoute for relay paths"
 **Files:**
 - Modify: `apps/secure-agent-pod/manifests/deployment.yaml`
 
-- [ ] **Step 1: Add the env var**
+- [x] **Step 1: Add the env var**
 
 In the kali container's `env` section, after `VK_SHARED_API_BASE`, add:
 
@@ -187,7 +187,7 @@ In the kali container's `env` section, after `VK_SHARED_API_BASE`, add:
               value: "https://vk.cluster.derio.net"
 ```
 
-- [ ] **Step 2: Commit**
+- [x] **Step 2: Commit**
 
 ```bash
 git add apps/secure-agent-pod/manifests/deployment.yaml
@@ -196,7 +196,7 @@ git commit -m "feat(agents): add VK_SHARED_RELAY_API_BASE for relay connection"
 
 ### Task 5: Commit all and push
 
-- [ ] **Step 1: Push to trigger ArgoCD sync**
+- [x] **Step 1: Push to trigger ArgoCD sync**
 
 ```bash
 git push origin main


### PR DESCRIPTION
## Summary

- Add relay-server sidecar container to the vk-remote pod (same image, `/usr/local/bin/relay-server` entrypoint, port 8082)
- Add relay port (8082) to the vk-remote Service
- Split the vk-remote IngressRoute so `/v1/relay/*` routes to the relay sidecar while all other traffic continues to the web UI
- Add `VK_SHARED_RELAY_API_BASE` env var to the secure-agent-pod so the local VK server knows where to register with the relay

Closes #50

## Test plan

- [ ] ArgoCD syncs the vk-remote and traefik apps without errors
- [ ] vk-remote pod shows two running containers (`vk-remote` + `relay-server`)
- [ ] `curl https://vk.cluster.derio.net/v1/relay/connect` returns 401 (endpoint routed correctly)
- [ ] `curl https://vk.cluster.derio.net` loads the VK remote UI (catch-all route still works)
- [ ] secure-agent-pod environment includes `VK_SHARED_RELAY_API_BASE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)