### PR TITLE
[derio-net/frank] cicd--stoa-gitea-primary · Phase 2/5 · Per-repo CI pipelines

### DIFF
--- a/apps/tekton/pipelines/content-factory-ci.yaml
+++ b/apps/tekton/pipelines/content-factory-ci.yaml
@@ -41,7 +41,8 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true
-              runAsUser: 1000
+              # Match git-clone (UID 65534) — see UID-alignment note in hum-ci.
+              runAsUser: 65534
               capabilities:
                 drop: ["ALL"]
               seccompProfile:
@@ -51,6 +52,10 @@ spec:
                 value: /tekton/home
               - name: PIP_CACHE_DIR
                 value: /tekton/home/.pip-cache
+              - name: PIP_DISABLE_PIP_VERSION_CHECK
+                value: "1"
+              - name: PYTHONDONTWRITEBYTECODE
+                value: "1"
             computeResources:
               requests:
                 cpu: 500m
@@ -59,12 +64,19 @@ spec:
                 memory: 2Gi
             script: |
               #!/bin/sh
+              # `set -eu` doesn't propagate into && / || chains. Use explicit
+              # `if [ -f X ]; then …; fi` so a missing requirements file is a
+              # no-op (correct) but a `pip install` failure on a present file
+              # still fails the run.
               set -eu
               python -m venv /tekton/home/venv
               . /tekton/home/venv/bin/activate
-              pip install --upgrade pip
-              [ -f requirements.txt ] && pip install -r requirements.txt
-              [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
+              if [ -f requirements.txt ]; then
+                pip install -r requirements.txt
+              fi
+              if [ -f requirements-dev.txt ]; then
+                pip install -r requirements-dev.txt
+              fi
               pytest -v
   finally:
     - name: report-success

--- a/apps/tekton/pipelines/content-factory-ci.yaml
+++ b/apps/tekton/pipelines/content-factory-ci.yaml
@@ -1,0 +1,105 @@
+# CI for agentic-stoa/content-factory: pip install + pytest.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: content-factory-ci
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: repo-url
+      type: string
+    - name: revision
+      type: string
+    - name: repo-full-name
+      type: string
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: clone
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.repo-url)
+        - name: revision
+          value: $(params.revision)
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+    - name: test
+      runAfter: ["clone"]
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: pytest
+            image: python:3.13-slim
+            workingDir: $(workspaces.source.path)
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              runAsUser: 1000
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+            env:
+              - name: HOME
+                value: /tekton/home
+              - name: PIP_CACHE_DIR
+                value: /tekton/home/.pip-cache
+            computeResources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+            script: |
+              #!/bin/sh
+              set -eu
+              python -m venv /tekton/home/venv
+              . /tekton/home/venv/bin/activate
+              pip install --upgrade pip
+              [ -f requirements.txt ] && pip install -r requirements.txt
+              [ -f requirements-dev.txt ] && pip install -r requirements-dev.txt || true
+              pytest -v
+  finally:
+    - name: report-success
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Succeeded", "Completed"]
+      taskRef:
+        name: gitea-status
+      params:
+        - name: repo-full-name
+          value: $(params.repo-full-name)
+        - name: revision
+          value: $(params.revision)
+        - name: state
+          value: "success"
+        - name: description
+          value: "All checks passed"
+        - name: context
+          value: "tekton/ci"
+    - name: report-failure
+      when:
+        - input: $(tasks.status)
+          operator: notin
+          values: ["Succeeded", "Completed"]
+      taskRef:
+        name: gitea-status
+      params:
+        - name: repo-full-name
+          value: $(params.repo-full-name)
+        - name: revision
+          value: $(params.revision)
+        - name: state
+          value: "failure"
+        - name: description
+          value: "CI failed"
+        - name: context
+          value: "tekton/ci"

--- a/apps/tekton/pipelines/hum-ci.yaml
+++ b/apps/tekton/pipelines/hum-ci.yaml
@@ -41,7 +41,10 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true
-              runAsUser: 1000
+              # Match git-clone (UID 65534) to avoid cross-UID handoff on the
+              # shared RWO PVC. fsGroup (set on the TriggerTemplate's PodTemplate)
+              # also = 65534, so writes by either step are group-readable.
+              runAsUser: 65534
               capabilities:
                 drop: ["ALL"]
               seccompProfile:
@@ -59,14 +62,30 @@ spec:
                 memory: 2Gi
             script: |
               #!/bin/sh
+              # `set -eu` doesn't propagate into && / || chains, so use explicit
+              # if/else around `npm run typecheck` / `npm test` — otherwise a
+              # real type-error or test-failure (exit 1) takes the `|| echo`
+              # branch and the run continues green. `npm pkg get` exits 0 even
+              # for missing keys, returning literal "{}", so check the value.
               set -eu
+              has_script() {
+                [ "$(npm pkg get "scripts.$1" 2>/dev/null)" != "{}" ]
+              }
               run_in() {
                 d="$1"
                 echo "=== $d ==="
                 cd "$d"
                 if [ -f package-lock.json ]; then npm ci; else npm install; fi
-                npm pkg get scripts.typecheck >/dev/null 2>&1 && npm run typecheck || echo "no typecheck script in $d"
-                npm pkg get scripts.test >/dev/null 2>&1 && npm test || echo "no test script in $d"
+                if has_script typecheck; then
+                  npm run typecheck
+                else
+                  echo "no typecheck script in $d"
+                fi
+                if has_script test; then
+                  npm test
+                else
+                  echo "no test script in $d"
+                fi
                 cd - >/dev/null
               }
               run_in .

--- a/apps/tekton/pipelines/hum-ci.yaml
+++ b/apps/tekton/pipelines/hum-ci.yaml
@@ -1,0 +1,112 @@
+# CI for agentic-stoa/hum: npm install + typecheck + test across workspaces.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: hum-ci
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: repo-url
+      type: string
+    - name: revision
+      type: string
+    - name: repo-full-name
+      type: string
+  workspaces:
+    - name: shared-workspace
+  tasks:
+    - name: clone
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.repo-url)
+        - name: revision
+          value: $(params.revision)
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+    - name: test
+      runAfter: ["clone"]
+      workspaces:
+        - name: source
+          workspace: shared-workspace
+      taskSpec:
+        workspaces:
+          - name: source
+        steps:
+          - name: npm-test
+            image: node:22-alpine
+            workingDir: $(workspaces.source.path)
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              runAsUser: 1000
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+            env:
+              - name: HOME
+                value: /tekton/home
+              - name: npm_config_cache
+                value: /tekton/home/.npm
+            computeResources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+            script: |
+              #!/bin/sh
+              set -eu
+              run_in() {
+                d="$1"
+                echo "=== $d ==="
+                cd "$d"
+                if [ -f package-lock.json ]; then npm ci; else npm install; fi
+                npm pkg get scripts.typecheck >/dev/null 2>&1 && npm run typecheck || echo "no typecheck script in $d"
+                npm pkg get scripts.test >/dev/null 2>&1 && npm test || echo "no test script in $d"
+                cd - >/dev/null
+              }
+              run_in .
+              for ws in backend shared; do
+                [ -f "$ws/package.json" ] && run_in "$ws"
+              done
+  finally:
+    - name: report-success
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Succeeded", "Completed"]
+      taskRef:
+        name: gitea-status
+      params:
+        - name: repo-full-name
+          value: $(params.repo-full-name)
+        - name: revision
+          value: $(params.revision)
+        - name: state
+          value: "success"
+        - name: description
+          value: "All checks passed"
+        - name: context
+          value: "tekton/ci"
+    - name: report-failure
+      when:
+        - input: $(tasks.status)
+          operator: notin
+          values: ["Succeeded", "Completed"]
+      taskRef:
+        name: gitea-status
+      params:
+        - name: repo-full-name
+          value: $(params.repo-full-name)
+        - name: revision
+          value: $(params.revision)
+        - name: state
+          value: "failure"
+        - name: description
+          value: "CI failed"
+        - name: context
+          value: "tekton/ci"

--- a/apps/tekton/triggers/eventlistener.yaml
+++ b/apps/tekton/triggers/eventlistener.yaml
@@ -152,11 +152,13 @@ metadata:
   name: hum-ci-template
   namespace: tekton-pipelines
 spec:
+  # `branch` is supplied by gitea-push-binding but unused here — the hum-ci
+  # Pipeline takes only repo-url/revision/repo-full-name. Tekton silently
+  # accepts the extra binding param; we just don't declare it.
   params:
     - name: repo-url
     - name: revision
     - name: repo-full-name
-    - name: branch
   resourcetemplates:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun
@@ -194,11 +196,11 @@ metadata:
   name: content-factory-ci-template
   namespace: tekton-pipelines
 spec:
+  # `branch` is supplied by gitea-push-binding but unused here — see hum-ci-template.
   params:
     - name: repo-url
     - name: revision
     - name: repo-full-name
-    - name: branch
   resourcetemplates:
     - apiVersion: tekton.dev/v1
       kind: PipelineRun

--- a/apps/tekton/triggers/eventlistener.yaml
+++ b/apps/tekton/triggers/eventlistener.yaml
@@ -18,7 +18,8 @@ spec:
           params:
             - name: "filter"
               value: >-
-                header.match('X-Gitea-Event', 'push')
+                header.match('X-Gitea-Event', 'push') &&
+                !body.repository.full_name.startsWith('agentic-stoa/')
             - name: "overlays"
               value:
                 - key: branch_name
@@ -49,6 +50,52 @@ spec:
           value: $(body.repository.clone_url)
       template:
         ref: agentic-stoa-backup-template
+    - name: agentic-stoa-hum-ci
+      interceptors:
+        - ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                header.match('X-Gitea-Event', 'push') &&
+                body.repository.full_name == 'agentic-stoa/hum'
+            - name: "overlays"
+              value:
+                - key: branch_name
+                  expression: "body.ref.split('/')[2]"
+        - ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                extensions.branch_name != ''
+      bindings:
+        - ref: gitea-push-binding
+      template:
+        ref: hum-ci-template
+    - name: agentic-stoa-content-factory-ci
+      interceptors:
+        - ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                header.match('X-Gitea-Event', 'push') &&
+                body.repository.full_name == 'agentic-stoa/content-factory'
+            - name: "overlays"
+              value:
+                - key: branch_name
+                  expression: "body.ref.split('/')[2]"
+        - ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                extensions.branch_name != ''
+      bindings:
+        - ref: gitea-push-binding
+      template:
+        ref: content-factory-ci-template
   resources:
     kubernetesResource:
       spec:
@@ -98,3 +145,87 @@ spec:
                   # if a future repo exceeds this.
                   requests:
                     storage: 5Gi
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: hum-ci-template
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: repo-url
+    - name: revision
+    - name: repo-full-name
+    - name: branch
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        generateName: hum-ci-
+        namespace: tekton-pipelines
+      spec:
+        pipelineRef:
+          name: hum-ci
+        params:
+          - name: repo-url
+            value: $(tt.params.repo-url)
+          - name: revision
+            value: $(tt.params.revision)
+          - name: repo-full-name
+            value: $(tt.params.repo-full-name)
+        taskRunTemplate:
+          podTemplate:
+            securityContext:
+              fsGroup: 65534
+        workspaces:
+          - name: shared-workspace
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: longhorn-cicd
+                resources:
+                  requests:
+                    storage: 2Gi
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: content-factory-ci-template
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: repo-url
+    - name: revision
+    - name: repo-full-name
+    - name: branch
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        generateName: content-factory-ci-
+        namespace: tekton-pipelines
+      spec:
+        pipelineRef:
+          name: content-factory-ci
+        params:
+          - name: repo-url
+            value: $(tt.params.repo-url)
+          - name: revision
+            value: $(tt.params.revision)
+          - name: repo-full-name
+            value: $(tt.params.repo-full-name)
+        taskRunTemplate:
+          podTemplate:
+            securityContext:
+              fsGroup: 65534
+        workspaces:
+          - name: shared-workspace
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                storageClassName: longhorn-cicd
+                resources:
+                  requests:
+                    storage: 2Gi

--- a/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
+++ b/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
@@ -869,7 +869,7 @@ The existing `gitea-push` trigger has no repo filter, so a push to `agentic-stoa
 
 ### Task 6: Commit, sync, and verify
 
-- [ ] **Step 1: Commit changes**
+- [x] **Step 1: Commit changes**
 
 ```bash
 cd ~/repos/frank

--- a/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
+++ b/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
@@ -457,7 +457,7 @@ Per-repo CI Pipelines for `hum` (Node) and `content-factory` (Python) plus their
 
 ### Task 1: hum-ci Pipeline
 
-- [ ] **Step 1: Create the Pipeline manifest**
+- [x] **Step 1: Create the Pipeline manifest**
 
   Create `apps/tekton/pipelines/hum-ci.yaml`:
 
@@ -582,7 +582,7 @@ END_FILE
 
 ### Task 2: content-factory-ci Pipeline
 
-- [ ] **Step 1: Create the Pipeline manifest**
+- [x] **Step 1: Create the Pipeline manifest**
 
   Create `apps/tekton/pipelines/content-factory-ci.yaml`:
 
@@ -698,7 +698,7 @@ END_FILE
 
 ### Task 3: Per-repo CI TriggerTemplates
 
-- [ ] **Step 1: Append two new TriggerTemplates to eventlistener.yaml**
+- [x] **Step 1: Append two new TriggerTemplates to eventlistener.yaml**
 
   At the bottom of `apps/tekton/triggers/eventlistener.yaml` (after `agentic-stoa-backup-template` from Phase 1), append:
 
@@ -791,7 +791,7 @@ spec:
 
 ### Task 4: Per-repo CI Triggers
 
-- [ ] **Step 1: Append the two CI Triggers inside spec.triggers**
+- [x] **Step 1: Append the two CI Triggers inside spec.triggers**
 
   In the EventListener's `spec.triggers` list (after `agentic-stoa-backup` from Phase 1), append:
 
@@ -848,7 +848,7 @@ spec:
 
 The existing `gitea-push` trigger has no repo filter, so a push to `agentic-stoa/*` would fire it (running default-`gitea-ci` with echo "no tests"). Adding a negative filter avoids the duplicate run.
 
-- [ ] **Step 1: Add agentic-stoa exclusion to existing trigger filter**
+- [x] **Step 1: Add agentic-stoa exclusion to existing trigger filter**
 
   In `apps/tekton/triggers/eventlistener.yaml`, find the existing `gitea-push` trigger's first CEL filter:
 


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
📐 Spec:   docs/superpowers/specs/2026-05-04--cicd--stoa-gitea-primary-design.md
🎯 Phase:  2/5 — Per-repo CI pipelines [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/231

**Goal (from plan):** Onboard `agentic-stoa/hum` and `agentic-stoa/content-factory` onto Frank's Gitea + Tekton stack as Gitea-primary repos with GitHub backup. Establish a reusable pattern (per-repo CI pipeline + shared backup-sync pipeline + branch protection) for future repos in the org.

---

## Summary

Implements Phase 2 of `2026-05-05--cicd--stoa-gitea-primary.md` — per-repo CI for the two `agentic-stoa` repos. Independent of Phase 1 (backup-sync), runs in parallel.

- `apps/tekton/pipelines/hum-ci.yaml` — Node 22 pipeline: clone → npm ci/install + typecheck + test across `.`, `backend/`, `shared/` workspaces. Reports status to Gitea via shared `gitea-status` Task with `context: tekton/ci`.
- `apps/tekton/pipelines/content-factory-ci.yaml` — Python 3.13 pipeline: clone → venv + pip install + pytest. Same status-reporting context.
- `apps/tekton/triggers/eventlistener.yaml`:
  - Two new `TriggerTemplate`s (`hum-ci-template`, `content-factory-ci-template`) — each mints a PipelineRun on `longhorn-cicd` RWO storage with `fsGroup: 65534` for non-root steps.
  - Two new EventListener `Triggers` routed by `body.repository.full_name` CEL filter.
  - Existing `gitea-push` trigger filter narrowed with `!body.repository.full_name.startsWith('agentic-stoa/')` to prevent duplicate default-pipeline runs on stoa repos.

The `tekton/ci` status context is the name Phase 3 branch protection will require.

## Tasks (from plan)

- [x] Task 1: hum-ci Pipeline
- [x] Task 2: content-factory-ci Pipeline
- [x] Task 3: Per-repo CI TriggerTemplates
- [x] Task 4: Per-repo CI Triggers
- [x] Task 5: Scope existing gitea-push trigger to non-stoa repos
- [x] Task 6: Commit + push (Steps 2-3 verification deferred — ArgoCD pulls from main, not feature branches; verify after merge)

## Test plan

- [ ] After merge, ArgoCD `tekton-extras` reconciles
- [ ] `kubectl get pipeline -n tekton-pipelines hum-ci content-factory-ci` returns both
- [ ] `kubectl get triggertemplate -n tekton-pipelines` lists `hum-ci-template`, `content-factory-ci-template`
- [ ] `kubectl get eventlistener -n tekton-pipelines gitea-listener -o jsonpath='{range .spec.triggers[*]}{.name}{"\n"}{end}'` lists `gitea-push`, `agentic-stoa-hum-ci`, `agentic-stoa-content-factory-ci`
- [ ] `el-gitea-listener` pod log free of CEL/parse errors after re-render

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)
