### PR TITLE
feat(agents): complete Phase 1 relay deployment verification

### DIFF
--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -60,8 +60,6 @@ spec:
               value: "https://vk.cluster.derio.net"
             - name: VK_SHARED_RELAY_API_BASE
               value: "https://vk.cluster.derio.net"
-            - name: RUST_LOG
-              value: "info,relay_registration=debug,relay_tunnel_core=debug,relay_hosts=debug,relay_control=debug"
           envFrom:
             - secretRef:
                 name: agent-secrets-tier1

--- a/docs/superpowers/plans/2026-04-13--agents--vk-relay-deployment.md
+++ b/docs/superpowers/plans/2026-04-13--agents--vk-relay-deployment.md
@@ -255,29 +255,31 @@ Open `https://vk.cluster.derio.net` in the browser. The local host should appear
 
 ### Task 3: Pair browser with local server (one-time)
 
-- [-] **Step 1: Port-forward to the local VK server** *(manual — requires operator browser access)*
+- [x] **Step 1: Port-forward to the local VK server**
 
 ```bash
 kubectl -n secure-agent-pod port-forward deploy/secure-agent-pod 8081:8081
 ```
 
-- [-] **Step 2: Generate pairing code** *(manual — requires operator browser access)*
+- [x] **Step 2: Generate pairing code**
 
 Open `http://localhost:8081` in the browser. Go to Settings → Relay Settings → "Generate pairing code". Note the 6-digit code.
 
-- [-] **Step 3: Enter code in remote UI** *(manual — requires operator browser access)*
+- [x] **Step 3: Enter code in remote UI**
 
 Open `https://vk.cluster.derio.net`. Go to Settings → "Pair host". Enter the 6-digit code.
 
 Expected: Pairing completes, host status changes to "online".
 
-- [-] **Step 4: Verify workspace repos are visible** *(manual — requires operator browser access)*
+> **Note:** The enrollment code is one-time-use. If the SPAKE2 exchange fails (e.g., relay tunnel not connected), generate a fresh code before retrying.
+
+- [x] **Step 4: Verify workspace repos are visible**
 
 Click into an active workspace in the remote UI.
 
 Expected: Repos, sessions, and workspace details are now visible (proxied via relay from the local server).
 
-- [-] **Step 5: Stop the port-forward** *(manual — requires operator browser access)*
+- [x] **Step 5: Stop the port-forward**
 
 The port-forward is no longer needed — the relay handles all communication going forward.
 


### PR DESCRIPTION
## Summary
- Removes temporary `RUST_LOG` debug env vars from secure-agent-pod (added during relay tunnel diagnosis)
- Marks all Phase 1 plan checkboxes complete after successful verification:
  - **Task 1:** Relay sidecar running 2/2, endpoint reachable (401), relay listening on 8082
  - **Task 2:** Host registered in relay DB as "secure-pod" (online), WebSocket tunnel connected
  - **Task 3:** Browser paired via SPAKE2, workspaces visible through relay proxy

## Deployment Deviations (from Phase 0)
- Image tag fixed `edccfb1` → `1cce857` to include relay-server binary (PR #54)
- Pod restart required for relay tunnel to connect (relay-server was crash-looping when tunnel first attempted)
- Enrollment code is one-time-use; failed SPAKE2 attempts consume the code

## Gotchas to add to `frank-gotchas.md`

- VK relay sidecar image tag must match a build that includes `/usr/local/bin/relay-server` — the binary was added to the Dockerfile after the initial vk-remote image. Using a pre-relay image tag causes CrashLoopBackOff (`no such file or directory`). Always verify the image contains the expected binary before deploying a sidecar with a different entrypoint
- VK local server relay tunnel uses exponential backoff (1s → 30s max). If the relay-server sidecar is unavailable when the local server boots, the tunnel may not reconnect for up to 30s. If the sidecar was crash-looping for minutes, restart the secure-agent-pod to force immediate tunnel reconnection rather than waiting for backoff to cycle
- VK SPAKE2 enrollment codes are one-time-use — the code is consumed on the first `/api/relay-auth/server/spake2/start` call, even if the full exchange fails (e.g., relay tunnel not connected). The error message `"Unauthorized. Please sign in again."` is misleading — it means the enrollment code was invalid/consumed, not a session expiry. Generate a fresh code via Settings → Relay Settings before each pairing attempt

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)