### PR TITLE
fix(agents): update vk-remote image to include relay-server binary

### DIFF
--- a/apps/vk-remote/manifests/deployment.yaml
+++ b/apps/vk-remote/manifests/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vk-remote
-          image: ghcr.io/derio-net/vk-remote:edccfb1
+          image: ghcr.io/derio-net/vk-remote:1cce857
           ports:
             - containerPort: 8081
           env:
@@ -56,7 +56,7 @@ spec:
               cpu: 500m
               memory: 256Mi
         - name: relay-server
-          image: ghcr.io/derio-net/vk-remote:edccfb1
+          image: ghcr.io/derio-net/vk-remote:1cce857
           command: ["/usr/local/bin/relay-server"]
           ports:
             - containerPort: 8082


### PR DESCRIPTION
## Summary
- Updates vk-remote image tag from `edccfb1` to `1cce857`
- The new image includes the `/usr/local/bin/relay-server` binary that was missing, causing CrashLoopBackOff on the relay-server sidecar container
- Part of Phase 1 (Deploy & Verify) for #51

## Context
Phase 0 (#50) deployed the relay-server sidecar with `command: ["/usr/local/bin/relay-server"]`, but the image tag `edccfb1` predates the Dockerfile change that adds the relay binary. The `1cce857` build (created today) includes both binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)