### PR TITLE
feat(paperclip): expose RESEND_API_KEY for agent transactional email

### DIFF
--- a/apps/paperclip/manifests/deployment.yaml
+++ b/apps/paperclip/manifests/deployment.yaml
@@ -45,6 +45,9 @@ spec:
             - secretRef:
                 name: paperclip-brave
                 optional: true
+            - secretRef:
+                name: paperclip-resend
+                optional: true
           env:
             - name: PG_PASSWORD
               valueFrom:

--- a/apps/paperclip/manifests/external-secret-resend.yaml
+++ b/apps/paperclip/manifests/external-secret-resend.yaml
@@ -1,0 +1,31 @@
+# Syncs Resend API key from Infisical for use by Paperclip agents that
+# send transactional email (e.g. the Resend MCP server, notification
+# tools, agent-driven outreach flows).
+# Marked `optional: true` on the Deployment's secretRef so a missing or
+# lagging sync does not block rollouts — same rule as the paperclip-brave
+# secret and the (now-retired) paperclip-anthropic secret.
+# See frank-gotchas.md for the optional-secretRef pattern rationale.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperclip-resend
+  namespace: paperclip-system
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: paperclip-resend
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    # In-cluster env var uses the standard `RESEND_API_KEY` name expected
+    # by the official Resend SDKs and the Resend MCP server; sourced from
+    # the `EMAIL_RESEND_API_KEY` Infisical entry.
+    - secretKey: RESEND_API_KEY
+      remoteRef:
+        key: EMAIL_RESEND_API_KEY
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/blog/content/docs/building/15-paperclip/index.md
+++ b/blog/content/docs/building/15-paperclip/index.md
@@ -32,6 +32,7 @@ paperclip-system
     ├── ExternalSecret     OPENAI_API_KEY + OPENAI_BASE_URL (LiteLLM)
     ├── ExternalSecret     BETTER_AUTH_SECRET
     ├── ExternalSecret     BRAVE_API_KEY (optional, web search)
+    ├── ExternalSecret     RESEND_API_KEY (optional, transactional email)
     ├── PVC                /paperclip data volume — Longhorn 2Gi
     └── Service (LB)       192.168.55.212:3100
 ```
@@ -120,17 +121,18 @@ spec:
 
 ## Secret Management
 
-Three ExternalSecrets sync from Infisical:
+Four ExternalSecrets sync from Infisical:
 
 | Secret | Contains | How Used |
 |--------|----------|----------|
 | `paperclip-llm-key` | `OPENAI_API_KEY` + `OPENAI_BASE_URL` | `envFrom` — routes LLM calls through LiteLLM |
 | `paperclip-auth` | `BETTER_AUTH_SECRET` | `envFrom` — session signing |
 | `paperclip-brave` | `BRAVE_API_KEY` | `envFrom` — Brave Search API key for agent web-search tools (optional) |
+| `paperclip-resend` | `RESEND_API_KEY` | `envFrom` — Resend API key for agent transactional email (optional) |
 
-`paperclip-brave` is marked `optional: true` in the Deployment — the pod starts normally without it. The Brave key is only needed by agents that invoke a web-search tool (e.g. the Brave Search MCP server). Lesson learned: any `secretRef` for a feature that isn't always provisioned should be `optional: true`, otherwise a missing Secret blocks rolling updates entirely (`CreateContainerConfigError` on the new pod, old pod stuck alive). An earlier `paperclip-anthropic` ExternalSecret carrying `ANTHROPIC_API_KEY` for the `claude_local` adapter taught the same lesson the hard way before being retired when Paperclip switched to the upstream public image; a `paperclip-ghcr` `imagePullSecret` (used while we built our own image, see *Building the Container Image* above) was retired at the same time.
+`paperclip-brave` and `paperclip-resend` are both marked `optional: true` in the Deployment — the pod starts normally without them. The Brave key is only needed by agents that invoke a web-search tool (e.g. the Brave Search MCP server); the Resend key is only needed by agents that send transactional email. Lesson learned: any `secretRef` for a feature that isn't always provisioned should be `optional: true`, otherwise a missing Secret blocks rolling updates entirely (`CreateContainerConfigError` on the new pod, old pod stuck alive). An earlier `paperclip-anthropic` ExternalSecret carrying `ANTHROPIC_API_KEY` for the `claude_local` adapter taught the same lesson the hard way before being retired when Paperclip switched to the upstream public image; a `paperclip-ghcr` `imagePullSecret` (used while we built our own image, see *Building the Container Image* above) was retired at the same time.
 
-The Brave key remaps the Infisical entry `BRAVE_SEARCH_KEY_PAPERCLIP` to the standard `BRAVE_API_KEY` env var that the Brave Search MCP server and SDKs expect — the same source-vs-consumer remap pattern the LiteLLM secret uses (`PAPERCLIP_LITELLM_KEY` → `OPENAI_API_KEY`).
+Both feature keys use the same source-vs-consumer remap pattern the LiteLLM secret uses (`PAPERCLIP_LITELLM_KEY` → `OPENAI_API_KEY`): the Brave key remaps `BRAVE_SEARCH_KEY_PAPERCLIP` to the standard `BRAVE_API_KEY` env var the Brave Search MCP server and SDKs expect, and the Resend key remaps `EMAIL_RESEND_API_KEY` to `RESEND_API_KEY` — the standard env var the Resend Node.js SDK and the Resend MCP server look for.
 
 The LiteLLM secret uses the template merge pattern from Sympozium: a single Infisical key (`PAPERCLIP_LITELLM_KEY`) is combined with a static base URL at sync time, so the Deployment just does `envFrom` and gets both variables.
 

--- a/blog/content/docs/operating/18-paperclip/index.md
+++ b/blog/content/docs/operating/18-paperclip/index.md
@@ -15,7 +15,7 @@ Paperclip is healthy when:
 - The paperclip pod is `1/1 Running` in the `paperclip-system` namespace
 - The web UI responds at `http://192.168.55.212:3100`
 - PostgreSQL is `1/1 Running` with the metrics sidecar
-- All three ExternalSecrets show `SecretSynced`
+- All four ExternalSecrets show `SecretSynced`
 - The PVC is `Bound`
 
 <!-- MEDIA: screenshot | Paperclip dashboard showing agent overview and recent runs | Navigate to http://192.168.55.212:3100, log in, capture the main dashboard view with at least one agent visible, dark mode preferred -->
@@ -28,7 +28,7 @@ Quick health check:
 kubectl get pods,pvc,externalsecret -n paperclip-system
 ```
 
-Expected output: one paperclip pod, one paperclip-db pod, one 2Gi PVC bound, three ExternalSecrets synced.
+Expected output: one paperclip pod, one paperclip-db pod, one 2Gi PVC bound, four ExternalSecrets synced.
 
 ```console
 $ kubectl get pods,pvc,externalsecret -n paperclip-system
@@ -44,6 +44,7 @@ NAME                                                   STORETYPE            STOR
 externalsecret.external-secrets.io/paperclip-auth      ClusterSecretStore   infisical   5m                 SecretSynced   True
 externalsecret.external-secrets.io/paperclip-brave     ClusterSecretStore   infisical   5m                 SecretSynced   True
 externalsecret.external-secrets.io/paperclip-llm-key   ClusterSecretStore   infisical   5m                 SecretSynced   True
+externalsecret.external-secrets.io/paperclip-resend    ClusterSecretStore   infisical   5m                 SecretSynced   True
 ```
 
 ## Observing State
@@ -90,10 +91,11 @@ kubectl get externalsecret -n paperclip-system
 kubectl describe externalsecret paperclip-llm-key -n paperclip-system
 ```
 
-Three ExternalSecrets exist:
+Four ExternalSecrets exist:
 - `paperclip-llm-key` — OPENAI_API_KEY and OPENAI_BASE_URL (points to LiteLLM)
 - `paperclip-auth` — BETTER_AUTH_SECRET for session signing
 - `paperclip-brave` — BRAVE_API_KEY for agent web-search tools (optional, marked `optional: true`); sourced from Infisical key `BRAVE_SEARCH_KEY_PAPERCLIP` and remapped to the standard `BRAVE_API_KEY` env var
+- `paperclip-resend` — RESEND_API_KEY for agent transactional email (optional, marked `optional: true`); sourced from Infisical key `EMAIL_RESEND_API_KEY` and remapped to the standard `RESEND_API_KEY` env var the Resend SDK and MCP server expect
 
 Earlier deployments included `paperclip-anthropic` (`ANTHROPIC_API_KEY` for the `claude_local` adapter) and `paperclip-ghcr` (`.dockerconfigjson` for pulling our custom image from GHCR). Both were retired when Paperclip switched to the upstream public image and stopped using the `claude_local` adapter — see the building-side post for the full history.
 
@@ -197,7 +199,7 @@ kubectl get ciliumpoolipaddress -A | grep 192.168.55.212
 
 - **PostgreSQL image uses GCR mirror.** Bitnami no longer serves named tags on Docker Hub. The chart uses `mirror.gcr.io/bitnamilegacy/*` images. If the mirror goes down, you'll need to find another source for the `14.1.10-debian-11-r16` tag.
 
-- **Optional Brave Search secret.** `paperclip-brave` ExternalSecret is marked `optional: true`. If `BRAVE_SEARCH_KEY_PAPERCLIP` doesn't exist in Infisical, the pod starts fine without it — agents that don't invoke a web-search tool are unaffected. The same `optional: true` pattern previously protected the now-retired `paperclip-anthropic` secret from blocking rollouts when its Infisical entry was missing.
+- **Optional feature secrets.** `paperclip-brave` (Brave Search) and `paperclip-resend` (Resend transactional email) are both marked `optional: true` on their `secretRef` entries. If `BRAVE_SEARCH_KEY_PAPERCLIP` or `EMAIL_RESEND_API_KEY` doesn't exist in Infisical, the pod starts fine without that key — agents that don't invoke the corresponding tool are unaffected. The same `optional: true` pattern previously protected the now-retired `paperclip-anthropic` secret from blocking rollouts when its Infisical entry was missing; new optional feature secrets should follow the same convention.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Add `paperclip-resend` ExternalSecret syncing `EMAIL_RESEND_API_KEY` from Infisical and remapping to the standard `RESEND_API_KEY` env var that the Resend Node.js SDK and the Resend MCP server expect.
- Wire it into the Deployment as an `optional: true` `secretRef` so a missing/lagging Infisical sync never blocks a rollout — same rule the `paperclip-brave` (#171) and retired `paperclip-anthropic` secrets established.
- Update the building (`15-paperclip`) and operating (`18-paperclip`) blog posts to reflect the new secret in the architecture diagram, the Secret Management table, the sample `kubectl` output (now alphabetically ordered to match real `kubectl` output), the ExternalSecret enumeration, and the optional-secret gotcha. Counts go from `Three` → `Four`.

## Test plan

- [ ] ArgoCD `paperclip` app reconciles to the new revision (`Synced` + `Healthy`)
- [ ] `kubectl get externalsecret -n paperclip-system` shows `paperclip-resend` with `SecretSynced=True`
- [ ] New paperclip pod starts cleanly under `strategy: Recreate` (old RWO PVC released, new pod mounts and reaches `1/1 Running`)
- [ ] Deployment manifest is wired correctly: `kubectl get deploy paperclip -n paperclip-system -o jsonpath='{...envFrom[*].secretRef.name}'` includes `paperclip-resend` with `optional=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)