### PR TITLE
chore(agents): bump agent-images + vk-remote [DRY-RUN]

### DIFF
--- a/apps/vk-remote/manifests/deployment.yaml
+++ b/apps/vk-remote/manifests/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: vk-remote
-          image: ghcr.io/derio-net/vk-remote:1cce857
+          image: ghcr.io/derio-net/vk-remote:5bd749c
           ports:
             - containerPort: 8081
           env:
@@ -56,7 +56,7 @@ spec:
               cpu: 500m
               memory: 256Mi
         - name: relay-server
-          image: ghcr.io/derio-net/vk-remote:1cce857  # keep in sync with vk-remote image above
+          image: ghcr.io/derio-net/vk-remote:5bd749c  # keep in sync with vk-remote image above
           command: ["/usr/local/bin/relay-server"]
           ports:
             - containerPort: 8082


### PR DESCRIPTION
**Phase 3 Task 2 dry-run** — generated by `agent-images-bump.yml` workflow run [24586433455](https://github.com/derio-net/frank/actions/runs/24586433455).

- agent-images: `325b23e1ede5d9fc4d626c7f27e7dd2e8c76bb6b` *(already current for kali + vk-local)*
- vk-remote: `5bd749c` *(was `1cce857`)*

Only `vk-remote` refs changed since the Phase 2 cutover already brought kali + vk-local to the current agent-images SHA.

Closing without merging per plan Task 2 Step 3.