### PR TITLE
chore(plans): dispatch vk-local OOMKill remediation (gh#140)

### DIFF
--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -151,7 +151,9 @@ kubectl -n monitoring exec vmagent-victoria-metrics-victoria-metrics-k8s-stack-*
 ---
 
 ## Phase 3: Housekeeping — npm cache + worktree prune [agentic]
-**Depends on:** —  *(can land in parallel with Phase 2)*
+**Depends on:** —
+
+*(Can land in parallel with Phase 2 — no blocking phase.)*
 
 This phase is a pure agent-images change. It targets the ~900 MiB retained npm file-cache and the ~17 MiB/worktree heap residue identified in the memprofile findings. After landing, saturated-idle for `vk-local` should drop from ~1,157 MiB toward ~220 MiB.
 
@@ -218,7 +220,9 @@ container_memory_working_set_bytes{namespace="secure-agent-pod", container="vk-l
 ---
 
 ## Phase 4: Option B1 — `max_concurrent_executions` cap [agentic]
-**Depends on:** Phase 3 (image bumper merged) — see note below
+**Depends on:** Phase 3
+
+*(Specifically: Phase 3's image-bumper PR must be merged before Phase 4 Task 2 picks up the new SHA. Strictly the Task 1 binary work in agent-images is independent — see note below.)*
 
 Adds a configurable concurrency cap to vibe-kanban (queue, not reject), surfaces it as a Frank env var, and adds a minimal `/metrics` endpoint so the cap is observable in cadvisor + a vmagent scrape.
 
@@ -314,7 +318,7 @@ kubectl -n monitoring exec vmagent-victoria-metrics-victoria-metrics-k8s-stack-*
 ---
 
 ## Phase 5: Soak + dial-back assessment [manual]
-**Depends on:** Phases 1, 2, 3, 4
+**Depends on:** Phase 1, Phase 2, Phase 3, Phase 4
 
 Run a **14-day soak** under normal operator workload. Then make a sized decision about the 8 Gi limit.
 
@@ -354,7 +358,9 @@ max_over_time(vibekanban_queued_executions[1d])
 ---
 
 ## Phase 6: File tracking issues for B2, B3, R [agentic]
-**Depends on:** —  *(can run any time after Phase 4 Task 1 PR is filed)*
+**Depends on:** —
+
+*(Can run any time after Phase 4 Task 1 PR is filed in agent-images.)*
 
 Three follow-up items deferred from this plan. Filed as GitHub issues so they appear on the Derio Ops board with explicit gating criteria. No implementation here.
 
@@ -379,7 +385,7 @@ Three follow-up items deferred from this plan. Filed as GitHub issues so they ap
 ---
 
 ## Phase 7: Post-Deploy Checklist [manual]
-**Depends on:** Phases 1–6
+**Depends on:** Phase 1, Phase 2, Phase 3, Phase 4, Phase 5, Phase 6
 
 This is a fix/extension plan (per the Type at top), so most post-deploy steps are skipped per `repo-workflows.md`.
 

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -17,6 +17,7 @@
 ---
 
 ## Phase 1: Verify Option A in production [agentic]
+<!-- Tracking: https://github.com/derio-net/frank/issues/152 -->
 **Depends on:** —
 
 PR [#142](https://github.com/derio-net/frank/pull/142) raised the limit from 2 Gi to 8 Gi. This phase confirms the live deployment carries the new value, captures a baseline restart count, and starts the 30-day no-OOMKill clock that the success criterion depends on.
@@ -63,6 +64,7 @@ kubectl -n secure-agent-pod top pod -l app=secure-agent-pod --containers
 ---
 
 ## Phase 2: Fix cadvisor metric pipeline for 5 nodes [agentic]
+<!-- Tracking: https://github.com/derio-net/frank/issues/153 -->
 **Depends on:** Phase 1
 
 The cadvisor `VMNodeScrape` reports all 7 nodes' targets healthy in vmagent, but `container_memory_working_set_bytes` series only persist for `raspi-1` and `raspi-2`. `count(scrape_samples_scraped{metrics_path="/metrics/cadvisor"}) by (node)` confirms the gap: 5 nodes (`mini-1`, `mini-2`, `mini-3`, `gpu-1`, `pc-1`) emit no samples through to vmsingle. Without this fix, Phase 5 cannot quantify the effect of housekeeping or B1.
@@ -151,6 +153,7 @@ kubectl -n monitoring exec vmagent-victoria-metrics-victoria-metrics-k8s-stack-*
 ---
 
 ## Phase 3: Housekeeping — npm cache + worktree prune [agentic]
+<!-- Tracking: https://github.com/derio-net/frank/issues/154 -->
 **Depends on:** —
 
 *(Can land in parallel with Phase 2 — no blocking phase.)*
@@ -220,6 +223,7 @@ container_memory_working_set_bytes{namespace="secure-agent-pod", container="vk-l
 ---
 
 ## Phase 4: Option B1 — `max_concurrent_executions` cap [agentic]
+<!-- Tracking: https://github.com/derio-net/frank/issues/155 -->
 **Depends on:** Phase 3
 
 *(Specifically: Phase 3's image-bumper PR must be merged before Phase 4 Task 2 picks up the new SHA. Strictly the Task 1 binary work in agent-images is independent — see note below.)*
@@ -318,6 +322,7 @@ kubectl -n monitoring exec vmagent-victoria-metrics-victoria-metrics-k8s-stack-*
 ---
 
 ## Phase 5: Soak + dial-back assessment [manual]
+<!-- Tracking: https://github.com/derio-net/frank/issues/156 -->
 **Depends on:** Phase 1, Phase 2, Phase 3, Phase 4
 
 Run a **14-day soak** under normal operator workload. Then make a sized decision about the 8 Gi limit.
@@ -358,6 +363,7 @@ max_over_time(vibekanban_queued_executions[1d])
 ---
 
 ## Phase 6: File tracking issues for B2, B3, R [agentic]
+<!-- Tracking: https://github.com/derio-net/frank/issues/157 -->
 **Depends on:** —
 
 *(Can run any time after Phase 4 Task 1 PR is filed in agent-images.)*
@@ -385,6 +391,7 @@ Three follow-up items deferred from this plan. Filed as GitHub issues so they ap
 ---
 
 ## Phase 7: Post-Deploy Checklist [manual]
+<!-- Tracking: https://github.com/derio-net/frank/issues/158 -->
 **Depends on:** Phase 1, Phase 2, Phase 3, Phase 4, Phase 5, Phase 6
 
 This is a fix/extension plan (per the Type at top), so most post-deploy steps are skipped per `repo-workflows.md`.


### PR DESCRIPTION
## Summary

Two commits:

1. **`chore(plans): fix vk-dispatch deps syntax for vk 1.4.3 parser`** — the plan as merged in #151 had `**Depends on:**` lines the vk 1.4.3 parser couldn't read (parenthetical inline notes, plural "Phases", em-dash range). Rewrote them to bare-directive form with explanatory parentheticals on the next line. No semantic change to the dependency DAG.
2. **`chore: link plan phases to GitHub Issues (vk dispatch)`** — auto-generated by `vk dispatch create` after the syntax fix. Injects `<!-- Tracking: ... -->` URLs after each `## Phase N:` heading.

## Issues created

| Phase | Issue |
|-------|-------|
| Phase 1: Verify Option A in production | #152 |
| Phase 2: Fix cadvisor metric pipeline for 5 nodes | #153 |
| Phase 3: Housekeeping — npm cache + worktree prune | #154 |
| Phase 4: Option B1 — `max_concurrent_executions` cap | #155 |
| Phase 5: Soak + dial-back assessment | #156 |
| Phase 6: File tracking issues for B2, B3, R | #157 |
| Phase 7: Post-Deploy Checklist | #158 |

## Test plan

- [x] `bash scripts/validate-plans.sh docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md` passes
- [x] `vk dispatch create ... --dry-run` parses cleanly
- [x] All 7 issues created on the Derio Ops board
- [ ] Reviewer confirms the depends-on rewrites preserve the original DAG semantics (compare commit `06248c6` vs the plan body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)