### PR TITLE
[derio-net/frank] agents--vk-local-oom-remediation · Phase 2/7 · Fix cadvisor metric pipeline for 5 nodes

### DIFF
--- a/apps/grafana-alerting/manifests/secure-agent-pod-dashboard-cm.yaml
+++ b/apps/grafana-alerting/manifests/secure-agent-pod-dashboard-cm.yaml
@@ -1,0 +1,121 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-secure-agent-pod-dashboard
+  namespace: monitoring
+data:
+  secure-agent-pod-provider.yaml: |
+    apiVersion: 1
+    providers:
+      - name: secure-agent-pod
+        folder: secure-agent-pod
+        type: file
+        disableDeletion: true
+        editable: false
+        options:
+          path: /var/lib/grafana/dashboards/secure-agent-pod
+  secure-agent-pod.json: |
+    {
+      "uid": "sap-operating",
+      "title": "Secure Agent Pod — Operating",
+      "tags": ["secure-agent-pod", "operating"],
+      "timezone": "browser",
+      "schemaVersion": 39,
+      "refresh": "30s",
+      "time": { "from": "now-24h", "to": "now" },
+      "panels": [
+        {
+          "id": 1,
+          "title": "vk-local working-set RSS",
+          "type": "timeseries",
+          "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+          "datasource": { "uid": "P4169E866C3094E38", "type": "prometheus" },
+          "targets": [
+            {
+              "datasource": { "uid": "P4169E866C3094E38", "type": "prometheus" },
+              "expr": "container_memory_working_set_bytes{namespace=\"secure-agent-pod\", container=\"vk-local\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "bytes",
+              "custom": {
+                "drawStyle": "line",
+                "lineWidth": 1,
+                "fillOpacity": 10,
+                "showPoints": "never"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 3221225472 },
+                  { "color": "red", "value": 6442450944 }
+                ]
+              }
+            }
+          },
+          "options": {
+            "tooltip": { "mode": "multi" },
+            "legend": { "displayMode": "table", "placement": "right", "calcs": ["last", "max", "mean"] }
+          }
+        },
+        {
+          "id": 2,
+          "title": "vk-local restart count (cumulative)",
+          "type": "stat",
+          "gridPos": { "h": 6, "w": 12, "x": 0, "y": 10 },
+          "datasource": { "uid": "P4169E866C3094E38", "type": "prometheus" },
+          "targets": [
+            {
+              "datasource": { "uid": "P4169E866C3094E38", "type": "prometheus" },
+              "expr": "kube_pod_container_status_restarts_total{namespace=\"secure-agent-pod\", container=\"vk-local\"}",
+              "legendFormat": "{{pod}}",
+              "refId": "A"
+            }
+          ],
+          "fieldConfig": {
+            "defaults": {
+              "unit": "short",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  { "color": "green", "value": null },
+                  { "color": "yellow", "value": 1 },
+                  { "color": "red", "value": 5 }
+                ]
+              }
+            }
+          },
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+          }
+        },
+        {
+          "id": 3,
+          "title": "vk-local last terminated reason",
+          "type": "table",
+          "gridPos": { "h": 6, "w": 12, "x": 12, "y": 10 },
+          "datasource": { "uid": "P4169E866C3094E38", "type": "prometheus" },
+          "targets": [
+            {
+              "datasource": { "uid": "P4169E866C3094E38", "type": "prometheus" },
+              "expr": "kube_pod_container_status_last_terminated_reason{namespace=\"secure-agent-pod\", container=\"vk-local\"} == 1",
+              "instant": true,
+              "format": "table",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": { "include": { "names": ["pod", "reason", "Value"] } }
+            }
+          ]
+        }
+      ]
+    }

--- a/apps/victoria-metrics/values.yaml
+++ b/apps/victoria-metrics/values.yaml
@@ -20,6 +20,31 @@ vmsingle:
         requests:
           storage: 20Gi
 
+# Kubelet scrape (cadvisor + resources + probes + kubelet) — drop high-cardinality
+# node-meta labels. The chart's default relabelConfigs labelmap every
+# `__meta_kubernetes_node_label_*` onto every metric. On Frank's amd64 nodes
+# (NFD CPU features, Talos extensions, NVIDIA driver labels) this puts each
+# series at 60–135 labels, exceeding VictoriaMetrics' default
+# -maxLabelsPerTimeseries=40, so vmsingle silently drops them — that is the
+# cause of the cadvisor metric gap on the 5 amd64 nodes (mini-1/2/3, gpu-1,
+# pc-1). raspi nodes carry ~33 labels and pass under the limit. Adding a
+# labeldrop after the chart's default keeps the useful node labels (tier,
+# zone, kubernetes_io_arch, node, instance, accelerator, igpu) and trims the
+# pure metadata noise.
+kubelet:
+  vmScrape:
+    spec:
+      metricRelabelConfigs:
+        - action: labeldrop
+          regex: (uid)
+        - action: labeldrop
+          regex: (id|name)
+        - action: drop
+          source_labels: [__name__]
+          regex: (rest_client_request_duration_seconds_bucket|rest_client_request_duration_seconds_sum|rest_client_request_duration_seconds_count)
+        - action: labeldrop
+          regex: (feature_node_kubernetes_io_.*|extensions_talos_dev_.*|nvidia_com_.*|beta_kubernetes_io_.*)
+
 # Grafana — exposed via Cilium L2 LoadBalancer
 grafana:
   enabled: true
@@ -67,6 +92,17 @@ grafana:
       mountPath: /var/lib/grafana/dashboards/feature-health/feature-health.json
       subPath: feature-health.json
       configMap: grafana-alerting-dashboard
+      readOnly: true
+    # secure-agent-pod operating dashboard (Phase 5 soak readings)
+    - name: sap-dashboard-provider
+      mountPath: /etc/grafana/provisioning/dashboards/secure-agent-pod-provider.yaml
+      subPath: secure-agent-pod-provider.yaml
+      configMap: grafana-secure-agent-pod-dashboard
+      readOnly: true
+    - name: sap-dashboard-json
+      mountPath: /var/lib/grafana/dashboards/secure-agent-pod/secure-agent-pod.json
+      subPath: secure-agent-pod.json
+      configMap: grafana-secure-agent-pod-dashboard
       readOnly: true
   # Authentik OIDC SSO (Phase 13) + Alerting secrets (Telegram, Health Bridge)
   envFromSecrets:

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -66,7 +66,7 @@ The cadvisor `VMNodeScrape` reports all 7 nodes' targets healthy in vmagent, but
 
 ### Task 1: Investigate root cause
 
-- [ ] **Step 1: Read vmagent scrape stats for cadvisor targets**
+- [x] **Step 1: Read vmagent scrape stats for cadvisor targets**
 
 ```bash
 VMAGENT=$(kubectl -n monitoring get pod -l app.kubernetes.io/name=vmagent -o jsonpath='{.items[0].metadata.name}')
@@ -81,7 +81,7 @@ for t in (x for x in d if x.get('labels',{}).get('metrics_path')=='/metrics/cadv
 
   Note the per-node `lastSamplesScraped`. If amd64 nodes return non-zero here but vmsingle has no series for them, the loss is in the relabel/ingestion pipeline (case 1 below). If they return zero here, cadvisor itself is silent on those nodes (case 2).
 
-- [ ] **Step 2: Test the relabel-rule hypothesis (case 1)**
+- [x] **Step 2: Test the relabel-rule hypothesis (case 1)**
 
   The `VMNodeScrape` for cadvisor includes:
 
@@ -95,7 +95,7 @@ metricRelabelConfigs:
 
   The second rule drops any label matching `id` or `name`. Some cadvisor metric variants legacy-mirror their identifiers in those exact label names. Test by temporarily commenting out the second rule on a non-prod scrape (or via a dedicated test `VMNodeScrape` selecting only `gpu-1`) and re-querying for amd64 series after one scrape interval.
 
-- [ ] **Step 3: Test cardinality / disk-usage limits (case 2)**
+- [x] **Step 3: Test cardinality / disk-usage limits (case 2)**
 
 ```bash
 kubectl -n monitoring logs deploy/vmagent-victoria-metrics-victoria-metrics-k8s-stack -c vmagent \
@@ -104,7 +104,7 @@ kubectl -n monitoring logs deploy/vmagent-victoria-metrics-victoria-metrics-k8s-
 
   Look for messages mentioning `gpu-1` / `mini-1` / `pc-1` instances, dropped samples, or per-target rate limits.
 
-- [ ] **Step 4: Test cadvisor endpoint directly on an affected node**
+- [x] **Step 4: Test cadvisor endpoint directly on an affected node**
 
 ```bash
 kubectl -n monitoring run cadvisor-test-$$ --rm -i --restart=Never \
@@ -121,7 +121,7 @@ kubectl -n monitoring run cadvisor-test-$$ --rm -i --restart=Never \
 
 Pick exactly one of the three sub-steps below depending on which case Task 1 confirmed; then run the verify and Grafana steps.
 
-- [ ] **Step 1: Apply the case-specific fix.** One of:
+- [x] **Step 1: Apply the case-specific fix.** One of:
   - **Case 1 (relabel rule):** Edit `apps/victoria-metrics/values.yaml` to override the cadvisor `VMNodeScrape` `metricRelabelConfigs`, removing the `(id|name)` labeldrop. Commit, ArgoCD syncs, wait one scrape interval (30 s), re-query.
   - **Case 2 (vmagent limit):** Edit `apps/victoria-metrics/values.yaml` to bump the relevant `vmagent.spec.extraArgs` flag (`promscrape.maxScrapeSize`, `remoteWrite.maxBlockSize`, etc., depending on the log message). Commit, ArgoCD sync, observe vmagent logs for resumed ingest.
   - **Case 3 (vmsingle limit):** Bump retention or per-tenant series limit in `vmsingle.spec` in the same values file. Commit, ArgoCD sync.
@@ -135,7 +135,7 @@ kubectl -n monitoring exec vmagent-victoria-metrics-victoria-metrics-k8s-stack-*
 
   All 7 nodes must appear with non-zero counts.
 
-- [ ] **Step 3 (Grafana panel):** Add a `vk-local working-set RSS` panel to the existing operating dashboard. Query: `container_memory_working_set_bytes{namespace="secure-agent-pod", container="vk-local"}`. Pin to the secure-agent-pod operating folder so Phase 5's soak readings have a UI.
+- [x] **Step 3 (Grafana panel):** Add a `vk-local working-set RSS` panel to the existing operating dashboard. Query: `container_memory_working_set_bytes{namespace="secure-agent-pod", container="vk-local"}`. Pin to the secure-agent-pod operating folder so Phase 5's soak readings have a UI.
 
 ### Task 3: 24h soak
 
@@ -143,7 +143,7 @@ kubectl -n monitoring exec vmagent-victoria-metrics-victoria-metrics-k8s-stack-*
 
 ### Task 4: Fallback if root cause cannot be isolated
 
-- [ ] **Step 1:** If after one working day the cause is still unknown, file a tracking issue in `derio-net/frank` titled `obs: cadvisor scrape data gap on amd64 nodes` with the investigation log so far. Mark Phase 2 as `Closed (deferred)` in this plan and continue with Phase 3 — the housekeeping work does not depend on Phase 2's outcome, only Phase 5's evaluation does.
+- [-] **Step 1:** *(skipped — root cause was isolated in Task 1, see Deployment Deviations below).* If after one working day the cause is still unknown, file a tracking issue in `derio-net/frank` titled `obs: cadvisor scrape data gap on amd64 nodes` with the investigation log so far. Mark Phase 2 as `Closed (deferred)` in this plan and continue with Phase 3 — the housekeeping work does not depend on Phase 2's outcome, only Phase 5's evaluation does.
 
 ---
 
@@ -403,6 +403,19 @@ This is a fix/extension plan (per the Type at top), so most post-deploy steps ar
 ---
 
 ## Deployment Deviations
+
+### Phase 2 — cadvisor gap root cause was *not* the `(id|name)` labeldrop (2026-05-02)
+
+The plan's Case 1 hypothesis (the cadvisor `VMNodeScrape`'s `(id|name)` labeldrop dropping data on amd64) was wrong. Investigation showed:
+
+- **Task 1 / Step 1** — vmagent reports all 7 cadvisor targets healthy with non-zero `lastSamplesScraped`. amd64 nodes scrape *more* samples than raspi (gpu-1=7575, mini-1=13658, raspi-1=3245). So the loss is downstream of vmagent's parser, not at the target.
+- **Task 1 / Step 3** — vmsingle logs are full of `timeserieslimits/timeseries_limits.go:72 ignoring series with N labels for {…}; either reduce the number of labels for this metric or increase -maxLabelsPerTimeseries=40 cmd-line flag value`, where N is 60–135 for amd64 series (containing all NFD `feature_node_kubernetes_io_*`, Talos `extensions_talos_dev_*`, NVIDIA `nvidia_com_*`, and `beta_kubernetes_io_*` labels propagated by the chart's default `labelmap __meta_kubernetes_node_label_(.+)` rule). raspi series carry ~33 labels and pass under VictoriaMetrics' default `-maxLabelsPerTimeseries=40`, which is why only the 2 raspi nodes were ever visible.
+
+This is not the canonical Case 1, 2, or 3 the plan enumerates — closest is Case 1 (a relabel-rule fix) but with a different rule than the plan suggested. **Fix applied:** added a 4th `metricRelabelConfigs` `labeldrop` rule under `kubelet.vmScrape.spec` in `apps/victoria-metrics/values.yaml` that strips `feature_node_kubernetes_io_.*|extensions_talos_dev_.*|nvidia_com_.*|beta_kubernetes_io_.*` before metrics are remoteWritten to vmsingle. The chart's default labelmap is preserved, so useful node labels (`tier`, `zone`, `kubernetes_io_arch`, `node`, `instance`, `accelerator`, `igpu`) still attach. The override applies to all four kubelet-derived scrapes (cadvisor, resources, probes, kubelet itself) since the chart's `kubelet.vmScrape.spec` is shared — intentional, the same root cause was visible for `/metrics/resource` series in vmsingle's drop logs.
+
+For Phase 5 soak visibility, a new **Secure Agent Pod — Operating** Grafana dashboard was added (`apps/grafana-alerting/manifests/secure-agent-pod-dashboard-cm.yaml`, mounted via `apps/victoria-metrics/values.yaml`'s `extraConfigmapMounts`). It pins three panels in a new `secure-agent-pod` folder: vk-local working-set RSS time series (with 3 GiB / 6 GiB thresholds matching the 8 GiB cgroup limit), a cumulative-restart stat panel, and a last-terminated-reason table. Verification (Task 2 Step 2) and 24 h soak (Task 3 Step 1) happen post-merge once ArgoCD syncs and the dashboard provisions. To be appended to the Verification Log on completion.
+
+**Operational gotcha for `frank-gotchas.md`** (apply during Phase 7): VictoriaMetrics' default `-maxLabelsPerTimeseries=40` silently drops entire series (logs at `timeserieslimits/timeseries_limits.go:72` only, no impact on vmagent target health). Frank's amd64 nodes (NFD CPU features + Talos extension labels + NVIDIA driver labels) produce 60–135 labels per series when the kubelet `VMNodeScrape` chart default `labelmap __meta_kubernetes_node_label_(.+)` runs, so they always exceed the threshold. Counter-fix: drop high-cardinality node-meta labels in `metricRelabelConfigs` rather than bumping `-maxLabelsPerTimeseries`. Bumping the limit just kicks the cardinality bomb downstream into vmsingle storage.
 
 ### Phase 1 — `kubectl top` unavailable (2026-04-30)
 


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
📐 Spec:   docs/superpowers/specs/2026-04-30--agents--vk-local-oom-remediation-design.md
🎯 Phase:  2/7 — Fix cadvisor metric pipeline for 5 nodes [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/153

**Goal (from plan):** Stop `vk-local` from OOMKilling under normal usage and put the cluster in a position to ratchet the memory limit back down once configurable safeguards land. Specifically: verify the already-shipped 8 Gi limit bump (PR #142), restore the cadvisor metric pipeline for 5 affected nodes, ship npm-cache + worktree-prune housekeeping in agent-images, add a `max_concurrent_executions` cap to the vibe-kanban fork, and file B2/B3/regression as tracking issues.

---

## Summary

Phase 2 fix: `container_memory_working_set_bytes` and other kubelet-derived series were missing in vmsingle for the 5 amd64 nodes (`mini-1`, `mini-2`, `mini-3`, `gpu-1`, `pc-1`). vmagent reported targets healthy with non-zero `lastSamplesScraped`, so the loss was downstream of the parser.

**Root cause** (deviates from the plan's Case 1 hypothesis — the `(id|name)` labeldrop was a red herring): the chart's default `relabelConfigs` includes `labelmap __meta_kubernetes_node_label_(.+)`, which copies every node label (NFD CPU feature labels, Talos extension labels, NVIDIA driver labels, `beta_kubernetes_io_*`) onto every scraped series. amd64 nodes carry 60–135 labels per series — well past VictoriaMetrics' default `-maxLabelsPerTimeseries=40`, so vmsingle silently rejects them at ingest with `timeserieslimits/timeseries_limits.go:72 ignoring series with N labels`. raspi nodes carry ~33 labels and slip under the threshold, which is why only the 2 arm64 nodes were ever visible.

**Fix.** Add a 4th `metricRelabelConfigs` `labeldrop` under `kubelet.vmScrape.spec` in `apps/victoria-metrics/values.yaml` that strips:

- `feature_node_kubernetes_io_.*`
- `extensions_talos_dev_.*`
- `nvidia_com_.*`
- `beta_kubernetes_io_.*`

The chart's labelmap is preserved, so the labels actually used in queries (`tier`, `zone`, `kubernetes_io_arch`, `node`, `instance`, `accelerator`, `igpu`) keep flowing. The chart's `kubelet.vmScrape.spec` is shared across all kubelet-derived scrapes (cadvisor, resources, probes, kubelet), so this also fixes the `/metrics/resource` drops that show up in the same vmsingle log — same root cause.

**UI for Phase 5 soak.** New `Secure Agent Pod — Operating` Grafana dashboard (`apps/grafana-alerting/manifests/secure-agent-pod-dashboard-cm.yaml`, mounted from `apps/victoria-metrics/values.yaml`'s `extraConfigmapMounts`) provisioned in a new `secure-agent-pod` folder. Three panels: vk-local working-set RSS (3 GiB / 6 GiB thresholds against the 8 GiB cgroup limit), cumulative restart count, last-terminated-reason table.

## Changes

- `apps/victoria-metrics/values.yaml`
  - Add `kubelet.vmScrape.spec.metricRelabelConfigs` override (preserves the 3 chart-default rules, adds the 4th labeldrop)
  - Mount the new `grafana-secure-agent-pod-dashboard` ConfigMap into Grafana via `extraConfigmapMounts`
- `apps/grafana-alerting/manifests/secure-agent-pod-dashboard-cm.yaml` *(new)*
  - Provider config + dashboard JSON
- `docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md`
  - Tick Task 1 / Steps 1–4
  - Tick Task 2 / Steps 1 (apply), 3 (Grafana panel)
  - Mark Task 4 fallback as skipped (root cause was isolated)
  - Add a Phase 2 entry to **Deployment Deviations** explaining why the canonical Case 1/2/3 framing didn't fit, and seed the gotcha for Phase 7 (`frank-gotchas.md`)

## Plan checkbox status (Phase 2)

- [x] Task 1 / Steps 1–4 — root cause isolated to vmsingle's `-maxLabelsPerTimeseries=40` default, *not* the `(id|name)` labeldrop.
- [x] Task 2 / Step 1 — fix applied (relabel-rule, but a different rule than the plan suggested).
- [ ] Task 2 / Step 2 — verify post-merge once ArgoCD syncs.
- [x] Task 2 / Step 3 — Grafana dashboard added.
- [ ] Task 3 / Step 1 — 24 h soak; will land in the Verification Log after the soak window.
- [-] Task 4 / Step 1 — skipped (root cause was isolated; no need to defer Phase 2).

## Test plan

The verification step (Task 2 / Step 2) cannot run pre-merge because the change is GitOps-applied. Once this PR lands and ArgoCD syncs `victoria-metrics` and `grafana-alerting`:

- [ ] Wait one scrape interval (~30 s) plus the vmsingle ingest path (~1 min total). Then:
  ```bash
  kubectl -n monitoring exec deploy/vmsingle-victoria-metrics-victoria-metrics-k8s-stack -- \
    wget -qO- 'http://127.0.0.1:8428/api/v1/query?query=count(container_memory_working_set_bytes)by(node)' \
    | python3 -m json.tool
  ```
  All 7 nodes (`mini-1/2/3`, `gpu-1`, `pc-1`, `raspi-1/2`) must appear with non-zero counts. If any node still has 0, re-check vmsingle logs for `timeserieslimits` warnings — there may be additional non-kubelet scrapes that need the same trim.
- [ ] Confirm the new Grafana dashboard appears under the `secure-agent-pod` folder at <https://grafana.frank.derio.net/dashboards>. The vk-local working-set RSS panel should plot a line for the live `secure-agent-pod` pod within ~1 minute.
- [ ] After 24 h, re-query the count. Series count must remain non-zero for all 7 nodes continuously. Append the result to the plan's Verification Log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
