### PR TITLE
fix(observability): drop Telegram parse_mode=Markdown so underscores survive

### DIFF
--- a/apps/grafana-alerting/manifests/contact-points-cm.yaml
+++ b/apps/grafana-alerting/manifests/contact-points-cm.yaml
@@ -16,7 +16,13 @@ data:
               bottoken: $FRANK_C2_TELEGRAM_BOT_TOKEN
               chatid: |
                 $FRANK_C2_TELEGRAM_CHAT_ID
-              parse_mode: Markdown
+              # parse_mode intentionally unset → plain text. Markdown mode
+              # interprets the underscore in labels like `job=session_manager`
+              # as italic delimiters and silently strips the underscores,
+              # which has caused real triage misdirection (alert renders as
+              # `job=sessionmanager`, runbook templates the wrong grep target).
+              # Plain text loses the **Firing**/**Resolved** bolding from the
+              # default Grafana template — accepted tradeoff: correctness > formatting.
       - orgId: 1
         name: "Health Bridge Webhook"
         receivers:


### PR DESCRIPTION
## Summary

- Remove `parse_mode: Markdown` from the Telegram contact point in `apps/grafana-alerting/manifests/contact-points-cm.yaml` so label/annotation values containing underscores (`session_manager`, `vk_issue_bridge`, `audit_digest`, etc.) render literally instead of being eaten by Telegram's italic parser.

## Why

During a 2026-04-29 incident, the Layer 18 alert posted to Telegram showed:

```
- job = sessionmanager
- runbook = kubectl logs -n secure-agent-pod -l app=secure-agent-pod --tail=50 | grep -i sessionmanager
```

…but the metric's actual label is `job=session_manager` (verified directly against VictoriaMetrics with `query=willikins_heartbeat_last_success_timestamp`). The underscore was eaten by Telegram's legacy Markdown parser, which treats `_` as italic delimiters and silently strips them.

Two real consequences observed:

1. The runbook ran by hand (`grep -i sessionmanager`) matches nothing in the container logs — the actual log lines say `session_manager` or `vk_issue_bridge` or `vk-issue-bridge.py`.
2. Triage went to the wrong cron entirely. The actual failing job in the incident was `vk_issue_bridge` (its heartbeat went stale because vk-local was OOM-crashlooping), but the alert label said `sessionmanager`, sending us to look at the session-manager cron — which was healthy throughout.

The Grafana alert rule itself is correct: the multi-job `or` query in `layer-18-persistent-agent-degraded` returns each clause with its own `job` label from the source metric, and the annotations correctly use `{{ $labels.job }}`. The only place the underscore disappears is in Telegram's Markdown rendering.

## Tradeoff

We lose the bold rendering of `**Firing**` / `**Resolved**` headers from Grafana's default Telegram message template. URLs (Source/Silence) were already rendering as plain text, so nothing else regresses. Correctness > formatting for an alerting channel.

If we want bolding back later, the right path is a custom message template in HTML mode (`parse_mode: HTML`), since HTML doesn't interpret `_` as formatting. That's a separate, larger change involving a new template ConfigMap and is out of scope here.

## Test plan

- [ ] Sync ArgoCD: `argocd app sync grafana-alerting --port-forward --port-forward-namespace argocd`
- [ ] Restart Grafana to reload provisioned contact points (per `frank-gotchas.md`): `kubectl delete pod -n monitoring -l app.kubernetes.io/name=grafana`
- [ ] Trigger a synthetic alert on a label containing an underscore (e.g. silence/unsilence the layer-18 rule, or wait for next vk-bridge fire) and confirm the Telegram message shows `job = session_manager` with the underscore preserved
- [ ] Confirm the templated runbook line says `grep -i session_manager` (or whichever job actually fired) so the operator can paste it directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)