### PR TITLE
fix(agents): raise vk-local memory limit 2Gi → 8Gi

### DIFF
--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -162,7 +162,7 @@ spec:
               cpu: "200m"
               memory: 512Mi
             limits:
-              memory: 2Gi
+              memory: 8Gi
           readinessProbe:
             httpGet:
               path: /api/health


### PR DESCRIPTION
## Summary

- Raise the `vk-local` container's memory limit from 2Gi to 8Gi in `apps/secure-agent-pod/manifests/deployment.yaml`.
- Implements Phase 3 decision (Option A) from `agent-images/kali/docs/findings/2026-04-22-vk-local-memory-profile.md`.

## Why

On 2026-04-28 the `vk-local` container OOMKilled **27 times in ~18h** at the existing 2Gi limit (boot → OOM in ~4 seconds at startup). During that window the bridge cron's `vk_unreachable` path returned before `push_heartbeat()`, which is what tripped the `Layer 18 Persistent Agent Heartbeat Stale` alert. The Phase 3 memprofile work concluded that idle drift is only ~1.5 MiB/h (no leak) — the crashloop is a working-set sizing problem, not a leak.

The pod is scheduled to `gpu-1` (128 GiB RAM), so an 8Gi limit (with a 16× burstable headroom on top of the unchanged 512Mi request) is well within budget.

## Test plan

- [ ] `argocd app diff secure-agent-pod` shows only the limit change
- [ ] After sync, `kubectl -n secure-agent-pod get pod -o jsonpath='{.items[0].spec.containers[?(@.name=="vk-local")].resources.limits.memory}'` returns `8Gi`
- [ ] `kubectl -n secure-agent-pod get pod -o jsonpath='{.items[0].status.containerStatuses[?(@.name=="vk-local")].restartCount}'` stays at 0 over the next 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)