### PR TITLE
feat(agent): preStop hook + 45s grace on secure-agent-pod

### DIFF
--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -18,7 +18,10 @@ spec:
         app: secure-agent-pod
     spec:
       serviceAccountName: agent-sa
-      terminationGracePeriodSeconds: 30
+      # shutdown.sh waits up to 30s for SIGTERM → bridge:shutdown drain
+      # (so claude deregisters from claude.ai), then SIGKILLs stragglers.
+      # 45s gives margin for preStop start + drain + final pidfile cleanup.
+      terminationGracePeriodSeconds: 45
       nodeSelector:
         kubernetes.io/hostname: gpu-1
       tolerations:
@@ -92,6 +95,14 @@ spec:
               port: ssh
             initialDelaySeconds: 30
             periodSeconds: 60
+          # preStop runs shutdown.sh, which signals claude remote-control
+          # so its own bridge:shutdown handler can DELETE the environment
+          # from the Anthropic API (avoids phantom sessions in claude.ai).
+          # Rationale: kali/docs/findings/2026-04-18-remote-control-shutdown.md
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/opt/scripts/shutdown.sh"]
         - name: vk-local
           image: ghcr.io/derio-net/vk-local:b3b0899cf88259fc97a9cabe29775ad0851ed2ab
           ports:


### PR DESCRIPTION
## Summary

- Adds `lifecycle.preStop.exec.command: ["/opt/scripts/shutdown.sh"]` to the `kali` container of `secure-agent-pod`
- Raises `terminationGracePeriodSeconds` from 30 → 45 (shutdown.sh waits up to 30s for bridge:shutdown drain; 45s gives comfort margin)

## Context — what this fixes

`shutdown.sh` was shipped in the kali image back on 2026-04-19 as part of Phase 2 of the `persistent-agent-reliability` plan (now in `derio-net/agent-images/kali/scripts/`). Its job: on pod drain, send SIGTERM to each `claude remote-control` PID so claude's own `bridge:shutdown` handler runs — which issues `DELETE /v1/environments/bridge/<env_id>` against the Anthropic API and **removes the phantom session from claude.ai**.

But there was no `preStop` hook on the deployment to actually invoke `shutdown.sh` on drain. `derio-net/frank#108` tracked this wiring change — it was closed on 2026-04-19T20:03:37Z with no comments and no linked PR. The Phase 3 soak baseline on 2026-04-20 (run from this host) caught the gap.

See `derio-net/agent-images#4` — companion PR documenting the full set of Phase 3 deviations and restoring the Phase 0 findings doc referenced in `shutdown.sh:4`.

## Why preStop on `kali` only, not `vk-local`

Only `kali` runs `claude remote-control`. The `vk-local` sidecar is a VK server — no Anthropic environments registered, nothing to deregister.

## Why 45s

`shutdown.sh`:
1. Signals each PID in `/home/claude/.willikins-agent/pids/*.pid`
2. Waits up to 30s (`SHUTDOWN_GRACE_SECONDS` default, matches claude CLI's `loop_grace_ms`) for `bridge:shutdown` to complete its `DELETE /v1/environments/bridge/<env_id>`
3. SIGKILLs stragglers and cleans pidfiles

30s drain + preStop start overhead + SIGKILL + pidfile cleanup fits comfortably in 45s.

## Caveats — OOMKills bypass preStop

`kali` has been OOMKilled once (32Gi limit) and `vk-local` 3× (2Gi limit) in the last ~170 min. Both paths use SIGKILL → `preStop` cannot fire. Any future phantom-count observation must stratify restart cause (SIGTERM-drained vs OOMKilled). If OOM frequency persists after this lands, a follow-up plan should profile memory use.

## Test plan

- [x] `kubectl apply --dry-run=client` accepts the manifest
- [ ] After ArgoCD syncs: `kubectl describe pod -n secure-agent-pod | grep -A2 lifecycle` shows the preStop hook
- [ ] `kubectl get deploy -n secure-agent-pod -o jsonpath='{.items[0].spec.template.spec.terminationGracePeriodSeconds}'` returns `45`
- [ ] `kubectl rollout restart deploy/secure-agent-pod -n secure-agent-pod` triggers preStop; `~/.willikins-agent/shutdown.log` gains entries
- [ ] Manual phantom-count check in claude.ai before/after the restart