### PR TITLE
[derio-net/frank] obs--cert-expiry-alerting · Phase 1/3 · Probe targets

### DIFF
--- a/apps/blackbox-exporter/manifests/vmprobe.yaml
+++ b/apps/blackbox-exporter/manifests/vmprobe.yaml
@@ -17,3 +17,20 @@ spec:
   module: http_2xx
   vmProberSpec:
     url: blackbox-exporter.monitoring.svc:9115
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMProbe
+metadata:
+  name: management-plane-probes
+  namespace: monitoring
+spec:
+  targets:
+    staticConfig:
+      targets:
+        - https://omni.frank.derio.net/
+        - https://omni.frank.derio.net:8100/
+      labels:
+        probe_group: management_plane
+  module: http_2xx
+  vmProberSpec:
+    url: blackbox-exporter.monitoring.svc:9115

--- a/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
+++ b/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
@@ -31,7 +31,7 @@ Add the Omni Pi endpoints to the cluster's blackbox-exporter probe list as a new
 
 ### Task 1: Extend `apps/blackbox-exporter/manifests/vmprobe.yaml`
 
-- [ ] **Step 1: Append a second `VMProbe` document for management-plane targets**
+- [x] **Step 1: Append a second `VMProbe` document for management-plane targets**
 
   Edit `apps/blackbox-exporter/manifests/vmprobe.yaml`, append (note the `---` separator):
 

--- a/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
+++ b/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
@@ -1,7 +1,7 @@
 # Obs — Cert-Expiry Alerting Implementation Plan
 
 **Spec:** `docs/superpowers/specs/2026-04-20--obs--pass3-followups-design.md`
-**Status:** Not Started
+**Status:** In Progress
 
 **Goal:** Close the cert-expiry observability gap surfaced by the 2026-05-11 Omni outage. Add cluster-side blackbox probe coverage for the Omni management plane and a global Grafana alert rule keyed on `probe_ssl_earliest_cert_expiry` that pages on Telegram 14 days ahead of expiry for *any* monitored HTTPS endpoint.
 


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
📐 Spec:   docs/superpowers/specs/2026-04-20--obs--pass3-followups-design.md
🎯 Phase:  1/3 — Probe targets [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/243

**Goal (from plan):** Close the cert-expiry observability gap surfaced by the 2026-05-11 Omni outage. Add cluster-side blackbox probe coverage for the Omni management plane and a global Grafana alert rule keyed on `probe_ssl_earliest_cert_expiry` that pages on Telegram 14 days ahead of expiry for *any* monitored HTTPS endpoint.

---

## Summary

Phase 1/3 of `2026-05-11--obs--cert-expiry-alerting.md`.

- Append a second `VMProbe` (`management-plane-probes`) to `apps/blackbox-exporter/manifests/vmprobe.yaml`, separate from `feature-health-probes` so management-plane semantics don't bleed into Layer-N feature-health rules.
- Targets: `https://omni.frank.derio.net/` and `https://omni.frank.derio.net:8100/`, labelled `probe_group=management_plane`.
- Module `http_2xx` — `probe_success` will be 0 on `:8100/` (Omni returns 404 there), but `probe_ssl_earliest_cert_expiry` is populated during the TLS handshake regardless. Phase 2's global alert keys on the SSL metric, not on `probe_success`.

## Test plan

Post-merge verification (deferred until ArgoCD picks up `main`):

- [ ] `kubectl -n argocd get application blackbox-exporter -o jsonpath='{.status.sync.status}'` → `Synced`
- [ ] `kubectl -n monitoring exec deploy/victoria-metrics-grafana -- wget -qO- 'http://vmsingle-victoria-metrics-victoria-metrics-k8s-stack.monitoring.svc.cluster.local:8428/api/v1/query?query=probe_ssl_earliest_cert_expiry%7Binstance%3D~%22https%3A%2F%2Fomni.frank.derio.net.%2A%22%7D'` → two `result` entries, one per target, each with a unix-ts ~90d in the future.

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)