### PR TITLE
edge: gitea-ssh.cluster.derio.net + document --accept-routes for clients

### DIFF
--- a/blog/content/docs/operating/11-public-edge/index.md
+++ b/blog/content/docs/operating/11-public-edge/index.md
@@ -174,15 +174,28 @@ The `--reusable` flag lets you register multiple devices with the same key (usef
 On the device you want to add (macOS, Linux, Windows, iOS, Android — anything that runs Tailscale):
 
 ```bash
-# Linux / macOS
-tailscale up --login-server https://headscale.hop.derio.net --authkey <PREAUTH_KEY>
+# Linux / macOS — note: --accept-routes is required to reach LAN-only
+# services (Frank cluster nodes on 192.168.55.0/24, home DNS at
+# 192.168.10.11/12, etc.). Without it, the raspi-vlan10-d/-e subnet
+# routers advertise routes but the client kernel won't actually
+# forward packets through them. Symptom: "Network is unreachable"
+# (not "no route to host") when reaching any 192.168.x.x address.
+tailscale up \
+  --login-server https://headscale.hop.derio.net \
+  --accept-routes \
+  --authkey <PREAUTH_KEY>
 
 # If Tailscale was previously connected to a different control server, reset first:
 tailscale logout
-tailscale up --login-server https://headscale.hop.derio.net --authkey <PREAUTH_KEY>
+tailscale up \
+  --login-server https://headscale.hop.derio.net \
+  --accept-routes \
+  --authkey <PREAUTH_KEY>
 ```
 
-On mobile devices (iOS/Android), you can set the control server URL in the Tailscale app settings before signing in. Enter `https://headscale.hop.derio.net` as the control server and use the pre-auth key.
+On mobile devices (iOS/Android), you can set the control server URL in the Tailscale app settings before signing in. Enter `https://headscale.hop.derio.net` as the control server and use the pre-auth key. Toggle "Use Tailscale subnets" (or equivalent) ON — it's the mobile equivalent of `--accept-routes`.
+
+**On an already-registered client without `--accept-routes`:** flip it on without re-registering: `sudo tailscale set --accept-routes` (or `tailscale up` with the existing args plus `--accept-routes`). `tailscale status` will print `Some peers are advertising routes but --accept-routes is false` as a health-check line whenever the flag is missing — that's the canonical signal.
 
 **Step 3 — Verify registration:**
 

--- a/clusters/hop/apps/headscale/manifests/configmap.yaml
+++ b/clusters/hop/apps/headscale/manifests/configmap.yaml
@@ -61,6 +61,16 @@ data:
         - name: entry.hop.derio.net
           type: A
           value: 100.64.0.4
+        # Frank Gitea SSH endpoint. The public DNS A record for
+        # gitea.cluster.derio.net points at 192.168.55.220 (Traefik LB) for
+        # HTTPS web access; Traefik does not speak SSH. Mesh peers reaching
+        # Gitea over git+ssh need a name that points at 192.168.55.209
+        # (the Gitea LB IP, port 2222). Requires --accept-routes on the
+        # client; the LAN IP is reachable via the raspi-vlan10 subnet
+        # routers (192.168.55.0/24).
+        - name: gitea-ssh.cluster.derio.net
+          type: A
+          value: 192.168.55.209
 
     log:
       level: info

--- a/docs/superpowers/archived-plans/2026-03-21--edge--subnet-router-autoapproval.md
+++ b/docs/superpowers/archived-plans/2026-03-21--edge--subnet-router-autoapproval.md
@@ -102,6 +102,8 @@ git commit -m "feat(edge): add autoApprovers and split DNS to Headscale config"
 
 ---
 
+> **Deviation (2026-05-09):** This plan documented the *advertising* side end-to-end (raspi-vlan10-d/-e with `--advertise-routes`) but never covered the *consuming* side: each new mesh client must run `tailscale up --accept-routes` (or `tailscale set --accept-routes`) or the kernel won't actually forward LAN-bound traffic through the subnet routers, even with the routes advertised and approved. The verification step `ping 192.168.55.21` (in the design spec) silently fails on a fresh client without `--accept-routes` — symptom is `Network is unreachable`, NOT `no route to host`. The omission stayed latent because the operator's primary client at the time happened to have `accept-routes` enabled by default. Caught when a different operator-laptop tried `git@gitea-ssh.cluster.derio.net:2222` while investigating Phase 3 of the stoa-gitea-primary plan. Fix: blog post `operating/11-public-edge` updated to include `--accept-routes` in the standard client-onboarding `tailscale up` invocation, with the Tailscale health-check line `Some peers are advertising routes but --accept-routes is false` flagged as the canonical diagnostic surface. No code-side change needed.
+
 ### Task 3: Update Operating Blog Post
 
 **Files:**

--- a/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
+++ b/docs/superpowers/plans/2026-05-05--cicd--stoa-gitea-primary.md
@@ -944,7 +944,7 @@ why_manual: "git clone --mirror runs from operator workstation, not in-cluster"
 commands:
   - "Run for each repo: hum, content-factory"
   - "git clone --mirror https://github.com/agentic-stoa/<repo>.git /tmp/<repo>.git"
-  - "cd /tmp/<repo>.git && git remote set-url --push origin git@gitea.cluster.derio.net:agentic-stoa/<repo>.git"
+  - "cd /tmp/<repo>.git && git remote set-url --push origin git@gitea-ssh.cluster.derio.net:agentic-stoa/<repo>.git"
   - "git push --mirror"
   - "cd / && rm -rf /tmp/<repo>.git"
 verify:
@@ -955,10 +955,16 @@ status: pending
 
 - [ ] **Step 1: Mirror-clone hum**
 
+**SSH prerequisites (operator workstation, one-time):**
+- Tailscale must accept LAN routes: `sudo tailscale up --accept-routes` (or `sudo tailscale set --accept-routes` on an already-registered client). Health-check signal: `tailscale status` prints `Some peers are advertising routes but --accept-routes is false` when the flag is missing.
+- The hostname `gitea-ssh.cluster.derio.net` (defined in Headscale's `extra_records`) resolves to `192.168.55.209` (the Gitea LB IP) and is what answers SSH on port 2222. Do NOT use `gitea.cluster.derio.net` for SSH — that resolves to Traefik (`192.168.55.220`), which is HTTPS-only.
+- Operator's SSH public key must be registered with a Gitea user that has write access to `agentic-stoa/*` (e.g. an admin account or `stoa-bot`). Use Gitea UI → Settings → SSH/GPG Keys.
+- `~/.ssh/config` Host entry: `Host gitea-ssh.cluster.derio.net` with `Port 2222` and `IdentityFile <key>`.
+
 ```bash
 git clone --mirror https://github.com/agentic-stoa/hum.git /tmp/hum.git
 cd /tmp/hum.git
-git remote set-url --push origin git@gitea.cluster.derio.net:agentic-stoa/hum.git
+git remote set-url --push origin git@gitea-ssh.cluster.derio.net:agentic-stoa/hum.git
 git push --mirror
 cd / && rm -rf /tmp/hum.git
 ```
@@ -1003,7 +1009,7 @@ status: pending
 ```bash
 cd ~/repos/hum
 # Add a temporary remote pointing at Gitea (origin still points at GitHub until Task 8)
-git remote add gitea git@gitea.cluster.derio.net:agentic-stoa/hum.git 2>/dev/null || true
+git remote add gitea git@gitea-ssh.cluster.derio.net:agentic-stoa/hum.git 2>/dev/null || true
 git checkout -b test/ci-smoke
 echo "" >> README.md
 git add README.md && git commit -m "test: ci smoke"
@@ -1033,7 +1039,7 @@ kubectl --context frank logs -n tekton-pipelines $PR -f --all-containers --max-l
 
 ```bash
 cd ~/repos/content-factory
-git remote add gitea git@gitea.cluster.derio.net:agentic-stoa/content-factory.git 2>/dev/null || true
+git remote add gitea git@gitea-ssh.cluster.derio.net:agentic-stoa/content-factory.git 2>/dev/null || true
 git checkout -b test/ci-smoke
 echo "" >> README.md && git add README.md && git commit -m "test: ci smoke"
 git push gitea test/ci-smoke
@@ -1212,11 +1218,11 @@ when: "Per repo, after Phase 3 Tasks 1–7 verified"
 why_manual: "Operator's local clones live outside the cluster"
 commands:
   - "cd ~/repos/<repo>"
-  - "git remote set-url origin git@gitea.cluster.derio.net:agentic-stoa/<repo>.git"
+  - "git remote set-url origin git@gitea-ssh.cluster.derio.net:agentic-stoa/<repo>.git"
   - "git remote remove gitea  # remove the temp remote added in Task 4 if present"
   - "git fetch origin --prune"
 verify:
-  - "git remote -v shows gitea.cluster.derio.net as origin"
+  - "git remote -v shows gitea-ssh.cluster.derio.net as origin"
   - "git pull works"
 status: pending
 ```
@@ -1225,18 +1231,18 @@ status: pending
 
 ```bash
 cd ~/repos/hum
-git remote set-url origin git@gitea.cluster.derio.net:agentic-stoa/hum.git
+git remote set-url origin git@gitea-ssh.cluster.derio.net:agentic-stoa/hum.git
 git remote remove gitea 2>/dev/null || true
 git fetch origin --prune
 git remote -v
-# Expect: origin → gitea.cluster.derio.net
+# Expect: origin → gitea-ssh.cluster.derio.net
 ```
 
 - [ ] **Step 2: Update content-factory clone remote**
 
 ```bash
 cd ~/repos/content-factory
-git remote set-url origin git@gitea.cluster.derio.net:agentic-stoa/content-factory.git
+git remote set-url origin git@gitea-ssh.cluster.derio.net:agentic-stoa/content-factory.git
 git remote remove gitea 2>/dev/null || true
 git fetch origin --prune
 git remote -v


### PR DESCRIPTION
## Summary

Two related gaps surfaced while working through Phase 3 of the stoa-gitea-primary plan:

1. **`gitea.cluster.derio.net` resolves to Traefik (`192.168.55.220`), not Gitea LB (`192.168.55.209`).** Correct for HTTPS web access; structurally broken for SSH (Traefik does not speak SSH). Mesh peers reaching Gitea over `git+ssh` need a different name. Adds `gitea-ssh.cluster.derio.net` → `192.168.55.209` to Headscale's `extra_records` — declarative, mesh-only, requires `--accept-routes` on the client (the LAN IP is reachable via the raspi-vlan10 subnet routers).
2. **The 2026-03-21 edge subnet-router-autoapproval spec/plan/blog never documented client-side `--accept-routes`.** It covered the *advertising* side (raspi-vlan10-d/-e with `--advertise-routes`) end-to-end but assumed/elided the *consuming* side. A fresh client joining the mesh without `--accept-routes` sees `Some peers are advertising routes but --accept-routes is false` in `tailscale status` and gets `Network is unreachable` (not `no route to host`) when reaching any `192.168.x.x` address. Updated `operating/11-public-edge` to require the flag in the standard onboarding `tailscale up` invocation, with the health-check line called out as the diagnostic surface. Mobile equivalent (toggling "Use Tailscale subnets") also documented.

Also updated `2026-05-05--cicd--stoa-gitea-primary` plan T2/T4/T8 to use the new `gitea-ssh.cluster.derio.net` hostname for SSH operations, and added a "SSH prerequisites" preamble to T2.S1 covering `--accept-routes`, the hostname distinction, and the SSH-key registration step that the original plan elided. The HTTPS clone in T7.S3 (branch-protection test) still uses `gitea.cluster.derio.net` — that's correct: HTTPS via Traefik works, SSH via Traefik does not.

Includes a retroactive Deviation note on the archived `2026-03-21--edge--subnet-router-autoapproval` plan documenting the missing client-side configuration and how it was caught.

This PR re-applies commits `27459a2` + `224e12f` that landed directly on `main` during a session; revert `779c103` is on `main`. Once this PR merges, Hop's headscale Application (auto-sync, selfHeal=true) picks the change up on its next poll. After sync, headscale needs a one-time `kubectl rollout restart` since it does not hot-reload its config file.

## Test plan

- [ ] Hop ArgoCD shows `headscale` Application Synced after merge
- [ ] `kubectl -n headscale-system rollout restart deploy/headscale` → pod ready
- [ ] From a mesh client with `--accept-routes`: `dig gitea-ssh.cluster.derio.net A` returns `192.168.55.209`
- [ ] `ssh -p 2222 git@gitea-ssh.cluster.derio.net` reaches the Gitea SSH endpoint (auth-success or `Permission denied (publickey)` — both confirm the route)
- [ ] On a fresh client missing `--accept-routes`: `tailscale status` health line surfaces; `tailscale set --accept-routes` resolves it; subsequent SSH succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
