### PR TITLE
agents: Phase 5 soak — reset branch to main when PR is merged (gh#156)

### DIFF
--- a/scripts/phase5-soak-daily.sh
+++ b/scripts/phase5-soak-daily.sh
@@ -228,16 +228,34 @@ PY
   )
   log "Day $day row: $row"
 
-  # Apply to plan on the soak branch in the dedicated clone. If the soak
-  # branch doesn't exist on origin yet (first fire post-merge), branch off
-  # the latest base branch (main).
+  # Apply to plan on the soak branch in the dedicated clone.
+  #
+  # Branch-state decision: an open PR with `--head $SOAK_BRANCH` is the
+  # signal that previous fires' commits are still un-merged and we should
+  # append to that branch. Without an open PR we treat the branch as
+  # post-merge — its commits are already on main (possibly via squash, so
+  # SHAs differ but content is identical) — and we reset it to
+  # origin/main so today's commit lands on a clean base. Without this
+  # reset, a stale branch ref would replay already-merged rows on top of
+  # main and the next push would CONFLICT with itself.
   ensure_clone
   cd "$CLONE_DIR"
   git fetch --quiet --prune origin
-  if git ls-remote --heads origin "$SOAK_BRANCH" | grep -q "$SOAK_BRANCH"; then
+  local has_open_pr
+  has_open_pr=$(gh pr list --repo "$REPO_SLUG" --state open --head "$SOAK_BRANCH" \
+    --json number --jq '.[].number' 2>>"$LOG" | head -1)
+  local branch_on_origin
+  branch_on_origin=$(git ls-remote --heads origin "$SOAK_BRANCH" | head -1)
+
+  if [[ -n "$has_open_pr" && -n "$branch_on_origin" ]]; then
+    log "  open PR #${has_open_pr} for $SOAK_BRANCH — appending to existing branch"
     git checkout --quiet -B "$SOAK_BRANCH" "origin/$SOAK_BRANCH"
   else
-    log "  $SOAK_BRANCH not on origin — branching from origin/$BASE_BRANCH"
+    if [[ -n "$branch_on_origin" && -z "$has_open_pr" ]]; then
+      log "  $SOAK_BRANCH on origin but no open PR — assuming post-merge; resetting to origin/$BASE_BRANCH"
+    else
+      log "  $SOAK_BRANCH not on origin — branching from origin/$BASE_BRANCH"
+    fi
     git checkout --quiet -B "$SOAK_BRANCH" "origin/$BASE_BRANCH"
   fi
 
@@ -283,7 +301,12 @@ PY
     git -c user.name="Clawdia" -c user.email="clawdia-ai-assistant@gmail.com" \
       commit --quiet -m "agents: Phase 5 soak Day $day (gh#156)" \
       -m "p99 working-set, queue peak, restart count for ${today}. Auto-filled by phase5-soak-daily.sh." >> "$LOG" 2>&1
-    git push --quiet --set-upstream origin "$SOAK_BRANCH" >> "$LOG" 2>&1
+    # --force-with-lease is needed for the post-merge case: when we reset
+    # the local branch to origin/main, the local history diverges from the
+    # stale origin ref. The lease check refuses to overwrite if origin has
+    # advanced since our fetch, so this is still safe under concurrent
+    # work (which we don't expect, but cheap insurance).
+    git push --quiet --force-with-lease --set-upstream origin "$SOAK_BRANCH" >> "$LOG" 2>&1
     log "  Day $day pushed to $SOAK_BRANCH"
   fi
 


### PR DESCRIPTION
## Summary

Follow-up to #206. Day 3's auto-fire opened PR #222 with two commits — Day 2 (already on main from #212) and Day 3 — which made #222 conflict with main on the Day-2 row.

The script's previous "branch exists on origin → append" logic doesn't survive squash-merges: after a merge, the branch SHA isn't an ancestor of main even though the content is, so the script replayed Day 2 on top of already-merged rows.

## What changed

- New branch-state decision: open-PR existence (`gh pr list --state open --head $SOAK_BRANCH`) is the signal to append vs. reset. Branch presence alone is meaningless after a squash-merge.
- If an open PR exists → checkout `origin/$SOAK_BRANCH` and append (unchanged).
- Otherwise → checkout `origin/main` and start fresh.
- Push now uses `--force-with-lease` to handle the reset case (where the local branch diverges from the stale origin ref). Lease keeps it safe under concurrent work.

## Hotfix already applied

PR #222 was rebuilt out-of-band on the soak-data branch: reset to `origin/main`, Day-3 row re-applied, force-pushed. State now: MERGEABLE/CLEAN, single commit, +1/-1.

## Test plan

- [x] `bash -n` syntax check
- [x] Today (Day 3, PR #222 open): script hits append path, logs "open PR #222 ... appending", "no diff — Day 3 already filled" (idempotent)
- [ ] Tomorrow 08:00 UTC (Day 4, after #222 is merged): script should hit the reset path, open a new PR with just Day 4
- [ ] If #222 is left open through Day 4: script appends Day 4 to it (existing-PR path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)