### PR TITLE
agents: Phase 5 soak data collection (gh#156)

### DIFF
--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -460,7 +460,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 8 | 2026-05-10 | 0 | 0 | 1.11 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 9 | 2026-05-11 | 0 | 0 | 0.99 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 10 | 2026-05-12 | 0 | 0 | 1.56 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
-| 11 | 2026-05-13 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 11 | 2026-05-13 | 0 | 0 | 1.73 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 12 | 2026-05-14 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 13 | 2026-05-15 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 14 | 2026-05-16 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -455,7 +455,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 3 | 2026-05-05 | 0 | 0 | 0.74 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
 | 4 | 2026-05-06 | 0 | 0 | 0.97 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
 | 5 | 2026-05-07 | 0 | 0 | 1.05 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
-| 6 | 2026-05-08 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 6 | 2026-05-08 | 0 | 0 | 0.24 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 7 | 2026-05-09 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 8 | 2026-05-10 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 9 | 2026-05-11 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -458,7 +458,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 6 | 2026-05-08 | 0 | 0 | 0.24 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 7 | 2026-05-09 | 0 | 0 | 0.38 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 8 | 2026-05-10 | 0 | 0 | 1.11 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
-| 9 | 2026-05-11 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 9 | 2026-05-11 | 0 | 0 | 0.99 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 10 | 2026-05-12 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 11 | 2026-05-13 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 12 | 2026-05-14 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -461,7 +461,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 9 | 2026-05-11 | 0 | 0 | 0.99 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 10 | 2026-05-12 | 0 | 0 | 1.56 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 11 | 2026-05-13 | 0 | 0 | 1.73 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
-| 12 | 2026-05-14 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 12 | 2026-05-14 | 0 | 0 | 1.90 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 13 | 2026-05-15 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 14 | 2026-05-16 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -456,7 +456,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 4 | 2026-05-06 | 0 | 0 | 0.97 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
 | 5 | 2026-05-07 | 0 | 0 | 1.05 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 6 | 2026-05-08 | 0 | 0 | 0.24 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
-| 7 | 2026-05-09 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 7 | 2026-05-09 | 0 | 0 | 0.38 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 8 | 2026-05-10 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 9 | 2026-05-11 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 10 | 2026-05-12 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -459,7 +459,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 7 | 2026-05-09 | 0 | 0 | 0.38 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 8 | 2026-05-10 | 0 | 0 | 1.11 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 9 | 2026-05-11 | 0 | 0 | 0.99 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
-| 10 | 2026-05-12 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 10 | 2026-05-12 | 0 | 0 | 1.56 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 11 | 2026-05-13 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 12 | 2026-05-14 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 13 | 2026-05-15 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -463,7 +463,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 11 | 2026-05-13 | 0 | 0 | 1.73 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 12 | 2026-05-14 | 0 | 0 | 1.90 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 13 | 2026-05-15 | 0 | 0 | 1.66 GiB | 0 | pod=secure-agent-pod-fc9585b8b-jn2rx |
-| 14 | 2026-05-16 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 14 | 2026-05-16 | 0 | 0 | 0.19 GiB | 0 | pod=secure-agent-pod-548744b988-dngfj |
 
 ### Day 1 raw query output (2026-05-03)
 

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -457,7 +457,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 5 | 2026-05-07 | 0 | 0 | 1.05 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 6 | 2026-05-08 | 0 | 0 | 0.24 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 7 | 2026-05-09 | 0 | 0 | 0.38 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
-| 8 | 2026-05-10 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 8 | 2026-05-10 | 0 | 0 | 1.11 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 9 | 2026-05-11 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 10 | 2026-05-12 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 11 | 2026-05-13 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -454,7 +454,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 2 | 2026-05-04 | 0 | 0 | 2.95 GiB | 3 | pod=secure-agent-pod-c976f9946-rqdqc |
 | 3 | 2026-05-05 | 0 | 0 | 0.74 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
 | 4 | 2026-05-06 | 0 | 0 | 0.97 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
-| 5 | 2026-05-07 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 5 | 2026-05-07 | 0 | 0 | 1.05 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 6 | 2026-05-08 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 7 | 2026-05-09 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 | 8 | 2026-05-10 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md
@@ -462,7 +462,7 @@ Daily readings — `restartCount`, p99 working-set RSS over the prior 24 h, and 
 | 10 | 2026-05-12 | 0 | 0 | 1.56 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 11 | 2026-05-13 | 0 | 0 | 1.73 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
 | 12 | 2026-05-14 | 0 | 0 | 1.90 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
-| 13 | 2026-05-15 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
+| 13 | 2026-05-15 | 0 | 0 | 1.66 GiB | 0 | pod=secure-agent-pod-fc9585b8b-jn2rx |
 | 14 | 2026-05-16 | _tbd_ | _tbd_ | _tbd_ | _tbd_ | _operator entry_ |
 
 ### Day 1 raw query output (2026-05-03)


### PR DESCRIPTION
Phase 5 soak data collection (gh#156). Auto-filled by
`scripts/phase5-soak-daily.sh` on the secure-agent-pod each day at
08:00 UTC for the soak window 2026-05-04 → 2026-05-16 (Days 2–14).

The Soak Log table on `main` (from #205) ships 14 placeholder rows;
this PR replaces `_tbd_` cells with actual readings as the days roll.
Merge when the table is full and the Phase 5 Task 2 decision (a/b/c)
is documented, OR earlier if you want to mid-cycle review.

Once Day 14 (2026-05-16) has been recorded, the daily script switches
to cleanup-nag mode automatically — see `scripts/phase5-soak-daily.sh`
header for the manual cleanup steps.