### PR TITLE
chore(deploy): synthetic canary trigger for first end-to-end Rollout rehearsal

### DIFF
--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -18,6 +18,14 @@ environmentSecrets:
 
 envVars:
   STORE_MODEL_IN_DB: "True"
+  # SYNTHETIC CANARY TRIGGER — to be reverted in immediately-following PR.
+  # This env var has no effect on LiteLLM behavior; its sole purpose is to
+  # mutate the Deployment's pod template so the Argo Rollouts controller
+  # observes a workload-template change and fires its canary steps. The
+  # post-#213/#214 Rollout has never been exercised end-to-end; this is the
+  # rehearsal run that produces the real captured outputs needed by the
+  # progressive-delivery doc rewrite (PR 2). Removed in the next commit.
+  CANARY_REHEARSAL_2026_05_04: "1"
 
 # LiteLLM proxy configuration (rendered as config.yaml)
 proxy_config:


### PR DESCRIPTION
## Summary

Adds a no-op env var (\`CANARY_REHEARSAL_2026_05_04: "1"\`) to LiteLLM's chart values. The variable has zero effect on LiteLLM behavior — its sole purpose is to mutate the Deployment's pod template so the \`workloadRef\`-bound Rollout sees a new workload generation and **fires its canary steps for the first time since the layer was deployed 39 days ago**.

This is the rehearsal run. PR 1.6 (immediately following) reverts the env var, triggering a second canary in the reverse direction — round-trip observation.

## Why this exists

#213 (replica-count canary) and #214 (workloadRef.scaleDown=onsuccess) were both spec-only changes — the controller observed "spec change, pod template unchanged" and skipped canary steps. Neither PR actually exercised the canary lifecycle. We have a Rollout that is now configured correctly and shows \`Status: Healthy\` at rest, but has never run a single \`setWeight: 20 → pause → analysis → setWeight: 50 → pause → analysis → 100%\` cycle. PR 2's docs/runbook need real captured outputs at each pause; this PR produces them.

## Test plan

Three-terminal observation:

- **Terminal #1** (me, the assistant) — \`kubectl argo rollouts get rollout litellm -n litellm --watch\`. Drives \`kubectl argo rollouts promote\` at each pause once the operator confirms expected shape.
- **Terminal #2** — \`watch -n 2 'kubectl get pods -n litellm -l app.kubernetes.io/name=litellm -L rollouts-pod-template-hash -o wide'\`. Observes pod distribution shift.
- **Terminal #3** — synthetic traffic loop (1 req/sec to the \`mistral-small\` alias). Keeps the AnalysisRun out of NaN territory so the 5-min analysis windows can complete with real data.

Expected lifecycle, observed and captured at each step:

- [ ] Canary fires within ~3 min of merge (ArgoCD sync + Rollout controller observes new pod-template hash)
- [ ] Step 2/6: \`Status: Paused, SetWeight: 20, ActualWeight: 20\` — 1 canary pod + 4 stable pods. Capture pod listing + Rollout state.
- [ ] \`promote\` → Step 3/6 (analysis). Confirm AnalysisRun spawns, query returns non-NaN with the traffic loop running. ~5 min.
- [ ] Auto-advance to Step 4/6: \`Status: Paused, SetWeight: 50, ActualWeight: 50\` — 3 canary + 2 stable. Capture again.
- [ ] \`promote\` → Step 5/6 (analysis). ~5 min.
- [ ] Auto-advance to Step 6/6 (100%). Old RS scales down, canary RS becomes stable. \`Status: Healthy\`. Capture final state.

Total wall-clock: ~15-20 min between merge and Healthy.

## Follow-up (PR 1.6)

Single commit reverting this PR. Triggers the reverse canary, second round of captured outputs. After both runs land, PR 2 swaps the captured real outputs into the docs/runbook in place of the fabricated samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)