### PR TITLE
chore(deploy): revert synthetic canary trigger (PR 1.6, second rehearsal canary)

### DIFF
--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -18,14 +18,6 @@ environmentSecrets:
 
 envVars:
   STORE_MODEL_IN_DB: "True"
-  # SYNTHETIC CANARY TRIGGER — to be reverted in immediately-following PR.
-  # This env var has no effect on LiteLLM behavior; its sole purpose is to
-  # mutate the Deployment's pod template so the Argo Rollouts controller
-  # observes a workload-template change and fires its canary steps. The
-  # post-#213/#214 Rollout has never been exercised end-to-end; this is the
-  # rehearsal run that produces the real captured outputs needed by the
-  # progressive-delivery doc rewrite (PR 2). Removed in the next commit.
-  CANARY_REHEARSAL_2026_05_04: "1"
 
 # LiteLLM proxy configuration (rendered as config.yaml)
 proxy_config:


### PR DESCRIPTION
## Summary

Reverts the \`CANARY_REHEARSAL_2026_05_04: "1"\` env var added in #215. Triggers the second canary execution in the reverse direction (current pod template → original pre-#215 pod template), completing the round-trip.

## Why a second canary

Two canary cycles in opposite directions gives PR 2's docs/runbook a complete dataset. The first cycle (post-#217) produced clean captures of the textbook lifecycle (1 canary + 4 stable → promote → 3+3 with maxSurge → promote → 5+0). This second cycle proves the same machinery handles the reverse direction symmetrically.

## What this PR's canary does NOT exercise

- **Metric-gated promotion** — still pause-only per #217. Path B brainstorm (see \`docs/superpowers/specs/2026-05-04--deploy--litellm-canary-metric-source-design.md\`) is the follow-up that restores automation.
- **Image bumps** — pod template change is just env var removal. Image still \`v1.82.3-stable\` throughout. PR #210 will be the third canary execution, and the first one with an actual image bump.

## Test plan

Same three-terminal flow as #215, but in reverse:

- [ ] After merge + ArgoCD sync (~3 min), the canary fires (Status: Paused, Step: 1/4, SetWeight: 20). 1 canary pod on the pre-#215 pod template hash + 4 stable on the current \`67b4ccbdb4\` hash.
- [ ] Operator promote → setWeight 50 → 3 canary + 2 stable (with maxSurge transient at 6 pods total).
- [ ] Operator promote → 100% Healthy. Old (current) RS scales to 0. Total 5 pods, all on the reverted pod template hash. Deployment stays at replicas: 0 (workloadRef invariant).
- [ ] LiteLLM continues to serve requests cleanly throughout (smoke: \`curl http://192.168.55.206:4000/v1/models -H "Authorization: Bearer \$LITELLM_MASTER_KEY"\` → HTTP 200).

Captures land at \`/tmp/frank-canary-captures/08-paused-at-20-revert.txt\`, \`09-paused-at-50-revert.txt\`, \`10-healthy-after-revert.txt\` for PR 2.

## Cascade after this lands

- **PR 2** — docs/blog/runbook rewrite using the captured outputs from both cycles. Postmortem cites the full discovery process: 5 latent bugs in the deploy layer, multi-agent observation that converged on Path A + Path B-spec, Argo Rollouts' fail-closed behavior validated under multiple distinct broken states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)