### PR TITLE
feat(agents): mosh tuning — 16 ports + 1h server timeout

### DIFF
--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -53,23 +53,31 @@ spec:
               protocol: TCP
             # mosh-server picks a port from this range at session start;
             # service-mosh.yaml exposes them via a separate LB IP (UDP).
-            - name: mosh-60000
-              containerPort: 60000
-              protocol: UDP
-            - name: mosh-60001
-              containerPort: 60001
-              protocol: UDP
-            - name: mosh-60002
-              containerPort: 60002
-              protocol: UDP
-            - name: mosh-60003
-              containerPort: 60003
-              protocol: UDP
+            - { name: mosh-60000, containerPort: 60000, protocol: UDP }
+            - { name: mosh-60001, containerPort: 60001, protocol: UDP }
+            - { name: mosh-60002, containerPort: 60002, protocol: UDP }
+            - { name: mosh-60003, containerPort: 60003, protocol: UDP }
+            - { name: mosh-60004, containerPort: 60004, protocol: UDP }
+            - { name: mosh-60005, containerPort: 60005, protocol: UDP }
+            - { name: mosh-60006, containerPort: 60006, protocol: UDP }
+            - { name: mosh-60007, containerPort: 60007, protocol: UDP }
+            - { name: mosh-60008, containerPort: 60008, protocol: UDP }
+            - { name: mosh-60009, containerPort: 60009, protocol: UDP }
+            - { name: mosh-60010, containerPort: 60010, protocol: UDP }
+            - { name: mosh-60011, containerPort: 60011, protocol: UDP }
+            - { name: mosh-60012, containerPort: 60012, protocol: UDP }
+            - { name: mosh-60013, containerPort: 60013, protocol: UDP }
+            - { name: mosh-60014, containerPort: 60014, protocol: UDP }
+            - { name: mosh-60015, containerPort: 60015, protocol: UDP }
           env:
             - name: PORT
               value: "18081"  # Deflect in-process VK to unused port; sidecar owns 8081
             - name: HOST
               value: "127.0.0.1"  # Bind only to loopback — not externally reachable
+            # Mosh default is 168h (7d) — too long for a 16-port range.
+            # 1h reaps stuck servers fast enough to keep ports available.
+            - name: MOSH_SERVER_NETWORK_TMOUT
+              value: "3600"
           envFrom:
             - secretRef:
                 name: agent-secrets-tier1

--- a/apps/secure-agent-pod/manifests/service-mosh.yaml
+++ b/apps/secure-agent-pod/manifests/service-mosh.yaml
@@ -12,22 +12,28 @@ spec:
   # mosh-server listens on a UDP port from this range, picked at session
   # start. SSH (TCP/22) bootstraps the mosh handshake on the SSH service IP;
   # the mosh client then talks directly to mosh-server on this UDP IP.
-  # Client invocation: mosh --ssh="ssh user@<ssh-ip>" \
-  #                         --server="mosh-server new -p 60000:60003" <udp-ip>
+  # Client invocation:
+  #   mosh --ssh="ssh user@<ssh-ip>" \
+  #        --server="mosh-server new -p 60000:60015" <udp-ip>
+  #
+  # 16 ports is enough headroom for normal use; combined with a 1h
+  # MOSH_SERVER_NETWORK_TMOUT (set in deployment.yaml), stuck mosh-server
+  # processes from ungraceful disconnects reap quickly enough that
+  # exhaustion is implausible in practice.
   ports:
-    - name: mosh-60000
-      port: 60000
-      targetPort: 60000
-      protocol: UDP
-    - name: mosh-60001
-      port: 60001
-      targetPort: 60001
-      protocol: UDP
-    - name: mosh-60002
-      port: 60002
-      targetPort: 60002
-      protocol: UDP
-    - name: mosh-60003
-      port: 60003
-      targetPort: 60003
-      protocol: UDP
+    - { name: mosh-60000, port: 60000, targetPort: 60000, protocol: UDP }
+    - { name: mosh-60001, port: 60001, targetPort: 60001, protocol: UDP }
+    - { name: mosh-60002, port: 60002, targetPort: 60002, protocol: UDP }
+    - { name: mosh-60003, port: 60003, targetPort: 60003, protocol: UDP }
+    - { name: mosh-60004, port: 60004, targetPort: 60004, protocol: UDP }
+    - { name: mosh-60005, port: 60005, targetPort: 60005, protocol: UDP }
+    - { name: mosh-60006, port: 60006, targetPort: 60006, protocol: UDP }
+    - { name: mosh-60007, port: 60007, targetPort: 60007, protocol: UDP }
+    - { name: mosh-60008, port: 60008, targetPort: 60008, protocol: UDP }
+    - { name: mosh-60009, port: 60009, targetPort: 60009, protocol: UDP }
+    - { name: mosh-60010, port: 60010, targetPort: 60010, protocol: UDP }
+    - { name: mosh-60011, port: 60011, targetPort: 60011, protocol: UDP }
+    - { name: mosh-60012, port: 60012, targetPort: 60012, protocol: UDP }
+    - { name: mosh-60013, port: 60013, targetPort: 60013, protocol: UDP }
+    - { name: mosh-60014, port: 60014, targetPort: 60014, protocol: UDP }
+    - { name: mosh-60015, port: 60015, targetPort: 60015, protocol: UDP }

--- a/docs/superpowers/plans/2026-04-26--agents--secure-pod-tmux-mosh.md
+++ b/docs/superpowers/plans/2026-04-26--agents--secure-pod-tmux-mosh.md
@@ -80,13 +80,13 @@ Append four UDP `containerPort` entries (60000-60003) to the kali container's `p
 
 ### Task 3: Land the manifests on `main`
 
-- [ ] **Step 1: Open a PR for the manifest changes**
+- [x] **Step 1: Open a PR for the manifest changes**  *(PR #125)*
 
 Branch: `feat/agents-mosh-service`. Title: `feat(agents): mosh UDP service + tmux availability`. Body summarises the deviation from the standard layer workflow (fix/extension of layer 12, retroactive plan). The bump PR #124 is independent — they can merge in either order without breakage:
 - Bump-only first: image has mosh installed but no UDP service yet → mosh would fail to reach pod, SSH unaffected.
 - Service-only first: UDP routes to a pod that does not yet have mosh-server → harmless, no listeners on those ports.
 
-- [ ] **Step 2: Operator merges both PRs**
+- [x] **Step 2: Operator merges both PRs**  *(#124 → a1a21b1, #125 → 88a4de7)*
 
 Once both #124 (image bump) and the manifest PR are merged, ArgoCD `secure-agent-pod` Application syncs. Pod is recreated (`strategy: Recreate` due to RWO PVC).
 
@@ -99,7 +99,7 @@ Once both #124 (image bump) and the manifest PR are merged, ArgoCD `secure-agent
 
 ### Task 1: Confirm tools are present
 
-- [ ] **Step 1: `kubectl exec` checks**
+- [x] **Step 1: `kubectl exec` checks**  *(tmux 3.6, mosh 1.4.0, LANG/LC_ALL=C.UTF-8)*
 
 ```bash
 kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- tmux -V
@@ -111,7 +111,7 @@ Expected: `tmux 3.x`, `mosh-server (mosh) 1.4.x`, `C.UTF-8` for both env vars.
 
 ### Task 2: Confirm Cilium L2 LB advertises mosh IP
 
-- [ ] **Step 1: Service status**
+- [x] **Step 1: Service status**  *(EXTERNAL-IP=192.168.55.219, 4×UDP ports allocated)*
 
 ```bash
 kubectl get svc -n secure-agent-pod secure-agent-mosh -o wide
@@ -178,6 +178,53 @@ Once Phases 1-4 are all checked off and verification passed.
 
 ---
 
+## Phase 5: Post-deploy tuning — 16 ports + 1h mosh timeout [agentic]
+**Depends on:** Phase 3
+
+<!-- Tracking: filed during Phase 3 review when the operator asked about the 4-port cap. -->
+
+After verification, the operator surfaced the 4-port-cap edge case: mosh's default `MOSH_SERVER_NETWORK_TMOUT` is 168 hours (7 days), so an ungraceful disconnect leaves a `mosh-server` process squatting its UDP port for a week. With only 4 ports, four bad disconnects in a week could lock new sessions out until the oldest aged out (or someone `kubectl exec ... pkill mosh-server`).
+
+Fix has two independent levers; we apply both:
+
+1. **Lower the timeout** (`MOSH_SERVER_NETWORK_TMOUT=3600` — 1h) so stuck servers reap fast.
+2. **Bump port count** from 4 to 16 to give comfortable headroom even before the timeout reaps.
+
+### Task 1: Expand the Service to 16 ports
+
+- [ ] **Step 1: Edit `apps/secure-agent-pod/manifests/service-mosh.yaml`**
+
+Add ports 60004–60015 in the same flow-style format. Update the comment block to reference `60000:60015` and the timeout-env mitigation.
+
+### Task 2: Add timeout env + matching containerPorts
+
+- [ ] **Step 1: Edit `apps/secure-agent-pod/manifests/deployment.yaml`**
+
+In the kali container: add `MOSH_SERVER_NETWORK_TMOUT=3600` to `env:`, and add containerPort entries 60004–60015 (UDP) to the `ports:` block. Convert all mosh containerPort entries to flow-style for readability.
+
+### Task 3: Land + roll
+
+- [ ] **Step 1: Open PR `feat(agents): mosh tuning — 16 ports + 1h timeout`**
+- [ ] **Step 2: Operator merges; ArgoCD syncs; pod recreates** (env-var change forces a Recreate; expected ~30-60s of unavailability)
+
+### Task 4: Re-verify
+
+- [ ] **Step 1: Confirm new pod has the env var**
+
+```bash
+kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- printenv MOSH_SERVER_NETWORK_TMOUT
+# expect: 3600
+```
+
+- [ ] **Step 2: Confirm Service has 16 UDP ports**
+
+```bash
+kubectl get svc -n secure-agent-pod secure-agent-mosh -o jsonpath='{.spec.ports[*].port}' | tr ' ' '\n' | wc -l
+# expect: 16
+```
+
+---
+
 ## Deployment Deviations
 
 The standard layer workflow (`docs/superpowers/rules/repo-workflows.md`) calls for brainstorm → plan → execute → deploy → blog → README → runbook. This plan deviates as follows:
@@ -186,3 +233,4 @@ The standard layer workflow (`docs/superpowers/rules/repo-workflows.md`) calls f
 2. **Direct push to `agent-images:main` without PR review.** Commit `eb6ae08` was pushed directly; the safety guard flagged this and the operator chose "let it stand". Future tmux/mosh-style image-only changes should go through a PR for traceability.
 3. **No new blog post.** Per the fix/extension rule, the existing operating post (14-secure-agent-pod) is extended in place; the building post (21-secure-agent-pod) gets a passing mention. No standalone post.
 4. **Mosh client UX trade-off.** SSH and mosh-UDP are on separate LB IPs (215 vs 219), so the client invocation needs explicit `--ssh="…"` and `<udp-ip>` arguments. A future iteration could use `lbipam.cilium.io/sharing-key` to put both Services on a single IP, restoring `mosh user@host` ergonomics — but that requires touching `service-ssh.yaml`, which the operator deferred.
+5. **Initial 4-port cap revised post-deploy.** The original plan exposed UDP 60000-60003 (4 ports). During Phase 3 review the operator flagged the 7-day stuck-server window; Phase 5 bumps the range to 60000-60015 (16 ports) and sets `MOSH_SERVER_NETWORK_TMOUT=3600`. Both changes ride a follow-up PR.


### PR DESCRIPTION
## Summary

Post-deploy tuning surfaced during Phase 3 review of #125.

- **16 ports** instead of 4. UDP 60000-60015 on `secure-agent-mosh`. YAML flow style keeps the 16 port entries readable.
- **`MOSH_SERVER_NETWORK_TMOUT=3600`** on the kali container. Mosh's default is 168h (7 days) — way too long for a finite port range. With 1h, stuck `mosh-server` processes from ungraceful disconnects reap quickly enough that port exhaustion is implausible in practice.

Why both: belt and braces. The timeout fix is the real cure (kills the failure mode); the port bump just gives more headroom while the timeout does its job.

## Pod restart expected

Env-var change + RWO PVC → `Recreate` strategy. Brief mosh/SSH unavailability during rollout (~30-60s).

## Plan

Amended `docs/superpowers/plans/2026-04-26--agents--secure-pod-tmux-mosh.md` with a new Phase 5 documenting this rework, and added a deviation entry explaining why the original 4-port choice was revised.

## Test plan

- [ ] `kubectl get pod -n secure-agent-pod` — new pod 2/2 Running on the bumped revision
- [ ] `kubectl exec ... -- printenv MOSH_SERVER_NETWORK_TMOUT` returns `3600`
- [ ] `kubectl get svc -n secure-agent-pod secure-agent-mosh -o jsonpath='{.spec.ports[*].port}' | wc -w` returns `16`
- [ ] Mosh client still connects end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)