### PR TITLE
fix(repo): use correct Hugo Docker image tag

### DIFF
--- a/blog/Dockerfile
+++ b/blog/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build Hugo site
-# Extended image includes Go (for Hugo modules) and SCSS support
-FROM ghcr.io/gohugoio/hugo:v0.157.0-extended AS builder
+# Hugo Docker image includes Go (for modules) and extended features by default
+FROM ghcr.io/gohugoio/hugo:v0.157.0 AS builder
 WORKDIR /src
 COPY . .
 RUN hugo mod get


### PR DESCRIPTION
## Summary

- Fix `build-container` CI failure: `ghcr.io/gohugoio/hugo:v0.157.0-extended` doesn't exist — Hugo publishes a single image per version that already includes Go and extended features
- Reverts to `ghcr.io/gohugoio/hugo:v0.157.0` with an accurate comment

The `-extended` tag was introduced in PR #77 and broke the container build job. `build-pages` and `deploy-pages` were unaffected (they use `peaceiris/actions-hugo`, not the Docker image).

Closes #72

## Test plan

- [ ] `build-container` job passes (Docker build with correct image tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)