### PR TITLE
docs(paperclip): reconcile blog with live deploy state

### DIFF
--- a/blog/content/docs/building/15-paperclip/index.md
+++ b/blog/content/docs/building/15-paperclip/index.md
@@ -28,10 +28,9 @@ paperclip-system
 ├── paperclip-db          (ArgoCD app, wave 0)
 │   └── Bitnami PostgreSQL 14.1.10 — Longhorn 5Gi
 └── paperclip             (ArgoCD app, wave 1)
-    ├── Deployment         ghcr.io/derio-net/paperclip:v0.3.1
+    ├── Deployment         ghcr.io/paperclipai/paperclip:sha-3494e84  (upstream)
     ├── ExternalSecret     OPENAI_API_KEY + OPENAI_BASE_URL (LiteLLM)
     ├── ExternalSecret     BETTER_AUTH_SECRET
-    ├── ExternalSecret     GHCR imagePullSecret
     ├── ExternalSecret     BRAVE_API_KEY (optional, web search)
     ├── PVC                /paperclip data volume — Longhorn 2Gi
     └── Service (LB)       192.168.55.212:3100
@@ -40,6 +39,8 @@ paperclip-system
 Two ArgoCD apps, ordered by sync-wave. The database deploys first (wave 0); the application follows (wave 1) once PostgreSQL is healthy. Agents route through the existing LiteLLM gateway — same `OPENAI_BASE_URL` pattern as Sympozium.
 
 ## Building the Container Image
+
+> **Historical, since v2026.428.0.** Paperclip now ships an upstream public image at `ghcr.io/paperclipai/paperclip` and we run that directly — no GHCR fork, no `paperclip-ghcr` `imagePullSecret`. The build/push workflow below describes how this layer worked while we maintained the `derio-net` fork; it's preserved for context on why the original architecture had a GHCR pull secret in it.
 
 Paperclip's Dockerfile is straightforward Node.js — `pnpm install`, `pnpm build`, `USER node`. But the image is not small. It installs Claude Code, Codex, and opencode-ai globally as part of the agent tooling. The final image sits around 2GB.
 
@@ -119,17 +120,15 @@ spec:
 
 ## Secret Management
 
-Five ExternalSecrets sync from Infisical:
+Three ExternalSecrets sync from Infisical:
 
 | Secret | Contains | How Used |
 |--------|----------|----------|
 | `paperclip-llm-key` | `OPENAI_API_KEY` + `OPENAI_BASE_URL` | `envFrom` — routes LLM calls through LiteLLM |
 | `paperclip-auth` | `BETTER_AUTH_SECRET` | `envFrom` — session signing |
-| `paperclip-ghcr` | `.dockerconfigjson` | `imagePullSecrets` — GHCR auth |
-| `paperclip-anthropic` | `ANTHROPIC_API_KEY` | `envFrom` — direct Anthropic access via `claude_local` adapter (optional) |
 | `paperclip-brave` | `BRAVE_API_KEY` | `envFrom` — Brave Search API key for agent web-search tools (optional) |
 
-`paperclip-anthropic` and `paperclip-brave` are both marked `optional: true` in the Deployment — the pod starts normally without them. The `claude_local` adapter only needs Anthropic if you want to bypass LiteLLM; the Brave key is only needed by agents that invoke a web-search tool (e.g. the Brave Search MCP server). Lesson learned: any `secretRef` for a feature that isn't always provisioned should be `optional: true`, otherwise a missing Secret blocks rolling updates entirely (`CreateContainerConfigError` on the new pod, old pod stuck alive).
+`paperclip-brave` is marked `optional: true` in the Deployment — the pod starts normally without it. The Brave key is only needed by agents that invoke a web-search tool (e.g. the Brave Search MCP server). Lesson learned: any `secretRef` for a feature that isn't always provisioned should be `optional: true`, otherwise a missing Secret blocks rolling updates entirely (`CreateContainerConfigError` on the new pod, old pod stuck alive). An earlier `paperclip-anthropic` ExternalSecret carrying `ANTHROPIC_API_KEY` for the `claude_local` adapter taught the same lesson the hard way before being retired when Paperclip switched to the upstream public image; a `paperclip-ghcr` `imagePullSecret` (used while we built our own image, see *Building the Container Image* above) was retired at the same time.
 
 The Brave key remaps the Infisical entry `BRAVE_SEARCH_KEY_PAPERCLIP` to the standard `BRAVE_API_KEY` env var that the Brave Search MCP server and SDKs expect — the same source-vs-consumer remap pattern the LiteLLM secret uses (`PAPERCLIP_LITELLM_KEY` → `OPENAI_API_KEY`).
 

--- a/blog/content/docs/operating/18-paperclip/index.md
+++ b/blog/content/docs/operating/18-paperclip/index.md
@@ -15,7 +15,7 @@ Paperclip is healthy when:
 - The paperclip pod is `1/1 Running` in the `paperclip-system` namespace
 - The web UI responds at `http://192.168.55.212:3100`
 - PostgreSQL is `1/1 Running` with the metrics sidecar
-- All four ExternalSecrets show `SecretSynced`
+- All three ExternalSecrets show `SecretSynced`
 - The PVC is `Bound`
 
 <!-- MEDIA: screenshot | Paperclip dashboard showing agent overview and recent runs | Navigate to http://192.168.55.212:3100, log in, capture the main dashboard view with at least one agent visible, dark mode preferred -->
@@ -28,7 +28,7 @@ Quick health check:
 kubectl get pods,pvc,externalsecret -n paperclip-system
 ```
 
-Expected output: one paperclip pod, one paperclip-db pod, one 2Gi PVC bound, five ExternalSecrets synced.
+Expected output: one paperclip pod, one paperclip-db pod, one 2Gi PVC bound, three ExternalSecrets synced.
 
 ```console
 $ kubectl get pods,pvc,externalsecret -n paperclip-system
@@ -40,12 +40,10 @@ NAME                                                   STATUS   VOLUME          
 persistentvolumeclaim/data-paperclip-db-postgresql-0   Bound    pvc-1929c98e-6a59-4eec-8c41-353833f43dec   5Gi        RWO            longhorn       <unset>                 37d
 persistentvolumeclaim/paperclip-data                   Bound    pvc-1ded449d-e2bc-4e38-b7c9-c5d5ee264294   2Gi        RWO            longhorn       <unset>                 37d
 
-NAME                                                     STORETYPE            STORE       REFRESH INTERVAL   STATUS         READY
-externalsecret.external-secrets.io/paperclip-anthropic   ClusterSecretStore   infisical   5m                 SecretSynced   True
-externalsecret.external-secrets.io/paperclip-auth        ClusterSecretStore   infisical   5m                 SecretSynced   True
-externalsecret.external-secrets.io/paperclip-brave       ClusterSecretStore   infisical   5m                 SecretSynced   True
-externalsecret.external-secrets.io/paperclip-ghcr        ClusterSecretStore   infisical   5m                 SecretSynced   True
-externalsecret.external-secrets.io/paperclip-llm-key     ClusterSecretStore   infisical   5m                 SecretSynced   True
+NAME                                                   STORETYPE            STORE       REFRESH INTERVAL   STATUS         READY
+externalsecret.external-secrets.io/paperclip-auth      ClusterSecretStore   infisical   5m                 SecretSynced   True
+externalsecret.external-secrets.io/paperclip-brave     ClusterSecretStore   infisical   5m                 SecretSynced   True
+externalsecret.external-secrets.io/paperclip-llm-key   ClusterSecretStore   infisical   5m                 SecretSynced   True
 ```
 
 ## Observing State
@@ -92,12 +90,12 @@ kubectl get externalsecret -n paperclip-system
 kubectl describe externalsecret paperclip-llm-key -n paperclip-system
 ```
 
-Five ExternalSecrets exist:
+Three ExternalSecrets exist:
 - `paperclip-llm-key` — OPENAI_API_KEY and OPENAI_BASE_URL (points to LiteLLM)
 - `paperclip-auth` — BETTER_AUTH_SECRET for session signing
-- `paperclip-anthropic` — ANTHROPIC_API_KEY (optional, marked `optional: true`)
-- `paperclip-brave` — BRAVE_API_KEY for agent web-search tools (optional, marked `optional: true`); sourced from Infisical key `BRAVE_SEARCH_KEY_PAPERCLIP` (typo preserved upstream) and remapped to the standard `BRAVE_API_KEY` env var
-- `paperclip-ghcr` — Image pull credentials for ghcr.io
+- `paperclip-brave` — BRAVE_API_KEY for agent web-search tools (optional, marked `optional: true`); sourced from Infisical key `BRAVE_SEARCH_KEY_PAPERCLIP` and remapped to the standard `BRAVE_API_KEY` env var
+
+Earlier deployments included `paperclip-anthropic` (`ANTHROPIC_API_KEY` for the `claude_local` adapter) and `paperclip-ghcr` (`.dockerconfigjson` for pulling our custom image from GHCR). Both were retired when Paperclip switched to the upstream public image and stopped using the `claude_local` adapter — see the building-side post for the full history.
 
 ## Common Operations
 
@@ -117,16 +115,16 @@ Expect a brief gap (10-30s) where Paperclip is unavailable while the old pod ter
 
 ### Updating the Image
 
-Paperclip uses a custom-built image pushed to GHCR. To deploy a new version:
+Paperclip runs the upstream public image. Upstream only publishes `latest` (master HEAD) and `sha-<short>` tags — no semver image tags — so we pin a specific `sha-<short>` build that maps to a known git tag. To deploy a new version:
 
 ```bash
-# Update the image tag
-kubectl set image deployment/paperclip \
-  paperclip=ghcr.io/derio-net/paperclip:v2026.325.0-derio.2 \
-  -n paperclip-system
+# Update the image tag (preferred: edit the manifest and let ArgoCD sync)
+# apps/paperclip/manifests/deployment.yaml → image: ghcr.io/paperclipai/paperclip:sha-<short>
 
-# Or edit the manifest and let ArgoCD sync
-# apps/paperclip/manifests/deployment.yaml → image tag
+# Imperative alternative (will drift from Git until the manifest catches up):
+kubectl set image deployment/paperclip \
+  paperclip=ghcr.io/paperclipai/paperclip:sha-<short> \
+  -n paperclip-system
 ```
 
 ### Database Backup and Restore
@@ -199,10 +197,10 @@ kubectl get ciliumpoolipaddress -A | grep 192.168.55.212
 
 - **PostgreSQL image uses GCR mirror.** Bitnami no longer serves named tags on Docker Hub. The chart uses `mirror.gcr.io/bitnamilegacy/*` images. If the mirror goes down, you'll need to find another source for the `14.1.10-debian-11-r16` tag.
 
-- **Optional Anthropic secret.** `paperclip-anthropic` ExternalSecret is marked `optional: true`. If the key doesn't exist in Infisical, the pod starts fine without it — Paperclip falls back to LiteLLM for all model access.
+- **Optional Brave Search secret.** `paperclip-brave` ExternalSecret is marked `optional: true`. If `BRAVE_SEARCH_KEY_PAPERCLIP` doesn't exist in Infisical, the pod starts fine without it — agents that don't invoke a web-search tool are unaffected. The same `optional: true` pattern previously protected the now-retired `paperclip-anthropic` secret from blocking rollouts when its Infisical entry was missing.
 
 ## References
 
-- [Paperclip GitHub](https://github.com/derio-net/paperclip) — Source repository
+- [Paperclip GitHub](https://github.com/paperclipai/paperclip) — Upstream source repository
 - [Building Post: Paperclip]({{< relref "/docs/building/15-paperclip" >}}) — Architecture and deployment walkthrough
 - [Operating on Progressive Delivery]({{< relref "/docs/operating/12-progressive-delivery" >}}) — Context on why Paperclip isn't a Rollout


### PR DESCRIPTION
## Summary

Pure documentation reconcile — no manifest changes, no cluster impact.

The Paperclip building/operating blog posts had drifted out of sync with the cluster: they listed **five** ExternalSecrets (`paperclip-llm-key`, `paperclip-auth`, `paperclip-ghcr`, `paperclip-anthropic`, `paperclip-brave`) but the cluster only has **three**. `paperclip-ghcr` and `paperclip-anthropic` were retired when Paperclip switched to the upstream public image (#d4060c8, #b35b781) and we stopped using the `claude_local` adapter.

- Drops `paperclip-ghcr` and `paperclip-anthropic` rows from the Secret Management table and the operating-side enumeration; updates count `Five` → `Three`.
- Updates the architecture diagram + "Updating the Image" recipe to reflect the upstream image (`ghcr.io/paperclipai/paperclip:sha-*`).
- Adds a "Historical" admonition above the "Building the Container Image" section so the fork-era build/push narrative is clearly framed as historical, not current.
- Repoints the GitHub reference link to upstream `paperclipai/paperclip`.
- Rewrites the "Optional Anthropic secret" gotcha as "Optional Brave Search secret" — same lesson, applied to the live optional secret.

The retired secrets are preserved as context paragraphs rather than deleted outright — they explain *why* the architecture had a GHCR pull secret in it and motivate the `optional: true` pattern that's still in active use today.

## Test plan

- [ ] `kubectl get externalsecret -n paperclip-system` shows exactly the three secrets the blog now claims (`paperclip-auth`, `paperclip-brave`, `paperclip-llm-key`)
- [ ] `kubectl get deploy paperclip -n paperclip-system -o yaml` confirms the image is `ghcr.io/paperclipai/paperclip:sha-3494e84` (matches the architecture diagram)
- [ ] Hugo build is clean — `cd blog && hugo --minify`
- [ ] Visual review of the rendered building + operating posts: admonition renders, table count is 3, no orphan references

🤖 Generated with [Claude Code](https://claude.com/claude-code)