### PR TITLE
fix(deploy): add workloadRef.scaleDown=onsuccess to litellm Rollout (PR #213 follow-up)

### DIFF
--- a/apps/litellm/manifests/rollout.yaml
+++ b/apps/litellm/manifests/rollout.yaml
@@ -16,8 +16,12 @@
 # → 1 canary + 4 stable; setWeight=50 → 3 canary + 2 stable.
 #
 # workloadRef: Rollout reads pod template from the Helm chart's Deployment.
-# The Deployment is scaled to 0 by the controller — this is expected.
-# ArgoCD ignoreDifferences on apps/Deployment/spec.replicas prevents fight.
+# scaleDown: onsuccess — controller scales the Deployment to 0 the moment
+# the Rollout reaches Healthy. Argo Rollouts' default for workloadRef.scaleDown
+# is "never", so without this field the Helm Deployment keeps running its
+# pod alongside the Rollout's pods (5+1 = 6 total). PR #213 left this field
+# off; this PR adds it. ArgoCD ignoreDifferences on apps/Deployment/spec.replicas
+# prevents ArgoCD from fighting the controller's scale-down.
 #
 # Canary steps:
 #   20% (1/5 pods) → manual pause → 5-min VictoriaMetrics analysis →
@@ -34,6 +38,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: litellm
+    scaleDown: onsuccess
   strategy:
     canary:
       steps:


### PR DESCRIPTION
## Summary

One-field fix discovered immediately after #213 merged: `workloadRef.scaleDown` defaults to **`never`**, not `onsuccess` as #213's PR description (and the existing \`frank-gotchas.md\` entry on workloadRef) implied. The controller therefore does not auto-scale \`Deployment/litellm\` to 0 when the Rollout reaches Healthy, leaving 5 Rollout pods + the original 1 Helm pod = **6 pods** sharing the Service selector.

This PR adds \`scaleDown: onsuccess\` to the workloadRef. The Rollout is already Healthy, so the controller scales the Deployment to 0 on the next reconcile after this lands (no canary fires; this is a Rollout-spec change, not a pod-template change — same reconcile shape as #213 itself).

## Why this is the third latent bug in the deploy layer

#213 fixed the broken Cilium plugin. The PR review caught a second latent bug: the deleted \`service-canary.yaml\` had an over-broad selector that would have selected all litellm pods (stable + canary) instead of just canary, double-counting traffic in both Service paths if the L7 plan had ever run. Now this third bug — \`scaleDown: never\` default — surfaces when the controller can finally do its job.

All three bugs only surfaced when we tried to actually use the canary end-to-end. Reinforcement of the lesson PR 2 will document.

## Test plan

- [ ] After merge + ArgoCD sync (~3min): \`kubectl get deploy litellm -n litellm -o jsonpath='{.spec.replicas}'\` returns \`0\`
- [ ] \`kubectl get pods -n litellm -l app.kubernetes.io/name=litellm\` shows exactly 5 pods (the original \`litellm-84d78cd556-rglgl\` is gone)
- [ ] \`kubectl argo rollouts get rollout litellm -n litellm\` still shows \`Status: Healthy, 5/5 Ready\`
- [ ] LiteLLM continues to serve requests (e.g. \`curl http://192.168.55.206:4000/v1/models -H "Authorization: Bearer \$LITELLM_MASTER_KEY"\` returns 200)
- [ ] Manual cleanup of leftover \`Service/litellm-canary\` (also flagged as OutOfSync on \`litellm-extras\` ArgoCD app):
  \`\`\`bash
  kubectl delete service litellm-canary -n litellm
  \`\`\`

## Cascade after this lands

PR 1.5 (synthetic env-var canary trigger) follows once this is verified. With the scaleDown fix in place, the synthetic canary should produce the textbook canary lifecycle: 5 stable → 1 canary + 4 stable → pause → analysis → 3 canary + 2 stable → pause → analysis → 5 canary, 0 stable. That's the run that produces the real captured output for PR 2's docs/runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)