### PR TITLE
docs(repo): design spec for PaperMod → Hextra migration

### DIFF
--- a/docs/superpowers/plans/2026-04-13--repo--blog-hextra-migration.md
+++ b/docs/superpowers/plans/2026-04-13--repo--blog-hextra-migration.md
@@ -1,0 +1,720 @@
+# Blog Hextra Migration Implementation Plan
+
+> **For VK agents:** Use vk-execute to implement assigned phases.
+> **For local execution:** Use subagent-driven-development or executing-plans.
+> **For dispatch:** Use vk-dispatch to create Issues from this plan.
+
+**Spec:** `docs/superpowers/specs/2026-04-13--repo--blog-hextra-migration-design.md`
+**Status:** Not Started
+
+**Goal:** Migrate the Frank blog from PaperMod to Hextra theme, gaining sidebar navigation, built-in search, and a modern documentation aesthetic, plus a client-side read-tracking feature.
+**Architecture:** In-place swap in `blog/` directory. PaperMod git submodule replaced by Hextra Hugo module. Content moved under `content/docs/` for sidebar navigation. Custom shortcodes ported. New read-tracking JS via localStorage.
+**Tech Stack:** Hugo 0.157.0, Hextra (Hugo module), Tailwind CSS, FlexSearch, localStorage API
+
+**Submodule note:** `.gitmodules` is at the repo root (not `blog/`). The PaperMod submodule path is `blog/themes/PaperMod`.
+
+---
+
+## Phase 1: Theme Swap Foundation [agentic]
+
+Remove PaperMod, install Hextra as a Hugo module, rewrite config, create landing page. The blog will be in a broken state during this phase until content migration in Phase 2.
+
+### Task 1: Remove PaperMod submodule
+
+- [ ] **Step 1: Deinit the submodule**
+
+  ```bash
+  cd /path/to/frank
+  git submodule deinit -f blog/themes/PaperMod
+  git rm -f blog/themes/PaperMod
+  rm -rf .git/modules/blog/themes/PaperMod
+  ```
+
+  Verify `.gitmodules` is either empty or deleted:
+  ```bash
+  cat .gitmodules  # should be empty or file not found
+  ```
+
+- [ ] **Step 2: Remove leftover themes directory**
+
+  ```bash
+  rm -rf blog/themes/
+  ```
+
+  Commit:
+  ```
+  refactor(repo): remove PaperMod submodule
+  ```
+
+### Task 2: Initialize Hugo modules and import Hextra
+
+- [ ] **Step 1: Initialize Hugo module in blog directory**
+
+  ```bash
+  cd blog
+  hugo mod init github.com/derio-net/frank/blog
+  ```
+
+  Verify `blog/go.mod` exists with:
+  ```
+  module github.com/derio-net/frank/blog
+  ```
+
+- [ ] **Step 2: Rewrite hugo.toml for Hextra**
+
+  Replace the entire `blog/hugo.toml` with:
+
+  ```toml
+  baseURL = "https://derio-net.github.io/frank/"
+  languageCode = "en-us"
+  title = "Frank, the Talos Cluster"
+
+  [module]
+    [[module.imports]]
+      path = "github.com/imfing/hextra"
+
+  [params]
+    description = "Tutorial series on building and operating an AI-hybrid Kubernetes homelab"
+
+    [params.navbar]
+      displayTitle = true
+      displayLogo = false
+
+    [params.footer]
+      displayPoweredBy = false
+
+    [params.editURL]
+      enable = false
+
+  [markup]
+    [markup.highlight]
+      codeFences = true
+      lineNos = false
+      style = "monokai"
+      noClasses = false
+
+  [outputs]
+    home = ["HTML", "RSS", "JSON"]
+  ```
+
+- [ ] **Step 3: Fetch the Hextra module**
+
+  ```bash
+  cd blog
+  hugo mod get -u
+  hugo mod tidy
+  ```
+
+  Verify `blog/go.sum` is populated. Verify `hugo mod graph` shows Hextra.
+
+### Task 3: Create landing page
+
+- [ ] **Step 1: Create root _index.md with Hextra landing layout**
+
+  Create `blog/content/_index.md`:
+
+  ```markdown
+  ---
+  title: "Frank, the Talos Cluster"
+  layout: hextra-home
+  ---
+
+  {{</* hextra/hero-badge link="https://github.com/derio-net/frank" */>}}
+    GitHub Repository
+  {{</* /hextra/hero-badge */>}}
+
+  <div class="hx-mt-6 hx-mb-6">
+  {{</* hextra/hero-headline */>}}
+    Frank, the Talos Cluster
+  {{</* /hextra/hero-headline */>}}
+  </div>
+
+  <div class="hx-mb-12">
+  {{</* hextra/hero-subtitle */>}}
+    Tutorial series on building and operating an AI-hybrid Kubernetes homelab
+    with Talos Linux, Cilium, Longhorn, ArgoCD, and GPU compute.
+  {{</* /hextra/hero-subtitle */>}}
+  </div>
+
+  <div class="hx-mb-6">
+  {{</* hextra/feature-grid */>}}
+    {{</* hextra/feature-card
+      title="Building Frank"
+      subtitle="26 posts — from bare metal to a fully operational AI-hybrid cluster"
+      link="docs/building/"
+      icon="wrench"
+    */>}}
+    {{</* hextra/feature-card
+      title="Operating on Frank"
+      subtitle="20 posts — day-to-day commands, health checks, and debugging guides"
+      link="docs/operating/"
+      icon="terminal"
+    */>}}
+    {{</* hextra/feature-card
+      title="Search"
+      subtitle="Full-text search across all posts"
+      link="docs/building/"
+      icon="magnifying-glass"
+    */>}}
+  {{</* /hextra/feature-grid */>}}
+  </div>
+  ```
+
+- [ ] **Step 2: Verify Hugo starts (will show empty docs)**
+
+  ```bash
+  cd blog
+  hugo server --buildDrafts
+  ```
+
+  Expect: landing page renders with hero + feature cards, no sidebar content yet. Check browser at `localhost:1313/frank/`.
+
+  Commit:
+  ```
+  feat(repo): install Hextra theme via Hugo module with landing page
+  ```
+
+---
+
+## Phase 2: Content Migration [agentic]
+
+Move both series under `content/docs/`, update section indexes, and migrate frontmatter across all 48 posts.
+
+### Task 1: Move content directories
+
+- [ ] **Step 1: Create docs parent and move series**
+
+  ```bash
+  cd blog
+  mkdir -p content/docs
+  mv content/building content/docs/building
+  mv content/operating content/docs/operating
+  ```
+
+- [ ] **Step 2: Update Building section index**
+
+  Rewrite `blog/content/docs/building/_index.md`:
+
+  ```markdown
+  ---
+  title: "Building Frank"
+  weight: 1
+  sidebar:
+    open: true
+  ---
+
+  A tutorial series on building an AI-hybrid Kubernetes homelab from scratch.
+  ```
+
+- [ ] **Step 3: Update Operating section index**
+
+  Rewrite `blog/content/docs/operating/_index.md`:
+
+  ```markdown
+  ---
+  title: "Operating on Frank"
+  weight: 2
+  sidebar:
+    open: true
+  ---
+
+  Day-to-day commands, health checks, and debugging guides for every component on the cluster.
+  ```
+
+### Task 2: Migrate frontmatter across all posts
+
+- [ ] **Step 1: Write a frontmatter migration script**
+
+  Create `scripts/migrate-frontmatter.sh`:
+
+  ```bash
+  #!/usr/bin/env bash
+  # Remove PaperMod-specific 'cover' block from all post frontmatter.
+  # Keeps: title, date, draft, tags, summary, weight
+  # Removes: cover (image, alt, relative)
+  set -euo pipefail
+
+  for f in blog/content/docs/building/*/index.md blog/content/docs/operating/*/index.md; do
+    echo "Processing: $f"
+    # Use awk to remove the cover block (cover: through next non-indented line)
+    awk '
+      /^cover:/ { in_cover=1; next }
+      in_cover && /^  / { next }
+      in_cover && !/^  / { in_cover=0 }
+      !in_cover { print }
+    ' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+  done
+
+  echo "Done. Processed $(find blog/content/docs -name 'index.md' | wc -l) files."
+  ```
+
+- [ ] **Step 2: Run the migration script**
+
+  ```bash
+  chmod +x scripts/migrate-frontmatter.sh
+  bash scripts/migrate-frontmatter.sh
+  ```
+
+  Verify a sample post no longer has the `cover:` block:
+  ```bash
+  head -12 blog/content/docs/building/01-introduction/index.md
+  ```
+
+  Expected frontmatter:
+  ```yaml
+  ---
+  title: "Why Build a Kubernetes Homelab?"
+  date: 2026-03-06
+  draft: false
+  tags: ["introduction", "architecture"]
+  summary: "The motivation behind Frank..."
+  weight: 2
+  ---
+  ```
+
+- [ ] **Step 3: Verify sidebar renders both series**
+
+  ```bash
+  cd blog && hugo server --buildDrafts
+  ```
+
+  Check:
+  - Sidebar shows "Building Frank" with all 26 posts
+  - Sidebar shows "Operating on Frank" with all 20 posts
+  - Posts are ordered by weight
+  - Clicking a post renders its content
+
+  Commit:
+  ```
+  feat(repo): migrate blog content to Hextra docs structure
+
+  Move building/ and operating/ under content/docs/ for sidebar
+  navigation. Remove PaperMod cover blocks from all 48 posts.
+  ```
+
+---
+
+## Phase 3: Custom Features [agentic]
+
+Port shortcodes, add cover image support, add series accent bars, and consolidate custom CSS.
+
+### Task 1: Port shortcodes
+
+- [ ] **Step 1: Update asciinema shortcode for Hextra dark mode detection**
+
+  Edit `blog/layouts/shortcodes/asciinema.html` — change the theme detection line from:
+
+  ```javascript
+  var theme = document.documentElement.dataset.theme === 'light' ? 'solarized-light' : 'asciinema';
+  ```
+
+  To:
+
+  ```javascript
+  var theme = document.documentElement.classList.contains('dark') ? 'asciinema' : 'solarized-light';
+  ```
+
+  The `screenshot.html` and `cluster-roadmap.html` shortcodes are theme-independent and need no changes to their templates.
+
+- [ ] **Step 2: Verify cluster-roadmap dark mode selector**
+
+  In `blog/layouts/shortcodes/cluster-roadmap.html`, the dark mode CSS uses `.dark .roadmap`. Hextra applies the `dark` class to `<html>`, so `.dark .roadmap` works because CSS class selectors match any ancestor. Verify in browser — no change expected.
+
+### Task 2: Create asciinema head partial for Hextra
+
+- [ ] **Step 1: Create custom head partial**
+
+  Create `blog/layouts/partials/custom/head.html`:
+
+  ```html
+  {{- if .HasShortcode "asciinema" }}
+  <link rel="stylesheet" href="https://unpkg.com/asciinema-player@3.9.0/dist/bundle/asciinema-player.css" />
+  <script src="https://unpkg.com/asciinema-player@3.9.0/dist/bundle/asciinema-player.min.js"></script>
+  {{- end }}
+  ```
+
+  This replaces the asciinema loading from `extend_head.html` (PaperMod's hook). Hextra's hook is `partials/custom/head.html`.
+
+### Task 3: Add cover image layout override
+
+- [ ] **Step 1: Create docs single page override**
+
+  Inspect Hextra's built-in single layout to understand the block structure:
+
+  ```bash
+  cd blog
+  hugo mod graph
+  # Find the module cache path and inspect:
+  find $(go env GOMODCACHE) -path '*/imfing/hextra*/layouts/docs/single.html' 2>/dev/null | head -1
+  ```
+
+  Create `blog/layouts/docs/single.html` that extends Hextra's layout and injects a cover image before the content. The exact template depends on Hextra's block structure — adapt from what the inspection reveals.
+
+  Starting point (will need adjustment):
+
+  ```html
+  {{ define "main" }}
+  {{ $cover := .Resources.GetMatch "cover.*" }}
+  {{ with $cover }}
+  <div class="post-cover">
+    <img src="{{ .RelPermalink }}" alt="{{ $.Title }}" loading="lazy" />
+  </div>
+  {{ end }}
+  {{ .Content }}
+  {{ end }}
+  ```
+
+  **Iteration note:** This is the step most likely to require trial-and-error. If overriding `single.html` breaks Hextra's sidebar/ToC/breadcrumbs, the fallback approach is to use Hugo's `render hooks` or inject the cover image via JavaScript (similar to how read-tracker works). Test thoroughly.
+
+### Task 4: Create custom CSS
+
+- [ ] **Step 1: Create assets/css/custom.css**
+
+  Create `blog/assets/css/custom.css` with all custom styles consolidated:
+
+  ```css
+  /* === Cover images === */
+  .post-cover {
+    margin-bottom: 1.5rem;
+    line-height: 0;
+    border-radius: 0.5rem;
+    overflow: hidden;
+  }
+
+  .post-cover img {
+    width: 100%;
+    max-height: 400px;
+    object-fit: cover;
+    object-position: center;
+    display: block;
+  }
+
+  /* === Series accent bars === */
+  /* Selectors will need adjustment based on Hextra's rendered DOM structure.
+     Inspect the page and find the correct container element. */
+
+  /* === Screenshot shortcode === */
+  .screenshot {
+    margin: 1.5rem 0;
+    text-align: center;
+  }
+
+  .screenshot a {
+    display: block;
+    line-height: 0;
+  }
+
+  .screenshot img {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 0.5rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    cursor: zoom-in;
+    transition: box-shadow 0.2s ease;
+  }
+
+  .screenshot img:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .screenshot figcaption {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+    font-style: italic;
+    color: var(--tw-prose-captions, #6b7280);
+  }
+
+  /* === Asciinema container === */
+  .asciinema-container {
+    margin: 1.5rem 0;
+    border-radius: 0.5rem;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  /* === Dark mode overrides === */
+  :is(html.dark) .screenshot img {
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  :is(html.dark) .screenshot img:hover {
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5);
+  }
+
+  :is(html.dark) .asciinema-container {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  :is(html.dark) .post-cover {
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  }
+
+  /* === Read tracker markers === */
+  .read-marker {
+    margin-left: 0.3em;
+    font-size: 0.75em;
+    color: #198754;
+    opacity: 0.7;
+  }
+
+  :is(html.dark) .read-marker {
+    color: #40c057;
+  }
+  ```
+
+- [ ] **Step 2: Verify shortcodes and cover images render**
+
+  ```bash
+  cd blog && hugo server --buildDrafts
+  ```
+
+  Check:
+  - Navigate to a post with a cover.png — verify image renders at top
+  - Check accent bar colors differ between Building and Operating
+  - Verify dark/light mode toggle works for all custom styles
+
+  Commit:
+  ```
+  feat(repo): port shortcodes and custom styles to Hextra
+
+  Asciinema dark mode detection updated for Hextra. Cover images via
+  layout override. Series accent bars. All styles in custom.css.
+  ```
+
+---
+
+## Phase 4: Read Tracking [agentic]
+
+Implement the localStorage-based read-tracking feature.
+
+### Task 1: Implement read tracker JavaScript
+
+- [ ] **Step 1: Create read-tracker.js**
+
+  Create `blog/assets/js/read-tracker.js`:
+
+  ```javascript
+  (function () {
+    'use strict';
+
+    var STORAGE_KEY = 'frank-read-posts';
+
+    function getReadPosts() {
+      try {
+        return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+      } catch (e) {
+        return [];
+      }
+    }
+
+    function markCurrentAsRead() {
+      var path = window.location.pathname;
+      var readPosts = getReadPosts();
+      if (readPosts.indexOf(path) === -1) {
+        readPosts.push(path);
+        try {
+          localStorage.setItem(STORAGE_KEY, JSON.stringify(readPosts));
+        } catch (e) {
+          // localStorage full or unavailable — fail silently
+        }
+      }
+    }
+
+    function markSidebarLinks() {
+      var readPosts = getReadPosts();
+      if (readPosts.length === 0) return;
+
+      // Hextra sidebar links — selector must be verified against actual DOM
+      var links = document.querySelectorAll('nav.hextra-sidebar a[href]');
+      links.forEach(function (link) {
+        var href = link.getAttribute('href');
+        // Normalize: ensure trailing slash for comparison
+        var normalizedHref = href.endsWith('/') ? href : href + '/';
+        var isRead = readPosts.some(function (p) {
+          var normalizedP = p.endsWith('/') ? p : p + '/';
+          return normalizedP === normalizedHref;
+        });
+        if (isRead && !link.querySelector('.read-marker')) {
+          var marker = document.createElement('span');
+          marker.className = 'read-marker';
+          marker.textContent = '\u2713'; // checkmark
+          marker.title = 'Read';
+          link.appendChild(marker);
+        }
+      });
+    }
+
+    // Only run on docs pages
+    if (window.location.pathname.indexOf('/docs/') !== -1 ||
+        window.location.pathname.indexOf('/frank/docs/') !== -1) {
+      markCurrentAsRead();
+    }
+
+    // Mark sidebar after DOM is ready
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', markSidebarLinks);
+    } else {
+      markSidebarLinks();
+    }
+  })();
+  ```
+
+  **Selector note:** `nav.hextra-sidebar a[href]` must be verified against Hextra's actual rendered DOM. Inspect the sidebar element in browser DevTools and adjust if needed.
+
+### Task 2: Wire up the read tracker
+
+- [ ] **Step 1: Add JS loading to custom head partial**
+
+  Append to `blog/layouts/partials/custom/head.html` (after the asciinema block):
+
+  ```html
+  {{ $readTracker := resources.Get "js/read-tracker.js" | minify | fingerprint }}
+  <script src="{{ $readTracker.RelPermalink }}" defer></script>
+  ```
+
+- [ ] **Step 2: Add reset link to custom footer partial**
+
+  Create `blog/layouts/partials/custom/footer.html`:
+
+  ```html
+  <a href="#" id="clear-read-history" style="font-size: 0.75rem; opacity: 0.5;">
+    Clear read history
+  </a>
+  <script>
+  document.getElementById('clear-read-history').addEventListener('click', function(e) {
+    e.preventDefault();
+    localStorage.removeItem('frank-read-posts');
+    window.location.reload();
+  });
+  </script>
+  ```
+
+- [ ] **Step 3: Verify read tracking works**
+
+  ```bash
+  cd blog && hugo server --buildDrafts
+  ```
+
+  Test flow:
+  1. Open the site, navigate to a Building post — no checkmarks yet
+  2. Return to sidebar — the visited post should have a ✓
+  3. Visit several posts — checkmarks accumulate
+  4. Click "Clear read history" in footer — checkmarks disappear
+  5. Verify `frank-read-posts` key in browser DevTools → Application → localStorage
+
+  Commit:
+  ```
+  feat(repo): add read-tracking feature to Hextra blog
+
+  localStorage-based tracking marks visited docs pages with a checkmark
+  in the sidebar. Reset link in footer. No cookies, no server state.
+  ```
+
+---
+
+## Phase 5: CI/CD & Cleanup [agentic]
+
+Update build pipeline, remove old PaperMod layouts, verify production build.
+
+### Task 1: Update Dockerfile
+
+- [ ] **Step 1: Add Hugo module fetch to Dockerfile**
+
+  Update `blog/Dockerfile`:
+
+  ```dockerfile
+  # Stage 1: Build Hugo site
+  FROM ghcr.io/gohugoio/hugo:v0.157.0 AS builder
+  WORKDIR /src
+  COPY . .
+  RUN hugo mod get
+  RUN hugo --minify --baseURL https://blog.derio.net/frank
+
+  # Stage 2: Serve with Caddy
+  FROM caddy:2.9-alpine
+  COPY --from=builder /src/public /usr/share/caddy
+  RUN printf ':8080 {\n    handle_path /frank/* {\n        root * /usr/share/caddy\n        file_server\n        header Cache-Control "public, max-age=3600"\n    }\n    handle /frank {\n        redir /frank/ permanent\n    }\n    handle {\n        root * /usr/share/caddy\n        file_server\n        header Cache-Control "public, max-age=3600"\n    }\n}\n' > /etc/caddy/Caddyfile
+  EXPOSE 8080
+  ```
+
+  **Fallback:** If `ghcr.io/gohugoio/hugo:v0.157.0` lacks Go for modules, switch to the extended image tag or add a Go install step.
+
+### Task 2: Remove old PaperMod layout overrides
+
+- [ ] **Step 1: Delete PaperMod-specific layout files**
+
+  ```bash
+  rm blog/layouts/partials/header.html
+  rm blog/layouts/partials/home_info.html
+  rm blog/layouts/partials/extend_head.html
+  rm blog/layouts/partials/post_nav_links.html
+  rm blog/layouts/_default/list.html
+  rm blog/layouts/index.html
+  rmdir blog/layouts/_default/ 2>/dev/null || true
+  ```
+
+  Replacements:
+  - `header.html` (sticky banner) → series accent bars in `custom.css`
+  - `home_info.html` → Hextra landing page
+  - `extend_head.html` → `partials/custom/head.html`
+  - `post_nav_links.html` → Hextra built-in prev/next
+  - `list.html` → Hextra built-in sidebar list
+  - `index.html` → Hextra landing page (`content/_index.md`)
+
+### Task 3: Full build verification
+
+- [ ] **Step 1: Production build test**
+
+  ```bash
+  cd blog && hugo --minify
+  ```
+
+  Verify:
+  - Build succeeds with no errors or warnings
+  - `public/` directory generated
+  - `public/docs/building/01-introduction/index.html` exists
+  - `public/docs/operating/01-cluster-nodes/index.html` exists
+
+- [ ] **Step 2: Verify search index**
+
+  ```bash
+  ls blog/public/search-data.json 2>/dev/null || ls blog/public/index.json 2>/dev/null
+  ```
+
+  Hextra generates a search index automatically. Verify it exists and is non-empty.
+
+- [ ] **Step 3: Dev server smoke test**
+
+  ```bash
+  cd blog && hugo server --buildDrafts
+  ```
+
+  Full checklist:
+  - [ ] Landing page renders with hero and feature cards
+  - [ ] Sidebar shows Building (26 posts) and Operating (20 posts)
+  - [ ] Posts ordered correctly by weight
+  - [ ] Cover images render at top of posts
+  - [ ] Dark/light mode toggle works
+  - [ ] Search (Ctrl+K or search icon) finds content
+  - [ ] Breadcrumbs show correct path
+  - [ ] Table of contents renders on posts
+  - [ ] Code blocks have syntax highlighting and copy buttons
+  - [ ] Read tracker checkmarks appear after visiting posts
+  - [ ] Series accent bars differentiate Building vs Operating
+  - [ ] "Clear read history" footer link works
+
+- [ ] **Step 4: Clean up migration script**
+
+  ```bash
+  rm scripts/migrate-frontmatter.sh
+  ```
+
+  Commit:
+  ```
+  feat(repo): finalize Hextra migration — CI/CD and cleanup
+
+  Update Dockerfile for Hugo modules. Remove PaperMod layout overrides.
+  Full production build verified.
+  ```

--- a/docs/superpowers/specs/2026-04-13--repo--blog-hextra-migration-design.md
+++ b/docs/superpowers/specs/2026-04-13--repo--blog-hextra-migration-design.md
@@ -200,3 +200,9 @@ Pure client-side implementation using localStorage:
 - Sidebar label cleanup (cosmetic, post-migration polish)
 - Media placeholder population (separate ongoing effort per existing plan)
 - Content changes to post bodies (only frontmatter changes)
+
+## Implementation Plans
+
+| Plan | Repo | File | Status | Depends on |
+|------|------|------|--------|------------|
+| Blog Hextra Migration Implementation Plan |  | `docs/superpowers/plans/2026-04-13--repo--blog-hextra-migration.md` | Not Started | — |

--- a/docs/superpowers/specs/2026-04-13--repo--blog-hextra-migration-design.md
+++ b/docs/superpowers/specs/2026-04-13--repo--blog-hextra-migration-design.md
@@ -1,0 +1,202 @@
+# Blog Theme Migration: PaperMod to Hextra
+
+**Layer:** repo
+**Date:** 2026-04-13
+**Status:** Approved
+
+## Summary
+
+Migrate the Frank blog from the PaperMod Hugo theme to Hextra — a modern, documentation-oriented theme with built-in sidebar navigation, full-text search, and dark mode. The migration addresses three pain points: difficulty navigating between posts in a series (no sidebar), lack of built-in search, and an aging visual aesthetic. Additionally, a client-side read-tracking feature will mark visited posts in the sidebar.
+
+## Motivation
+
+The blog has grown to 48 posts across two structured series (Building Frank, Operating on Frank). PaperMod is a blog theme — it renders posts as chronological card feeds with no persistent sidebar navigation. Readers cannot easily browse between related posts or find content without scrolling through lists. The content is narrative documentation — blog-shaped but documentation-structured (numbered series, ToC, code blocks, diagrams). A documentation-first theme with blog capabilities is a better fit than a blog theme with documentation bolted on.
+
+### Why Hextra
+
+- Sidebar navigation with collapsible sections (solves the "where am I" problem)
+- Built-in FlexSearch for full-text client-side search
+- Modern Tailwind CSS aesthetic with dark/light mode
+- First-class support for both docs and blog content types
+- Active maintenance, ~1.7k GitHub stars, Hugo module installation
+- Clean Nextra-inspired design without JavaScript framework overhead
+
+## Architecture
+
+### Approach: In-Place Swap via Hugo Module
+
+Replace the PaperMod git submodule with Hextra as a Hugo module in the existing `blog/` directory. No parallel directory, no intermediate state.
+
+- Remove `blog/themes/PaperMod/` git submodule
+- Initialize Hugo modules: `hugo mod init` creates `blog/go.mod` + `blog/go.sum`
+- Import Hextra via `hugo.toml` module config
+- Rewrite `hugo.toml` for Hextra's configuration format
+- Restructure content directory to match Hextra's docs layout
+- Port custom shortcodes and add custom features
+
+### Content Structure
+
+Current:
+```
+blog/content/
+  building/
+    _index.md
+    01-introduction/index.md  (+ cover.png, images)
+    02-foundation/index.md
+    ...26 posts
+  operating/
+    _index.md
+    01-cluster-nodes/index.md
+    ...20 posts
+```
+
+Target:
+```
+blog/content/
+  _index.md                    # Hextra landing page (hero + feature cards)
+  docs/
+    building/
+      _index.md                # Section index, sidebar root for Building
+      01-introduction/
+        index.md               # Post content
+        cover.png              # Page bundle images preserved
+        ...
+      02-foundation/
+        index.md
+        ...
+    operating/
+      _index.md                # Section index, sidebar root for Operating
+      01-cluster-nodes/
+        index.md
+        ...
+```
+
+Both series live under `content/docs/` to get Hextra's sidebar navigation. Page bundles (directory with `index.md` + images) are preserved as-is. Sidebar ordering uses the `weight` frontmatter already present on every post.
+
+The root `content/_index.md` uses Hextra's landing page layout with a hero section ("Frank, the Talos Cluster") and two feature cards linking to Building and Operating.
+
+### Configuration
+
+`hugo.toml` is rewritten from PaperMod format to Hextra format:
+
+| Setting | PaperMod (current) | Hextra (target) |
+|---------|-------------------|-----------------|
+| Theme source | `theme = "PaperMod"` (submodule) | `module.imports` (Hugo module) |
+| Dark mode | `defaultTheme = "auto"` | `theme.default = "system"` |
+| Search | JSON output + custom JS | FlexSearch (built-in, enabled by default) |
+| ToC | `ShowToc = true` | Built-in, enabled by default on docs pages |
+| Code copy | `ShowCodeCopyButtons = true` | Built-in |
+| Breadcrumbs | `ShowBreadCrumbs = true` | Built-in on docs pages |
+| Syntax style | `markup.highlight.style = "monokai"` | Same (Hugo-level config, theme-independent) |
+| Navigation | Top menu (Building, Operating, Tags, RSS) | Navbar + sidebar auto-generated from docs tree |
+
+### Frontmatter Migration
+
+Mechanical transformation across 48 posts:
+
+- **Remove:** `cover` block (image, alt, relative) — handled by layout override
+- **Keep:** `title`, `date`, `draft`, `tags`, `summary`, `weight`
+- **Optional (post-migration):** Add `sidebar: { label: "..." }` for cleaner sidebar titles
+
+The `summary` field stays for RSS/meta description. The `cover` block is removed because Hextra doesn't use it — instead, a layout override detects `cover.png` in the page bundle via Hugo's `Resources.GetMatch`.
+
+### Custom Features to Port
+
+**Shortcodes (port as-is):**
+
+All three shortcodes are self-contained Hugo templates that don't depend on PaperMod internals. They move to `blog/layouts/shortcodes/` (same location, already outside the theme directory).
+
+| Shortcode | Function | Migration Effort |
+|-----------|----------|-----------------|
+| `asciinema.html` | Terminal recording player, CDN-loaded, theme auto-detect | Minimal — update theme detection from PaperMod's body class to Hextra's `html[class~="dark"]` attribute |
+| `screenshot.html` | Figure with border, box-shadow, click-to-zoom | None — pure HTML/CSS, theme-independent |
+| `cluster-roadmap.html` | Interactive SVG roadmap visualization | Minimal — move inline styles to `assets/css/custom.css` |
+
+**Cover images (layout override):**
+
+Override `layouts/docs/single.html` to render `cover.png` from the page bundle as a hero image at the top of each post. Uses Hugo's `Resources.GetMatch "cover.*"` to detect the image. Posts without a cover render normally.
+
+**Series accent bar (CSS-only):**
+
+A subtle colored top-border on docs pages, differentiated by section:
+- Building series: one accent color
+- Operating series: different accent color
+
+Implemented via `assets/css/custom.css` using CSS selectors on the URL path. Lighter touch than PaperMod's sticky banners — the sidebar already provides series context.
+
+### Read-Tracking Feature
+
+Pure client-side implementation using localStorage:
+
+**Components:**
+- `assets/js/read-tracker.js` — loaded via `layouts/partials/custom/head.html`
+- Styles in `assets/css/custom.css`
+- Reset link in `layouts/partials/custom/footer.html`
+
+**Behavior:**
+1. On every docs page load, store the current URL path in `localStorage` key `frank-read-posts` (JSON array)
+2. On sidebar render (after DOM ready), query all sidebar anchor elements
+3. Compare each `href` against the stored array
+4. Append `<span class="read-marker">✓</span>` to visited links
+5. Style the checkmark as small, muted-color text via CSS
+
+**Reset:** A "Clear read history" link in the footer clears the localStorage key and reloads the page.
+
+**Scope:** No cookies, no server-side state, no GDPR concerns. localStorage-only, single-browser, personal use.
+
+### CI/CD & Deployment
+
+**Dockerfile (`blog/Dockerfile`):**
+- Base image `gohugoio/hugo:v0.157.0` (extended, includes Go for modules)
+- Add `hugo mod get` step before `hugo --minify` to fetch Hextra at build time
+- Rest of the multi-stage build (Caddy serving) unchanged
+
+**GitHub Actions (`deploy-blog.yml`):**
+- Verify the Hugo action includes Go for module downloads
+- No workflow structural changes expected
+
+**Netlify (`netlify.toml`):**
+- Hugo modules work natively on Netlify when `go.mod` is present
+- Verify Hugo version compatibility
+
+**baseURL:** Unchanged — `https://derio-net.github.io/frank/` for Pages, overridden in Dockerfile for self-hosted.
+
+## Files Changed
+
+### Removed
+- `blog/themes/PaperMod/` (git submodule)
+- `blog/layouts/index.html` (home page series cards — replaced by Hextra landing)
+- `blog/layouts/partials/header.html` (PaperMod sticky banner override)
+- `blog/layouts/partials/home_info.html` (PaperMod home info override)
+- `blog/layouts/partials/extend_head.html` (PaperMod CSS extensions)
+- `blog/layouts/_default/list.html` (PaperMod list override)
+- `blog/layouts/partials/post_nav_links.html` (PaperMod nav override)
+
+### Added
+- `blog/go.mod`, `blog/go.sum` (Hugo module files)
+- `blog/content/_index.md` (Hextra landing page)
+- `blog/content/docs/` (new parent directory for both series)
+- `blog/layouts/docs/single.html` (cover image override)
+- `blog/layouts/partials/custom/head.html` (load read-tracker JS)
+- `blog/layouts/partials/custom/footer.html` (read history reset link)
+- `blog/assets/js/read-tracker.js` (localStorage read tracking)
+- `blog/assets/css/custom.css` (accent bars, read markers, shortcode styles)
+
+### Modified
+- `blog/hugo.toml` (full rewrite for Hextra config)
+- `blog/Dockerfile` (add `hugo mod get` step)
+- `blog/netlify.toml` (verify Hugo version)
+- `blog/.gitmodules` (remove PaperMod entry)
+- `blog/layouts/shortcodes/asciinema.html` (update theme detection class)
+- `blog/layouts/shortcodes/screenshot.html` (verify compatibility)
+- `blog/layouts/shortcodes/cluster-roadmap.html` (move styles to custom.css)
+- 48 post `index.md` files (frontmatter migration — remove cover block)
+- 2 section `_index.md` files (move under docs/, update for Hextra)
+
+## Out of Scope
+
+- Cross-device read sync (future enhancement if needed)
+- Blog section for announcements (can be added later if wanted)
+- Sidebar label cleanup (cosmetic, post-migration polish)
+- Media placeholder population (separate ongoing effort per existing plan)
+- Content changes to post bodies (only frontmatter changes)


### PR DESCRIPTION
## Summary
- Adds design spec for migrating the blog from PaperMod to Hextra Hugo theme
- Covers content restructuring (both series as docs sections), Hugo module installation, shortcode porting, cover image layout override, localStorage-based read tracking, and CI/CD updates
- Result of brainstorming session exploring documentation-oriented Hugo themes

## Context
The blog has grown to 48 posts across two structured series. PaperMod lacks sidebar navigation and search — Hextra provides both natively, along with a modern Tailwind CSS aesthetic. This spec is the design document; implementation plan follows after approval.

## Test plan
- [ ] Review spec for completeness and accuracy against brainstorming decisions
- [ ] Confirm content structure mapping (both series under `content/docs/`)
- [ ] Confirm scope of custom features (shortcodes, cover images, read tracking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)