### PR TITLE
inference: add qwen3.6:35b-a3b to local model lineup

### DIFF
--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -68,11 +68,14 @@ envVars:
 
 # LiteLLM proxy configuration (rendered as config.yaml)
 #
-# Lineup refresh — 2026-05-03
+# Lineup refresh — 2026-05-03 (qwen3.6:35b-a3b added 2026-05-06)
 # Sized for gpu-1's RTX 5070 Ti (16GB GDDR7). With OLLAMA_MAX_LOADED_MODELS=1,
-# each loaded model can use up to ~14GB after KV cache + multimodal overhead.
-# Local covers default + multimodal + coding + reasoning; cloud covers
-# frontier-scale, video, and 200B+-class reasoning.
+# only one model loads at a time. Most entries are dense and fully resident
+# in VRAM (≤14GB after KV cache + multimodal overhead); qwen36-a3b is the
+# exception — MoE 35B-A3B that relies on partial CPU offload of inactive
+# experts to gpu-1's 128GB host RAM. Local covers default + multimodal +
+# coding + reasoning + MoE-flagship; cloud covers frontier-scale, video,
+# and 200B+-class reasoning.
 proxy_config:
   model_list:
     # ──────────────────────────────────────────────
@@ -122,6 +125,31 @@ proxy_config:
     - model_name: qwen-think-14b
       litellm_params:
         model: ollama/qwen3:14b
+        api_base: http://ollama.ollama.svc.cluster.local:11434
+
+    # Qwen3.6 35B-A3B — MoE reasoning/general flagship, 256K context
+    # 35B total / 3B active params per token. Q4_K_M ≈ 24GB on disk —
+    # does NOT fit fully in 16GB VRAM. Ollama partially offloads
+    # inactive experts to host RAM (gpu-1 has 128GB). The only local
+    # model in the lineup that relies on partial offload; the dense
+    # 14B/24B siblings remain fully resident.
+    # Measured 2026-05-06 with num_ctx=4096: 41% CPU / 59% GPU split
+    # (~15.3GB host RAM + ~10.7GB VRAM, 95% of the 16GB card),
+    # ~20 tok/s generation, ~126 tok/s prefill. MoE routing keeps
+    # throughput usable since only ~3B active weights are hot per
+    # token — a dense 35B at the same split would be ~5x slower.
+    # Cap num_ctx well below 256K — KV cache at full context would
+    # dwarf the model itself. 8K-16K is the practical ceiling on a
+    # 16GB card; higher contexts force more weights to CPU and the
+    # generation rate drops sharply.
+    # Thinking mode is ON by default (Qwen3.6 family characteristic).
+    # Callers who want terse output should pass "think": false in the
+    # API request body, or include "/no_think" in the prompt — without
+    # this, even trivial questions trigger ~hundreds of reasoning
+    # tokens before the answer.
+    - model_name: qwen36-a3b
+      litellm_params:
+        model: ollama/qwen3.6:35b-a3b
         api_base: http://ollama.ollama.svc.cluster.local:11434
 
     # ──────────────────────────────────────────────

--- a/apps/ollama/values.yaml
+++ b/apps/ollama/values.yaml
@@ -22,10 +22,11 @@ extraEnv:
 
 persistentVolume:
   enabled: true
-  # 200Gi — sized for the 5-model lineup (~55GB at rest) plus headroom for
-  # experimentation. The 5070 Ti has 16GB VRAM; only one model loads at a
-  # time per OLLAMA_MAX_LOADED_MODELS=1, so disk is the only soft limit on
-  # how many models can cohabit.
+  # 200Gi — sized for the 6-model lineup (~79GB at rest, qwen3.6:35b-a3b
+  # added 2026-05-06 brought it from ~55GB) plus headroom for experimentation.
+  # The 5070 Ti has 16GB VRAM; only one model loads at a time per
+  # OLLAMA_MAX_LOADED_MODELS=1, so disk is the only soft limit on how many
+  # models can cohabit.
   size: 200Gi
   storageClass: longhorn
   accessModes:


### PR DESCRIPTION
## Summary

- Adds the Qwen3.6 35B-A3B MoE flagship to the local Ollama lineup, exposed through LiteLLM as `qwen36-a3b`.
- First local model in the lineup that does **not** fit fully in the 16GB VRAM budget — relies on partial CPU offload to gpu-1's 128GB host RAM.
- Pre-pulled on the gpu-1 Ollama pod before merging so the LiteLLM ServerSideApply roll lands with the model already warm on disk.

## Why this model

Qwen3.6-35B-A3B (released 2026-04-16, Apache-2.0) is the largest local-friendly model in the Qwen3.6 generation. The MoE architecture (35B total / 3B active per token) is what makes a 35B viable on a 16GB card with 128GB host RAM — a dense 35B at the same offload split would be ~5x slower. The Qwen3.6 line only ships at 27B (dense, 17GB Q4_K_M — also overflows VRAM but pays full dense-offload tax) and 35B-A3B, so this is the right choice for "best Qwen3.6 quality on gpu-1."

## Measured performance (gpu-1, num_ctx=4096, smoke-test prompt)

| Metric | Value |
|---|---|
| Memory split | **41% CPU / 59% GPU** |
| GPU memory | 15.45 / 16.3 GiB (**95%**) |
| Generation rate | **~20 tok/s** |
| Prefill rate | ~126 tok/s |
| Load duration (first call) | 7.8s (disk pages were hot from the recent pull) |

## Operational notes

- **Thinking mode is ON by default** for the Qwen3.6 family. Callers who want terse output must pass `"think": false` in the API request body or include `/no_think` in the prompt — otherwise even trivial questions emit hundreds of reasoning tokens before the answer.
- **VRAM is at 95% utilization** with just 4K context. Anything else trying to claim GPU memory on gpu-1 (e.g. a concurrent ComfyUI inference) will OOM unless coordinated. Higher context (16K+) pushes more weights to CPU and tanks throughput.
- **`OLLAMA_MAX_LOADED_MODELS=1`** is unchanged — first call to `qwen36-a3b` evicts whatever was loaded (typically `mistral-small-24b`); subsequent calls to other models evict it back. No lineup-wide contention.
- **`apps/ollama/values.yaml` `models.pull` was intentionally not touched** — none of the existing five models are declared there either; the convention is "LiteLLM is the source of truth, Ollama PVC is hand-fed." Adding only the new entry would be inconsistent. Disk-budget comment was bumped from "5-model lineup (~55GB)" to "6-model lineup (~79GB)" to reflect the new addition.

## Test plan

- [x] `ollama pull qwen3.6:35b-a3b` completes on gpu-1 (23GB on disk, manifest verified)
- [x] `ollama run qwen3.6:35b-a3b "..."` produces a correct response (smoke-test: simple arithmetic word problem, model answered correctly)
- [x] `ollama ps` shows the model loads with a healthy CPU/GPU split (41/59) and stays inside the 16GB VRAM budget at num_ctx=4096
- [ ] Post-merge: ArgoCD syncs LiteLLM with the new `qwen36-a3b` entry (will be visible in `kubectl -n litellm get cm litellm-config -o yaml | grep qwen36`)
- [ ] Post-merge: `curl -s http://192.168.55.206:4000/v1/chat/completions -H 'Authorization: Bearer $LITELLM_KEY' -d '{"model":"qwen36-a3b","messages":[{"role":"user","content":"hi"}]}'` returns a 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)