### PR TITLE
chore(agents): post-review cleanup for relay deployment

### DIFF
--- a/apps/vk-remote/manifests/deployment.yaml
+++ b/apps/vk-remote/manifests/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               cpu: 500m
               memory: 256Mi
         - name: relay-server
-          image: ghcr.io/derio-net/vk-remote:1cce857
+          image: ghcr.io/derio-net/vk-remote:1cce857  # keep in sync with vk-remote image above
           command: ["/usr/local/bin/relay-server"]
           ports:
             - containerPort: 8082

--- a/docs/superpowers/plans/2026-04-13--agents--vk-relay-deployment.md
+++ b/docs/superpowers/plans/2026-04-13--agents--vk-relay-deployment.md
@@ -5,7 +5,7 @@
 > **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Spec:** `docs/superpowers/specs/2026-04-13--agents--vk-relay-self-host-design.md`
-**Status:** In Progress
+**Status:** Deployed
 
 **Goal:** Deploy the VK relay server as a sidecar in the vk-remote pod and configure the secure-agent-pod to connect to it, enabling the remote web UI to proxy API calls to the local VK server.
 **Architecture:** Add relay sidecar to vk-remote deployment (same image, different entrypoint), split IngressRoute for relay paths, add `VK_SHARED_RELAY_API_BASE` to secure-agent-pod.
@@ -18,7 +18,7 @@
 | File | Action | Responsibility |
 |------|--------|----------------|
 | `apps/vk-remote/manifests/deployment.yaml` | Modify | Add relay sidecar container |
-| `apps/vk-remote/manifests/service.yaml` | Create | Service with both ports (8081 + 8082) |
+| `apps/vk-remote/manifests/deployment.yaml` | Modify | Add relay port to Service (Deployment + Service in same file) |
 | `apps/traefik/manifests/ingressroutes.yaml` | Modify | Split VK route for relay paths |
 | `apps/secure-agent-pod/manifests/deployment.yaml` | Modify | Add VK_SHARED_RELAY_API_BASE env var |
 


### PR DESCRIPTION
## Summary

- Add `# keep in sync with vk-remote image above` comment on relay-server sidecar image tag to prevent version drift
- Update plan status from `In Progress` → `Deployed` (relay is live and verified)
- Fix File Structure table: Service lives in `deployment.yaml`, not a separate `service.yaml`

## Test plan

- [ ] No functional changes — comment and docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)