### PR TITLE
[derio-net/frank] orch--paperclip-shell-sidecar · Phase 2/6 · Frank manifests for sidecar

### DIFF
--- a/apps/paperclip/client-setup/laptop/README.md
+++ b/apps/paperclip/client-setup/laptop/README.md
@@ -1,0 +1,40 @@
+# Paperclip — Client Setup
+
+Operator-side configs for connecting to the **paperclip-shell** sidecar at `192.168.55.221`.
+
+The sidecar is co-located with the upstream Paperclip web UI in a single Pod (see `../../manifests/deployment.yaml`). The upstream `paperclip` container is unmodified; the `paperclip-shell` container is a separate sidecar based on `agent-shell-base` that adds SSH+Mosh, a persistent home PVC, and a declarative install-on-boot inventory.
+
+Cluster-side manifests live in `../../manifests/`. This directory captures everything *outside* the cluster you need to actually use the pod day-to-day.
+
+```
+client-setup/laptop/
+├── ssh-config.snippet  → append to ~/.ssh/config
+├── mosh-wrapper.sh     → e.g. ~/bin/paperclip-mosh, made executable
+└── README.md           ← this file
+```
+
+## SSH
+
+```bash
+cat ssh-config.snippet >> ~/.ssh/config       # then edit the IdentityFile path
+ssh paperclip                                 # uses the Host alias above
+```
+
+## Mosh
+
+```bash
+install -m 0755 mosh-wrapper.sh ~/bin/paperclip-mosh
+paperclip-mosh                                # opens a mosh session into the sidecar
+```
+
+The wrapper pins mosh-server to UDP 60000–60015 — the same range the LoadBalancer Service publishes. The default range (60000–61000) would wander outside the published ports and the session would silently fail to handshake.
+
+## SSH key rotation
+
+Public keys live in the `paperclip-shell-ssh-keys` Secret, mounted read-only into the container at `/etc/ssh-keys`. SOPS-bootstrap pattern — see `secrets/paperclip/README.md` for the rotation procedure. (ESO via Infisical was on the original plan; we mirror the existing SOPS pattern used by `secure-agent-pod`'s `agent-ssh-keys` and `ruflo-shell-ssh-keys` instead.)
+
+## Architecture context
+
+Unlike `secure-agent-pod`, which splits SSH and mosh across two LB IPs (192.168.55.215 + 192.168.55.219), `paperclip-shell` consolidates both onto a single LB IP (192.168.55.221). Same shape as `ruflo-shell` (192.168.55.222).
+
+The sidecar shares the Paperclip data PVC at `/paperclip` (read-write), so the operator can inspect or surgically edit Paperclip's persistent state from the shell. It does **not** share a process namespace with the `paperclip` container — `shareProcessNamespace: true` is incompatible with the `agent-shell-base` s6-overlay v3 init under `runAsNonRoot` (see deployment.yaml comment block for the trace).

--- a/apps/paperclip/client-setup/laptop/mosh-wrapper.sh
+++ b/apps/paperclip/client-setup/laptop/mosh-wrapper.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Mosh into the paperclip-shell sidecar.
+#
+# Why a wrapper:
+#   - mosh-server picks one UDP port from a *fixed range* at session start.
+#     We pin that range to 60000–60015 to match the LoadBalancer Service
+#     (apps/paperclip/manifests/service-shell.yaml). Default 60000–61000
+#     would wander outside the published range and the session would
+#     never reach the client.
+#   - Single LB IP for paperclip-shell (TCP/22 + UDP 60000–60015), like
+#     ruflo-shell. So mosh's positional argument doubles as the SSH host:
+#     192.168.55.221.
+set -euo pipefail
+exec mosh \
+    --server="mosh-server new -p 60000:60015" \
+    --ssh="ssh agent@192.168.55.221" \
+    "$@" \
+    192.168.55.221

--- a/apps/paperclip/client-setup/laptop/ssh-config.snippet
+++ b/apps/paperclip/client-setup/laptop/ssh-config.snippet
@@ -1,0 +1,16 @@
+# Append to ~/.ssh/config (or include from a modular ~/.ssh/config.d/).
+# Substitute the IdentityFile path for the private key whose public half
+# is mounted into the paperclip-shell container via the
+# paperclip-shell-ssh-keys Secret (see secrets/paperclip/README.md
+# for rotation).
+
+Host paperclip
+    HostName 192.168.55.221
+    Port 22
+    User agent
+    IdentityFile ~/.ssh/<your_private_key>
+    # The container's SSH host key is regenerated per-pod-restart-without-PVC.
+    # We bind to the home PVC, so it's stable across restarts; on the rare
+    # PVC-rebuild event you may need to clear the old known_hosts entry.
+    UserKnownHostsFile ~/.ssh/known_hosts
+    StrictHostKeyChecking accept-new

--- a/apps/paperclip/manifests/configmap-shell-inventory.yaml
+++ b/apps/paperclip/manifests/configmap-shell-inventory.yaml
@@ -1,0 +1,26 @@
+# Layer-2 inventory for the paperclip-shell sidecar.
+# `cont-init.d` reconciles this against installed tools at boot, then
+# again whenever the operator runs `paperclip-shell-reconcile`.
+#
+# Phase 4 of the orch--paperclip-shell-sidecar plan populates these
+# arrays with the operator's expected toolset. For the initial deploy
+# we ship empty arrays so the reconcile is a no-op and the pod boots
+# cleanly.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: paperclip-shell-inventory
+  namespace: paperclip-system
+data:
+  inventory.yaml: |
+    # Layer-2 declarations — installed at boot via cont-init.d.
+    # See docs/superpowers/specs/2026-05-02--orch--paperclip-shell-sidecar-design.md
+    mise: []
+    npm-global: []
+    pipx: []
+    cargo: []
+    removed:
+      mise: []
+      npm-global: []
+      pipx: []
+      cargo: []

--- a/apps/paperclip/manifests/deployment.yaml
+++ b/apps/paperclip/manifests/deployment.yaml
@@ -20,10 +20,22 @@ spec:
         app.kubernetes.io/name: paperclip
         app.kubernetes.io/component: server
     spec:
+      # cont-finish.d (s6 shutdown) saves the shell sidecar's tmux state
+      # and similar housekeeping. Mirrors secure-agent-pod / ruflo grace.
+      terminationGracePeriodSeconds: 45
       nodeSelector:
         zone: core
       securityContext:
         fsGroup: 1000
+      # NOTE: `shareProcessNamespace: true` was in the original Phase 2 plan
+      # so the shell sidecar could `ps -ef` paperclip's tree, but it's
+      # incompatible with the agent-shell-base s6-overlay v3 init under
+      # `runAsNonRoot`: `s6-overlay-suexec: fatal: can only run as pid 1`.
+      # With the shared namespace the second container's entrypoint is not
+      # pid 1, so s6 bails before any service starts. Same trade-off ruflo
+      # made (see PR #196): we forgo the cross-container `ps` for a working
+      # sshd; the shell still gets full visibility into `/paperclip` (the
+      # actual debugging surface) via the shared PVC.
       containers:
         - name: paperclip
           # Upstream public image. Pinned by digest-equivalent sha tag.
@@ -78,7 +90,99 @@ spec:
               port: http
             initialDelaySeconds: 30
             periodSeconds: 15
+
+        # ----- paperclip-shell (interactive maintainer sidecar) ------
+        # Operator's SSH+Mosh entry point. Independent home PVC keeps
+        # mise/cargo/pipx state across pod restarts. The cont-init.d
+        # inventory installer reconciles the operator's declared toolset
+        # against the home PVC at boot. Image SHA pinned to agent-images
+        # main HEAD (8af0d08) — see plan Deployment Notes.
+        - name: paperclip-shell
+          image: ghcr.io/derio-net/paperclip-shell:8af0d0800905487dfdb1716218d64bc1f915aecc
+          imagePullPolicy: IfNotPresent
+          ports:
+            - { name: ssh,         containerPort: 2222,  protocol: TCP }
+            - { name: mosh-60000,  containerPort: 60000, protocol: UDP }
+            - { name: mosh-60001,  containerPort: 60001, protocol: UDP }
+            - { name: mosh-60002,  containerPort: 60002, protocol: UDP }
+            - { name: mosh-60003,  containerPort: 60003, protocol: UDP }
+            - { name: mosh-60004,  containerPort: 60004, protocol: UDP }
+            - { name: mosh-60005,  containerPort: 60005, protocol: UDP }
+            - { name: mosh-60006,  containerPort: 60006, protocol: UDP }
+            - { name: mosh-60007,  containerPort: 60007, protocol: UDP }
+            - { name: mosh-60008,  containerPort: 60008, protocol: UDP }
+            - { name: mosh-60009,  containerPort: 60009, protocol: UDP }
+            - { name: mosh-60010,  containerPort: 60010, protocol: UDP }
+            - { name: mosh-60011,  containerPort: 60011, protocol: UDP }
+            - { name: mosh-60012,  containerPort: 60012, protocol: UDP }
+            - { name: mosh-60013,  containerPort: 60013, protocol: UDP }
+            - { name: mosh-60014,  containerPort: 60014, protocol: UDP }
+            - { name: mosh-60015,  containerPort: 60015, protocol: UDP }
+          env:
+            # Consumed by the s6 cont-init.d scripts in paperclip-shell
+            # (agent-images/paperclip-shell/rootfs/etc/cont-init.d/) to
+            # set the user the sshd serves. Default in the image is
+            # `agent`; we set it explicitly so the deployment is the
+            # source of truth if the image default ever changes.
+            - name: PAPERCLIP_SHELL_USER
+              value: "agent"
+            # 1h (vs upstream 168h default) — see service-shell.yaml
+            # for the 16-port-range coupling rationale.
+            - name: MOSH_SERVER_NETWORK_TMOUT
+              value: "3600"
+          envFrom:
+            # Telegram bot creds for notify-telegram.sh. `optional: true`
+            # per frank-gotchas.md: an ESO sync hiccup would otherwise
+            # CreateContainerConfigError instead of letting the shell
+            # boot without alerts. The notify helper is fail-silent if
+            # the env vars are missing.
+            - secretRef:
+                name: paperclip-shell-alerts
+                optional: true
+          volumeMounts:
+            - { name: shell-home,      mountPath: /home/agent }
+            - { name: data,            mountPath: /paperclip }
+            - { name: shell-ssh-keys,  mountPath: /etc/ssh-keys, readOnly: true }
+            - { name: shell-inventory, mountPath: /etc/paperclip-shell, readOnly: true }
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: "4"
+              memory: 8Gi
+          readinessProbe:
+            tcpSocket: { port: ssh }
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          livenessProbe:
+            tcpSocket: { port: ssh }
+            initialDelaySeconds: 30
+            periodSeconds: 60
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: paperclip-data
+        - name: shell-home
+          persistentVolumeClaim:
+            claimName: paperclip-shell-home
+        - name: shell-ssh-keys
+          # SOPS-managed bootstrap secret in secrets/paperclip/. See the
+          # README there for rotation. ESO-via-Infisical was the original
+          # plan, but agent-ssh-keys (the analogous secret on
+          # secure-agent-pod) and ruflo-shell-ssh-keys are SOPS-bootstrap,
+          # so paperclip follows the same pattern.
+          secret:
+            secretName: paperclip-shell-ssh-keys
+            optional: true
+            defaultMode: 0400
+        - name: shell-inventory
+          configMap:
+            name: paperclip-shell-inventory

--- a/apps/paperclip/manifests/externalsecret-shell-alerts.yaml
+++ b/apps/paperclip/manifests/externalsecret-shell-alerts.yaml
@@ -1,0 +1,32 @@
+# Telegram bot credentials for the paperclip-shell sidecar's
+# notify-telegram.sh helper (fired when the cont-init.d inventory
+# installer reports failures). Same Infisical entries the rest of
+# Frank uses for FRANK_C2_* alerting (grafana-alerting, argocd-
+# notifications, ruflo-shell-alerts).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperclip-shell-alerts
+  namespace: paperclip-system
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: paperclip-shell-alerts
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: FRANK_C2_TELEGRAM_BOT_TOKEN
+      remoteRef:
+        key: FRANK_C2_TELEGRAM_BOT_TOKEN
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: FRANK_C2_TELEGRAM_CHAT_ID
+      remoteRef:
+        key: FRANK_C2_TELEGRAM_CHAT_ID
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/apps/paperclip/manifests/pvc-shell-home.yaml
+++ b/apps/paperclip/manifests/pvc-shell-home.yaml
@@ -1,0 +1,15 @@
+# Persistent home dir for the paperclip-shell sidecar (UID 1000).
+# Mirrors secure-agent-pod's agent-home PVC pattern — keeps installed
+# tools, dotfiles, tmux state, mise/pipx caches across pod restarts.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: paperclip-shell-home
+  namespace: paperclip-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 20Gi

--- a/apps/paperclip/manifests/service-shell.yaml
+++ b/apps/paperclip/manifests/service-shell.yaml
@@ -5,11 +5,16 @@
 # any other published Service port range on a different IP.
 #
 # UDP range 60000–60015 matches the secure-agent-pod's mosh range,
-# which is fine: each Service has its own LB IP and each pod its own
-# network namespace, so the per-IP UDP listener does not conflict.
-# (ruflo-shell deliberately picked 60016–60031 to be obviously distinct;
-# paperclip-shell does not need that distinction since the published
-# ports here are the ones from the original Phase 2 plan.)
+# which is fine *only because* each Service has its own LB IP and Cilium
+# DNATs per ingress IP, and each pod has its own network namespace. The
+# per-IP UDP listener does not conflict.
+#
+# Caveat: do not promote any of these mosh ports to `hostPort` later —
+# the moment two pods on the same node both try to bind 60000–60015 on
+# the host network, the overlap with secure-agent-pod becomes a real
+# collision. (ruflo-shell deliberately picked the disjoint range
+# 60016–60031 partly to keep that future option open; paperclip-shell
+# stays on the originally-planned range and accepts the constraint.)
 #
 # 192.168.55.221 confirmed unused across `apps/` and the live cluster.
 #

--- a/apps/paperclip/manifests/service-shell.yaml
+++ b/apps/paperclip/manifests/service-shell.yaml
@@ -1,0 +1,48 @@
+# SSH + Mosh LoadBalancer for the paperclip-shell sidecar.
+# Mirrors the ruflo-shell single-LB-IP shape rather than the
+# secure-agent-pod split-IP shape — both TCP/22 and the mosh UDP
+# range terminate on a single Service, since neither overlaps with
+# any other published Service port range on a different IP.
+#
+# UDP range 60000–60015 matches the secure-agent-pod's mosh range,
+# which is fine: each Service has its own LB IP and each pod its own
+# network namespace, so the per-IP UDP listener does not conflict.
+# (ruflo-shell deliberately picked 60016–60031 to be obviously distinct;
+# paperclip-shell does not need that distinction since the published
+# ports here are the ones from the original Phase 2 plan.)
+#
+# 192.168.55.221 confirmed unused across `apps/` and the live cluster.
+#
+# Client invocation:
+#   mosh --ssh="ssh agent@192.168.55.221" \
+#        --server="mosh-server new -p 60000:60015" 192.168.55.221
+apiVersion: v1
+kind: Service
+metadata:
+  name: paperclip-shell
+  namespace: paperclip-system
+  annotations:
+    lbipam.cilium.io/ips: "192.168.55.221"
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: paperclip
+    app.kubernetes.io/component: server
+  ports:
+    - { name: ssh,         port: 22,    targetPort: 2222,  protocol: TCP }
+    - { name: mosh-60000,  port: 60000, targetPort: 60000, protocol: UDP }
+    - { name: mosh-60001,  port: 60001, targetPort: 60001, protocol: UDP }
+    - { name: mosh-60002,  port: 60002, targetPort: 60002, protocol: UDP }
+    - { name: mosh-60003,  port: 60003, targetPort: 60003, protocol: UDP }
+    - { name: mosh-60004,  port: 60004, targetPort: 60004, protocol: UDP }
+    - { name: mosh-60005,  port: 60005, targetPort: 60005, protocol: UDP }
+    - { name: mosh-60006,  port: 60006, targetPort: 60006, protocol: UDP }
+    - { name: mosh-60007,  port: 60007, targetPort: 60007, protocol: UDP }
+    - { name: mosh-60008,  port: 60008, targetPort: 60008, protocol: UDP }
+    - { name: mosh-60009,  port: 60009, targetPort: 60009, protocol: UDP }
+    - { name: mosh-60010,  port: 60010, targetPort: 60010, protocol: UDP }
+    - { name: mosh-60011,  port: 60011, targetPort: 60011, protocol: UDP }
+    - { name: mosh-60012,  port: 60012, targetPort: 60012, protocol: UDP }
+    - { name: mosh-60013,  port: 60013, targetPort: 60013, protocol: UDP }
+    - { name: mosh-60014,  port: 60014, targetPort: 60014, protocol: UDP }
+    - { name: mosh-60015,  port: 60015, targetPort: 60015, protocol: UDP }

--- a/docs/superpowers/plans/2026-05-02--orch--paperclip-shell-sidecar.md
+++ b/docs/superpowers/plans/2026-05-02--orch--paperclip-shell-sidecar.md
@@ -283,7 +283,7 @@ docker run --rm --user 1000:1000 \
 
 - [x] **Step 1: Open PR titled `feat: add paperclip-shell image`** with body linking to this plan. Wait for CI green.
 
-- [ ] **Step 2: Capture the merged commit SHA** — record in this plan's *Deployment Notes* as `agent-images SHA: <sha>` and corresponding tag `ghcr.io/derio-net/paperclip-shell:<sha>`. Phase 2 references this SHA.
+- [x] **Step 2: Capture the merged commit SHA** — record in this plan's *Deployment Notes* as `agent-images SHA: <sha>` and corresponding tag `ghcr.io/derio-net/paperclip-shell:<sha>`. Phase 2 references this SHA.
 
 ---
 
@@ -295,7 +295,7 @@ All work in this repo (`derio-net/frank`). Adds new resources without modifying 
 
 ### Task 1: Add `paperclip-shell-home` PVC
 
-- [ ] **Step 1: Create `apps/paperclip/manifests/pvc-shell-home.yaml`**
+- [x] **Step 1: Create `apps/paperclip/manifests/pvc-shell-home.yaml`**
 
 ```
 BEGIN apps/paperclip/manifests/pvc-shell-home.yaml
@@ -315,7 +315,7 @@ END apps/paperclip/manifests/pvc-shell-home.yaml
 
 ### Task 2: Add the inventory ConfigMap (initially empty)
 
-- [ ] **Step 1: Create `apps/paperclip/manifests/configmap-shell-inventory.yaml`**
+- [x] **Step 1: Create `apps/paperclip/manifests/configmap-shell-inventory.yaml`**
 
   Start with empty arrays — Phase 4 populates them. This proves the installer is wired up and idempotent before any tools are declared:
 
@@ -344,7 +344,7 @@ END apps/paperclip/manifests/configmap-shell-inventory.yaml
 
 ### Task 3: Add ExternalSecrets
 
-- [ ] **Step 1: Read existing `agent-ssh-keys` ESO definition** to mirror its shape
+- [x] **Step 1: Read existing `agent-ssh-keys` ESO definition** to mirror its shape
 
 ```bash
 ls apps/secure-agent-pod/manifests/ | grep -i 'externalsecret\|ssh-key'
@@ -353,7 +353,7 @@ cat apps/secure-agent-pod/manifests/externalsecret-github-token.yaml | head -40 
 
   Capture: `secretStoreRef`, Infisical project / path, the exact `dataFrom` or `data:` shape that produces `agent-ssh-keys`.
 
-- [ ] **Step 2: Audit existing Telegram-credentials wiring**
+- [x] **Step 2: Audit existing Telegram-credentials wiring**
 
 ```bash
 grep -rE 'FRANK_C2_TELEGRAM_BOT_TOKEN|FRANK_C2_TELEGRAM_CHAT_ID' apps/ secrets/ 2>/dev/null
@@ -361,13 +361,13 @@ grep -rE 'FRANK_C2_TELEGRAM_BOT_TOKEN|FRANK_C2_TELEGRAM_CHAT_ID' apps/ secrets/ 
 
   Decision: if a Secret containing both values already exists in another namespace, replicate the ESO (one ESO per namespace, same Infisical source). If not, create one specifically for `paperclip-system`.
 
-- [ ] **Step 3: Create `apps/paperclip/manifests/externalsecret-shell-ssh-keys.yaml`** mirroring the discovered shape; produces Secret `paperclip-shell-ssh-keys` from the same Infisical entries as `agent-ssh-keys`.
+- [x] **Step 3: Create `apps/paperclip/manifests/externalsecret-shell-ssh-keys.yaml`** mirroring the discovered shape; produces Secret `paperclip-shell-ssh-keys` from the same Infisical entries as `agent-ssh-keys`.
 
-- [ ] **Step 4: Create `apps/paperclip/manifests/externalsecret-shell-alerts.yaml`** producing Secret `paperclip-shell-alerts` with `FRANK_C2_TELEGRAM_BOT_TOKEN` + `FRANK_C2_TELEGRAM_CHAT_ID`.
+- [x] **Step 4: Create `apps/paperclip/manifests/externalsecret-shell-alerts.yaml`** producing Secret `paperclip-shell-alerts` with `FRANK_C2_TELEGRAM_BOT_TOKEN` + `FRANK_C2_TELEGRAM_CHAT_ID`.
 
 ### Task 4: Add the LoadBalancer Service
 
-- [ ] **Step 1: Confirm `192.168.55.221` is free**
+- [x] **Step 1: Confirm `192.168.55.221` is free**
 
 ```bash
 kubectl get svc -A -o jsonpath='{range .items[*]}{.status.loadBalancer.ingress[0].ip}{"\n"}{end}' \
@@ -375,7 +375,7 @@ kubectl get svc -A -o jsonpath='{range .items[*]}{.status.loadBalancer.ingress[0
   || echo "192.168.55.221 is free"
 ```
 
-- [ ] **Step 2: Create `apps/paperclip/manifests/service-shell.yaml`**
+- [x] **Step 2: Create `apps/paperclip/manifests/service-shell.yaml`**
 
 ```
 BEGIN apps/paperclip/manifests/service-shell.yaml
@@ -414,7 +414,7 @@ END apps/paperclip/manifests/service-shell.yaml
 
 ### Task 5: Update `deployment.yaml` to add the sidecar
 
-- [ ] **Step 1: Investigate the upstream paperclip container's UID**
+- [x] **Step 1: Investigate the upstream paperclip container's UID**
 
 ```bash
 docker run --rm --entrypoint id ghcr.io/paperclipai/paperclip:sha-3494e84
@@ -423,7 +423,7 @@ docker run --rm --entrypoint id ghcr.io/paperclipai/paperclip:sha-3494e84
 
   If the value is not `1000`, decide between option (a) `initContainer` chowning `/paperclip` to `fsGroup: 1000`, or (b) overriding `paperclip` container's `securityContext.runAsUser: 1000`. Document the decision inline in this plan's *Deployment Notes* section.
 
-- [ ] **Step 2: Edit `apps/paperclip/manifests/deployment.yaml`** — add `shareProcessNamespace: true` at pod-spec level, add the sidecar container, add the new volumes. Use `Edit` (not `Write`) on the existing file.
+- [x] **Step 2: Edit `apps/paperclip/manifests/deployment.yaml`** — add `shareProcessNamespace: true` at pod-spec level, add the sidecar container, add the new volumes. Use `Edit` (not `Write`) on the existing file.
 
   Sidecar container fragment:
 
@@ -479,7 +479,7 @@ docker run --rm --entrypoint id ghcr.io/paperclipai/paperclip:sha-3494e84
 
 ### Task 6: Add operator client-setup files
 
-- [ ] **Step 1: Create `apps/paperclip/client-setup/laptop/`** mirroring `apps/secure-agent-pod/client-setup/laptop/`:
+- [x] **Step 1: Create `apps/paperclip/client-setup/laptop/`** mirroring `apps/secure-agent-pod/client-setup/laptop/`:
 
   - `ssh-config.snippet` — `Host paperclip-shell` block with `HostName 192.168.55.221`, `Port 22`, `User agent`, `IdentityFile ~/.ssh/<your_key>`.
   - `mosh-wrapper.sh` — invokes `mosh --server="mosh-server new -p 60000:60015" agent@192.168.55.221`.
@@ -776,3 +776,9 @@ This is a fix/extension plan, so most post-deploy steps are absorbed into Phase 
 | 2026-05-02 | Phase 1 | Deviation from plan: `install-inventory.sh` uses `mise where "$tool"` rather than the plan's `mise ls "$tool" \| grep`. `mise where` returns 0 when a matching version family is installed (incl. when the operator did `mise install python@3.12.4` interactively and the inventory says `python@3.12`); `mise ls` would require parsing. Cleaner idempotency + closer to mise's intended public API. |
 | 2026-05-02 | Phase 1 | Deviation from plan: investigation evidence was that `agent-shell-base` ships **no** `/etc/profile.d/` additions and **no** PAM motd configuration today (`sshd_config` L7 sets `UsePAM no`; `etc/skel/` only contains `.tmux.conf`). `paperclip-shell` is the first image in this lineage to add either, so there is no inherited motd convention to reuse — the `/etc/profile.d/50-paperclip-shell-motd.sh` decision is the new convention for now. |
 | 2026-05-02 | Phase 1 | Post-review corrections (commit `64e5a42`, agent-images PR #46): pre-create `/var/log/cont-init.d` and `/var/lib/paperclip-shell` owned by AGENT_UID at image-build time (without this the installer's `tee` + MOTD write fail silently under K8s `cap-drop=ALL` / `runAsUser: 1000`); drop dead `RUSTUP_HOME=/usr/local/lib/rustup` in favour of per-user `~/.rustup` initialisation; harden `run()` rc capture; switch `cargo install --list` parsing to a whitespace-strip pipeline; drop trailing blank line in Telegram body via `printf` instead of HEREDOC. |
+| 2026-05-03 | Phase 1 | P1.T4.S2 — agent-images PR #46 merged (merge commit `146b7a6`); current `main` HEAD is `8af0d0800905487dfdb1716218d64bc1f915aecc` (also tagged `latest`). Phase 2 pins `ghcr.io/derio-net/paperclip-shell:8af0d0800905487dfdb1716218d64bc1f915aecc`. |
+| 2026-05-03 | Phase 2 | Deviation from plan: dropped `shareProcessNamespace: true` from the Pod spec. The plan assumed it would let the shell sidecar `ps -ef` paperclip's tree, but it's incompatible with `agent-shell-base` s6-overlay v3 init under `runAsNonRoot` (`s6-overlay-suexec: fatal: can only run as pid 1`). Sibling `ruflo` discovered the same in PR #196 — paperclip-shell follows that resolution. The shell still has full visibility into `/paperclip` (the actual debugging surface) via the shared PVC. |
+| 2026-05-03 | Phase 2 | Deviation from plan: P2.T3 SSH-keys ESO rewritten as a SOPS-bootstrap Secret in `secrets/paperclip/` (mirrors `secrets/ruflo/` and `secrets/secure-agent-pod/`). The plan's premise — that `agent-ssh-keys` is ESO-managed and we should mirror it — turned out to be wrong: `agent-ssh-keys` is a manually-applied SOPS Secret with no ExternalSecret backing it. Following the existing convention rather than introducing a one-off Infisical entry just for this Secret. The Telegram-alerts Secret (`paperclip-shell-alerts`) remains a real ESO since the `FRANK_C2_TELEGRAM_*` Infisical entries are already used by `grafana-alerting` and `ruflo-shell-alerts`. |
+| 2026-05-03 | Phase 2 | Deviation from plan: kept the existing `data` volume name on the Deployment (reused by both the upstream paperclip container and the sidecar at `/paperclip`) rather than renaming to `paperclip-data`. Volume name in pod spec is purely an alias for the PVC `paperclip-data`; renaming would have churned the upstream container's mount unnecessarily. |
+| 2026-05-03 | Phase 2 | Deviation from plan: P2.T5.S1 paperclip-container UID investigation skipped at write-time. The pod already sets `fsGroup: 1000` (pre-existing), so the shared `/paperclip` PVC is group-writable by group 1000, and the sidecar's `runAsUser: 1000` falls within that group. No initContainer chown needed; no override of the upstream paperclip container. Phase 3 will validate this empirically (Phase 3 Task 1 Step 3). |
+| 2026-05-03 | Phase 2 | Added `terminationGracePeriodSeconds: 45` to the Pod spec to give the shell sidecar's `cont-finish.d` (s6 shutdown) hooks time to drain tmux state, mirroring `ruflo`. |

--- a/docs/superpowers/plans/2026-05-02--orch--paperclip-shell-sidecar.md
+++ b/docs/superpowers/plans/2026-05-02--orch--paperclip-shell-sidecar.md
@@ -504,6 +504,15 @@ kubectl -n argocd get application paperclip -o jsonpath='{.status.sync.status} {
 
 Confirms the sidecar deploys cleanly, paperclip is unaffected, and the alerting path works end-to-end.
 
+### Task 0: Pre-flight (manual, before anything else)
+
+- [ ] **Step 1: Apply the SOPS-encrypted ssh-keys Secret** — without this, sshd is up but rejects every login (the `paperclip-shell-ssh-keys` Secret volume is `optional: true` so the pod *boots*, but `authorized_keys` is empty). See `secrets/paperclip/README.md` for the bootstrap procedure. After applying, verify:
+
+```bash
+kubectl -n paperclip-system get secret paperclip-shell-ssh-keys -o jsonpath='{.data.authorized_keys}' | base64 -d
+# expect: at least one ssh public key
+```
+
 ### Task 1: Pod-level health
 
 - [ ] **Step 1: Confirm both containers Ready**
@@ -514,12 +523,7 @@ kubectl -n paperclip-system get pod -l app.kubernetes.io/name=paperclip \
 # expect both 'paperclip' and 'paperclip-shell' with ready=true
 ```
 
-- [ ] **Step 2: Confirm shareProcessNamespace works**
-
-```bash
-kubectl -n paperclip-system exec -c paperclip-shell deploy/paperclip -- ps -ef | grep -E 'paperclip|node|sshd'
-# expect to see paperclip's process(es) AND sshd in the output
-```
+- [-] **Step 2: ~~Confirm shareProcessNamespace works~~** *(obsolete — Phase 2 dropped `shareProcessNamespace: true` per the agent-shell-base / s6-overlay v3 incompatibility under `runAsNonRoot`; see Deployment Notes 2026-05-03 row. Cross-container `ps` is no longer expected to work; the actual debugging surface is the shared `/paperclip` PVC, validated in Step 3.)*
 
 - [ ] **Step 3: Confirm `/paperclip` is shared and writable from both containers**
 

--- a/secrets/paperclip/README.md
+++ b/secrets/paperclip/README.md
@@ -1,0 +1,38 @@
+# SOPS-encrypted bootstrap secrets for paperclip
+
+Apply with: `sops --decrypt <file> | kubectl apply -f -`
+
+Currently this directory holds:
+
+- `paperclip-shell-ssh-keys.yaml` *(to be created on first deploy — see below)* — Secret in `paperclip-system` mounted read-only into the `paperclip-shell` container at `/etc/ssh-keys`. Same shape as `secrets/secure-agent-pod/`'s `agent-ssh-keys` and `secrets/ruflo/`'s `ruflo-shell-ssh-keys`.
+
+## Why SOPS not ESO
+
+The original Phase 2 plan called for an `ExternalSecret` reading SSH public keys from Infisical. Frank's existing pattern for SSH host/user keys is SOPS-bootstrap — `secure-agent-pod`'s `agent-ssh-keys` is a SOPS Secret applied out-of-band, and the sibling `ruflo` work picked up the same convention (`secrets/ruflo/`). We mirror that pattern here so the Deployment can reference a stable Secret name without bootstrapping ESO state.
+
+## On first deploy
+
+```bash
+# 1. Generate a fresh keypair on your laptop (or reuse the one already
+#    paired with secure-agent-pod / ruflo so a single private key opens
+#    every shell sidecar).
+ssh-keygen -t ed25519 -f ~/.ssh/paperclip -C "operator@paperclip"
+
+# 2. Build a Secret manifest
+kubectl create secret generic paperclip-shell-ssh-keys \
+  --namespace=paperclip-system \
+  --from-file=authorized_keys=<(cat ~/.ssh/paperclip.pub) \
+  --dry-run=client -o yaml > /tmp/paperclip-shell-ssh-keys.yaml
+
+# 3. SOPS-encrypt + commit. `sops --encrypt` resolves recipients from
+#    the repo-root .sops.yaml `path_regex` rules — no need to plumb the
+#    age key by hand.
+mv /tmp/paperclip-shell-ssh-keys.yaml secrets/paperclip/paperclip-shell-ssh-keys.yaml
+sops --encrypt --in-place secrets/paperclip/paperclip-shell-ssh-keys.yaml
+git add secrets/paperclip/paperclip-shell-ssh-keys.yaml
+
+# 4. Apply once (subsequent rotations: re-encrypt + re-apply)
+sops --decrypt secrets/paperclip/paperclip-shell-ssh-keys.yaml | kubectl apply -f -
+```
+
+The Deployment (`apps/paperclip/manifests/deployment.yaml`) marks the volume `optional: true`, so the pod still boots if the Secret is missing — sshd just won't accept any keys until the bootstrap runs.


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-02--orch--paperclip-shell-sidecar.md
📐 Spec:   docs/superpowers/specs/2026-05-02--orch--paperclip-shell-sidecar-design.md
🎯 Phase:  2/6 — Frank manifests for sidecar [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/176

**Goal (from plan):** Add an SSH-able shell sidecar (`paperclip-shell`) to the `paperclip` pod, with a persistent home PVC, declarative software inventory, and fail-open Telegram alerting on install failure. Keep the upstream Paperclip container completely unmodified.

---

## Summary

Adds the Frank-side manifests for the `paperclip-shell` sidecar. The upstream `paperclip` container is unchanged — it runs alongside a new sidecar container based on `agent-shell-base` that exposes SSH (TCP/22) and Mosh (UDP 60000–60015) on a single LoadBalancer IP `192.168.55.221`.

### New resources

- `apps/paperclip/manifests/pvc-shell-home.yaml` — 20Gi RWO Longhorn home PVC for the sidecar's `/home/agent` (mise/cargo/pipx state survives restarts).
- `apps/paperclip/manifests/configmap-shell-inventory.yaml` — Layer-2 install inventory; ships empty so the cont-init.d reconciler is a no-op on first deploy. Phase 4 populates it.
- `apps/paperclip/manifests/externalsecret-shell-alerts.yaml` — `paperclip-shell-alerts` Secret produced from the existing `FRANK_C2_TELEGRAM_*` Infisical entries (same source `grafana-alerting` and `ruflo-shell-alerts` use).
- `apps/paperclip/manifests/service-shell.yaml` — Cilium L2 LB on `192.168.55.221`, TCP/22 + UDP 60000–60015.
- `apps/paperclip/client-setup/laptop/{ssh-config.snippet,mosh-wrapper.sh,README.md}` — operator-side SSH config and a Mosh wrapper that pins the UDP range to match the Service.
- `secrets/paperclip/README.md` — bootstrap procedure for the SOPS-managed `paperclip-shell-ssh-keys` Secret.

### Modified

- `apps/paperclip/manifests/deployment.yaml` — adds the `paperclip-shell` sidecar container (image pinned to `ghcr.io/derio-net/paperclip-shell:8af0d08…`, the agent-images main HEAD from Phase 1), three new volumes (`shell-home`, `shell-ssh-keys`, `shell-inventory`), and `terminationGracePeriodSeconds: 45` for s6 shutdown grace.

### Plan deviations (recorded inline in the plan)

- **No `shareProcessNamespace: true`.** Incompatible with `agent-shell-base` s6-overlay v3 init under `runAsNonRoot` (`s6-overlay-suexec: fatal: can only run as pid 1`). Sibling `ruflo` discovered the same in PR #196; we follow that resolution. The shell still has the actual debugging surface — `/paperclip` — via the shared PVC.
- **SSH keys via SOPS bootstrap, not ESO.** The plan assumed `agent-ssh-keys` is ESO-managed; it isn't. Mirrors the existing convention used by `secrets/ruflo/` and `secrets/secure-agent-pod/`. The Telegram-alerts Secret remains a real ESO since the source Infisical entries already exist cluster-wide.
- **`data` volume name retained.** Plan called it `paperclip-data` (the PVC name); we kept the existing alias `data` to minimize churn on the upstream container's mount.
- **No initContainer chown for `/paperclip`.** The pod's pre-existing `fsGroup: 1000` plus the sidecar's `runAsUser: 1000` means the shared PVC is already group-writable by both containers. Phase 3 will validate empirically.

## Test plan

Manifests-only PR. ArgoCD auto-syncs after merge; Phase 3 (issue #177) handles end-to-end validation. Pre-merge sanity:

- [x] `kubectl --dry-run=client apply -f apps/paperclip/manifests/{pvc-shell-home,configmap-shell-inventory,externalsecret-shell-alerts,service-shell,deployment}.yaml` — clean.
- [ ] After merge: `kubectl -n argocd get application paperclip` — `Synced Healthy`.
- [ ] After merge: confirm `paperclip` web UI on `192.168.55.212:3100` is unaffected (regression check).
- [ ] Phase 3 covers SSH/Mosh connectivity, MOTD plumbing, and induced-failure Telegram alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)