### PR TITLE
[derio-net/frank] orch--ruflo-pod · Phase 3/6 · First-deploy validation

### DIFF
--- a/.github/workflows/agent-images-bump.yml
+++ b/.github/workflows/agent-images-bump.yml
@@ -51,6 +51,16 @@ jobs:
           sed -i "s|ghcr.io/derio-net/vk-local:[a-f0-9]\+|ghcr.io/derio-net/vk-local:$AI_SHA|g" \
             apps/secure-agent-pod/manifests/deployment.yaml
 
+          # paperclip-shell + ruflo-server + ruflo-shell ride the same agent-images
+          # SHA (CI builds them all from the same commit). Bump them in lockstep
+          # so the orch pods stay in sync with the secure-agent kali sidecar.
+          for f in apps/paperclip/manifests/deployment.yaml apps/ruflo/manifests/deployment.yaml; do
+            [ -f "$f" ] || continue
+            sed -i "s|ghcr.io/derio-net/paperclip-shell:[a-f0-9]\+|ghcr.io/derio-net/paperclip-shell:$AI_SHA|g" "$f"
+            sed -i "s|ghcr.io/derio-net/ruflo-server:[a-f0-9]\+|ghcr.io/derio-net/ruflo-server:$AI_SHA|g" "$f"
+            sed -i "s|ghcr.io/derio-net/ruflo-shell:[a-f0-9]\+|ghcr.io/derio-net/ruflo-shell:$AI_SHA|g" "$f"
+          done
+
           if [ -n "$VKR_SHA" ]; then
             sed -i "s|ghcr.io/derio-net/vk-remote:[a-f0-9]\+|ghcr.io/derio-net/vk-remote:$VKR_SHA|g" \
               apps/vk-remote/manifests/deployment.yaml

--- a/apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml
+++ b/apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml
@@ -281,27 +281,27 @@ data:
           provider: !KeyOf provider-tekton-cluster
           meta_launch_url: https://tekton.cluster.derio.net
 
-        # VK Remote (cluster) proxy provider
-        - model: authentik_providers_proxy.proxyprovider
-          state: present
-          identifiers:
-            name: VK Remote (cluster)
-          id: provider-vk-remote-cluster
-          attrs:
-            authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
-            authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
-            invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
-            mode: forward_single
-            external_host: https://vk.cluster.derio.net
+      # VK Remote (cluster) proxy provider
+      - model: authentik_providers_proxy.proxyprovider
+        state: present
+        identifiers:
+          name: VK Remote (cluster)
+        id: provider-vk-remote-cluster
+        attrs:
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          invalidation_flow: !Find [authentik_flows.flow, [slug, default-provider-invalidation-flow]]
+          mode: forward_single
+          external_host: https://vk.cluster.derio.net
 
-        - model: authentik_core.application
-          state: present
-          identifiers:
-            slug: vk-remote-cluster
-          attrs:
-            name: VK Remote (cluster)
-            provider: !KeyOf provider-vk-remote-cluster
-            meta_launch_url: https://vk.cluster.derio.net
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: vk-remote-cluster
+        attrs:
+          name: VK Remote (cluster)
+          provider: !KeyOf provider-vk-remote-cluster
+          meta_launch_url: https://vk.cluster.derio.net
 
       # Ruflo (cluster) proxy provider
       - model: authentik_providers_proxy.proxyprovider

--- a/apps/ruflo/manifests/deployment.yaml
+++ b/apps/ruflo/manifests/deployment.yaml
@@ -3,11 +3,19 @@
 # workspace and shell-home PVCs are RWO and a rolling update would
 # deadlock waiting for the mount to release (see frank-gotchas.md).
 #
-# Image SHAs reference agent-images PR derio-net/agent-images#48
-# (merge SHA 7960ed111ba504c6523ac18e75e033574bff6d63). At the time this
-# manifest was written, that PR's merge had not yet propagated to
-# agent-images main and the images had not been published to GHCR. Phase
-# 1 cleanup must land before this Deployment can reconcile to Healthy.
+# Image SHAs reference agent-images main commit
+# 8af0d0800905487dfdb1716218d64bc1f915aecc (merge of derio-net/agent-images#53,
+# tail of the four-PR fix chain that recovered Phase 1's images:
+#   #50 — re-land of PR #48 (the original Phase 1 squash-merged onto the wrong
+#         branch and never reached main, leaving its images unbuilt)
+#   #51 — fix the COPY paths (upstream tree has src/ruvocal under an extra
+#         leading `ruflo/` dir, not at the repo root)
+#   #52 — sed-patch upstream's ChatWindow.svelte IIFE that vite-plugin-svelte
+#         rejects with js_parse_error
+#   #53 — chown /app to UID 1000 (ruvocal mkdirs /app/db at startup) and
+#         re-introduce paperclip-shell's install -d for /var/log/cont-init.d
+#         + /var/lib/ruflo-shell that ruflo-shell's fork-from-paperclip lost
+# See plan Deployment Notes for the full trace.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -65,7 +73,7 @@ spec:
       containers:
         # ----- ruvocal (the multi-agent web server) ------------------
         - name: ruflo
-          image: ghcr.io/derio-net/ruflo-server:7960ed111ba504c6523ac18e75e033574bff6d63
+          image: ghcr.io/derio-net/ruflo-server:8af0d0800905487dfdb1716218d64bc1f915aecc
           imagePullPolicy: IfNotPresent
           ports:
             - { name: http, containerPort: 3000, protocol: TCP }
@@ -119,7 +127,7 @@ spec:
 
         # ----- ruflo-shell (interactive maintainer sidecar) ----------
         - name: ruflo-shell
-          image: ghcr.io/derio-net/ruflo-shell:7960ed111ba504c6523ac18e75e033574bff6d63
+          image: ghcr.io/derio-net/ruflo-shell:8af0d0800905487dfdb1716218d64bc1f915aecc
           imagePullPolicy: IfNotPresent
           ports:
             - { name: ssh,         containerPort: 2222,  protocol: TCP }

--- a/docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md
+++ b/docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md
@@ -223,7 +223,7 @@ docker network rm ruflo-test-net
 
 - [x] **Step 1: Open PR titled `feat: add ruflo-server and ruflo-shell images`** with body linking to this plan. Wait for CI green on both images' smoke tests.
 
-- [ ] **Step 2: Capture both merged image SHAs** — record in this plan's *Deployment Notes* as:
+- [x] **Step 2: Capture both merged image SHAs** — record in this plan's *Deployment Notes* as:
 
 ```
 agent-images SHA: <sha>
@@ -637,9 +637,9 @@ END apps/ruflo/manifests/deployment.yaml
 
 ### Task 12: Open frank PR
 
-- [ ] **Step 1: Open PR titled `feat(orch): add ruflo pod (manifests, ruflo-db sub-app, ingress, Authentik)`** with body linking to this plan and the spec. Note: the inventory ConfigMap is empty — Phase 4 populates it; the Authentik outpost provider assignment is a manual op in Phase 3.
+- [x] **Step 1: Open PR titled `feat(orch): add ruflo pod (manifests, ruflo-db sub-app, ingress, Authentik)`** with body linking to this plan and the spec. Note: the inventory ConfigMap is empty — Phase 4 populates it; the Authentik outpost provider assignment is a manual op in Phase 3.
 
-- [ ] **Step 2: Wait for ArgoCD auto-sync after merge**
+- [x] **Step 2: Wait for ArgoCD auto-sync after merge**
 
 ```bash
 kubectl -n argocd get application ruflo-db -o jsonpath='{.status.sync.status} {.status.health.status}{"\n"}'
@@ -1075,3 +1075,4 @@ Confirms each canonical step happened or was rationally skipped.
 | 2026-05-02 | P2.T7 | **Image SHAs pinned to `7960ed111ba504c6523ac18e75e033574bff6d63`** (agent-images PR #48 merge commit). Image not yet on GHCR — see P1.T6 cleanup row. The Deployment will not reach Healthy until the agent-images cleanup re-merges the work onto `main` and CI rebuilds. |
 | 2026-05-02 | P2.T7 | `LITELLM_BASE_URL=http://litellm.litellm.svc:4000` is set explicitly on **both** the ruflo container and the ruflo-shell container `env:` (per the P1 review TODO). The shell's `/etc/profile.d/60-ruflo-shell-banner.sh` drop-in only fires for login shells; container env covers non-login non-interactive paths (`ssh … -- claude`). |
 | 2026-05-02 | P2.T9 | IngressRoute appended to `apps/traefik/manifests/ingressroutes.yaml`; Authentik proxy provider + application appended to `apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml`. The manual outpost-provider assignment (per `frank-argocd.md`) is captured below as a fresh `# manual-operation` block — it must run after the blueprint syncs into Authentik. |
+| 2026-05-03 | P3 | **Phase 1 cleanup landed via four-PR fix chain in `derio-net/agent-images`.** PR #48's squash-merge had `baseRefName=feat/paperclip-shell` (operator opened the PR against the wrong base while paperclip-shell was still in flight) — the merge commit `7960ed1…` landed on that source branch and was never on main. ghcr's `ruflo-server` / `ruflo-shell` packages did not exist. Recovery: PR #50 (re-land of #48 unchanged: `git cherry-pick 7960ed1`) → CI surfaced four latent bugs in the original Phase 1 work → PR #51 (correct upstream COPY paths from `/src/ruflo/src/ruvocal/` to `/src/ruflo/ruflo/src/ruvocal/` — extra leading `ruflo/` dir was already noted as a path quirk in P1.T2 above but the Dockerfile still used the wrong form) → PR #52 (sed-patch upstream's `ChatWindow.svelte` IIFE `let x = $derived<T>(() => {...}())` which vite-plugin-svelte 5.0.3 rejects with `js_parse_error`; converts to `$derived.by<T>(...)`) → PR #53 (chown `/app` to UID 1000 in ruflo-server runtime stage so ruvocal's `Database.init` can mkdir `/app/db` on startup; re-introduce paperclip-shell's `install -d -o ${AGENT_UID}` for `/var/log/cont-init.d` + `/var/lib/ruflo-shell` in ruflo-shell — that line was lost when ruflo-shell forked from paperclip-shell). Final agent-images main SHA: `8af0d0800905487dfdb1716218d64bc1f915aecc`. Frank deployment.yaml SHAs bumped from the orphan `7960ed1…` to this. Comment block at the top of `apps/ruflo/manifests/deployment.yaml` records the chain. |


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md
📐 Spec:   docs/superpowers/specs/2026-05-02--orch--ruflo-pod-design.md
🎯 Phase:  3/6 — First-deploy validation [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/184

**Goal (from plan):** Deploy `ruflo` (the rebrand of ruvnet's `claude-flow`) as a 24/7 multi-agent orchestration pod on Frank, with the ruvocal web UI exposed at `https://ruflo.cluster.derio.net` behind Authentik forward-auth, an SSH+Mosh shell sidecar at `192.168.55.222`, and zero direct frontier-LLM provider keys (all traffic through the in-cluster LiteLLM gateway and OpenRouter).

---

## What this PR actually is

Phase 3 is "first-deploy validation" — confirm the pod is healthy, run through eight validation tasks, then ship. **In practice it became a recovery effort** because Phase 1's images had never reached GHCR. This PR lands the Frank-side fixes that the four-PR recovery chain in `derio-net/agent-images` requires, plus a pre-existing Authentik blueprint bug that surfaced once I started looking at Task 3 readiness.

## The recovery chain

Phase 1's [agent-images PR #48](https://github.com/derio-net/agent-images/pull/48) was opened with `baseRefName: feat/paperclip-shell` instead of `main` — the squash-merge commit `7960ed1…` landed on the source branch and was never on main. Build CI (push-to-main only) never ran, no images reached GHCR, and the ruflo pod has been in `ImagePullBackOff` since Phase 2 manifests merged. Recovery, all in `derio-net/agent-images`:

| PR  | Fix |
|-----|-----|
| [#50](https://github.com/derio-net/agent-images/pull/50) | Re-land of #48 unchanged (`git cherry-pick 7960ed1` onto a fresh branch off main). |
| [#51](https://github.com/derio-net/agent-images/pull/51) | Correct upstream COPY paths from `/src/ruflo/src/ruvocal/` to `/src/ruflo/ruflo/src/ruvocal/`. The extra leading `ruflo/` was already noted as a path quirk in plan Deployment Notes (P1.T2 row) but the Dockerfile still used the wrong form. CI surfaced it. |
| [#52](https://github.com/derio-net/agent-images/pull/52) | sed-patch upstream's `ChatWindow.svelte:434` IIFE `let x = $derived<T>(() => {...}())` which vite-plugin-svelte 5.0.3 rejects with `js_parse_error`. Convert to `$derived.by<T>(...)`. |
| [#53](https://github.com/derio-net/agent-images/pull/53) | `chown /app` to UID 1000 (ruvocal's `Database.init` `mkdir`s `/app/db` unconditionally on startup); re-introduce paperclip-shell's `install -d` for `/var/log/cont-init.d` + `/var/lib/ruflo-shell` that ruflo-shell's fork-from-paperclip lost. |

Final agent-images SHA `8af0d0800905487dfdb1716218d64bc1f915aecc` — both `ruflo-server` and `ruflo-shell` are now public on GHCR with that tag.

## Frank-side changes (this PR)

* **`apps/ruflo/manifests/deployment.yaml`** — bump both image SHAs from the orphan `7960ed1…` to `8af0d08…`. Comment block updated to record the recovery trace.

* **`apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml`** — fix indentation on the VK Remote (cluster) block. Lines 284–304 had 8-space indent vs the rest of the file's 6-space, which broke YAML parsing with `expected <block end>, but found '-'`. The Authentik worker has been logging this on every blueprint discovery cycle since 2026-04-12 — three weeks of silently-failing blueprint applies. paperclip's earlier providers exist only because they were applied *before* the malformed VK Remote block landed. Phase 3 Task 3 (manual outpost-provider assignment for ruflo) needs the blueprint to apply cleanly first.

* **`.github/workflows/agent-images-bump.yml`** — extend the auto-bump workflow to also bump `paperclip-shell`, `ruflo-server`, and `ruflo-shell` SHAs in `apps/paperclip/` and `apps/ruflo/` deployment manifests. Same agent-images SHA gates all four images; lockstep-bumping prevents drift.

* **`docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md`** — tick the three stale Phase 2 checkboxes that PR #191 left un-ticked (P1.T6.S2, P2.T12.S1, P2.T12.S2 — the corresponding work all shipped); add a Phase-3 Deployment Notes row recording the four-PR fix chain.

## Two follow-up gotchas observed (not fixed in this PR — different problems)

1. `apps/authentik-extras/manifests/blueprints-agent-auth.yaml:33` has `redirect_uris: ""` (empty string), which Authentik 2026.x rejects ("Expected a list of items but got type 'str'."). Pre-existing; unrelated to ruflo. Worth a fix-up PR.
2. The "Build agent images" CI workflow is `push: branches: [main]`-only with no PR-level validation. Combined with non-default-base PRs being silently mergeable, this is how Phase 1 broke in the first place. Worth either adding a PR-level smoke build, or adding a guard that fails the merge if `baseRefName != main`.

## Phase 3 validation status

Validation will run after this PR merges and ArgoCD syncs the new SHAs. Tasks 1–8 from the plan map to:

- **Task 1: ruflo-db Postgres health** — already verified (DB pod has been Running for 7h).
- **Task 2: ruflo pod-level health** — gated on this PR.
- **Task 3: Authentik outpost provider assignment** — gated on the blueprint YAML fix syncing into Authentik (manual Django ORM step ready to run).
- **Task 4: Web UI loads through Authentik SSO** — gated on Tasks 2 + 3.
- **Task 5: SSH connectivity from operator laptop** — gated on Task 2 *and* the SSH-keys SOPS bootstrap (operator-only manual op, plan-documented in `secrets/ruflo/README.md`).
- **Task 6: MOTD shows last-reconcile summary** — gated on Task 5.
- **Task 7: Telegram alert path (induced failure)** — gated on Task 5.
- **Task 8: Zero direct frontier-LLM keys** — gated on Task 2; trivially verified once pod is up.

I'll comment with the validation results after ArgoCD reconciles.

## Test plan

- [ ] After merge: `kubectl get app ruflo -n argocd` → `Synced/Healthy`.
- [ ] `kubectl get pods -n ruflo-system` → both containers `Ready`.
- [ ] Authentik blueprint discovery applies cleanly (no parse errors in worker logs).
- [ ] `Ruflo (cluster)` proxy provider exists; manual ORM step adds it to the embedded outpost.
- [ ] Curl `https://ruflo.cluster.derio.net/` returns 302 to Authentik.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #184