### PR TITLE
fix(ruflo): persist /app/db RVF state + record Phase 3 manual ops

### DIFF
--- a/apps/ruflo/manifests/deployment.yaml
+++ b/apps/ruflo/manifests/deployment.yaml
@@ -59,6 +59,12 @@ spec:
         - name: workspace
           persistentVolumeClaim:
             claimName: ruflo-workspace
+        # /app/db is where ruvocal writes its file-based RVF JSON store
+        # (hives, runs, settings, conversations). Without persistence the
+        # state is on overlay fs and is lost on every pod restart.
+        - name: data
+          persistentVolumeClaim:
+            claimName: ruflo-data
         - name: shell-home
           persistentVolumeClaim:
             claimName: ruflo-shell-home
@@ -112,6 +118,9 @@ spec:
                 optional: true
           volumeMounts:
             - { name: workspace, mountPath: /workspace }
+            # ruvocal writes /app/db/ruvocal.rvf.json (and any future
+            # RVF files) on every state mutation. Mount the data PVC there.
+            - { name: data,      mountPath: /app/db   }
           resources:
             requests:
               cpu: 500m

--- a/apps/ruflo/manifests/pvc-data.yaml
+++ b/apps/ruflo/manifests/pvc-data.yaml
@@ -1,0 +1,22 @@
+# ruvocal's persistent state (hives, runs, settings, conversations).
+# At the upstream SHA pinned in Phase 1, ruvocal uses a file-based JSON store
+# at `/app/db/ruvocal.rvf.json` (the "RVF" format), not the Postgres database
+# that the plan's Phase 1 deviation note assumed. The `ruflo-db` Bitnami
+# postgresql sub-app is currently provisioned but unused — kept around in case
+# a future re-vendor of upstream switches to Postgres (the plan's Phase 1.T2
+# deviation row had it the right way but for the wrong file).
+#
+# 5Gi is plenty: each hive+run record is small JSON; 50Gi (matching workspace)
+# would be wasteful. Bump if the operator hits it.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ruflo-data
+  namespace: ruflo-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -505,27 +505,7 @@ operations:
   - kubectl create namespace argocd
   - helm repo add argo https://argoproj.github.io/argo-helm
   - helm install argocd argo/argo-cd --version 9.4.6 --namespace argocd -f clusters/hop/apps/argocd/values.yaml
-  - |
-    kubectl apply -f - <<'EOF'
-    apiVersion: argoproj.io/v1alpha1
-    kind: Application
-    metadata:
-      name: root
-      namespace: argocd
-    spec:
-      project: default
-      source:
-        repoURL: https://github.com/derio-net/frank.git
-        targetRevision: main
-        path: clusters/hop/apps/root
-      destination:
-        server: https://kubernetes.default.svc
-        namespace: argocd
-      syncPolicy:
-        automated:
-          prune: false
-          selfHeal: true
-    EOF
+  - "kubectl apply -f - <<'EOF'\napiVersion: argoproj.io/v1alpha1\nkind: Application\nmetadata:\n  name: root\n  namespace: argocd\nspec:\n  project: default\n  source:\n    repoURL: https://github.com/derio-net/frank.git\n    targetRevision: main\n    path: clusters/hop/apps/root\n  destination:\n    server: https://kubernetes.default.svc\n    namespace: argocd\n  syncPolicy:\n    automated:\n      prune: false\n      selfHeal: true\nEOF\n"
   verify:
   - 'kubectl -n argocd get pods  # all pods Running'
   - 'kubectl -n argocd get app root  # should show Synced/Healthy'
@@ -538,17 +518,7 @@ operations:
   when: Before Caddy deployment — needs Cloudflare API token
   why_manual: SOPS-encrypted secret applied out-of-band
   commands:
-  - |
-    cat <<'EOF' > /tmp/caddy-cloudflare.yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: caddy-cloudflare
-      namespace: caddy-system
-    type: Opaque
-    stringData:
-      api-token: "<CLOUDFLARE_API_TOKEN_WITH_DNS_EDIT>"
-    EOF
+  - "cat <<'EOF' > /tmp/caddy-cloudflare.yaml\napiVersion: v1\nkind: Secret\nmetadata:\n  name: caddy-cloudflare\n  namespace: caddy-system\ntype: Opaque\nstringData:\n  api-token: \"<CLOUDFLARE_API_TOKEN_WITH_DNS_EDIT>\"\nEOF\n"
   - sops --encrypt --age <AGE_PUBLIC_KEY> /tmp/caddy-cloudflare.yaml > secrets/hop/caddy-cloudflare.yaml
   - sops --decrypt secrets/hop/caddy-cloudflare.yaml | kubectl --kubeconfig <HOP_KUBECONFIG> apply -f -
   - rm /tmp/caddy-cloudflare.yaml
@@ -614,21 +584,7 @@ operations:
   why_manual: SOPS-encrypted secrets must be applied before the workloads start
   commands:
   - mkdir -p secrets/hop
-  - |
-    # Caddy Cloudflare API token (for ACME DNS challenge)
-    cat <<'EOF' > /tmp/caddy-cloudflare.yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: caddy-cloudflare
-      namespace: caddy-system
-    type: Opaque
-    stringData:
-      api-token: "<CLOUDFLARE_API_TOKEN>"
-    EOF
-    sops --encrypt --age <AGE_PUBLIC_KEY> /tmp/caddy-cloudflare.yaml > secrets/hop/caddy-cloudflare.yaml
-    sops --decrypt secrets/hop/caddy-cloudflare.yaml | kubectl --kubeconfig <HOP_KUBECONFIG> apply -f -
-    rm /tmp/caddy-cloudflare.yaml
+  - "# Caddy Cloudflare API token (for ACME DNS challenge)\ncat <<'EOF' > /tmp/caddy-cloudflare.yaml\napiVersion: v1\nkind: Secret\nmetadata:\n  name: caddy-cloudflare\n  namespace: caddy-system\ntype: Opaque\nstringData:\n  api-token: \"<CLOUDFLARE_API_TOKEN>\"\nEOF\nsops --encrypt --age <AGE_PUBLIC_KEY> /tmp/caddy-cloudflare.yaml > secrets/hop/caddy-cloudflare.yaml\nsops --decrypt secrets/hop/caddy-cloudflare.yaml | kubectl --kubeconfig <HOP_KUBECONFIG> apply -f -\nrm /tmp/caddy-cloudflare.yaml\n"
   verify:
   - kubectl --kubeconfig <HOP_KUBECONFIG> -n caddy-system get secret caddy-cloudflare
   status: pending
@@ -639,23 +595,7 @@ operations:
   when: After hop-1 is registered in Omni and hop-data volume is attached
   why_manual: Requires Omni machine config patch with actual Hetzner Volume device ID
   commands:
-  - |
-    # First, format the volume (one-time via Talos machine config disk partition)
-    # Then mount it using kubelet extraMounts so pods can access it
-    cat <<'EOF' > /tmp/hop-volume-patch.yaml
-    machine:
-      disks:
-        - device: /dev/disk/by-id/scsi-0HC_Volume_<VOLUME_ID>
-          partitions:
-            - mountpoint: /var/mnt/hop-data
-              size: 0
-      kubelet:
-        extraMounts:
-          - destination: /var/mnt/hop-data
-            type: bind
-            source: /var/mnt/hop-data
-            options: ["bind", "rshared", "rw"]
-    EOF
+  - "# First, format the volume (one-time via Talos machine config disk partition)\n# Then mount it using kubelet extraMounts so pods can access it\ncat <<'EOF' > /tmp/hop-volume-patch.yaml\nmachine:\n  disks:\n    - device: /dev/disk/by-id/scsi-0HC_Volume_<VOLUME_ID>\n      partitions:\n        - mountpoint: /var/mnt/hop-data\n          size: 0\n  kubelet:\n    extraMounts:\n      - destination: /var/mnt/hop-data\n        type: bind\n        source: /var/mnt/hop-data\n        options: [\"bind\", \"rshared\", \"rw\"]\nEOF\n"
   - 'talosctl apply-config --config-patch @/tmp/hop-volume-patch.yaml  # applied via talosctl, not omnictl'
   verify:
   - talosctl --nodes <HOP_IP> read /proc/mounts | grep hop-data
@@ -790,17 +730,7 @@ operations:
   when: Before Traefik deployment
   why_manual: Bootstrap secret must exist before Traefik starts ACME challenge
   commands:
-  - |
-    cat <<EOF > secrets/traefik-cloudflare-credentials.yaml
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: traefik-cloudflare-credentials
-      namespace: traefik-system
-    type: Opaque
-    stringData:
-      api-token: "<CF_DNS_API_TOKEN value from .env_hop>"
-    EOF
+  - "cat <<EOF > secrets/traefik-cloudflare-credentials.yaml\napiVersion: v1\nkind: Secret\nmetadata:\n  name: traefik-cloudflare-credentials\n  namespace: traefik-system\ntype: Opaque\nstringData:\n  api-token: \"<CF_DNS_API_TOKEN value from .env_hop>\"\nEOF\n"
   - sops --encrypt --in-place secrets/traefik-cloudflare-credentials.yaml
   - kubectl create namespace traefik-system || true
   - sops --decrypt secrets/traefik-cloudflare-credentials.yaml | kubectl apply -f -
@@ -815,47 +745,12 @@ operations:
   why_manual: Grafana alert rules are API-provisioned
   commands:
   - description: List current alert rules to get UIDs
-    command: |
-      curl -s "$GRAFANA_URL/api/v1/provisioning/alert-rules" \
-        -H "Authorization: Bearer $GRAFANA_API_KEY" | \
-        jq '.[] | {uid: .uid, title: .title}'
+    command: "curl -s \"$GRAFANA_URL/api/v1/provisioning/alert-rules\" \\\n  -H \"Authorization: Bearer $GRAFANA_API_KEY\" | \\\n  jq '.[] | {uid: .uid, title: .title}'\n"
   - description: Update each rule to add github_issue label
-    command: |
-      # For each rule, GET the full rule, add the label, PUT back.
-      # Mapping (from M1 issue table):
-      #   exercise-reminder-stale → github_issue=willikins#11
-      #   session-manager-stale → github_issue=willikins#13
-      #   audit-digest-stale → github_issue=willikins#12
-      #   endpoint-down → (per-target, handled by bridge using instance label)
-      #   agent-pod-not-running → github_issue=frank#8
-
-      for RULE_UID in exercise-reminder-stale session-manager-stale audit-digest-stale agent-pod-not-running; do
-        RULE=$(curl -s "$GRAFANA_URL/api/v1/provisioning/alert-rules/$RULE_UID" \
-          -H "Authorization: Bearer $GRAFANA_API_KEY")
-
-        case $RULE_UID in
-          exercise-reminder-stale) ISSUE="willikins#11" ;;
-          session-manager-stale) ISSUE="willikins#13" ;;
-          audit-digest-stale) ISSUE="willikins#12" ;;
-          agent-pod-not-running) ISSUE="frank#8" ;;
-        esac
-
-        UPDATED=$(echo "$RULE" | jq --arg issue "$ISSUE" '.labels.github_issue = $issue')
-
-        curl -s -X PUT "$GRAFANA_URL/api/v1/provisioning/alert-rules/$RULE_UID" \
-          -H "Authorization: Bearer $GRAFANA_API_KEY" \
-          -H "Content-Type: application/json" \
-          -H "X-Disable-Provenance: true" \
-          -d "$UPDATED"
-
-        echo "Updated $RULE_UID → github_issue=$ISSUE"
-      done
+    command: "# For each rule, GET the full rule, add the label, PUT back.\n# Mapping (from M1 issue table):\n#   exercise-reminder-stale → github_issue=willikins#11\n#   session-manager-stale → github_issue=willikins#13\n#   audit-digest-stale → github_issue=willikins#12\n#   endpoint-down → (per-target, handled by bridge using instance label)\n#   agent-pod-not-running → github_issue=frank#8\n\nfor RULE_UID in exercise-reminder-stale session-manager-stale audit-digest-stale agent-pod-not-running; do\n  RULE=$(curl -s \"$GRAFANA_URL/api/v1/provisioning/alert-rules/$RULE_UID\" \\\n    -H \"Authorization: Bearer $GRAFANA_API_KEY\")\n\n  case $RULE_UID in\n    exercise-reminder-stale) ISSUE=\"willikins#11\" ;;\n    session-manager-stale) ISSUE=\"willikins#13\" ;;\n    audit-digest-stale) ISSUE=\"willikins#12\" ;;\n    agent-pod-not-running) ISSUE=\"frank#8\" ;;\n  esac\n\n  UPDATED=$(echo \"$RULE\" | jq --arg issue \"$ISSUE\" '.labels.github_issue = $issue')\n\n  curl -s -X PUT \"$GRAFANA_URL/api/v1/provisioning/alert-rules/$RULE_UID\" \\\n    -H \"Authorization: Bearer $GRAFANA_API_KEY\" \\\n    -H \"Content-Type: application/json\" \\\n    -H \"X-Disable-Provenance: true\" \\\n    -d \"$UPDATED\"\n\n  echo \"Updated $RULE_UID → github_issue=$ISSUE\"\ndone\n"
   verify:
   - description: Verify labels on alert rules
-    command: |
-      curl -s "$GRAFANA_URL/api/v1/provisioning/alert-rules" \
-        -H "Authorization: Bearer $GRAFANA_API_KEY" | \
-        jq '.[] | {title: .title, github_issue: .labels.github_issue}'
+    command: "curl -s \"$GRAFANA_URL/api/v1/provisioning/alert-rules\" \\\n  -H \"Authorization: Bearer $GRAFANA_API_KEY\" | \\\n  jq '.[] | {title: .title, github_issue: .labels.github_issue}'\n"
     expected: Each rule shows its github_issue label
   status: done
 - id: grafana-health-bridge-webhook
@@ -866,30 +761,9 @@ operations:
   why_manual: Grafana provisioning is API-only (not GitOps)
   commands:
   - description: Create webhook contact point
-    command: |
-      GRAFANA_URL="https://grafana.frank.derio.net"
-      GRAFANA_API_KEY="<from Infisical or env>"
-      WEBHOOK_SECRET="<same as HEALTH_BRIDGE_WEBHOOK_SECRET in Infisical>"
-
-      curl -s -X POST "$GRAFANA_URL/api/v1/provisioning/contact-points" \
-        -H "Authorization: Bearer $GRAFANA_API_KEY" \
-        -H "Content-Type: application/json" \
-        -H "X-Disable-Provenance: true" \
-        -d '{
-          "name": "Health Bridge Webhook",
-          "type": "webhook",
-          "settings": {
-            "url": "http://health-bridge.monitoring.svc.cluster.local:8080/webhook",
-            "httpMethod": "POST",
-            "authorization_scheme": "Bearer",
-            "authorization_credentials": "'"$WEBHOOK_SECRET"'"
-          },
-          "disableResolveMessage": false
-        }'
+    command: "GRAFANA_URL=\"https://grafana.frank.derio.net\"\nGRAFANA_API_KEY=\"<from Infisical or env>\"\nWEBHOOK_SECRET=\"<same as HEALTH_BRIDGE_WEBHOOK_SECRET in Infisical>\"\n\ncurl -s -X POST \"$GRAFANA_URL/api/v1/provisioning/contact-points\" \\\n  -H \"Authorization: Bearer $GRAFANA_API_KEY\" \\\n  -H \"Content-Type: application/json\" \\\n  -H \"X-Disable-Provenance: true\" \\\n  -d '{\n    \"name\": \"Health Bridge Webhook\",\n    \"type\": \"webhook\",\n    \"settings\": {\n      \"url\": \"http://health-bridge.monitoring.svc.cluster.local:8080/webhook\",\n      \"httpMethod\": \"POST\",\n      \"authorization_scheme\": \"Bearer\",\n      \"authorization_credentials\": \"'\"$WEBHOOK_SECRET\"'\"\n    },\n    \"disableResolveMessage\": false\n  }'\n"
   - description: Verify contact point was created
-    command: |
-      curl -s "$GRAFANA_URL/api/v1/provisioning/contact-points" \
-        -H "Authorization: Bearer $GRAFANA_API_KEY" | jq '.[] | select(.name == "Health Bridge Webhook")'
+    command: "curl -s \"$GRAFANA_URL/api/v1/provisioning/contact-points\" \\\n  -H \"Authorization: Bearer $GRAFANA_API_KEY\" | jq '.[] | select(.name == \"Health Bridge Webhook\")'\n"
   verify:
   - description: Contact point exists
     command: curl -s "$GRAFANA_URL/api/v1/provisioning/contact-points" -H "Authorization:Bearer $GRAFANA_API_KEY" | jq '.[].name' | grep "Health Bridge"
@@ -917,10 +791,13 @@ operations:
   - description: Generate a webhook secret
     command: openssl rand -hex 32
   - description: Create secret in Infisical
-    command: |
-      Navigate to Infisical UI → derio-net project → prod environment
+    command: 'Navigate to Infisical UI → derio-net project → prod environment
+
       Create secret: HEALTH_BRIDGE_WEBHOOK_SECRET = <generated hex string>
+
       Create secret: HEALTH_BRIDGE_GITHUB_TOKEN = <GitHub PAT with project and repo scope>
+
+      '
   verify:
   - description: Verify secrets exist
     command: kubectl get externalsecret -n monitoring health-bridge-secrets -o jsonpath='{.status.conditions[0].status}'
@@ -933,41 +810,18 @@ operations:
   when: After Task 8 verification confirms file-provisioned resources work
   why_manual: API-provisioned Grafana resources can only be deleted via REST API calls
   commands:
-  - |
-    GRAFANA_AUTH="admin:$(kubectl get secret -n monitoring victoria-metrics-grafana -o jsonpath='{.data.admin-password}' | base64 -d)"
+  - "GRAFANA_AUTH=\"admin:$(kubectl get secret -n monitoring victoria-metrics-grafana -o jsonpath='{.data.admin-password}' | base64 -d)\"\n\n# Delete API-provisioned alert rules (only deletes non-file-provisioned copies)\nfor uid in exercise-reminder-stale session-manager-stale audit-digest-stale endpoint-down agent-pod-not-running; do\n  echo \"Deleting API-provisioned rule: $uid\"\n  curl -sk -u \"$GRAFANA_AUTH\" -X DELETE \\\n    \"https://grafana.frank.derio.net/api/v1/provisioning/alert-rules/$uid\" \\\n    -H \"X-Disable-Provenance: true\"\ndone\n\n# Note: File-provisioned rules with the same UID cannot be deleted via API\n# (Grafana returns 400 for file-provisioned resources). If the DELETE returns\n# 400 \"cannot delete provisioned resource\", the API version was already deleted\n# or never existed separately.\n"
+  - '# Delete the API-provisioned notification policy by resetting to default
 
-    # Delete API-provisioned alert rules (only deletes non-file-provisioned copies)
-    for uid in exercise-reminder-stale session-manager-stale audit-digest-stale endpoint-down agent-pod-not-running; do
-      echo "Deleting API-provisioned rule: $uid"
-      curl -sk -u "$GRAFANA_AUTH" -X DELETE \
-        "https://grafana.frank.derio.net/api/v1/provisioning/alert-rules/$uid" \
-        -H "X-Disable-Provenance: true"
-    done
-
-    # Note: File-provisioned rules with the same UID cannot be deleted via API
-    # (Grafana returns 400 for file-provisioned resources). If the DELETE returns
-    # 400 "cannot delete provisioned resource", the API version was already deleted
-    # or never existed separately.
-  - |
-    # Delete the API-provisioned notification policy by resetting to default
     # File-provisioned policy takes precedence and will be reloaded on next restart
+
     # This step may not be needed if file-provisioning already overrides the API version
+
     echo "Notification policy — file-provisioned version takes precedence, skip manual delete"
-  - |
-    # Delete API-provisioned contact points if they exist as separate objects
-    # Check for duplicates first:
-    curl -sk -u "$GRAFANA_AUTH" \
-      "https://grafana.frank.derio.net/api/v1/provisioning/contact-points" | \
-      python3 -c "import json,sys; cps=json.load(sys.stdin); [print(f'{cp[\"uid\"]}: {cp[\"name\"]} (provenance: {cp.get(\"provenance\",\"none\")})') for cp in cps]"
-    # Delete any with provenance != file (these are the API-provisioned originals)
-  - |
-    # Delete the old API-provisioned Feature Health dashboard (if it exists at root level)
-    # The file-provisioned version lives in the feature-health folder with the same UID
-    # Grafana may have already merged them or the old one may have a different internal ID
-    curl -sk -u "$GRAFANA_AUTH" \
-      "https://grafana.frank.derio.net/api/dashboards/uid/fh-overview" | python3 -m json.tool
-    # If the response shows folderTitle != "feature-health", delete the old one:
-    # curl -sk -u "$GRAFANA_AUTH" -X DELETE "https://grafana.frank.derio.net/api/dashboards/uid/fh-overview"
+
+    '
+  - "# Delete API-provisioned contact points if they exist as separate objects\n# Check for duplicates first:\ncurl -sk -u \"$GRAFANA_AUTH\" \\\n  \"https://grafana.frank.derio.net/api/v1/provisioning/contact-points\" | \\\n  python3 -c \"import json,sys; cps=json.load(sys.stdin); [print(f'{cp[\\\"uid\\\"]}: {cp[\\\"name\\\"]} (provenance: {cp.get(\\\"provenance\\\",\\\"none\\\")})') for cp in cps]\"\n# Delete any with provenance != file (these are the API-provisioned originals)\n"
+  - "# Delete the old API-provisioned Feature Health dashboard (if it exists at root level)\n# The file-provisioned version lives in the feature-health folder with the same UID\n# Grafana may have already merged them or the old one may have a different internal ID\ncurl -sk -u \"$GRAFANA_AUTH\" \\\n  \"https://grafana.frank.derio.net/api/dashboards/uid/fh-overview\" | python3 -m json.tool\n# If the response shows folderTitle != \"feature-health\", delete the old one:\n# curl -sk -u \"$GRAFANA_AUTH\" -X DELETE \"https://grafana.frank.derio.net/api/dashboards/uid/fh-overview\"\n"
   verify:
   - 'curl -sk -u "$GRAFANA_AUTH" "https://grafana.frank.derio.net/api/v1/provisioning/alert-rules" | python3 -c "import json,sys; rules=json.load(sys.stdin); assert all(r.get(\"provenance\")==\"file\" for r in rules), \"Non-file rules still exist\"; print(f\"OK: {len(rules)} rules, all file-provisioned\")"'
   - 'curl -sk -u "$GRAFANA_AUTH" "https://grafana.frank.derio.net/api/v1/provisioning/contact-points" | python3 -c "import json,sys; cps=json.load(sys.stdin); print(f\"Contact points: {len(cps)}\"); [print(f\"  {cp[\"name\"]}: provenance={cp.get(\"provenance\",\"none\")}\") for cp in cps]"'
@@ -1022,11 +876,15 @@ operations:
   verify:
   - docker pull ghcr.io/derio-net/paperclip:v0.3.1
   status: done
-  notes: |
-    OBSOLETE as of 2026-04-30. Paperclip now runs from the upstream public
+  notes: 'OBSOLETE as of 2026-04-30. Paperclip now runs from the upstream public
+
     image (ghcr.io/paperclipai/paperclip:sha-<short>); the derio fork is
+
     no longer built or deployed. Kept as a historical record of how the
+
     fork image was originally produced. Do not run.
+
+    '
 - id: orch-create-infisical-secrets
   layer: orch
   app: paperclip
@@ -1042,18 +900,29 @@ operations:
   - infisical secrets get PAPERCLIP_AUTH_SECRET
   - kubectl get externalsecret -n paperclip-system
   status: done
-  notes: |
-    PARTIALLY OBSOLETE as of 2026-04-30. PAPERCLIP_LITELLM_KEY and
+  notes: 'PARTIALLY OBSOLETE as of 2026-04-30. PAPERCLIP_LITELLM_KEY and
+
     PAPERCLIP_AUTH_SECRET are still required (paperclip-llm-key and
+
     paperclip-auth ExternalSecrets remain in use). The GHCR_PAT line
+
     is obsolete — paperclip now runs from the upstream public image,
+
     no pull credentials needed; the paperclip-ghcr ExternalSecret/Secret
+
     have been deleted from the cluster. The GHCR_PAT entry in Infisical
+
     has no remaining consumer in this repo and can be removed.
+
     A separate (untracked) ANTHROPIC_API_KEY entry was added later for
+
     the paperclip-anthropic ExternalSecret; that ExternalSecret has
+
     also been deleted, so the Infisical entry is also unused by paperclip
+
     (other consumers may still reference it — verify before deleting).
+
+    '
 - id: orch-ruflo-authentik-outpost-assign
   layer: orch
   app: ruflo
@@ -1062,28 +931,45 @@ operations:
   why_manual: Authentik blueprints cannot manage outpost provider assignments without replacing existing assignments — must add via Django ORM
   commands:
   - description: Add Ruflo (cluster) proxy provider to the embedded outpost
-    command: |
-      kubectl exec -n authentik deploy/authentik-server -- python -c "
-      import os; os.environ.setdefault('DJANGO_SETTINGS_MODULE','authentik.root.settings')
+    command: 'kubectl exec -n authentik deploy/authentik-server -- python -c "
+
+      import os; os.environ.setdefault(''DJANGO_SETTINGS_MODULE'',''authentik.root.settings'')
+
       import django; django.setup()
+
       from authentik.providers.proxy.models import ProxyProvider
+
       from authentik.outposts.models import Outpost
-      outpost = Outpost.objects.get(name='authentik Embedded Outpost')
-      provider = ProxyProvider.objects.get(name='Ruflo (cluster)')
+
+      outpost = Outpost.objects.get(name=''authentik Embedded Outpost'')
+
+      provider = ProxyProvider.objects.get(name=''Ruflo (cluster)'')
+
       outpost.providers.add(provider)
-      print(f'Added {provider.name} to {outpost.name}')
+
+      print(f''Added {provider.name} to {outpost.name}'')
+
       "
+
+      '
   verify:
   - description: '''Ruflo (cluster)'' is now in the embedded outpost''s provider list'
-    command: |
-      kubectl exec -n authentik deploy/authentik-server -- python -c "
-      import os; os.environ.setdefault('DJANGO_SETTINGS_MODULE','authentik.root.settings')
+    command: 'kubectl exec -n authentik deploy/authentik-server -- python -c "
+
+      import os; os.environ.setdefault(''DJANGO_SETTINGS_MODULE'',''authentik.root.settings'')
+
       import django; django.setup()
+
       from authentik.outposts.models import Outpost
-      o = Outpost.objects.get(name='authentik Embedded Outpost')
+
+      o = Outpost.objects.get(name=''authentik Embedded Outpost'')
+
       print([p.name for p in o.providers.all()])
-      " | grep -q 'Ruflo (cluster)' && echo OK
-  status: pending
+
+      " | grep -q ''Ruflo (cluster)'' && echo OK
+
+      '
+  status: done
 - id: orch-ruflo-infisical-bootstrap
   layer: orch
   app: ruflo
@@ -1092,23 +978,46 @@ operations:
   why_manual: Infisical entries are not reproducible from git; ESO needs the secret to exist before Phase 2 manifests reference it
   commands:
   - description: Add RUFLO_DB_PASSWORD to Infisical
-    command: |
-      # Via Infisical UI at https://infisical.derio.net or `infisical secrets set`:
+    command: '# Via Infisical UI at https://infisical.derio.net or `infisical secrets set`:
+
       # Path:  /shared (or whichever path apps/ruflo/manifests/externalsecret-db-credentials.yaml references)
+
       # Key:   RUFLO_DB_PASSWORD
+
       # Value: <generated 32+ char random>
+
+      '
   - description: Confirm OPENROUTER_API_KEY is reachable from a ruflo-system path
-    command: |
-      # Either copy the existing entry under /shared, or grant the ruflo-system ServiceAccount
+    command: '# Either copy the existing entry under /shared, or grant the ruflo-system ServiceAccount
+
       # access to the path that hosts it. Check apps/litellm/manifests/externalsecret-*.yaml
+
       # for the reference shape.
+
+      '
   - description: Confirm EMAIL_RESEND_API_KEY is reachable from a ruflo-system path
-    command: |
-      # Same pattern — see apps/paperclip/manifests/external-secret-resend.yaml for reference.
+    command: '# Same pattern — see apps/paperclip/manifests/external-secret-resend.yaml for reference.
+
+      '
   verify:
   - description: All three keys appear in Infisical for the path the ESOs will reference
     command: infisical secrets list --path /shared | grep -E 'RUFLO_DB_PASSWORD|OPENROUTER_API_KEY|EMAIL_RESEND_API_KEY'
   status: pending
+- id: orch-ruflo-litellm-virtual-key
+  layer: orch
+  app: ruflo
+  plan: docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md
+  when: before opening the Phase 3 fix PR that re-points OPENAI_API_KEY at RUFLO_LITELLM_KEY (derio-net/frank#197)
+  why_manual: LiteLLM virtual keys are created via the LiteLLM admin API; the master key isn't reproducible from git, and Infisical entries are operator-side
+  commands:
+  - description: Create a virtual key in LiteLLM scoped to the ruflo namespace
+    command: "# 1. Pull the LiteLLM master key from the cluster (or from Infisical):\nMASTER_KEY=$(kubectl -n litellm get secret litellm-api-keys \\\n  -o jsonpath='{.data.LITELLM_MASTER_KEY}' | base64 -d)\n\n# 2. Call /key/generate. Adjust models/metadata as you like; this\n#    snapshot mirrors paperclip's PAPERCLIP_LITELLM_KEY.\nkubectl -n litellm exec deploy/litellm -- curl -fsS \\\n  -H \"Authorization: Bearer $MASTER_KEY\" \\\n  -H 'Content-Type: application/json' \\\n  -X POST http://localhost:4000/key/generate \\\n  -d '{\"key_alias\": \"ruflo\", \"metadata\": {\"app\": \"ruflo\"}}'\n\n# 3. The response includes `key`: paste it into Infisical at the path\n#    apps/ruflo/manifests/externalsecret-llm.yaml reads\n#    (`/shared` or wherever PAPERCLIP_LITELLM_KEY lives), keyed RUFLO_LITELLM_KEY.\n"
+  verify:
+  - description: ESO has synced the new key into the ruflo-llm Secret
+    command: "kubectl -n ruflo-system get secret ruflo-llm \\\n  -o jsonpath='{.data.OPENAI_API_KEY}' | base64 -d | head -c 4\n# expect: \"sk-c\" or similar — i.e. a LiteLLM virtual key prefix, NOT \"sk-or-\" (OpenRouter)\n"
+  - description: ruvocal can list models through LiteLLM with the key
+    command: "kubectl -n ruflo-system exec deploy/ruflo -c ruflo -- bash -c '\n  curl -fsS -o /dev/null -w \"%{http_code}\\n\" \\\n    -H \"Authorization: Bearer $OPENAI_API_KEY\" $OPENAI_BASE_URL/models'\n# expect: 200\n"
+  status: done
 - id: orch-ruflo-shell-ssh-keys-bootstrap
   layer: orch
   app: ruflo
@@ -1117,35 +1026,32 @@ operations:
   why_manual: 'agent-ssh-keys (the analogous secret on secure-agent-pod) is SOPS-bootstrap, not Infisical-ESO; ruflo follows the same pattern. Operator''s private SSH identity is per-laptop and outside the secret store. The Deployment volume is `optional: true` so the pod boots cleanly even before this op runs — sshd just rejects key-based logins until the Secret exists.'
   commands:
   - description: Build the Secret manifest from the operator's chosen public key (Secret data key MUST be `authorized_keys`)
-    command: |
-      kubectl create secret generic ruflo-shell-ssh-keys \
-        --namespace=ruflo-system \
-        --from-file=authorized_keys="$HOME/.ssh/<your_private_key>.pub" \
-        --dry-run=client -o yaml > secrets/ruflo/ruflo-shell-ssh-keys.yaml
+    command: "kubectl create secret generic ruflo-shell-ssh-keys \\\n  --namespace=ruflo-system \\\n  --from-file=authorized_keys=\"$HOME/.ssh/<your_private_key>.pub\" \\\n  --dry-run=client -o yaml > secrets/ruflo/ruflo-shell-ssh-keys.yaml\n"
   - description: SOPS-encrypt in place (recipients resolve from repo-root .sops.yaml — no flags needed)
-    command: |
-      sops --encrypt --in-place secrets/ruflo/ruflo-shell-ssh-keys.yaml
+    command: 'sops --encrypt --in-place secrets/ruflo/ruflo-shell-ssh-keys.yaml
+
       git add secrets/ruflo/ruflo-shell-ssh-keys.yaml
-  - description: Apply to cluster (decrypts in-memory, never writes plaintext to disk)
-    command: |
-      sops --decrypt secrets/ruflo/ruflo-shell-ssh-keys.yaml | kubectl apply -f -
-  - description: "If the pod is ALREADY RUNNING (initial bootstrap on a live pod, or any subsequent key rotation), re-run the cont-init.d hook by hand. Reason: /etc/cont-init.d/30-authorized-keys only fires at pod boot, and it COPIES (not symlinks) /etc/ssh-keys/authorized_keys into ~agent/.ssh/authorized_keys, so a Secret applied or rotated mid-life never reaches sshd's AuthorizedKeysFile (the default ~/.ssh/authorized_keys). Hand-run is zero-downtime and idempotent. Alternative: kubectl rollout restart deploy/ruflo -n ruflo-system (Recreate strategy → ~30-60s outage)."
-    command: |
-      kubectl exec -n ruflo-system deploy/ruflo -c ruflo-shell -- bash -c '
-        cp /etc/ssh-keys/authorized_keys "${AGENT_HOME:-/home/agent}/.ssh/authorized_keys"
-        chmod 600 "${AGENT_HOME:-/home/agent}/.ssh/authorized_keys"
+
       '
+  - description: Apply to cluster (decrypts in-memory, never writes plaintext to disk)
+    command: 'sops --decrypt secrets/ruflo/ruflo-shell-ssh-keys.yaml | kubectl apply -f -
+
+      '
+  - description: 'If the pod is ALREADY RUNNING (initial bootstrap on a live pod, or any subsequent key rotation), re-run the cont-init.d hook by hand. Reason: /etc/cont-init.d/30-authorized-keys only fires at pod boot, and it COPIES (not symlinks) /etc/ssh-keys/authorized_keys into ~agent/.ssh/authorized_keys, so a Secret applied or rotated mid-life never reaches sshd''s AuthorizedKeysFile (the default ~/.ssh/authorized_keys). Hand-run is zero-downtime and idempotent. Alternative: kubectl rollout restart deploy/ruflo -n ruflo-system (Recreate strategy → ~30-60s outage).'
+    command: "kubectl exec -n ruflo-system deploy/ruflo -c ruflo-shell -- bash -c '\n  cp /etc/ssh-keys/authorized_keys \"${AGENT_HOME:-/home/agent}/.ssh/authorized_keys\"\n  chmod 600 \"${AGENT_HOME:-/home/agent}/.ssh/authorized_keys\"\n'\n"
   verify:
   - description: Secret exists in ruflo-system namespace
     command: kubectl get secret -n ruflo-system ruflo-shell-ssh-keys
-  - description: "kubelet has projected the data into the running ruflo-shell container at /etc/ssh-keys/authorized_keys (the projection itself doesn't need a restart — optional-volume rotates on next kubelet resync, ≤90s)"
+  - description: kubelet has projected the data into the running ruflo-shell container at /etc/ssh-keys/authorized_keys (the projection itself doesn't need a restart — optional-volume rotates on next kubelet resync, ≤90s)
     command: kubectl exec -n ruflo-system deploy/ruflo -c ruflo-shell -- ls /etc/ssh-keys/authorized_keys
   - description: ~agent/.ssh/authorized_keys carries the same content (cont-init.d hook either fired at boot or you re-ran it via the exec-copy command above)
     command: kubectl exec -n ruflo-system deploy/ruflo -c ruflo-shell -- diff /etc/ssh-keys/authorized_keys /home/agent/.ssh/authorized_keys
-  - description: "Operator can SSH in. Note: clear stale host-key entry first if 192.168.55.222 was previously bound to a different pod's host key — StrictHostKeyChecking=accept-new only auto-accepts new hosts, not changed ones."
-    command: |
-      ssh-keygen -R 192.168.55.222 2>/dev/null; ssh-keygen -R "[192.168.55.222]:22" 2>/dev/null
+  - description: 'Operator can SSH in. Note: clear stale host-key entry first if 192.168.55.222 was previously bound to a different pod''s host key — StrictHostKeyChecking=accept-new only auto-accepts new hosts, not changed ones.'
+    command: 'ssh-keygen -R 192.168.55.222 2>/dev/null; ssh-keygen -R "[192.168.55.222]:22" 2>/dev/null
+
       ssh -i ~/.ssh/<your_private_key> -o StrictHostKeyChecking=accept-new agent@192.168.55.222 "hostname"
+
+      '
   status: done
 - id: orch-traefik-paperclip-route
   layer: orch
@@ -1166,19 +1072,7 @@ operations:
   when: After arc-controller and arc-runners apps are synced by ArgoCD, before runner pod reaches Running state
   why_manual: GitHub App credentials are a bootstrap secret. The runner cannot register without it, and SOPS+ArgoCD don't mix per repo convention.
   commands:
-  - |
-    # Create the Secret manifest
-    kubectl create secret generic arc-github-app-secret \
-      --namespace arc-system \
-      --from-literal=github_app_id=<APP_ID> \
-      --from-literal=github_app_installation_id=<INSTALLATION_ID> \
-      --from-literal=github_app_private_key="$(cat path/to/private-key.pem)" \
-      --dry-run=client -o yaml > /tmp/arc-secret.yaml
-    # Encrypt with SOPS (use the same age key as other secrets/)
-    sops --encrypt /tmp/arc-secret.yaml > secrets/arc/github-app-secret.yaml
-    rm /tmp/arc-secret.yaml
-    # Apply to cluster
-    sops --decrypt secrets/arc/github-app-secret.yaml | kubectl apply -f -
+  - "# Create the Secret manifest\nkubectl create secret generic arc-github-app-secret \\\n  --namespace arc-system \\\n  --from-literal=github_app_id=<APP_ID> \\\n  --from-literal=github_app_installation_id=<INSTALLATION_ID> \\\n  --from-literal=github_app_private_key=\"$(cat path/to/private-key.pem)\" \\\n  --dry-run=client -o yaml > /tmp/arc-secret.yaml\n# Encrypt with SOPS (use the same age key as other secrets/)\nsops --encrypt /tmp/arc-secret.yaml > secrets/arc/github-app-secret.yaml\nrm /tmp/arc-secret.yaml\n# Apply to cluster\nsops --decrypt secrets/arc/github-app-secret.yaml | kubectl apply -f -\n"
   verify:
   - kubectl get secret arc-github-app-secret -n arc-system
   - kubectl get pods -n arc-system
@@ -1191,14 +1085,7 @@ operations:
   when: After smoke-test.yaml workflow exists on main branch and has run at least once successfully
   why_manual: Branch protection rules must be configured via GitHub UI or API. The smoke-test/readiness check must be a required status check so Renovate's automerge only fires after tests pass.
   commands:
-  - |
-    # Via GitHub CLI — sets branch protection on main requiring smoke-test/readiness
-    gh api repos/:owner/:repo/branches/main/protection \
-      --method PUT \
-      --field required_status_checks='{"strict":false,"checks":[{"context":"smoke-test/readiness"}]}' \
-      --field enforce_admins=false \
-      --field required_pull_request_reviews=null \
-      --field restrictions=null
+  - "# Via GitHub CLI — sets branch protection on main requiring smoke-test/readiness\ngh api repos/:owner/:repo/branches/main/protection \\\n  --method PUT \\\n  --field required_status_checks='{\"strict\":false,\"checks\":[{\"context\":\"smoke-test/readiness\"}]}' \\\n  --field enforce_admins=false \\\n  --field required_pull_request_reviews=null \\\n  --field restrictions=null\n"
   verify:
   - gh api repos/:owner/:repo/branches/main/protection --jq '.required_status_checks.checks'
   status: pending

--- a/docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md
+++ b/docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md
@@ -275,6 +275,53 @@ status: pending
 - [-] **Step 1: Generate `RUFLO_DB_PASSWORD`** (32+ char random) and add to Infisical under the path the `apps/ruflo/manifests/externalsecret-db-credentials.yaml` ESO will reference. <!-- Manual op — operator action before this PR can deploy. Tracked in Deployment Notes. -->
 - [-] **Step 2: Confirm `OPENROUTER_API_KEY` and `EMAIL_RESEND_API_KEY` are accessible from a `ruflo-system`-permitted Infisical path.** If not, copy the entries under `/shared` (the path used by paperclip's ESOs) or extend ServiceAccount access. <!-- Manual op — operator action before this PR can deploy. Tracked in Deployment Notes. -->
 
+### Task 1b: Provision LiteLLM virtual key for ruflo (manual)
+
+Surfaced during Phase 3 first-deploy validation: `apps/ruflo/manifests/externalsecret-llm.yaml` aliases `OPENAI_API_KEY` to `RUFLO_LITELLM_KEY` (a LiteLLM virtual key scoped to ruflo) — same shape paperclip uses with `PAPERCLIP_LITELLM_KEY`. The earlier alias to `OPENROUTER_API_KEY` produced 401s from LiteLLM because LiteLLM authenticates against its own virtual keys, not the upstream provider key.
+
+```yaml
+# manual-operation
+id: orch-ruflo-litellm-virtual-key
+layer: orch
+app: ruflo
+plan: docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md
+when: before opening the Phase 3 fix PR that re-points OPENAI_API_KEY at RUFLO_LITELLM_KEY (derio-net/frank#197)
+why_manual: LiteLLM virtual keys are created via the LiteLLM admin API; the master key isn't reproducible from git, and Infisical entries are operator-side
+commands:
+  - description: Create a virtual key in LiteLLM scoped to the ruflo namespace
+    command: |
+      # 1. Pull the LiteLLM master key from the cluster (or from Infisical):
+      MASTER_KEY=$(kubectl -n litellm get secret litellm-api-keys \
+        -o jsonpath='{.data.LITELLM_MASTER_KEY}' | base64 -d)
+
+      # 2. Call /key/generate. Adjust models/metadata as you like; this
+      #    snapshot mirrors paperclip's PAPERCLIP_LITELLM_KEY.
+      kubectl -n litellm exec deploy/litellm -- curl -fsS \
+        -H "Authorization: Bearer $MASTER_KEY" \
+        -H 'Content-Type: application/json' \
+        -X POST http://localhost:4000/key/generate \
+        -d '{"key_alias": "ruflo", "metadata": {"app": "ruflo"}}'
+
+      # 3. The response includes `key`: paste it into Infisical at the path
+      #    apps/ruflo/manifests/externalsecret-llm.yaml reads
+      #    (`/shared` or wherever PAPERCLIP_LITELLM_KEY lives), keyed RUFLO_LITELLM_KEY.
+verify:
+  - description: ESO has synced the new key into the ruflo-llm Secret
+    command: |
+      kubectl -n ruflo-system get secret ruflo-llm \
+        -o jsonpath='{.data.OPENAI_API_KEY}' | base64 -d | head -c 4
+      # expect: "sk-c" or similar — i.e. a LiteLLM virtual key prefix, NOT "sk-or-" (OpenRouter)
+  - description: ruvocal can list models through LiteLLM with the key
+    command: |
+      kubectl -n ruflo-system exec deploy/ruflo -c ruflo -- bash -c '
+        curl -fsS -o /dev/null -w "%{http_code}\n" \
+          -H "Authorization: Bearer $OPENAI_API_KEY" $OPENAI_BASE_URL/models'
+      # expect: 200
+status: done   # provisioned 2026-05-03 by operator; ESO + verify both green
+```
+
+- [x] **Step 1: Provision the virtual key** via the LiteLLM admin API and store the returned secret as `RUFLO_LITELLM_KEY` in Infisical. *(Done 2026-05-03 — confirmed via `OPENAI_API_KEY` prefix `sk-cEqfu9e8…` in the running pod; LiteLLM `/models` returns 200.)*
+
 ### Task 2: Add `apps/ruflo-db/` ArgoCD sub-app
 
 - [x] **Step 1: Read `apps/paperclip-db/` to mirror its shape**
@@ -777,12 +824,12 @@ verify:
       o = Outpost.objects.get(name='authentik Embedded Outpost')
       print([p.name for p in o.providers.all()])
       " | grep -q 'Ruflo (cluster)' && echo OK
-status: pending
+status: done   # ran 2026-05-03; provider list now includes 'Ruflo (cluster)'
 ```
 
-- [ ] **Step 1: Run the Django ORM command** above to add the ruflo proxy provider to the embedded outpost.
+- [x] **Step 1: Run the Django ORM command** above to add the ruflo proxy provider to the embedded outpost. *(Done 2026-05-03 during Phase 3 validation.)*
 
-- [ ] **Step 2: Verify the outpost provider list includes `ruflo`** via the verify command.
+- [x] **Step 2: Verify the outpost provider list includes `ruflo`** via the verify command. *(Confirmed — `Ruflo (cluster)` in the embedded outpost provider list.)*
 
 ### Task 4: Web UI loads through Authentik SSO
 
@@ -1122,5 +1169,6 @@ Confirms each canonical step happened or was rationally skipped.
 | 2026-05-03 | P3 | **Plan deviation: `OPENAI_API_KEY` aliased to `OPENROUTER_API_KEY` in `apps/ruflo/manifests/externalsecret-llm.yaml` doesn't work** — LiteLLM authenticates against its own virtual keys / master key, not the upstream provider key, so model-list calls came back 401 and the SSR-rendered `/` returned 500. Operator manually provisioned `RUFLO_LITELLM_KEY` (a LiteLLM virtual key scoped to ruflo, mirroring `PAPERCLIP_LITELLM_KEY`) in Infisical; ESO updated to read it for `OPENAI_API_KEY`. Same shape paperclip uses. |
 | 2026-05-03 | P3 | **Plan deviation: `shareProcessNamespace: true` is incompatible with agent-shell-base's s6-overlay v3 init** — second container's entrypoint inherits a non-pid-1 process slot, `s6-overlay-suexec: fatal: can only run as pid 1`, sshd never starts. Dropped the share. Cross-container `ps -ef` was the only motivation per the plan; debugging surface is `/workspace` (shared PVC) which still works. Phase 3 plan Task 2 Step 2 ("Confirm shareProcessNamespace works") is obsolete — re-mark as `[-]` skipped during validation. |
 | 2026-05-03 | P3 | **Plan deviation: readiness/liveness probe path `/` is not a process-liveness check** — ruvocal SSR-renders the model list at request time, so a probe against `/` is a full upstream-dependency check (LiteLLM auth, Postgres, etc.). Switched probes to `/api/v2/feature-flags`: same Express stack, no LLM dependency. The plan's comment ("the SPA root reliably returns 2xx once the Node server is bound") is wrong; the comment block in the deployment manifest now records the correct shape. |
-| 2026-05-03 | P3 | **Open follow-up: supercronic crashloops on a fresh `ruflo-shell-home` PVC.** agent-shell-base's `services.d/supercronic/run` does `exec supercronic ${AGENT_HOME}/.crontab`; on a fresh PVC `~/.crontab` doesn't exist, supercronic exits 1, s6 restarts it, etc. paperclip-shell will hit this too once its sidecar deploys. Fix belongs in `agent-shell-base` (touch `~/.crontab` in `cont-init.d` if missing, or have supercronic skip when crontab is absent). Not blocking ruflo Phase 3 — sshd is independent. |
+| 2026-05-03 | P3 | **Open follow-up: supercronic crashloops on a fresh `ruflo-shell-home` PVC.** agent-shell-base's `services.d/supercronic/run` does `exec supercronic ${AGENT_HOME}/.crontab`; on a fresh PVC `~/.crontab` doesn't exist, supercronic exits 1, s6 restarts it, etc. paperclip-shell will hit this too once its sidecar deploys. Fix belongs in `agent-shell-base` (touch `~/.crontab` in `cont-init.d` if missing, or have supercronic skip when crontab is absent). Not blocking ruflo Phase 3 — sshd is independent. **Fixed in derio-net/agent-images#54** (supercronic's `run` script now `touch`es the crontab if missing — keeps the existing on-the-fly reload behaviour when the operator writes real entries). |
+| 2026-05-03 | P3 | **Plan deviation: ruvocal uses a file-based RVF JSON store at `/app/db/`, not Postgres.** Surfaced during Phase 3 validation when the just-started pod logged `[RuVocal] Database: /app/db/ruvocal.rvf.json` and `[RVF] No existing database at /app/db/ruvocal.rvf.json, starting fresh`. The Phase 1 Deployment Notes (P1.T2) had said "ruvocal now uses PostgreSQL via DATABASE_URL"; that was right about the migration direction (away from Mongo) but wrong about the destination — at the pinned SHA, the migration target is RVF (a local JSON store), not Postgres. `DATABASE_URL` is being silently ignored. **Fix landed:** new `apps/ruflo/manifests/pvc-data.yaml` (5Gi, RWO, longhorn) mounted at `/app/db` so hive/run/conversation state survives pod restarts. The `ruflo-db` Bitnami postgresql sub-app stays for now — kept around in case a future re-vendor of upstream switches back to Postgres; size 20Gi for that hypothetical future. Phase 4 Task 3 Step 3 ("Confirm ruvocal Mongo state survived") becomes "Confirm ruvocal RVF state survived" — same intent, different file. |
 | 2026-05-03 | P3 | **Pre-existing bug surfaced during P3.T3 readiness check, fixed in passing:** `apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml` had 8-space indentation on the VK Remote (cluster) block (lines 284–304) vs the rest of the file's 6-space — the YAML failed to parse with `expected <block end>, but found '-'`. The Authentik worker had been logging this on every blueprint discovery cycle since 2026-04-12, silently blocking all proxy-provider blueprint applies for three weeks (paperclip's earlier providers exist only because they were applied *before* the malformed VK Remote block landed). Fixed indentation; blueprint applied cleanly; the manual outpost-provider assignment for ruflo (Phase 3 Task 3) ran after that. |


### PR DESCRIPTION
Follow-up to derio-net/frank#184 validation comment. **Three commits, no auto-merge — leaving open for review.**

Companion: [agent-images PR #54](https://github.com/derio-net/agent-images/pull/54) (supercronic-on-fresh-PVC fix).

## What's in this PR

### 1. Persist `/app/db` (the actual ruvocal state)

The validation pass on the just-Ready pod surfaced this in `kubectl logs`:

\`\`\`
[RuVocal] Database: /app/db/ruvocal.rvf.json
[RVF] No existing database at /app/db/ruvocal.rvf.json, starting fresh
Listening on http://0.0.0.0:3000
\`\`\`

At the pinned upstream SHA, ruvocal uses a file-based **\"RVF\" JSON store** under \`/app/db/\`, not the Postgres database we provisioned. The Phase 1 Deployment Notes (P1.T2) had said \"ruvocal now uses PostgreSQL via DATABASE_URL\" — that was right about the migration direction (away from Mongo) but wrong about the destination. \`DATABASE_URL\` is being silently ignored.

Without persistence, every pod bounce wipes hive/run/conversation state. **Fix:** new `apps/ruflo/manifests/pvc-data.yaml` (5Gi, RWO, longhorn) mounted at `/app/db` in the ruflo container.

The `ruflo-db` Bitnami postgresql sub-app stays for now — kept in case a future re-vendor of upstream switches back to Postgres (per the original P1.T2 finding). 5Gi vs 20Gi for the Postgres claim because the RVF JSON is a single small file per record; bump if the operator hits it.

Phase 4 Task 3 Step 3 (\"Confirm ruvocal Mongo state survived\") becomes \"Confirm ruvocal RVF state survived\" — same intent, different file.

### 2. Document `RUFLO_LITELLM_KEY` as a manual op (already implemented)

You provisioned it earlier today; this PR formalises the runbook so the next operator on this layer doesn't have to figure it out. New `# manual-operation` block under Phase 2 Task 1b (\`orch-ruflo-litellm-virtual-key\`):

- **commands:** the LiteLLM `/key/generate` admin API call (master-key-gated), with a note about pasting the returned `key` into Infisical at the same path paperclip uses for `PAPERCLIP_LITELLM_KEY`.
- **verify:** ESO has synced the new key (`OPENAI_API_KEY` prefix is `sk-c…`, not `sk-or-`); ruvocal can list models through LiteLLM with the key (200, not 401).
- **status:** `done` — the work has shipped.

### 3. Mark `orch-ruflo-authentik-outpost-assign` as done in the runbook

This one was implemented during Phase 3 validation but the runbook still listed it as `pending`. The sync skill preserves human-set status by rule, so the plan-side `status: done` annotation is documentation only — the actual flip happens in `docs/runbooks/manual-operations.yaml` directly.

## Companion (separate PR for review)

- **derio-net/agent-images#54** — `agent-shell-base/etc/services.d/supercronic/run` now `touch`es `~/.crontab` if missing, so supercronic doesn't crashloop on a fresh PVC. Surfaced same Phase 3 validation pass; paperclip-shell will hit the same issue once its sidecar deploys.

## Plan updates

`docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md` Deployment Notes:

- Updated the Phase-3 \"Open follow-up: supercronic crashloops\" row with the link to agent-images#54.
- New row recording the RVF-vs-Postgres deviation and the `/app/db` PVC fix.
- Authentik outpost-assign block updated to `status: done` (matches runbook).
- LiteLLM virtual key block added with `status: done`.

## Test plan

- [ ] After merge: `kubectl get pvc ruflo-data -n ruflo-system` → Bound, 5Gi.
- [ ] `kubectl exec deploy/ruflo -c ruflo -- ls -la /app/db` → directory exists, owned by 1000:1000, contains `ruvocal.rvf.json` after first interaction.
- [ ] Manual: create a hive in the UI → `kubectl rollout restart deploy/ruflo` → confirm hive still present.
- [ ] After agent-images#54 merges and Frank picks up the new SHA: `kubectl exec deploy/ruflo -c ruflo-shell -- /command/s6-svstat /run/service/supercronic` → \`up\`.
- [ ] `docs/runbooks/manual-operations.yaml` shows three `orch-ruflo-*` entries: Authentik=done, LiteLLM=done, Infisical-bootstrap=pending (the Postgres-password sub-step is obsolete per P2.T2 deviation; the OpenRouter+Resend sub-steps are operator-confirmed but not formally re-marked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)