### PR TITLE
fix(deploy): AnalysisTemplate must count 4xx as failure, not just 5xx

### DIFF
--- a/apps/litellm/manifests/analysis-template.yaml
+++ b/apps/litellm/manifests/analysis-template.yaml
@@ -4,14 +4,23 @@
 # failure condition, so Argo Rollouts treats them as inconclusive automatically.
 # inconclusiveLimit: 3 = after 3 inconclusive intervals, abort and hold rollout.
 #
-# Scope: this query sums across ALL litellm pods (stable + canary). Without the
-# Cilium L7 traffic split we don't have per-service request labels, so we measure
-# the union. A canary that's 100% broken at 20% weight contributes ~20% of total
-# requests as 5xx, which trips the >=5% failure threshold immediately. A canary
-# that's marginally worse than stable (e.g. 6% errors) only adds ~1.2% to overall
-# error rate — accepted noise for this gateway. Per-pod labelling would let us
-# bucket cleanly; for now, replica-count + whole-deployment error rate is good
-# enough for the homelab.
+# Scope: this query sums across ALL litellm pods (stable + canary). Without per-RS
+# label propagation on the metric we don't have per-service request labels, so we
+# measure the union. A canary that's 100% broken at 20% weight contributes ~20%
+# of total requests as errors, which trips the >=5% failure threshold immediately.
+# Per-pod labelling would let us bucket cleanly; for now, replica-count +
+# whole-deployment error rate is good enough for the homelab.
+#
+# Error definition: status!~"2..|3.." catches anything that isn't a 2xx success
+# or a 3xx redirect. Earlier the query was status=~"5.." (5xx only), which had
+# a critical blind spot: a canary serving 100% 4xx responses (e.g. upstream
+# OpenRouter free tier returns 404 "no endpoints found") would evaluate as
+# 0 numerator / N denominator = 0% error → AUTO-PROMOTED while completely
+# broken to consumers. Discovered 2026-05-04 during the first end-to-end
+# canary rehearsal — the synthetic-traffic loop hit a freshly-broken upstream
+# (mistral-small-3.1-24b-instruct:free) and produced 0/114 success with all
+# 4xx, which the 5xx-only query would have green-lit. See building/19
+# postmortem for the full story.
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:
@@ -29,6 +38,6 @@ spec:
         prometheus:
           address: "http://vmsingle-victoria-metrics-victoria-metrics-k8s-stack.monitoring.svc.cluster.local:8428"
           query: |
-            sum(rate(litellm_request_total{status=~"5.."}[5m]))
+            sum(rate(litellm_request_total{status!~"2..|3.."}[5m]))
             /
             sum(rate(litellm_request_total[5m]))


### PR DESCRIPTION
## Summary

The litellm \`AnalysisTemplate\` query was \`status=~"5.."\` — only counting 5xx as errors. A canary serving 100% 4xx (e.g. broken upstream returning 404 "no endpoints found", or 429 rate-limit) would evaluate as \`0 numerator / N denominator = 0%\` and **be auto-promoted while completely broken to consumers**.

This PR changes the query to \`status!~"2.. |3.."\` — anything that isn't a 2xx success or 3xx redirect counts as a canary error.

## How this was discovered

During the first end-to-end canary rehearsal (PR #215, mid-flight as I write this — currently paused at Step 1/6, SetWeight: 20):

- Terminal #3 ran a 1 req/sec synthetic traffic loop against the \`mistral-small\` alias to keep the upcoming AnalysisRun out of NaN territory.
- Result: **0 success / 114 requests, 100% failure** — 66× 404 + 48× 429.
- Cause: OpenRouter's \`mistralai/mistral-small-3.1-24b-instruct:free\` route is currently dead (no endpoints). Independent of our work; #210 swaps the alias out anyway.
- **Implication for the AnalysisTemplate**: under the old \`status=~"5.."\` query, those 114 requests would have all been counted in the denominator and zero in the numerator → 0% error rate → AnalysisRun passes → canary promoted to 50% → eventually to 100%. A completely broken canary, fully approved.

That's the kind of silent-pass that makes progressive delivery worse than no progressive delivery: the system gives you confidence in a deployment that has none of the actual properties confidence requires.

## Test plan

- [ ] After merge + ArgoCD sync (~3min), confirm the AnalysisTemplate is updated:
  \`\`\`bash
  kubectl get analysistemplate litellm-error-rate -n litellm -o yaml | grep -A 4 query:
  \`\`\`
  Expected: \`status!~"2..|3.."\`
- [ ] PR #215's canary is currently paused at Step 1/6. After this PR syncs, the next \`promote\` (which advances to Step 3/6 = AnalysisRun) will use the corrected template.
- [ ] PR 1.6 (revert of #215, immediately following this) provides a second canary cycle to verify the template behaves correctly under both "all 2xx" and "spiked 4xx" scenarios.

## Why this lands mid-rehearsal

Honest answer: we caught the defect during the rehearsal itself, in a way that proves both (a) the rehearsal is producing real value before any formal canary execution and (b) the template was unsafe in production from day 1 of the deploy layer (2026-03-25). Better to fix it before the canary advances to its first AnalysisRun than to capture an output of the broken template "passing" and explain the defect after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)