### PR TITLE
chore(agents): kali cutover (VK stripped)

### DIFF
--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             defaultMode: 0400
       containers:
         - name: kali
-          image: ghcr.io/derio-net/secure-agent-kali:869ebc6
+          image: ghcr.io/derio-net/secure-agent-kali:325b23e1ede5d9fc4d626c7f27e7dd2e8c76bb6b
           ports:
             - name: ssh
               containerPort: 2222  # Non-root sshd; Service maps 22→2222

--- a/docs/superpowers/RESUMING.md
+++ b/docs/superpowers/RESUMING.md
@@ -1,42 +1,41 @@
-# RESUMING — Phase 2 Task A
+# RESUMING — Phase 2 Task B
 
 Plan: `docs/superpowers/plans/2026-04-15--agents--agent-images-and-vk-local-sidecar.md`
 
 ## Bounce trigger
 
-Merging frank PR [#86](https://github.com/derio-net/frank/pull/86) — "feat(agents): add vk-local sidecar to secure-agent-pod".
+Merging frank PR [#104](https://github.com/derio-net/frank/pull/104) — "chore(agents): kali cutover (VK stripped)".
 ArgoCD syncs `secure-agent-pod` → pod re-creates (strategy: `Recreate`) → this VK session dies.
 
 ## Expected state after bounce
 
 - `kubectl -n secure-agent-pod get pod -l app=secure-agent-pod` shows `Ready: 2/2`.
-- `vk-local` sidecar serves on 8081 (winning the port race because it starts faster than kali's in-process VK).
-- Kali's npm-installed VK still spawns but fails to bind 8081 — logs show bind error; not fatal.
-- `/home/claude` is shared between both containers via `agent-home` PVC.
+- Kali container now runs image `ghcr.io/derio-net/secure-agent-kali:325b23e1ede5d9fc4d626c7f27e7dd2e8c76bb6b` (VK stripped).
+- No `vibe-kanban` binary in kali; no process bound to 18081 on loopback.
+- `vk-local` sidecar unchanged — continues to own port 8081.
+- The `PORT=18081`/`HOST=127.0.0.1` env vars on kali are now dead config (nothing reads them).
 
 ## Next step
 
-Phase 2 Task A **Step 6** (verification — run from another host after reconnect):
+Phase 2 Task B **Step 6** (verification — run from another host after reconnect):
 
 ```bash
-kubectl -n secure-agent-pod get pod -l app=secure-agent-pod
-kubectl -n secure-agent-pod logs deploy/secure-agent-pod -c vk-local --tail=30
-kubectl -n secure-agent-pod exec deploy/secure-agent-pod -c vk-local -- ls /home/claude/repos
-kubectl -n secure-agent-pod exec deploy/secure-agent-pod -c kali     -- ls /home/claude/repos
-# Expected: same directory listing in both containers
-```
+kubectl -n secure-agent-pod exec deploy/secure-agent-pod -c kali -- sh -c 'command -v vibe-kanban; pgrep -a vibe-kanban || echo NO_PROCESS'
+# Expected: (empty output for command -v) + NO_PROCESS
 
-Then **Step 7**:
-
-```bash
 curl -sSf -o /dev/null -w "%{http_code}\n" http://192.168.55.218:8081/api/health
-# Expected: 200 (note: /api/health, not /v1/health — see Phase 1 Deviation)
+# Expected: 200 (sidecar still serving — note /api/health per Phase 1 Deviation)
 ```
 
-After verification, proceed with Phase 2 **Task B** (strip VK from kali image + second bounce).
+After verification, Phase 2 is complete. Proceed with:
 
-## Verification artifacts (current pre-bounce state)
+- **Phase 3** — the bumper workflow is already written on branch `vk/49aa-ffe-39-gh-82` (Phase 3 Task 1 Step 2). That branch needs a PR opened, merged, then Task 2/3 can run workflow_dispatch from main to dry-run and verify the dispatch chain.
+- **Phase 4** — Post-Deploy Checklist: blog post, README update, `/sync-runbook`, set plan status to Deployed.
 
-- Plan deviation for health endpoint: recorded in "Phase 1 Deviation: Health endpoint path" (`/api/health` not `/v1/health`).
-- VK footprint measured pre-bounce: PID 52, RSS 521232 KB (~509 MiB), 0.0% CPU idle.
-- Sidecar image: `ghcr.io/derio-net/vk-local:325b23e1ede5d9fc4d626c7f27e7dd2e8c76bb6b`.
+## Pre-bounce state (verified 2026-04-17)
+
+- `frank`: branch `chore/kali-cutover`, HEAD `e29154d`, clean, HEAD == `@{u}`.
+- `agent-images`: HEAD `325b23e`, clean, HEAD == `@{u}`.
+- `vibe-kanban`: HEAD `5bd749c`, clean, HEAD == `@{u}`.
+- Plan checkboxes for Task A Steps 5-7 and Task B Steps 1-3 updated + committed.
+- Port-collision deviation (commit 79cf7d0) documented in "Deployment Deviations".

--- a/docs/superpowers/plans/2026-04-15--agents--agent-images-and-vk-local-sidecar.md
+++ b/docs/superpowers/plans/2026-04-15--agents--agent-images-and-vk-local-sidecar.md
@@ -750,7 +750,7 @@ git diff apps/secure-agent-pod/manifests/deployment.yaml
 # Expected: exactly one hash changed on the kali image line
 ```
 
-- [ ] **Step 3: Commit, push, open PR — do NOT merge.**
+- [x] **Step 3: Commit, push, open PR — do NOT merge.** *(PR [#104](https://github.com/derio-net/frank/pull/104) on branch `chore/kali-cutover`; two commits — plan docs + manifest bump)*
 
 ```bash
 git checkout -b chore/kali-cutover
@@ -760,7 +760,7 @@ git push -u origin chore/kali-cutover
 gh pr create --title "chore(agents): kali cutover (VK stripped)" --body "Final Phase 2 step — removes VK from kali image." --base main
 ```
 
-- [ ] **Step 4: [bounce-gate] Pre-bounce checklist.**
+- [x] **Step 4: [bounce-gate] Pre-bounce checklist.** *(2026-04-17: frank/agent-images/vibe-kanban all clean, HEAD == @{u}; RESUMING.md updated with Task B breadcrumb; awaiting user merge)*
 
 Follow the protocol. `RESUMING.md` update:
 

--- a/docs/superpowers/plans/2026-04-15--agents--agent-images-and-vk-local-sidecar.md
+++ b/docs/superpowers/plans/2026-04-15--agents--agent-images-and-vk-local-sidecar.md
@@ -703,9 +703,9 @@ verify:
 status: pending
 ```
 
-- [ ] **Step 5: [after-bounce] Reconnect from another host.**
+- [x] **Step 5: [after-bounce] Reconnect from another host.** *(resumed 2026-04-17; pod bounced cleanly after commit 79cf7d0 applied the port-collision workaround)*
 
-- [ ] **Step 6: Verify sidecar + shared volume.**
+- [x] **Step 6: Verify sidecar + shared volume.** *(both containers list identical `/home/claude/repos` contents: agent-images, content-factory, derio-profile, frank, kid-laptops, repos.code-workspace, secure-agent-kali, superpowers-for-vk, vibe-kanban, willikins)*
 
 ```bash
 kubectl -n secure-agent-pod get pod -l app=secure-agent-pod
@@ -715,7 +715,7 @@ kubectl -n secure-agent-pod exec deploy/secure-agent-pod -c kali     -- ls /home
 # Expected: same directory listing in both containers
 ```
 
-- [ ] **Step 7: Verify external VK endpoint.**
+- [x] **Step 7: Verify external VK endpoint.** *(`curl http://192.168.55.218:8081/api/health` returns 200 — note path is `/api/health` per Phase 1 Deviation, not `/v1/health`)*
 
 ```bash
 curl -sSf -o /dev/null -w "%{http_code}\n" http://192.168.55.218:8081/v1/health
@@ -731,7 +731,7 @@ Task A complete.
 - Verify: `agent-images/kali/entrypoint.sh` (ditto)
 - Modify: `apps/secure-agent-pod/manifests/deployment.yaml` (bump kali SHA)
 
-- [ ] **Step 1: Confirm Phase 0 removed VK from kali.**
+- [x] **Step 1: Confirm Phase 0 removed VK from kali.** *(verified: `grep -c 'vibe\|8081'` returns 0 for both `kali/Dockerfile` and `kali/entrypoint.sh`)*
 
 ```bash
 grep -c 'vibe' ~/repos/agent-images/kali/Dockerfile
@@ -739,7 +739,7 @@ grep -c 'vibe' ~/repos/agent-images/kali/entrypoint.sh
 # Expected: 0 from both. If nonzero, remove remaining refs, commit+push, wait for CI.
 ```
 
-- [ ] **Step 2: Bump kali image SHA in frank.**
+- [x] **Step 2: Bump kali image SHA in frank.** *(bumped `869ebc6` → `325b23e1ede5d9fc4d626c7f27e7dd2e8c76bb6b` on branch `chore/kali-cutover`; diff is exactly one line; `kubectl --dry-run=server apply` accepted)*
 
 ```bash
 LATEST_KALI_SHA=$(gh api /repos/derio-net/agent-images/commits/main --jq '.sha')
@@ -988,6 +988,14 @@ Phase 3 complete when a fork push reliably produces a reviewable frank PR withou
 **Fix applied:** Resolve vk-remote SHA from GHCR package tags via `/orgs/derio-net/packages/container/vk-remote/versions` API. This works because the package is accessible within the org with `packages: read` permission. Falls back gracefully (skips vk-remote bump with a warning) if resolution fails.
 
 **Impact:** The vk-remote tags from GHCR are 7-char short SHAs (from `docker/metadata-action type=sha,prefix=`), matching the current deployment format. No functional difference.
+
+### Phase 2 Deviation: Port 8081 bind race — kali won
+
+**Issue:** The plan (Step 2, Task A) assumed the lighter vk-local sidecar would win the 8081 bind race and kali's in-process VK would fail to bind (non-fatal). In practice, kali's npm-installed VK won the race on every pod restart because it boots earlier than the sidecar's readiness probe succeeds. Result: vk-local CrashLoopBackOff (246 restarts in ~20h, bind address-already-in-use).
+
+**Fix applied (commit 79cf7d0):** Deflect kali's in-process VK to `PORT=18081` on `HOST=127.0.0.1` via env vars on the kali container, and move the `name: vk-http` port declaration from kali to the sidecar so the Service routes to the sidecar. This makes the outcome deterministic rather than race-dependent.
+
+**Impact:** Resolved. Pod stable at 2/2 Ready. The `PORT=18081`/`HOST=127.0.0.1` env vars on kali become dead config once Task B bumps kali to the VK-stripped image — deliberately left in place to keep the Task B diff minimal (a separate chore can strip them later).
 
 ### Phase 3 Deviation: Dry-run and dispatch chain verification deferred
 


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-04-15--agents--agent-images-and-vk-local-sidecar.md
📐 Spec:   docs/superpowers/specs/2026-04-15--agents--agent-images-and-vk-local-sidecar-design.md
🎯 Phase:  2/4 Task B — kali cutover
🔗 Issue:  https://github.com/derio-net/frank/issues/81

## Summary

Final step of Phase 2 — cuts over the `kali` container to the new VK-stripped image from `derio-net/agent-images`. After this, only the `vk-local` sidecar runs VibeKanban.

- **New kali image:** `ghcr.io/derio-net/secure-agent-kali:325b23e1ede5d9fc4d626c7f27e7dd2e8c76bb6b` (VK removed from entrypoint and Dockerfile, verified in Phase 0 Task 5)
- **Old kali image:** `ghcr.io/derio-net/secure-agent-kali:869ebc6` (still had in-process VK; deflected to loopback:18081 by commit 79cf7d0 to stop colliding with the sidecar)
- **vk-local sidecar:** unchanged — continues to own port 8081

## Deadweight left behind

The `PORT=18081`/`HOST=127.0.0.1` env vars on the kali container (added in commit 79cf7d0 as a port-collision workaround) become no-ops after this merge — the new image has no VK process to read them. Deliberately left in place to keep this diff to a single line per the plan's expectation. A separate chore can strip them.

## Bounce gate

Merging this PR bounces the pod (strategy: `Recreate`). This kills the VK session executing this plan. Post-merge verification (Phase 2 Task B Step 6) must be performed from another host. See `docs/superpowers/RESUMING.md`.

## Test plan

- [x] `git diff` shows exactly one line changed on the kali image
- [x] `kubectl --dry-run=server apply` accepts the manifest
- [ ] Post-merge: pod reports `Ready: 2/2`
- [ ] Post-merge: `kubectl exec -c kali -- command -v vibe-kanban` → not found
- [ ] Post-merge: `kubectl exec -c kali -- pgrep -a vibe-kanban` → no matches
- [ ] Post-merge: `curl http://192.168.55.218:8081/api/health` still returns 200 (sidecar unchanged)

Phase 2 complete on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)