### PR TITLE
[derio-net/frank] agents--restart-resilience · Phase 3/5 · Drop preStop, add notification annotations

### DIFF
--- a/apps/root/templates/secure-agent-pod.yaml
+++ b/apps/root/templates/secure-agent-pod.yaml
@@ -3,6 +3,9 @@ kind: Application
 metadata:
   name: secure-agent-pod
   namespace: argocd
+  annotations:
+    notifications.argoproj.io/subscribe.on-sync-running.webhook: telegram
+    notifications.argoproj.io/subscribe.on-sync-succeeded.webhook: telegram
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -18,9 +18,8 @@ spec:
         app: secure-agent-pod
     spec:
       serviceAccountName: agent-sa
-      # shutdown.sh waits up to 30s for SIGTERM → bridge:shutdown drain
-      # (so claude deregisters from claude.ai), then SIGKILLs stragglers.
-      # 45s gives margin for preStop start + drain + final pidfile cleanup.
+      # s6 cont-finish.d runs shutdown.sh (bridge:shutdown drain) then saves
+      # the tmux layout. 45s gives cont-finish.d time to complete before SIGKILL.
       terminationGracePeriodSeconds: 45
       nodeSelector:
         kubernetes.io/hostname: gpu-1
@@ -117,14 +116,6 @@ spec:
               port: ssh
             initialDelaySeconds: 30
             periodSeconds: 60
-          # preStop runs shutdown.sh, which signals claude remote-control
-          # so its own bridge:shutdown handler can DELETE the environment
-          # from the Anthropic API (avoids phantom sessions in claude.ai).
-          # Rationale: kali/docs/findings/2026-04-18-remote-control-shutdown.md
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/opt/scripts/shutdown.sh"]
         - name: vk-local
           image: ghcr.io/derio-net/vk-local:efc07ee28e050d30f5404629406dc5ae2f7829dc
           ports:

--- a/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
+++ b/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
@@ -337,7 +337,7 @@ notifications.argoproj.io/subscribe.on-sync-succeeded.webhook: telegram
 
 ### Task 3: Open PR + merge
 
-- [ ] **Step 1: Open PR `feat(agents): drop preStop, subscribe to ArgoCD bump alerts`**
+- [x] **Step 1: Open PR `feat(agents): drop preStop, subscribe to ArgoCD bump alerts`**
 
 - [ ] **Step 2: Merge after CI green**
 

--- a/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
+++ b/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
@@ -313,13 +313,13 @@ Open a tmux session, split panes, attach `claude` REPL, type a message, observe 
 
 ### Task 1: Remove `lifecycle.preStop` from deployment.yaml
 
-- [ ] **Step 1: Edit `apps/secure-agent-pod/manifests/deployment.yaml`**
+- [x] **Step 1: Edit `apps/secure-agent-pod/manifests/deployment.yaml`**
 
 Delete the entire `lifecycle:` block from the kali container spec. cont-finish.d/01-shutdown now handles the same shutdown.sh call, with the bonus that cont-finish.d/02-tmux-save runs after.
 
 ### Task 2: Add notification subscription annotations to the Application CR
 
-- [ ] **Step 1: Edit `apps/root/templates/secure-agent-pod.yaml`**
+- [x] **Step 1: Edit `apps/root/templates/secure-agent-pod.yaml`**
 
 Add to the Application CR's `metadata.annotations`:
 


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
📐 Spec:   docs/superpowers/specs/2026-04-27--agents--restart-resilience-design.md
🎯 Phase:  3/5 — Drop preStop, add notification annotations [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/134

**Goal (from plan):** The cluster-side and verification work to make the secure-agent-pod (and the planned fleet of sibling agent pods) survive container restarts gracefully. Specifically: deploy ArgoCD Notifications → Telegram for bump alerts; cut the running pod over to the new s6-based image; drop the redundant `lifecycle.preStop` hook in favor of s6's `cont-finish.d`; verify end-to-end resilience; document.

---

## Phase 3: Drop preStop, add notification annotations

### Changes

**`apps/secure-agent-pod/manifests/deployment.yaml`**
- Removed the `lifecycle.preStop` block from the kali container. The `cont-finish.d/01-shutdown` script (shipping in the s6-based image from Phase 2) now handles the same `shutdown.sh` call. The bonus: `cont-finish.d/02-tmux-save` runs after — something preStop couldn't do.
- Updated the `terminationGracePeriodSeconds` comment to reflect the s6 cont-finish.d model.

**`apps/root/templates/secure-agent-pod.yaml`**
- Added two ArgoCD Notifications subscription annotations to the Application CR:
  - `notifications.argoproj.io/subscribe.on-sync-running.webhook: telegram` — fires when a sync starts (~30s heads-up before pod recreates)
  - `notifications.argoproj.io/subscribe.on-sync-succeeded.webhook: telegram` — fires when sync completes (all-clear)
- Annotation format uses `.webhook` suffix matching the `service.webhook.telegram` webhook service configured in Phase 1 (the native Telegram service was replaced with a webhook to work around positive-integer chat ID routing).

### Result

After merge, ArgoCD will sync the Application CR change, which also touches deployment.yaml (preStop removal). This is the **first cutover with the heads-up** — the operator will receive a Telegram alert before the pod recreates.

Tasks 4 (re-spawn mosh + verify Telegram fired) are manual verification steps for the operator post-merge.

Closes #134