### PR TITLE
fix(infer): bump LiteLLM to v1.83.14-stable.patch.1 (unblock PR #210 canary)

### DIFF
--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: ghcr.io/berriai/litellm-database
-  tag: "main-v1.83.14-stable"
+  tag: "main-v1.83.14-stable.patch.1"
   pullPolicy: IfNotPresent
 
 # Master key from ExternalSecret-managed K8s Secret


### PR DESCRIPTION
## Summary

Bumps the LiteLLM image tag from \`main-v1.83.14-stable\` to \`main-v1.83.14-stable.patch.1\`. One-line change to \`apps/litellm/values.yaml\`.

## Why

PR #210's canary is currently stuck. ArgoCD's PreSync migration Job has failed 5 times — the new image's arm64 layer is broken upstream:

- Job pod scheduled to raspi-1 (cluster's only ARM node)
- Pulled the arm64 manifest layer for v1.83.14-stable
- exec'd \`/app/.venv/bin/python\` → \`exec format error\` (binary is actually amd64)
- Failed; backoff → repeated → ArgoCD gave up

v1.82.3-stable's arm64 layer worked fine in yesterday's rehearsal, so this is a v1.83.14-stable upstream regression. BerriAI published \`v1.83.14-stable.patch.1\` shortly after, presumably with the arm64 layer fixed (manifest is the same multi-arch shape but a patch release after this class of issue strongly implies "we re-pushed the broken layer corrected").

## Test plan

- [ ] After merge + ArgoCD sync, the PreSync migration Job spawns with image \`main-v1.83.14-stable.patch.1\`. Whatever node it lands on (probably raspi-1 again, since the chart has no nodeSelector), it should now exec cleanly.
- [ ] Migration Job completes successfully (\`prisma migrate deploy\`).
- [ ] ArgoCD wave 0 applies: PVC stays at 200Gi (already there), Deployment template updates with the new image tag.
- [ ] Argo Rollouts controller observes new pod-template hash, fires the canary at Step 1/4 (SetWeight 20).
- [ ] Three-terminal canary observation per the runbook proceeds end-to-end.

## Adjacent follow-up (separate, not in this PR)

T2 noted in the rehearsal that the migration Job should be pinned to amd64 nodes via \`nodeSelector\` to avoid the 4-7 min cold-pull tax on raspi-1's ARM image. That improvement just escalated from "save 4 minutes" to "would have prevented an entire class of upstream-broken-arm64 failure." Worth a small follow-up PR adding \`migrationJob.nodeSelector: {kubernetes.io/arch: amd64}\` (or chart-equivalent) once we confirm the patch.1 bump unblocks us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)