### PR TITLE
fix(ruflo): drop shareProcessNamespace — incompatible with agent-shell-base s6 init

### DIFF
--- a/apps/ruflo/manifests/deployment.yaml
+++ b/apps/ruflo/manifests/deployment.yaml
@@ -46,9 +46,14 @@ spec:
         zone: core
       securityContext:
         fsGroup: 1000
-      # Both containers share PID namespace so the shell sidecar can
-      # observe ruvocal's process tree (useful for debugging).
-      shareProcessNamespace: true
+      # NOTE: `shareProcessNamespace: true` was in the original plan (so the
+      # shell sidecar could `ps -ef` ruvocal's tree), but it's incompatible
+      # with the agent-shell-base s6-overlay v3 init under `runAsNonRoot`:
+      # `s6-overlay-suexec: fatal: can only run as pid 1`. With the shared
+      # namespace the second container's entrypoint is not pid 1, so s6
+      # bails before any service starts. We trade the cross-container `ps`
+      # for a working sshd; the shell still gets full visibility into
+      # `/workspace` (the actual debugging surface) via the shared PVC.
 
       volumes:
         - name: workspace


### PR DESCRIPTION
## Summary

Follow-up to #195. After the image SHA bump landed and the new pod started pulling cleanly, the ruflo-shell sidecar failed at startup with:

\`\`\`
s6-overlay-suexec: fatal: can only run as pid 1
\`\`\`

agent-shell-base's s6-overlay v3 init is designed to run as pid 1 in non-root mode. With \`shareProcessNamespace: true\`, the second container's entrypoint inherits whatever pid is next after the first container's init — so s6-overlay-suexec sees \`getpid() != 1\` and bails before any service (sshd, supercronic) starts.

The plan's "useful for debugging" rationale doesn't survive contact with reality. Drop the share. The shell sidecar still has full visibility into \`/workspace\` (the actual debugging surface) via the shared PVC.

Phase 3 plan Task 2 Step 2 (\"Confirm shareProcessNamespace works\") is now obsolete — the validation comment on #195 will note that.

## Test plan

- [ ] After merge: \`kubectl get pods -n ruflo-system\` → ruflo pod \`2/2 Running\`.
- [ ] \`kubectl logs deploy/ruflo -c ruflo-shell\` → s6-overlay services up (sshd, supercronic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)