### PR TITLE
inference: refresh model lineup + bump LiteLLM to v1.83.14

### DIFF
--- a/.claude/rules/frank-infrastructure.md
+++ b/.claude/rules/frank-infrastructure.md
@@ -5,7 +5,7 @@
 | mini-1 | 192.168.55.21 | control-plane | Core HA | Intel Ultra 5, 64GB, iGPU |
 | mini-2 | 192.168.55.22 | control-plane | Core HA | Intel Ultra 5, 64GB, iGPU |
 | mini-3 | 192.168.55.23 | control-plane | Core HA | Intel Ultra 5, 64GB, iGPU |
-| gpu-1 | 192.168.55.31 | worker | AI Compute | i9, 128GB, RTX 5070 |
+| gpu-1 | 192.168.55.31 | worker | AI Compute | i9, 128GB, RTX 5070 Ti (16GB GDDR7) |
 | pc-1 | 192.168.55.71 | worker | Edge | 64GB, general purpose |
 | raspi-1 | 192.168.55.41 | worker | Edge | RPi 4, low-power |
 | raspi-2 | 192.168.55.42 | worker | Edge | RPi 4, low-power |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Enterprise-grade Kubernetes cluster on Talos Linux across heterogeneous hardware
 |------|----------|------|-------------|-------|
 | A — Management | Raspberry Pi 5 (8GB) | Sidero Omni, Authentik, Traefik | raspi-omni | 192.168.55.1 |
 | B — Core HA | 3x ASUS NUC (Intel Ultra 5, 64GB, 1TB NVMe, Arc iGPU) | Control-plane + worker | mini-1/2/3 | 192.168.55.21-23 |
-| C — AI Compute | Desktop (i9, 128GB, RTX 5070, 2x4TB SSD) | GPU worker | gpu-1 | 192.168.55.31 |
+| C — AI Compute | Desktop (i9, 128GB, RTX 5070 Ti 16GB, 2x4TB SSD) | GPU worker | gpu-1 | 192.168.55.31 |
 | D — Edge | 2x RPi 4 + 1x legacy desktop | General workers | raspi-1/2, pc-1 | 192.168.55.41-42, .71 |
 | E — Public Edge | Hetzner CX23 (2 vCPU, 4GB) | Hop cluster (standalone talosctl) | hop-1 | Hetzner public IP |
 
@@ -38,7 +38,7 @@ Enterprise-grade Kubernetes cluster on Talos Linux across heterogeneous hardware
 | Backup | Longhorn → Cloudflare R2 | Daily + weekly PVC backup, SOPS-encrypted credentials |
 | Secrets | Infisical + External Secrets Operator | Self-hosted secret store, ExternalSecret → K8s Secret sync |
 | RGB | OpenRGB | GitOps-managed LED control on gpu-1 via USB HID (IT5701 V3.5.14.0 firmware lock under investigation) |
-| Local Inference | Ollama | LLM serving on gpu-1's RTX 5070 (qwen3.5:9b, deepseek-coder:6.7b) |
+| Local Inference | Ollama | LLM serving on gpu-1's RTX 5070 Ti 16GB — multimodal (Gemma 3 12B, Qwen2.5-VL 7B), general (Mistral Small 3.2 24B, Qwen3 14B), code (Qwen2.5-Coder 14B) |
 | API Gateway | LiteLLM | Unified OpenAI-compatible proxy routing to Ollama + OpenRouter cloud models |
 | Agentic Control Plane | Sympozium | K8s-native agents — every agent is a Pod, every policy a CRD, every execution a Job |
 | Identity & Auth | Authentik | Self-hosted IdP — OIDC SSO for ArgoCD, Grafana; forward-auth proxy for Longhorn, Hubble, Sympozium |

--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/berriai/litellm-database
-  tag: "main-v1.82.3-stable"
+  tag: "main-v1.83.14-stable"
   pullPolicy: IfNotPresent
 
 # Master key from ExternalSecret-managed K8s Secret

--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -20,90 +20,118 @@ envVars:
   STORE_MODEL_IN_DB: "True"
 
 # LiteLLM proxy configuration (rendered as config.yaml)
+#
+# Lineup refresh — 2026-05-03
+# Sized for gpu-1's RTX 5070 Ti (16GB GDDR7). With OLLAMA_MAX_LOADED_MODELS=1,
+# each loaded model can use up to ~14GB after KV cache + multimodal overhead.
+# Local covers default + multimodal + coding + reasoning; cloud covers
+# frontier-scale, video, and 200B+-class reasoning.
 proxy_config:
   model_list:
     # ──────────────────────────────────────────────
-    # LOCAL MODELS (Ollama on gpu-1)
+    # LOCAL MODELS (Ollama on gpu-1, RTX 5070 Ti 16GB)
     # ──────────────────────────────────────────────
 
-    # Qwen 3.5 9B — default general-purpose model
-    # Multimodal (text+image), 256K context, tool calling, thinking mode
-    # Runs fully in VRAM on RTX 5070 (6.6GB Q4)
-    - model_name: qwen3.5
+    # Mistral Small 3.2 24B — default general-purpose, 128K context
+    # Strong all-rounder with function calling. Q4_K_M ≈ 14GB VRAM.
+    # Replaces qwen3.5:9b as default.
+    - model_name: mistral-small-24b
       litellm_params:
-        model: ollama/qwen3.5:9b
+        model: ollama/mistral-small3.2:24b
         api_base: http://ollama.ollama.svc.cluster.local:11434
 
-    # DeepSeek Coder 6.7B — code generation and completion
-    # Swapped in on-demand (~5s cold load)
-    - model_name: deepseek-coder
+    # Gemma 3 12B — multimodal (text + image), 128K context
+    # Best practical local vision model — OCR, charts, screenshot analysis.
+    # Q4_K_M ≈ 8GB + ~1.4GB vision tower.
+    - model_name: gemma-12b
       litellm_params:
-        model: ollama/deepseek-coder:6.7b
+        model: ollama/gemma3:12b
         api_base: http://ollama.ollama.svc.cluster.local:11434
 
-    # Tesslate OmniCoder-9B
-    # Swapped in on-demand (~5s cold load)
-    - model_name: omnicoder
+    # Qwen2.5-VL 7B (Q8) — multimodal specialist for structured visual content
+    # Tables, scanned docs, charts with dense text. Q8_0 chosen over Q4 for
+    # OCR fidelity at this small parameter count. ≈ 8GB + vision tower.
+    - model_name: qwen-vl-7b
       litellm_params:
-        model: ollama/carstenuhlig/omnicoder-9b
+        model: ollama/qwen2.5vl:7b-q8_0
+        api_base: http://ollama.ollama.svc.cluster.local:11434
+
+    # Qwen2.5-Coder 14B (Q6) — code generation and completion
+    # Q6_K instead of default Q4 — measurably fewer syntax errors at the
+    # cost of ~3GB more VRAM. Replaces both deepseek-coder:6.7b and
+    # carstenuhlig/omnicoder-9b with a single stronger model.
+    - model_name: qwen-coder-14b
+      litellm_params:
+        model: ollama/qwen2.5-coder:14b-instruct-q6_K
+        api_base: http://ollama.ollama.svc.cluster.local:11434
+
+    # Qwen3 14B — reasoning model with native thinking mode, 32K context
+    # Useful when a problem benefits from extended reasoning steps.
+    # Q4_K_M ≈ 9GB VRAM.
+    - model_name: qwen-think-14b
+      litellm_params:
+        model: ollama/qwen3:14b
         api_base: http://ollama.ollama.svc.cluster.local:11434
 
     # ──────────────────────────────────────────────
     # CLOUD MODELS — Free tier via OpenRouter
     # Rate limit: 20 req/min, 200 req/day per model
-    # Free model availability shifts — update as needed
+    # Slugs verified live against /api/v1/models on 2026-05-03 — refresh
+    # via /update-openrouter-models when entries start 404'ing.
     # ──────────────────────────────────────────────
 
-    # Qwen3 Coder — 480B MoE (35B active), 262K context
-    # Top-tier coding model, strong reasoning
+    # Gemma 4 31B Instruct — flagship free multimodal, 256K context
+    # Text + image + video input, function calling, 140+ languages.
+    # ✅ Data: Open-weight, served by third-party
+    - model_name: gemma-31b
+      litellm_params:
+        model: openrouter/google/gemma-4-31b-it:free
+        api_key: os.environ/OPENROUTER_API_KEY
+
+    # NVIDIA Nemotron Nano 2 VL — 12B multimodal, 128K context
+    # Video understanding + document intelligence; the smaller, faster
+    # video-capable companion to Gemma 4 31B.
+    # ✅ Data: Open-weight, served by third-party
+    - model_name: nemotron-vl-12b
+      litellm_params:
+        model: openrouter/nvidia/nemotron-nano-12b-v2-vl:free
+        api_key: os.environ/OPENROUTER_API_KEY
+
+    # NVIDIA Nemotron 3 Nano Omni 30B — multimodal + reasoning, 256K context
+    # Accepts text/image/video/audio; reasoning mode. Largest free omni model.
+    # ✅ Data: Open-weight, served by third-party
+    - model_name: nemotron-omni-30b
+      litellm_params:
+        model: openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
+        api_key: os.environ/OPENROUTER_API_KEY
+
+    # Qwen3 Next 80B A3B Instruct — top free general/reasoning, 262K context
+    # MoE (3B active), strong on coding + math + general knowledge.
+    # Replaces step-flash slot.
     # ⚠ Data: Alibaba Cloud; prompts may be retained
-    - model_name: qwen3-coder
+    - model_name: qwen-next-80b
+      litellm_params:
+        model: openrouter/qwen/qwen3-next-80b-a3b-instruct:free
+        api_key: os.environ/OPENROUTER_API_KEY
+
+    # Qwen3 Coder — 480B MoE (35B active), 262K context
+    # Frontier free coding model — for cases the local 14B coder isn't enough.
+    # ⚠ Data: Alibaba Cloud; prompts may be retained
+    - model_name: qwen-coder-480b
       litellm_params:
         model: openrouter/qwen/qwen3-coder:free
         api_key: os.environ/OPENROUTER_API_KEY
 
     # Hermes 3 405B — NousResearch fine-tune of Llama 3.1 405B, 131K context
-    # Largest free model, strong general-purpose and instruction following
+    # Largest free open-weight model; backstop for general-purpose at scale.
     # ✅ Data: Open-weight, served by third-party
     - model_name: hermes-405b
       litellm_params:
         model: openrouter/nousresearch/hermes-3-llama-3.1-405b:free
         api_key: os.environ/OPENROUTER_API_KEY
 
-    # Gemma 3 27B — Google's best free open model, 131K context
-    # Good general-purpose, vision capable
-    # ✅ Data: Open-weight, served by third-party
-    - model_name: gemma-27b
-      litellm_params:
-        model: openrouter/google/gemma-3-27b-it:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
-    # Mistral Small 3.1 24B — Mistral's efficient model, 128K context
-    # Fast, good for coding and general tasks
-    # ✅ Data: Open-weight, served by third-party
-    - model_name: mistral-small
-      litellm_params:
-        model: openrouter/mistralai/mistral-small-3.1-24b-instruct:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
-    # Llama 3.3 70B — Meta's general-purpose open model, 128K context
-    # Strong all-rounder
-    # ✅ Data: Open-weight, served by third-party
-    - model_name: llama-70b
-      litellm_params:
-        model: openrouter/meta-llama/llama-3.3-70b-instruct:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
-    # Step 3.5 Flash — StepFun's 196B MoE (11B active), 256K context
-    # Reasoning model, strong general-purpose
-    # ⚠ Data: Training disabled, but prompts retained by StepFun
-    - model_name: step-flash
-      litellm_params:
-        model: openrouter/stepfun/step-3.5-flash:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
   litellm_settings:
-    default_model: qwen3.5
+    default_model: mistral-small-24b
 
   general_settings:
     master_key: os.environ/LITELLM_MASTER_KEY

--- a/apps/ollama/values.yaml
+++ b/apps/ollama/values.yaml
@@ -22,7 +22,11 @@ extraEnv:
 
 persistentVolume:
   enabled: true
-  size: 30Gi
+  # 200Gi — sized for the 5-model lineup (~55GB at rest) plus headroom for
+  # experimentation. The 5070 Ti has 16GB VRAM; only one model loads at a
+  # time per OLLAMA_MAX_LOADED_MODELS=1, so disk is the only soft limit on
+  # how many models can cohabit.
+  size: 200Gi
   storageClass: longhorn
   accessModes:
     - ReadWriteOnce

--- a/blog/content/docs/building/10-local-inference/index.md
+++ b/blog/content/docs/building/10-local-inference/index.md
@@ -3,13 +3,13 @@ title: "Local Inference — Ollama, LiteLLM, and OpenRouter"
 date: 2026-03-09
 draft: false
 tags: ["ollama", "litellm", "openrouter", "llm", "inference", "gpu", "ai"]
-summary: "A unified OpenAI-compatible gateway that routes between a local RTX 5070 running Ollama and free cloud models via OpenRouter — one API for everything."
+summary: "A unified OpenAI-compatible gateway that routes between a local RTX 5070 Ti running Ollama and free cloud models via OpenRouter — one API for everything."
 weight: 11
 ---
 
 The cluster has a GPU. Layer 4 installed the NVIDIA operator. Layer 5 gave the mini nodes their Intel iGPUs. But none of that is useful until something actually runs inference.
 
-Layer 10 wires up a unified LLM gateway. Any tool on the network — agentic frameworks, document processors, coding assistants — talks to one OpenAI-compatible endpoint at `192.168.55.206:4000`. Behind that endpoint, requests route to either a local model on gpu-1's RTX 5070 or a free cloud model via OpenRouter. The consumer never needs to know which.
+Layer 10 wires up a unified LLM gateway. Any tool on the network — agentic frameworks, document processors, coding assistants — talks to one OpenAI-compatible endpoint at `192.168.55.206:4000`. Behind that endpoint, requests route to either a local model on gpu-1's RTX 5070 Ti or a free cloud model via OpenRouter. The consumer never needs to know which.
 
 ## The Architecture
 
@@ -30,12 +30,15 @@ LiteLLM Gateway (192.168.55.206:4000)
     |  virtual keys, spend tracking, rate limits
     |
     |---> Ollama (gpu-1, ClusterIP)
-    |       |-- qwen3.5:9b  (default, kept warm)
-    |       +-- deepseek-coder:6.7b  (on-demand)
+    |       |-- mistral-small3.2:24b   (default, kept warm)
+    |       |-- gemma3:12b             (multimodal — vision general)
+    |       |-- qwen2.5vl:7b-q8_0      (multimodal — OCR/structured)
+    |       |-- qwen2.5-coder:14b q6   (code)
+    |       +-- qwen3:14b              (reasoning, thinking mode)
     |
-    +---> OpenRouter (cloud)
-            +-- qwen3-coder, hermes-405b, gemma-27b,
-                mistral-small, llama-70b, step-flash
+    +---> OpenRouter (cloud, free tier)
+            +-- gemma-31b, nemotron-vl-12b, nemotron-omni-30b,
+                qwen-next-80b, qwen-coder-480b, hermes-405b
 ```
 
 Any consumer that speaks OpenAI's API format works out of the box:
@@ -51,20 +54,31 @@ Ollama alone handles local models well. But the moment you want cloud fallback, 
 
 It also means model migration is invisible to consumers. If a cloud model gets retired or a better local model appears, you update LiteLLM's config. No consumer reconfiguration.
 
-## Local Models: What Fits in 12GB?
+## Local Models: What Fits in 16GB?
 
-The RTX 5070 has 12GB of VRAM. That is the hard constraint. Ollama quantizes models to Q4 by default, which cuts memory roughly in half.
+The RTX 5070 Ti has 16GB of GDDR7. That is the hard constraint. Ollama quantizes models to Q4 by default, which cuts memory roughly in half — but at 16GB there is enough headroom to upgrade specific models to Q6 or Q8 where it matters.
 
-Two models are available:
+Five models in the current lineup, each chosen to fit alongside ~1.5GB of KV cache (and, for vision models, a ~1.4GB vision tower):
 
-| Model | Size (Q4) | Context | Best For |
-|-------|-----------|---------|----------|
-| `qwen3.5:9b` | 6.6 GB | 256K | General-purpose, multimodal, tool calling |
-| `deepseek-coder:6.7b` | ~4 GB | 16K | Code generation and completion |
+| Alias | Tag | Quant | VRAM | Context | Best For |
+|-------|-----|-------|------|---------|----------|
+| `mistral-small-24b` | `mistral-small3.2:24b` | Q4_K_M | ~14 GB | 128K | Default general-purpose, function calling |
+| `gemma-12b` | `gemma3:12b` | Q4_K_M | ~9 GB | 128K | Multimodal — general vision, screenshots, charts |
+| `qwen-vl-7b` | `qwen2.5vl:7b-q8_0` | Q8_0 | ~9 GB | 128K | Multimodal — OCR, tables, scanned docs |
+| `qwen-coder-14b` | `qwen2.5-coder:14b-instruct-q6_K` | Q6_K | ~12 GB | 32K | Code generation and completion |
+| `qwen-think-14b` | `qwen3:14b` | Q4_K_M | ~10 GB | 32K | Reasoning with native thinking mode |
 
-Only one model stays loaded in VRAM at a time (`OLLAMA_MAX_LOADED_MODELS=1`). The default model is kept warm for 24 hours (`OLLAMA_KEEP_ALIVE=24h`). Switching to the other model takes about 5 seconds — Ollama unloads one and loads the other from the Longhorn PVC.
+Only one model stays loaded in VRAM at a time (`OLLAMA_MAX_LOADED_MODELS=1`). The default model is kept warm for 24 hours (`OLLAMA_KEEP_ALIVE=24h`). Switching takes about 5 seconds — Ollama unloads one and loads the other from the Longhorn PVC.
 
-This is a deliberate trade-off. Loading two models simultaneously would leave each with less VRAM for KV cache, reducing effective context length. For a homelab with low concurrency, fast swapping is better than degraded context.
+This is a deliberate trade-off. Loading multiple models simultaneously would leave each with less VRAM for KV cache, reducing effective context length. For a homelab with low concurrency, fast swapping is better than degraded context.
+
+### Why Two Multimodal Models?
+
+`gemma-12b` and `qwen-vl-7b` look redundant on paper — both are vision models that fit in VRAM. They are not. Gemma 3's vision tower was trained on a wide image corpus and excels at "what is in this picture": general visual reasoning, screenshots, photographs. Qwen2.5-VL was specifically trained on structured visual content — tables, charts with dense text, scanned documents — and produces noticeably more accurate OCR. Picking one would force every vision request through a model that is wrong for half the cases.
+
+### Why Q6 for the Coder?
+
+Code is the one place where quantization quality is measurable in production. At Q4_K_M, 14B-class coding models produce more syntax errors and forget API surface details. At Q6_K the model uses ~3GB more VRAM but the error rate drops noticeably. The 16GB budget makes that trade-off available; the 12GB original config didn't.
 
 ### Why Not the Mini iGPUs?
 
@@ -74,16 +88,16 @@ The three mini nodes each have an Intel Arc iGPU. These share system RAM instead
 
 OpenRouter aggregates providers and offers free tiers for many models. The catch: free model availability shifts constantly. Models get promoted, retired, or rate-limited without notice. This is a maintenance concern, not an architectural one.
 
-The current free model roster (as of March 2026):
+The current free model roster (refreshed May 2026 — see "Refresh" below):
 
-| Alias | Model | Context | Strengths | Data Policy |
-|-------|-------|---------|-----------|-------------|
-| `qwen3-coder` | Qwen3 Coder 480B MoE | 262K | Coding, reasoning | Alibaba Cloud; may retain |
-| `hermes-405b` | Hermes 3 (Llama 3.1 405B) | 131K | General purpose, instruction following | Open-weight |
-| `gemma-27b` | Gemma 3 27B | 131K | General purpose, vision | Open-weight |
-| `mistral-small` | Mistral Small 3.1 24B | 128K | Fast, coding | Open-weight |
-| `llama-70b` | Llama 3.3 70B Instruct | 128K | Strong all-rounder | Open-weight |
-| `step-flash` | Step 3.5 Flash 196B MoE | 256K | Reasoning | Prompts retained |
+| Alias | Model | Context | Modalities | Strengths | Data Policy |
+|-------|-------|---------|------------|-----------|-------------|
+| `gemma-31b` | Gemma 4 31B Instruct | 256K | text + image + video | Flagship multimodal, function calling, 140+ langs | Open-weight |
+| `nemotron-vl-12b` | NVIDIA Nemotron Nano 2 VL | 128K | text + image + video | Document intelligence, video understanding | Open-weight |
+| `nemotron-omni-30b` | NVIDIA Nemotron 3 Nano Omni 30B | 256K | text + image + video + audio | Multimodal + reasoning | Open-weight |
+| `qwen-next-80b` | Qwen3 Next 80B A3B Instruct | 262K | text | Strong reasoning, coding, math | Alibaba; may retain |
+| `qwen-coder-480b` | Qwen3 Coder 480B MoE | 262K | text | Frontier coding | Alibaba; may retain |
+| `hermes-405b` | Hermes 3 (Llama 3.1 405B) | 131K | text | Largest open-weight backstop | Open-weight |
 
 The data policy column matters. Some free providers train on prompts. The config comments document this per model so you can make informed choices about what you send where.
 
@@ -103,9 +117,8 @@ ollama:
     type: nvidia
     number: 1
   models:
-    pull:
-      - qwen3.5:9b
-      - deepseek-coder:6.7b
+    pull: []   # pulled on first request via LiteLLM
+    run: []
 
 extraEnv:
   - name: OLLAMA_KEEP_ALIVE
@@ -115,7 +128,7 @@ extraEnv:
 
 persistentVolume:
   enabled: true
-  size: 30Gi
+  size: 200Gi   # 5-model shelf ≈ 55GB at rest, with experimentation room
   storageClass: longhorn
 
 tolerations:
@@ -140,12 +153,12 @@ The model routing config lives in `values.yaml` under `proxy_config.model_list`.
 ```yaml
 proxy_config:
   model_list:
-    - model_name: qwen3.5
+    - model_name: mistral-small-24b
       litellm_params:
-        model: ollama/qwen3.5:9b
+        model: ollama/mistral-small3.2:24b
         api_base: http://ollama.ollama.svc.cluster.local:11434
 
-    - model_name: qwen3-coder
+    - model_name: qwen-coder-480b
       litellm_params:
         model: openrouter/qwen/qwen3-coder:free
         api_key: os.environ/OPENROUTER_API_KEY
@@ -201,8 +214,22 @@ During deployment, four of the six originally selected cloud models had already 
 
 LiteLLM has built-in virtual key management. Each consumer gets its own key with optional per-key budgets and rate limits. When multi-tenancy via vCluster arrives in a future layer, tenant isolation is a configuration concern — not an architectural change.
 
+## Refresh — May 2026
+
+The original lineup (`qwen3.5:9b`, `deepseek-coder:6.7b`, plus a six-model OpenRouter shelf) was assembled before the GPU Operator fix landed. Two things changed since:
+
+1. **The card had 16GB all along.** The first version of this post said "12GB" because that is the spec for the non-Ti RTX 5070 — but gpu-1 actually runs the Ti variant with 16GB GDDR7. The 4GB extra unlocked the 24B class at Q4 (Mistral Small 3.2) and let the coder model jump to Q6 quantization.
+2. **The OpenRouter free tier had churned.** Mistral Small 3.1 and Step Flash were no longer free; Qwen3-Next, Nemotron-VL, Nemotron-Omni, and Gemma 4 had appeared. The `/update-openrouter-models` skill confirmed the live list against `/api/v1/models`.
+
+The replacement strategy:
+- Move Mistral Small 24B from cloud to local — the 16GB card can run it.
+- Add two local multimodal models (Gemma 3 12B for general vision, Qwen2.5-VL 7B at Q8 for OCR), removing the old text-only-only constraint.
+- Replace the aging cloud shelf with three multimodal options (Gemma 4 31B, Nemotron-VL, Nemotron-Omni) plus a stronger reasoning option (Qwen3-Next 80B).
+- Drop `deepseek-coder:6.7b` and `omnicoder:9b` in favor of one stronger `qwen2.5-coder:14b` at Q6.
+- Bump the Ollama PVC from 30Gi to 200Gi — the new lineup occupies ~55GB at rest, and disk is no longer scarce.
+
+Aliases changed in this refresh — consumers using the old names (`qwen3.5`, `deepseek-coder`, `mistral-small`, `gemma-27b`, `llama-70b`, `step-flash`) need to update to the new ones (`mistral-small-24b`, `qwen-coder-14b`, `gemma-31b`, etc.). The data-policy comments per model are kept and re-verified against each provider's current terms.
+
 ## What is Next
 
-**Update:** The GPU Operator fix landed. The RTX 5070 Ti is running Ollama at 100% GPU with 15.9 GiB VRAM. Local models are live. See [GPU Containers on Talos — The Validation Fix]({{< relref "/docs/building/12-gpu-talos-fix" >}}) for the full debugging story.
-
-Any consumer on the network can use `192.168.55.206:4000` today — both local GPU models and cloud fallback are operational.
+Any consumer on the network can use `192.168.55.206:4000` today — local GPU models, multimodal vision (local + cloud), and frontier-scale reasoning (cloud) are all operational behind one OpenAI-compatible endpoint.

--- a/blog/content/docs/operating/07-inference/index.md
+++ b/blog/content/docs/operating/07-inference/index.md
@@ -60,7 +60,7 @@ litellm-postgresql-0       1/1     Running   0          28d   10.244.12.161   mi
 kubectl exec -n ollama deploy/ollama -- nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu --format=csv
 ```
 
-> Only one model is loaded in VRAM at a time on the RTX 5070 Ti (12 GB). Switching models means the old one gets evicted.
+> Only one model is loaded in VRAM at a time on the RTX 5070 Ti (16 GB GDDR7). Switching models means the old one gets evicted.
 
 ## Routine Operations
 
@@ -68,10 +68,10 @@ kubectl exec -n ollama deploy/ollama -- nvidia-smi --query-gpu=memory.used,memor
 
 ```bash
 # Pull a new model
-kubectl exec -n ollama deploy/ollama -- ollama pull qwen3:8b
+kubectl exec -n ollama deploy/ollama -- ollama pull qwen3:14b
 
 # Remove a model to free disk space
-kubectl exec -n ollama deploy/ollama -- ollama rm deepseek-coder:6.7b
+kubectl exec -n ollama deploy/ollama -- ollama rm qwen2.5-coder:14b-instruct-q6_K
 ```
 
 > Do not use `postStart` hooks for model pulls on Talos — the nvidia-container-runtime exec hooks fail. Always pull via `kubectl exec` after the pod is running.
@@ -79,18 +79,31 @@ kubectl exec -n ollama deploy/ollama -- ollama rm deepseek-coder:6.7b
 ### Test Inference
 
 ```bash
-# Quick test via LiteLLM (routes to Ollama)
+# Quick test via LiteLLM (routes to Ollama via the LiteLLM alias, not the Ollama tag)
 curl -s http://192.168.55.206:4000/v1/chat/completions \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "ollama/qwen3.5:9b",
+    "model": "mistral-small-24b",
     "messages": [{"role": "user", "content": "Hello, one sentence reply."}],
     "max_tokens": 50
   }' | jq '.choices[0].message.content'
 
-# Direct Ollama test (bypassing LiteLLM)
+# Direct Ollama test (bypassing LiteLLM — uses the Ollama tag, not the alias)
 kubectl exec -n ollama deploy/ollama -- curl -s http://localhost:11434/api/generate \
-  -d '{"model": "qwen3.5:9b", "prompt": "Hello", "stream": false}' | jq '.response'
+  -d '{"model": "mistral-small3.2:24b", "prompt": "Hello", "stream": false}' | jq '.response'
+
+# Multimodal test — send an image to gemma-12b
+curl -s http://192.168.55.206:4000/v1/chat/completions \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gemma-12b",
+    "messages": [{"role": "user", "content": [
+      {"type": "text", "text": "Describe this image in one sentence."},
+      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
+    ]}]
+  }' | jq '.choices[0].message.content'
 ```
 
 ### Check LiteLLM Routing
@@ -121,17 +134,29 @@ kubectl logs -n ollama deploy/ollama --tail=100
 
 ### Out of Memory on GPU
 
-If a model is too large for the 12 GB VRAM:
+If a model is too large for the 16 GB VRAM (e.g., trying to run a 14B at Q8 alongside a vision tower):
 
 ```bash
 # Check current memory usage
 kubectl exec -n ollama deploy/ollama -- nvidia-smi
 
 # Unload current model
-kubectl exec -n ollama deploy/ollama -- ollama stop qwen3.5:9b
+kubectl exec -n ollama deploy/ollama -- ollama stop mistral-small3.2:24b
 
-# Try a smaller quantization
-kubectl exec -n ollama deploy/ollama -- ollama pull qwen3:8b-q4_0
+# Drop to a lower quantization
+kubectl exec -n ollama deploy/ollama -- ollama pull qwen2.5-coder:14b-instruct-q4_K_M
+```
+
+### Reconciling LiteLLM Aliases vs. Ollama Tags
+
+Two name spaces are in play. LiteLLM aliases (`mistral-small-24b`, `gemma-12b`, `qwen-vl-7b`, `qwen-coder-14b`, `qwen-think-14b`) live in `apps/litellm/values.yaml` under `model_list[].model_name` — these are what consumers send. Ollama tags (`mistral-small3.2:24b`, `qwen2.5-coder:14b-instruct-q6_K`, etc.) live under `model_list[].litellm_params.model` — these are what Ollama pulls and runs. If a request returns "model not found", check both: either the alias is wrong on the consumer side, or the underlying Ollama tag was never pulled.
+
+```bash
+# What aliases does LiteLLM advertise?
+curl -s http://192.168.55.206:4000/v1/models -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.data[].id'
+
+# What Ollama tags actually exist on disk?
+kubectl exec -n ollama deploy/ollama -- ollama list
 ```
 
 ### LiteLLM Routing Errors


### PR DESCRIPTION
## Summary

Two co-deployed changes; split into two commits for clean git-bisect during the canary pause windows.

**1. Model lineup refresh** (`e7484de`) — sized for gpu-1's actual 16GB RTX 5070 Ti (was being treated as 12GB):

Local Ollama:
- Replace `qwen3.5:9b` / `deepseek-coder:6.7b` / `omnicoder-9b` with a 5-model lineup:
  - `mistral-small3.2:24b` — default general-purpose (was cloud-only at the 12GB tier)
  - `gemma3:12b` — multimodal, general vision
  - `qwen2.5vl:7b-q8_0` — multimodal, OCR/structured visual content
  - `qwen2.5-coder:14b-instruct-q6_K` — code (Q6 reduces syntax errors vs Q4)
  - `qwen3:14b` — reasoning with native thinking mode
- Bump Ollama PVC 30Gi → 200Gi for the bigger shelf + experimentation room

Cloud OpenRouter (verified live against `/api/v1/models` on 2026-05-03):
- Drop: `mistral-small` (now local), `llama-70b` (overtaken), `step-flash` (no longer free), `gemma-27b` (replaced by Gemma 4)
- Add three multimodal options (was zero before): `gemma-4-31b-it` (256K + video), `nemotron-nano-12b-v2-vl` (video), `nemotron-3-nano-omni-30b-a3b-reasoning` (omni + reasoning)
- Add `qwen3-next-80b-a3b-instruct` (top free reasoning); keep `qwen3-coder` and `hermes-405b`

Docs:
- Fix `RTX 5070` → `RTX 5070 Ti (16GB GDDR7)` in `frank-infrastructure.md` and `README.md`
- Rewrite `building/10-local-inference` and `operating/07-inference` to reflect the new lineup; add a `Refresh — May 2026` section explaining why the lineup changed

**2. LiteLLM image bump** (`7ab1992`) — `main-v1.82.3-stable` → `main-v1.83.14-stable` (~7 weeks of stable-channel releases).

## Test plan

The Argo Rollouts canary in `apps/litellm/manifests/rollout.yaml` will roll both changes together: `20% → manual promote → 5min litellm-error-rate analysis → 50% → manual promote → 5min analysis → 100%`.

- [ ] After merge, watch `kubectl argo rollouts get rollout litellm -n litellm --watch`
- [ ] Drive synthetic traffic during the analysis windows (otherwise NaN → inconclusive → abort)
- [ ] Promote past each pause: `kubectl argo rollouts promote litellm -n litellm`
- [ ] Verify each new alias resolves end-to-end via `/v1/chat/completions`
- [ ] Pre-pull local Ollama tags after the canary settles (otherwise first request times out): `kubectl exec -n ollama deploy/ollama -- ollama pull <tag>` for each of the five
- [ ] Clean up stale local models (`qwen3.5:9b`, `deepseek-coder:6.7b`, `carstenuhlig/omnicoder-9b`) once the new lineup is verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)