### PR TITLE
[derio-net/frank] agents--agent-images-and-vk-local-sidecar · Phase 3/4 · Lockstep bumper workflow

### DIFF
--- a/.github/workflows/agent-images-bump.yml
+++ b/.github/workflows/agent-images-bump.yml
@@ -1,0 +1,90 @@
+name: Bump agent image SHAs
+
+on:
+  repository_dispatch:
+    types: [agent-images-bumped]
+  workflow_dispatch:
+    inputs:
+      agent_images_sha:
+        description: agent-images commit SHA to bump to
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: read
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve SHAs
+        id: shas
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH_SHA: ${{ github.event.client_payload.agent_images_sha }}
+          INPUT_SHA: ${{ inputs.agent_images_sha }}
+        run: |
+          AI_SHA="${DISPATCH_SHA:-$INPUT_SHA}"
+          if ! [[ "$AI_SHA" =~ ^[a-f0-9]{7,40}$ ]]; then
+            echo "::error::Invalid agent_images_sha: must be 7-40 hex chars"
+            exit 1
+          fi
+
+          # vk-remote: resolve latest tag from GHCR (7-char short SHA from metadata-action)
+          VKR_SHA=$(gh api /orgs/derio-net/packages/container/vk-remote/versions \
+            --jq '.[0].metadata.container.tags[] | select(. != "latest")' 2>/dev/null || true)
+
+          echo "ai_sha=$AI_SHA"   >> "$GITHUB_OUTPUT"
+          echo "vkr_sha=$VKR_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved: AI_SHA=$AI_SHA VKR_SHA=$VKR_SHA"
+
+      - name: Update manifests
+        env:
+          AI_SHA: ${{ steps.shas.outputs.ai_sha }}
+          VKR_SHA: ${{ steps.shas.outputs.vkr_sha }}
+        run: |
+          sed -i "s|ghcr.io/derio-net/secure-agent-kali:[a-f0-9]\+|ghcr.io/derio-net/secure-agent-kali:$AI_SHA|g" \
+            apps/secure-agent-pod/manifests/deployment.yaml
+          sed -i "s|ghcr.io/derio-net/vk-local:[a-f0-9]\+|ghcr.io/derio-net/vk-local:$AI_SHA|g" \
+            apps/secure-agent-pod/manifests/deployment.yaml
+
+          if [ -n "$VKR_SHA" ]; then
+            sed -i "s|ghcr.io/derio-net/vk-remote:[a-f0-9]\+|ghcr.io/derio-net/vk-remote:$VKR_SHA|g" \
+              apps/vk-remote/manifests/deployment.yaml
+          else
+            echo "::warning::Could not resolve vk-remote SHA — skipping vk-remote bump"
+          fi
+
+      - name: Open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AI_SHA: ${{ steps.shas.outputs.ai_sha }}
+          VKR_SHA: ${{ steps.shas.outputs.vkr_sha }}
+        run: |
+          git config user.name  "clawdia-bumper[bot]"
+          git config user.email "clawdia-bumper[bot]@users.noreply.github.com"
+
+          BRANCH="bump/agent-images-${AI_SHA:0:7}"
+          git checkout -b "$BRANCH"
+
+          if git diff --quiet; then
+            echo "No changes to bump."
+            exit 0
+          fi
+
+          git add apps/
+          BODY="agent-images: \`$AI_SHA\`"
+          if [ -n "$VKR_SHA" ]; then
+            git commit -m "chore(agents): bump agent-images to ${AI_SHA:0:7}, vk-remote to ${VKR_SHA:0:7}"
+            BODY="$BODY"$'\n'"vk-remote: \`$VKR_SHA\`"
+          else
+            git commit -m "chore(agents): bump agent-images to ${AI_SHA:0:7}"
+          fi
+
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore(agents): bump agent-images + vk-remote" \
+            --body "$BODY"


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   /home/claude/repos/frank/docs/superpowers/plans/2026-04-15--agents--agent-images-and-vk-local-sidecar.md
📐 Spec:   docs/superpowers/specs/2026-04-15--agents--agent-images-and-vk-local-sidecar-design.md
🎯 Phase:  3/4 — Lockstep bumper workflow [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/82

**Goal (from plan):** Replace the in-process VibeKanban (npm-installed, baked into `secure-agent-kali`) with a shared-volume sidecar built from the fork, and move the Kali Dockerfile into a new multi-image repo (`derio-net/agent-images`) that also produces a common `agent-base` image for future pods. Add a lockstep bumper in frank that opens a single PR whenever fork or base SHAs move.

---

## Summary

- Adds `.github/workflows/agent-images-bump.yml` — the lockstep bumper that coalesces image SHA updates into a single reviewable PR
- Triggers on `repository_dispatch` (from agent-images CI) or manual `workflow_dispatch`
- Bumps `secure-agent-kali`, `vk-local`, and `vk-remote` image refs via sed in deployment manifests
- Opens a PR authored by `clawdia-bumper[bot]` for human review before merge (bounce-gate)

## Deviations from plan

1. **File extension**: `.yml` (not `.yaml`) to match existing workflow convention
2. **vk-remote SHA resolution**: Uses GHCR package tags API instead of querying private vibe-kanban repo commits (GITHUB_TOKEN can't read cross-repo private repos)
3. **Input validation**: Adds hex SHA format validation for dispatch/input payloads (injection safety)
4. **Graceful fallback**: Skips vk-remote bump with warning if SHA can't be resolved
5. **Tasks 2-3 deferred**: Dry-run and full dispatch chain verification require the workflow on `main` — `workflow_dispatch` can't target feature branches for workflows not yet on default branch

## Post-merge verification

After merging, run the dry-run (Task 2) manually:
```bash
AI_SHA=$(gh api /repos/derio-net/agent-images/commits/main --jq '.sha')
gh workflow run agent-images-bump.yml --repo derio-net/frank -f agent_images_sha=$AI_SHA
```

Full dispatch chain (Task 3) also requires `DISPATCH_PAT` configured in both `derio-net/vibe-kanban` and `derio-net/agent-images` repos.

## Test plan

- [ ] Review workflow YAML for correctness (sed patterns, SHA resolution, PR creation)
- [ ] Merge to main, then trigger dry-run via `workflow_dispatch`
- [ ] Verify generated PR only touches expected deployment files
- [ ] Close dry-run PR if SHAs are already current

🤖 Generated with [Claude Code](https://claude.com/claude-code)