### PR TITLE
fix(deploy): drop AnalysisRun steps from canary, replace with manual pauses (Path A) + Path B spec

### DIFF
--- a/apps/litellm/manifests/rollout.yaml
+++ b/apps/litellm/manifests/rollout.yaml
@@ -24,9 +24,29 @@
 # prevents ArgoCD from fighting the controller's scale-down.
 #
 # Canary steps:
-#   20% (1/5 pods) → manual pause → 5-min VictoriaMetrics analysis →
-#   50% (3/5 pods) → manual pause → 5-min analysis →
+#   20% (1/5 pods) → manual pause → operator promote →
+#   50% (3/5 pods) → manual pause → operator promote →
 #   100% (full promotion)
+#
+# Metric-gated analysis is currently DISABLED. The original design referenced
+# `litellm_request_total` from VictoriaMetrics, but that metric is part of
+# LiteLLM's Enterprise (paid) Prometheus integration — the OSS image we run
+# does not emit it, and there's no scrape config either. The first end-to-end
+# rehearsal on 2026-05-04 (PR #215) proved this: AnalysisRun panicked with
+# `reflect: slice index out of range` because the query returned an empty
+# vector, controller treated 5 consecutive Errors as abort signal, rollout
+# correctly failed closed.
+#
+# `apps/litellm/manifests/analysis-template.yaml` is left in place as a
+# scaffold but is not referenced from any step here. A real signal source —
+# Cilium Hubble L7 stats, a JSON-log → Prometheus sidecar exporter, or an
+# Argo Rollouts `web` provider against /health/readiness — is brainstormed
+# in `docs/superpowers/specs/2026-05-04--deploy--litellm-canary-metric-source-design.md`.
+# Once one of those lands, re-introduce `analysis: { templates: ... }` between
+# each setWeight and the next manual pause.
+#
+# Until then: gating is fully manual at each pause. Operator is the
+# AnalysisRun.
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:
@@ -44,11 +64,5 @@ spec:
       steps:
         - setWeight: 20
         - pause: {}
-        - analysis:
-            templates:
-              - templateName: litellm-error-rate
         - setWeight: 50
         - pause: {}
-        - analysis:
-            templates:
-              - templateName: litellm-error-rate

--- a/docs/superpowers/specs/2026-05-04--deploy--litellm-canary-metric-source-design.md
+++ b/docs/superpowers/specs/2026-05-04--deploy--litellm-canary-metric-source-design.md
@@ -1,0 +1,184 @@
+# Spec: LiteLLM Canary Metric-Gated Promotion (Path B)
+
+**Status:** Skeleton — pending brainstorm
+**Layer:** deploy
+**Filed:** 2026-05-04
+**Filed by:** Terminal #1 (canary-rehearsal coordinator), with input from Terminal #2 (data-plane observer) and Terminal #3 (synthetic traffic driver)
+**Related:** `docs/superpowers/archived-plans/2026-03-25--deploy--argo-rollouts.md` (original layer plan), `docs/runbooks/litellm-canary-observation.md` (operating runbook), `apps/litellm/manifests/rollout.yaml` (currently pause-only canary), `apps/litellm/manifests/analysis-template.yaml` (orphaned scaffold)
+
+---
+
+## Problem
+
+The LiteLLM Argo Rollouts canary on Frank lacks a working metric source for gated promotion. The original `AnalysisTemplate` queries `litellm_request_total` from VictoriaMetrics, but **that metric does not exist on this cluster** because:
+
+- LiteLLM's Prometheus integration is part of LiteLLM Enterprise (paid). The OSS Helm chart we deploy does not emit any `litellm_*` metrics.
+- The chart's Service has no metrics port; pods return HTTP 404 on `/metrics`.
+- No `ServiceMonitor` or `VMServiceScrape` was ever added for LiteLLM.
+
+The defect was latent for 39 days because the canary itself was stuck on a separate broken plumbing (the never-published Cilium traffic-router plugin — see `building/19-progressive-delivery` postmortem). It surfaced on 2026-05-04 during the first end-to-end rehearsal: with no metric series, the AnalysisRun's query returned an empty vector, the Argo Rollouts Prometheus provider panicked with `reflect: slice index out of range` on `result[0]`, hit `consecutiveErrorLimit: 4`, and the controller correctly failed closed — aborted the canary, scaled stable back to 5/5.
+
+As of 2026-05-04, the LiteLLM canary in `apps/litellm/manifests/rollout.yaml` is **pause-only** (no analysis gating). Operator promotes manually at each step. This works for a homelab where the operator is also the user, but loses the value proposition of metric-gated progressive delivery.
+
+This spec captures the design space for restoring metric-gated promotion, with three concrete candidate signal sources that don't require LiteLLM Enterprise.
+
+---
+
+## Goals
+
+1. **A working `litellm_request_total` (or equivalent) metric in VictoriaMetrics**, scraped from a non-Enterprise source.
+2. **Per-pod / per-ReplicaSet labelling** on the metric, so the AnalysisTemplate query can filter to the canary RS only — sidesteps the dilution problem in the current "union-of-stable+canary" aggregation (a 100%-broken canary at 20% weight only contributes 20% of total to a union error rate, which is exactly at the 5% threshold's noise floor for marginal regressions).
+3. **Failure-mode coverage** that catches the 4xx silent-pass risk (already addressed in PR #216 by switching the query from `status=~"5.."` to `status!~"2..|3.."`, but moot until the metric exists).
+4. **Operating-runbook viability** — the new signal source must be inspectable from `kubectl exec` / `wget` for a human debugging "why did this canary abort?" without needing Grafana access.
+
+## Non-goals
+
+- Replacing Argo Rollouts itself.
+- Adding LiteLLM Enterprise to the cluster (out of scope; cost/value mismatch for a homelab).
+- Re-architecting LiteLLM's exposure pattern (raw Cilium L2 LB at `192.168.55.206:4000` + Traefik IngressRoute `litellm.cluster.derio.net` stays).
+
+---
+
+## Candidate signal sources
+
+### Option 1 — Cilium Hubble L7 stats (Terminal #3's preferred)
+
+**Idea:** Use `hubble_http_responses_total{destination_workload="litellm", destination_pod=~"litellm-<canary-hash>-.*"}` from the Hubble metrics endpoint already running on this cluster.
+
+**Pros:**
+- Zero app-side changes. LiteLLM stays exactly as-is.
+- Per-pod labelling is free. Hubble carries `destination_pod` natively.
+- Catches things app-side metrics can't: connection-level RST, 502 from a sidecar/proxy, kube-proxy mis-routing.
+- Hubble metrics are already scraped on Frank.
+
+**Cons:**
+- Requires Hubble L7 visibility to be enabled cluster-wide for the LiteLLM namespace (currently L4 only by default; check `apps/cilium/values.yaml`).
+- Granularity is HTTP request — no per-model bucketing (would need URL-path inspection or LiteLLM-specific request attributes Hubble doesn't see).
+- Cardinality: per-pod × per-status-code × per-source-app explosion if not labelled-down at scrape time.
+
+**Open questions:**
+- What's the cardinality cost of enabling L7 visibility for the LiteLLM namespace?
+- Does Hubble's `destination_pod` label survive the canary-pod hash being a moving target across rollouts?
+- How does the AnalysisTemplate query reference the canary RS hash (which only Argo Rollouts knows)? Likely needs a templating layer or `metricArgs` from the Rollout spec.
+
+### Option 2 — JSON-log → Prometheus sidecar exporter (Terminal #3's "cheap and concrete")
+
+**Idea:** ~50-line Python sidecar in each LiteLLM pod that tails LiteLLM's JSON access logs from a shared `emptyDir`, parses `request_completed` events, emits `litellm_request_total{model, status, api_user}` as a Prometheus counter on `:9090`. ServiceMonitor scrapes it.
+
+Sketch (from Terminal #3's note in `docs/agentic-discussion/terminal-3.md`):
+```python
+import json, sys
+from prometheus_client import Counter, start_http_server
+
+req = Counter("litellm_request_total", "Requests",
+              ["model", "status", "api_user"])
+start_http_server(9090)
+for line in sys.stdin:
+    try:
+        e = json.loads(line)
+        if e.get("event") == "request_completed":
+            req.labels(e["model"], str(e["status_code"]),
+                       e.get("api_user", "anon")).inc()
+    except (ValueError, KeyError): pass
+```
+
+**Pros:**
+- Carries the *exact* metric name our existing `AnalysisTemplate` references — once deployed, AnalysisTemplate query is unchanged.
+- Per-pod by construction (each sidecar emits its own pod's traffic).
+- Per-model labelling is free (closes Terminal #3's "single-model probing has a blind spot" concern).
+- No upstream license cost.
+
+**Cons:**
+- New code to maintain (sidecar image needs a CI pipeline).
+- Requires LiteLLM JSON logging to be configured (env var `LITELLM_LOG=JSON` or similar — needs verification).
+- Sidecar fails → metrics gap. Need a probe story.
+- Adds a sidecar to every LiteLLM pod (5 of them) — cumulative resource cost.
+
+**Open questions:**
+- Does LiteLLM OSS's structured-log output actually carry `model`, `status_code`, `api_user` reliably for every request? Need to capture a sample.
+- Where does the sidecar image live? `agent-images` repo, or new `derio-net/litellm-metrics-exporter`?
+- How is the sidecar wired into the Helm chart's pod template — fork the chart, or override via `extraContainers`?
+
+### Option 3 — Argo Rollouts `web` provider against `/health/readiness` (cheapest, coarsest)
+
+**Idea:** Drop the Prometheus provider entirely. AnalysisTemplate uses AR's `web` provider to GET each canary pod's `/health/readiness` (which is a real LiteLLM endpoint, returns 200 when the proxy is up). Treat consecutive 5xx or non-200 as failure.
+
+**Pros:**
+- Zero new infrastructure. AR ships with `web` provider out of the box.
+- Cheap to implement (~10 min PR).
+- Catches the "pod is up and the proxy responds" failure mode — which is at least *something* gated.
+
+**Cons:**
+- Coarsest signal. Doesn't catch per-route degradations (e.g. mistral-small upstream-flap), per-model 4xx spikes, latency regressions, or anything that happens *after* the readiness probe.
+- Health-probe failures already gate readiness at the kubelet level. Adding a probe-based AR is largely redundant with what the kubelet does — we'd just be making the same signal "manual-promotion-blocking" instead of just "pod-removed-from-Service-endpoints."
+
+**Open questions:**
+- Is there any non-trivial signal `/health/readiness` catches that the kubelet's existing readinessProbe doesn't already act on?
+- Can AR `web` provider hit per-pod URLs (vs Service URLs)? Per-pod is needed for canary-vs-stable distinction.
+
+---
+
+## Decision criteria
+
+In rough priority order:
+
+1. **Does it catch the failure modes we discovered on 2026-05-04?** Specifically: (a) the empty-vector / NaN trap in the current Prometheus path, (b) the silent-4xx-pass risk PR #216 closed, (c) per-model degradation hidden by aggregate metrics.
+2. **Per-RS / per-pod labelling — yes/no.** Without it, dilution makes the threshold meaningless at low canary weights.
+3. **Operating cost** — new code? new image? new sidecar? new license?
+4. **Inspectability without Grafana** — can a human curl/exec to debug "why did this canary abort?"
+5. **Compatibility with the existing `AnalysisTemplate` shape** — minimises blast radius of the change.
+
+| Criterion | Hubble L7 | Sidecar exporter | Web provider |
+|---|---|---|---|
+| Catches 2026-05-04 failure modes | ✅ all | ✅ all | ⚠️ partial (only pod-up) |
+| Per-pod labelling | ✅ free | ✅ by construction | ⚠️ manual URL-per-pod |
+| New code/image | ❌ none | ✅ ~50 LOC + image | ❌ none |
+| New scrape config | ✅ already scraped | ✅ ServiceMonitor | ❌ none |
+| Inspectable via curl | ⚠️ requires Hubble Relay access | ✅ `wget pod:9090/metrics` | ✅ `wget pod:4000/health/readiness` |
+| Reuses existing `AnalysisTemplate` | ❌ different query, different metric name | ✅ literally unchanged | ❌ different provider entirely |
+| Operating cost | low (config only) | medium (new image, sidecar in every pod) | very low (config only) |
+
+---
+
+## Tentative recommendation (for the brainstorm to confirm or push back)
+
+**Hybrid: Sidecar exporter (Option 2) + Hubble L7 (Option 1) as a defence-in-depth pair.**
+
+- **Sidecar exporter as the primary AR signal** — carries the exact metric name our existing `AnalysisTemplate` references, per-pod by construction, per-model labelling closes Terminal #3's blind-spot concern. Cheapest to wire into AR.
+- **Hubble L7 as the secondary signal** for things app-side metrics can't see (kube-proxy mis-routing, RSTs, 502 from anything between the pod and the LB). Could be a separate AR step, or just a Grafana alert that pages the operator out-of-band.
+- **Web provider rejected** — too coarse, redundant with the kubelet's readiness gating.
+
+Pure Option 1 vs pure Option 2 trade-off: Option 2 carries more surface area (image to maintain, sidecar in every pod) but reuses the existing `AnalysisTemplate` and gives per-model labels. Option 1 is zero app-side change but requires per-canary-RS templating in the AR query and doesn't see model-level failures. The hybrid uses each for what it's best at.
+
+---
+
+## Adjacent improvements to fold in (out of scope for the metric-source decision proper, but logged here so they don't get lost)
+
+- **`lifecycle.preStop` hook on canary pods** that `tar`s `/var/log` to a known PVC mount before scale-down — captures canary pod logs at the exact moment we need them most (post-abort), which is the exact moment they vanish today. Suggested by Terminal #2. Cheap, idempotent, doesn't touch the chart.
+- **Migration Job nodeSelector** — pin the LiteLLM `litellm-migrations` PreSync hook to amd64 so it doesn't land on raspi-1 and pay a 4-minute cold-pull tax on a 714 MB ARM image per canary. Suggested by Terminal #2.
+- **Synthetic-traffic-driver split** — the role Terminal #3 played today (1 req/sec curl loop) doesn't need an LLM. Convert to a Tekton task with a Telegram webhook on non-200, free the agent slot for narrative observation. Suggested by Terminal #3.
+- **Multi-model traffic loop** — synthetic traffic should rotate through *all* important model classes, not pick one. Today Terminal #3 picked qwen3.5 (all-200) which would have *masked* a per-route degradation in mistral-small if the canary had been gating on it. Suggested by Terminal #3.
+- **PR #215's date-coded synthetic-trigger env var → counter or nonce** — `CANARY_REHEARSAL_2026_05_04: "1"` doesn't differentiate same-day repeats. Recommend `CANARY_REHEARSAL_NONCE: "<uuid>"` or `CANARY_REHEARSAL_COUNT: "<int>"`. Suggested by Terminal #3.
+- **Pre-merge query smoke test** — Tekton task that runs proposed AR queries against live VM with a healthy time window and asserts non-empty result. Would have caught Bug #5 at PR #216 review time. Suggested by Terminal #3.
+
+---
+
+## Open questions for the brainstorm
+
+1. Hybrid (Hubble + sidecar exporter) vs pure-sidecar-exporter — is the defence-in-depth worth the extra moving piece?
+2. If sidecar-exporter is chosen: where does the sidecar image live (which repo, which CI), and how does it get into the LiteLLM Helm chart's pod template (chart fork, override, or admission webhook)?
+3. If Hubble is in the picture: what's the cardinality cost of enabling L7 visibility on the litellm namespace, and what scrape-time labelling do we need to keep series count sane?
+4. Should this layer also pick up the adjacent improvements above, or split them off into separate plans?
+
+---
+
+## Implementation phases (sketch, for whoever picks this up)
+
+- **Phase 1 — confirm signal source.** Manually run the chosen approach against the live cluster (e.g., shell into a LiteLLM pod, configure JSON logging, pipe to a local exporter, verify metric shape). Capture the time-series and decide whether the per-pod / per-model resolution is what we expected.
+- **Phase 2 — wire it into the chart.** Image, sidecar config, ServiceMonitor / VMServiceScrape, RBAC if needed.
+- **Phase 3 — re-introduce `analysis: { templates: ... }` to the canary.** Update `apps/litellm/manifests/rollout.yaml` to put an analysis step back between each `setWeight` and the next `pause`. Update or replace the existing `apps/litellm/manifests/analysis-template.yaml` with the new query.
+- **Phase 4 — third end-to-end rehearsal.** Synthetic env-var trigger, three-terminal observation, capture real metric-gated outputs. Compare to PR 1.5/1.6's pause-only outputs. Update the operating runbook to document the metric-gated path as the canonical operation.
+
+---
+
+*This skeleton is intentionally opinionated to give the brainstorm a starting point. Push back hard, especially on the hybrid recommendation — the "use both" instinct is often wrong when one of them does 80% of the job for half the cost.*


### PR DESCRIPTION
## Summary

Disable the metric-gated AnalysisRun steps in the litellm canary; gating becomes fully manual at each pause. Concurrent: file the design spec for Path B (a real metric source) so the loss of automation is documented and recoverable, not abandoned.

This is the 5th-latent-bug fix from the 2026-05-04 rehearsal cascade — see context below — and adopts the **Path A** option from the discussion in \`docs/agentic-discussion/\`.

## What changes

- \`apps/litellm/manifests/rollout.yaml\` — drop the two \`analysis: { templates: [litellm-error-rate] }\` steps. Canary becomes \`setWeight: 20 → pause: {} → setWeight: 50 → pause: {} → 100%\`. Header comment expanded to explain the gap and reference the spec.
- \`docs/superpowers/specs/2026-05-04--deploy--litellm-canary-metric-source-design.md\` — new design spec for Path B. Captures three candidate signal sources (Cilium Hubble L7, JSON-log → Prometheus sidecar exporter, Argo Rollouts \`web\` provider) with trade-off matrix, decision criteria, tentative recommendation, and adjacent improvements harvested from the multi-agent discussion.

\`apps/litellm/manifests/analysis-template.yaml\` is **not deleted** — kept as a scaffold for when Path B lands and we re-introduce \`analysis\` steps to the Rollout.

## Why

The 2026-05-04 rehearsal discovered the AnalysisTemplate references a metric (\`litellm_request_total\`) that does not exist on this cluster. LiteLLM's Prometheus integration is a **paid Enterprise feature**; the OSS image we run does not emit it, the chart's Service has no metrics port, and no scrape config was ever added. The PR #216 4xx-fix and the original \`status=~"5.."\` query are both equally moot against an empty metric series.

Discovery sequence (5 bugs in the deploy layer, in order found):

1. ✅ #213 — broken Cilium traffic-router plugin (39-day silent stall)
2. (caught in code review) — over-broad \`service-canary\` selector
3. ✅ #214 — missing \`workloadRef.scaleDown: onsuccess\`
4. ✅ #216 — \`AnalysisTemplate\` query missed 4xx
5. **THIS PR** — AnalysisTemplate references a metric source that was never present; canary aborts with \`reflect: slice index out of range\` panic on empty vector. Structural, not surgical. Replaced with manual gating; spec'd for proper fix.

Argo Rollouts behaved correctly throughout: when its Prometheus provider panicked, the controller treated 5 consecutive \`Error\` measurements as abort signal and rolled back. **The system failed closed, not open.** That property holds whether or not we have working metrics, which is the right ordering of concerns.

## Test plan

After merge + ArgoCD sync (~3 min):

- [ ] \`kubectl get rollout litellm -n litellm -o yaml | grep -c "analysis"\` returns 0 (Rollout no longer references the AnalysisTemplate)
- [ ] \`kubectl get analysistemplate litellm-error-rate -n litellm\` still exists (kept as scaffold)
- [ ] \`kubectl argo rollouts retry rollout litellm -n litellm\` re-triggers the canary on the new analysis-less spec
- [ ] Canary advances cleanly: 1 canary on \`67b4ccbdb4\` + 4 stable → promote → 3 canary + 2 stable → promote → 5 canary, 0 stable. Status flips to Healthy.
- [ ] Captures from this run feed PR 2's docs/runbook (replacing the fabricated samples and the existing \`/tmp/frank-canary-captures/\` files from the aborted run).

## Cascade after this lands

- **Retry the canary** via \`kubectl argo rollouts retry\` — this proves end-to-end via the new pause-only path. Captures real outputs at each pause.
- **PR 1.6** (revert PR #215's synthetic env var) — second canary, roundtrip back. Two clean observations completed.
- **PR 2** — docs/blog/runbook rewrite using the captured outputs. Postmortem cites all five bugs and the multi-agent discovery process.
- **Path B brainstorm** — separate session, working from the spec. Implementation when chosen.

## Multi-agent discussion artifact

\`docs/agentic-discussion/\` (untracked, local only — operator may decide whether to commit it) contains the full back-and-forth between Terminal #1 (this agent), Terminal #2 (data-plane observer), and Terminal #3 (synthetic traffic driver) that converged on Path A + Path B-spec. Notable contributions:

- **T2** caught that Argo Rollouts retries \`Error\` at 10s cadence (not the configured 1m), so the abort budget for a zero-traffic canary is ~50s, not 5+ minutes. Runbook rewrite needed.
- **T2** measured per-stable-pod request distribution (152/142/127/139, σ/μ ≈ 6.7%) — strong evidence the replica-count weighting splits cleanly at the kube-proxy layer.
- **T3** sketched a ~50-line Python sidecar-exporter that would emit the *exact* metric name our existing AnalysisTemplate references (closes both Bug #5 and the per-pod labelling problem at once). Folded into the spec as Option 2.
- **T3** flagged that single-model probing has a blind spot — qwen3.5 (all-200) would have masked a per-route degradation in mistral-small. Captured as an adjacent improvement in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)