### PR TITLE
agents: Phase 5 soak data collection (gh#156)

### DIFF
--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -453,7 +453,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 1 | 2026-05-03 | 0 | 0 | ~2.35 GiB (cadvisor) / ~2.53 GiB (resource), instant 2.09 GiB | 0 (active=2 at sample time, max=4) | Soak start. Phase 4 image `8af0d080` live, env `VK_MAX_CONCURRENT_EXECUTIONS=4` confirmed via `/metrics`. No queue events yet. |
 | 2 | 2026-05-04 | 0 | 0 | 2.95 GiB | 3 | pod=secure-agent-pod-c976f9946-rqdqc |
 | 3 | 2026-05-05 | 0 | 0 | 0.74 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
-| 4 | 2026-05-06 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 4 | 2026-05-06 | 0 | 0 | 0.97 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
 | 5 | 2026-05-07 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 6 | 2026-05-08 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 7 | 2026-05-09 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |


### PR DESCRIPTION
Phase 5 soak data collection (gh#156). Auto-filled by
`scripts/phase5-soak-daily.sh` on the secure-agent-pod each day at
08:00 UTC for the soak window 2026-05-04 → 2026-05-16 (Days 2–14).

The Soak Log table on `main` (from #205) ships 14 placeholder rows;
this PR replaces `_tbd_` cells with actual readings as the days roll.
Merge when the table is full and the Phase 5 Task 2 decision (a/b/c)
is documented, OR earlier if you want to mid-cycle review.

Once Day 14 (2026-05-16) has been recorded, the daily script switches
to cleanup-nag mode automatically — see `scripts/phase5-soak-daily.sh`
header for the manual cleanup steps.