### PR TITLE
[derio-net/frank] cicd--stoa-gitea-primary · Phase 1/5 · Shared github-backup-sync pipeline

### DIFF
--- a/apps/tekton/manifests/externalsecret-stoa-github-mirror.yaml
+++ b/apps/tekton/manifests/externalsecret-stoa-github-mirror.yaml
@@ -1,0 +1,26 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: stoa-github-mirror
+  namespace: tekton-pipelines
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: stoa-github-mirror
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: token
+      remoteRef:
+        # Absolute path: the `infisical` ClusterSecretStore is scoped to
+        # secretsPath: / (frank infra secrets). Stoa-org secrets live under
+        # /agentic-stoa to keep them separated from cluster infra. Per ESO's
+        # Infisical provider, any key outside the store's secretsPath must be
+        # referenced by absolute path.
+        key: /agentic-stoa/STOA_GITHUB_MIRROR_TOKEN
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/apps/tekton/pipelines/github-backup-sync.yaml
+++ b/apps/tekton/pipelines/github-backup-sync.yaml
@@ -1,5 +1,8 @@
-# Backup-sync: pushes main and tags from agentic-stoa/* repos in Gitea
-# to their GitHub counterparts. Triggered by Gitea webhooks on main/tag pushes.
+# Backup direction: Gitea (primary, source of truth) -> GitHub (backup).
+# Force-push main is safe by contract; humans/CI never push to GitHub directly.
+# --tags is additive (tag deletes don't propagate, by design).
+# Pushes main and tags from agentic-stoa/* repos in Gitea to their GitHub
+# counterparts. Triggered by Gitea webhooks on main/tag pushes.
 # See spec: docs/superpowers/specs/2026-05-04--cicd--stoa-gitea-primary-design.md
 apiVersion: tekton.dev/v1
 kind: Pipeline
@@ -46,6 +49,8 @@ spec:
                 value: /tekton/home
               - name: GITEA_URL
                 value: $(params.gitea-clone-url)
+            # Higher limit than push-github: --mirror clone materializes every
+            # ref and pack-file in memory before fsck.
             computeResources:
               requests:
                 cpu: 100m
@@ -95,6 +100,8 @@ spec:
                   secretKeyRef:
                     name: stoa-github-mirror
                     key: token
+            # Lower limit than clone-mirror: push touches less working memory
+            # than --mirror clone (which materializes every ref and object).
             computeResources:
               requests:
                 cpu: 100m
@@ -105,7 +112,15 @@ spec:
               #!/bin/sh
               set -eu
               git config --global --add safe.directory '*'
-              GITHUB_URL="https://oauth2:${GITHUB_TOKEN}@github.com/${REPO_FULL_NAME}.git"
+              # Route credentials via `url.insteadOf` so the token never appears
+              # in the remote URL string. If git fails (network blip, GitHub
+              # 5xx, etc.), its stderr quotes the URL it tried to reach — keeping
+              # the token out of that URL keeps it out of TaskRun logs (which
+              # are RBAC-readable across the namespace and persist indefinitely).
+              git config --global \
+                "url.https://oauth2:${GITHUB_TOKEN}@github.com/.insteadOf" \
+                "https://github.com/"
+              GITHUB_URL="https://github.com/${REPO_FULL_NAME}.git"
               # Force-push main; --tags is additive (tag deletes don't propagate, by design)
               git push --force "$GITHUB_URL" refs/heads/main:refs/heads/main
               git push "$GITHUB_URL" --tags

--- a/apps/tekton/pipelines/github-backup-sync.yaml
+++ b/apps/tekton/pipelines/github-backup-sync.yaml
@@ -1,0 +1,112 @@
+# Backup-sync: pushes main and tags from agentic-stoa/* repos in Gitea
+# to their GitHub counterparts. Triggered by Gitea webhooks on main/tag pushes.
+# See spec: docs/superpowers/specs/2026-05-04--cicd--stoa-gitea-primary-design.md
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: github-backup-sync
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: repo-full-name
+      type: string
+      description: "Repo as owner/repo (e.g., agentic-stoa/hum)"
+    - name: gitea-clone-url
+      type: string
+      description: "Gitea HTTP clone URL"
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: clone-mirror
+      params:
+        - name: gitea-clone-url
+          value: $(params.gitea-clone-url)
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      taskSpec:
+        workspaces:
+          - name: source
+        params:
+          - name: gitea-clone-url
+        steps:
+          - name: clone
+            image: alpine/git:2.47.2
+            workingDir: $(workspaces.source.path)
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              runAsUser: 65534
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+            env:
+              - name: HOME
+                value: /tekton/home
+              - name: GITEA_URL
+                value: $(params.gitea-clone-url)
+            computeResources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+            script: |
+              #!/bin/sh
+              set -eu
+              git config --global --add safe.directory '*'
+              git clone --mirror "$GITEA_URL" repo.git
+              cd repo.git
+              echo "Refs cloned (first 20):"
+              git for-each-ref --format='%(refname)' refs/heads refs/tags | head -20
+    - name: push-github
+      runAfter: ["clone-mirror"]
+      params:
+        - name: repo-full-name
+          value: $(params.repo-full-name)
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      taskSpec:
+        workspaces:
+          - name: source
+        params:
+          - name: repo-full-name
+        steps:
+          - name: push
+            image: alpine/git:2.47.2
+            workingDir: $(workspaces.source.path)/repo.git
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              runAsUser: 65534
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+            env:
+              - name: HOME
+                value: /tekton/home
+              - name: REPO_FULL_NAME
+                value: $(params.repo-full-name)
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: stoa-github-mirror
+                    key: token
+            computeResources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+            script: |
+              #!/bin/sh
+              set -eu
+              git config --global --add safe.directory '*'
+              GITHUB_URL="https://oauth2:${GITHUB_TOKEN}@github.com/${REPO_FULL_NAME}.git"
+              # Force-push main; --tags is additive (tag deletes don't propagate, by design)
+              git push --force "$GITHUB_URL" refs/heads/main:refs/heads/main
+              git push "$GITHUB_URL" --tags
+              echo "Backup-sync OK for ${REPO_FULL_NAME}"

--- a/apps/tekton/triggers/eventlistener.yaml
+++ b/apps/tekton/triggers/eventlistener.yaml
@@ -33,6 +33,22 @@ spec:
         - ref: gitea-push-binding
       template:
         ref: gitea-pipeline-template
+    - name: agentic-stoa-backup
+      interceptors:
+        - ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                header.match('X-Gitea-Event', 'push') &&
+                body.repository.full_name.startsWith('agentic-stoa/') &&
+                (body.ref == 'refs/heads/main' || body.ref.startsWith('refs/tags/'))
+      bindings:
+        - ref: gitea-push-binding
+        - name: gitea-clone-url
+          value: $(body.repository.clone_url)
+      template:
+        ref: agentic-stoa-backup-template
   resources:
     kubernetesResource:
       spec:
@@ -40,3 +56,42 @@ spec:
           spec:
             nodeSelector:
               kubernetes.io/hostname: pc-1
+---
+# Backup-sync: fires only for agentic-stoa/* on main or tag pushes
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: agentic-stoa-backup-template
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: repo-full-name
+    - name: gitea-clone-url
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        generateName: stoa-backup-
+        namespace: tekton-pipelines
+      spec:
+        pipelineRef:
+          name: github-backup-sync
+        params:
+          - name: repo-full-name
+            value: $(tt.params.repo-full-name)
+          - name: gitea-clone-url
+            value: $(tt.params.gitea-clone-url)
+        taskRunTemplate:
+          podTemplate:
+            securityContext:
+              fsGroup: 65534
+        workspaces:
+          - name: shared-workspace
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: longhorn-cicd
+                resources:
+                  requests:
+                    storage: 1Gi

--- a/apps/tekton/triggers/eventlistener.yaml
+++ b/apps/tekton/triggers/eventlistener.yaml
@@ -93,5 +93,8 @@ spec:
                   - ReadWriteOnce
                 storageClassName: longhorn-cicd
                 resources:
+                  # 5Gi headroom for `git clone --mirror` of repos with large
+                  # blob history. agentic-stoa/* repos are small today; revisit
+                  # if a future repo exceeds this.
                   requests:
-                    storage: 1Gi
+                    storage: 5Gi

--- a/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
+++ b/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
@@ -1279,3 +1279,10 @@ Auto-appended checklist, scoped for the fix/extension nature of this plan.
 ## Deployment Deviations
 
 (Append entries here if the implementation deviates from the spec or this plan during execution.)
+
+### Phase 1 — implementation tweaks (PR #238, 2026-05-09)
+
+- **ExternalSecret apiVersion**: plan body specifies `external-secrets.io/v1beta1`; implementation uses `external-secrets.io/v1` to match the canonical convention used by every other tekton-namespace ExternalSecret in this repo (`externalsecret-gitea-token.yaml`, `externalsecret-cosign.yaml`, etc.). Also added `deletionPolicy: Retain` for symmetry with those siblings.
+- **Token leakage hardening on `push-github`**: instead of inlining `https://oauth2:${GITHUB_TOKEN}@github.com/` into the remote URL (which would surface the token in git's stderr on push failure, persisting in TaskRun logs indefinitely), the credential is plumbed via `git config --global url."https://oauth2:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"`. The push then targets the bare `https://github.com/<repo>.git` and git resolves credentials internally without echoing the token in error paths.
+- **Workspace storage**: bumped from `1Gi` to `5Gi` to leave headroom for `git clone --mirror` on repos with non-trivial blob history. Stoa repos are small today; cheap insurance.
+- **Phase-1/Phase-2 double-firing window**: until Phase 2 Task 5 lands, every push to `agentic-stoa/*` fires *both* the existing `gitea-push` trigger (running `gitea-ci`, which has no required checks defined for these repos and will no-op or fail loudly with no side effects) *and* the new `agentic-stoa-backup` trigger. Acceptable because `gitea-ci` has no destructive steps without an `image` param, and Phase 2 closes the window. Operating note for the reviewer: ignore stray `gitea-ci-*` PipelineRuns labeled with `agentic-stoa/*` repo names during this transition.

--- a/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
+++ b/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
@@ -159,7 +159,7 @@ Deploys the shared backup-sync mechanism: ExternalSecret + Pipeline + Trigger. P
 
 ### Task 1: ExternalSecret for STOA_GITHUB_MIRROR_TOKEN
 
-- [ ] **Step 1: Confirm the ClusterSecretStore name**
+- [x] **Step 1: Confirm the ClusterSecretStore name**
 
 ```bash
 kubectl --context frank get externalsecret -n tekton-pipelines gitea-api-token \
@@ -167,7 +167,7 @@ kubectl --context frank get externalsecret -n tekton-pipelines gitea-api-token \
 # Capture the exact ClusterSecretStore name (e.g., infisical-frank). Use it in Step 2.
 ```
 
-- [ ] **Step 2: Create the ExternalSecret manifest**
+- [x] **Step 2: Create the ExternalSecret manifest**
 
   Create `apps/tekton/manifests/externalsecret-stoa-github-mirror.yaml` (substitute `<STORE_NAME>` with the value from Step 1):
 
@@ -198,7 +198,7 @@ spec:
 
 ### Task 2: github-backup-sync Pipeline manifest
 
-- [ ] **Step 1: Create the Pipeline manifest**
+- [x] **Step 1: Create the Pipeline manifest**
 
   Create `apps/tekton/pipelines/github-backup-sync.yaml`:
 
@@ -323,7 +323,7 @@ END_FILE
 
 ### Task 3: Add backup-sync Trigger and TriggerTemplate to gitea-listener
 
-- [ ] **Step 1: Read the current EventListener config**
+- [x] **Step 1: Read the current EventListener config**
 
 ```bash
 sed -n '1,80p' apps/tekton/triggers/eventlistener.yaml
@@ -331,7 +331,7 @@ sed -n '1,80p' apps/tekton/triggers/eventlistener.yaml
 
   Locate the end of the existing `gitea-pipeline-template` resource and the closing of the `triggers:` list in the EventListener.
 
-- [ ] **Step 2: Append the new TriggerTemplate**
+- [x] **Step 2: Append the new TriggerTemplate**
 
   At the bottom of `apps/tekton/triggers/eventlistener.yaml`, append:
 
@@ -377,7 +377,7 @@ spec:
                     storage: 1Gi
 ```
 
-- [ ] **Step 3: Add the new Trigger inside the EventListener spec.triggers list**
+- [x] **Step 3: Add the new Trigger inside the EventListener spec.triggers list**
 
   Inside the EventListener (`metadata.name: gitea-listener`), append a new entry to `spec.triggers` (after the existing `gitea-push` entry):
 

--- a/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
+++ b/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
@@ -404,7 +404,7 @@ spec:
 
 ### Task 4: Commit, sync, and verify backup pipeline is healthy
 
-- [ ] **Step 1: Commit changes**
+- [x] **Step 1: Commit changes**
 
 ```bash
 cd ~/repos/frank


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
📐 Spec:   docs/superpowers/specs/2026-05-04--cicd--stoa-gitea-primary-design.md
🎯 Phase:  1/5 — Shared github-backup-sync pipeline [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/230

**Goal (from plan):** Onboard `agentic-stoa/hum` and `agentic-stoa/content-factory` onto Frank's Gitea + Tekton stack as Gitea-primary repos with GitHub backup. Establish a reusable pattern (per-repo CI pipeline + shared backup-sync pipeline + branch protection) for future repos in the org.

---

## Summary

Lands the shared backup-sync mechanism for any `agentic-stoa/*` repo:

- **`apps/tekton/manifests/externalsecret-stoa-github-mirror.yaml`** — projects `/agentic-stoa/STOA_GITHUB_MIRROR_TOKEN` from Infisical into a `stoa-github-mirror` Secret in `tekton-pipelines`. Absolute Infisical path because the shared `infisical` ClusterSecretStore is scoped to `/`; stoa-org secrets live under `/agentic-stoa` per the Phase 0 follow-up. Matches the existing `external-secrets.io/v1` + `deletionPolicy: Retain` convention used by `gitea-api-token` etc.
- **`apps/tekton/pipelines/github-backup-sync.yaml`** — two-step inline `taskSpec`: `alpine/git --mirror` clone from Gitea, then force-push `refs/heads/main` and additive `--tags` push to `https://oauth2:$TOKEN@github.com/<repo>.git`. No reuse of the catalog `git-clone` Task because `--mirror` is required (not depth-limited `git checkout`). Tag deletes intentionally do not propagate.
- **`apps/tekton/triggers/eventlistener.yaml`** — adds `agentic-stoa-backup` Trigger and `agentic-stoa-backup-template` TriggerTemplate. CEL filter scopes to `agentic-stoa/*` on `refs/heads/main` or `refs/tags/*`; inline `gitea-clone-url` binding because the shared `gitea-push-binding` doesn't expose it.

## Plan steps completed

- [x] P1.T1.S1 — Confirmed ClusterSecretStore name (`infisical`) from existing `gitea-api-token` ExternalSecret.
- [x] P1.T1.S2 — Created `externalsecret-stoa-github-mirror.yaml`.
- [x] P1.T2.S1 — Created `github-backup-sync.yaml`.
- [x] P1.T3.S1 — Read existing EventListener config.
- [x] P1.T3.S2 — Appended TriggerTemplate.
- [x] P1.T3.S3 — Added Trigger inside EventListener `spec.triggers`.
- [x] P1.T4.S1 — Commit & push.

## Post-merge verification (P1.T4.S2 and P1.T4.S3)

ArgoCD reconciles `tekton-extras` from `main`, not feature branches. After merge, the operator (or follow-up automation) runs:

```bash
sleep 30
kubectl --context frank get application -n argocd tekton-extras \
  -o jsonpath='{.status.sync.status}{" "}{.status.health.status}{"\n"}'
# Expect: Synced Healthy

kubectl --context frank get pipeline -n tekton-pipelines github-backup-sync
kubectl --context frank get externalsecret -n tekton-pipelines stoa-github-mirror \
  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
# Expect: True
kubectl --context frank get secret -n tekton-pipelines stoa-github-mirror \
  -o jsonpath='{.data.token}' | base64 -d | wc -c
# Expect: > 50

kubectl --context frank get eventlistener -n tekton-pipelines gitea-listener \
  -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}{"\n"}'
kubectl --context frank logs -n tekton-pipelines deploy/el-gitea-listener --tail=20 \
  | grep -iE "error|panic|cel" || echo "no errors"
```

End-to-end smoke is exercised in **Phase 3 Task 5** (merge a PR on `agentic-stoa/hum` and confirm the `stoa-backup-XXXXX` PipelineRun pushes `main` to GitHub).

## Notes

- No new secrets were created in the cluster — Phase 0 already populated `/agentic-stoa/STOA_GITHUB_MIRROR_TOKEN` in Infisical.
- The new resources are inert until Phase 3 creates Gitea repos under `agentic-stoa/`. Until then the CEL filter never matches, so no PipelineRun fires.
- Phase 2 (per-repo CI pipelines) is independent of this phase and runs in parallel.

Closes #230
