### PR TITLE
plan(obs): tick Phase 1 T1.S2/T1.S3 + log post-merge verification

### DIFF
--- a/apps/blackbox-exporter/manifests/vmprobe.yaml
+++ b/apps/blackbox-exporter/manifests/vmprobe.yaml
@@ -17,3 +17,20 @@ spec:
   module: http_2xx
   vmProberSpec:
     url: blackbox-exporter.monitoring.svc:9115
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMProbe
+metadata:
+  name: management-plane-probes
+  namespace: monitoring
+spec:
+  targets:
+    staticConfig:
+      targets:
+        - https://omni.frank.derio.net/
+        - https://omni.frank.derio.net:8100/
+      labels:
+        probe_group: management_plane
+  module: http_2xx
+  vmProberSpec:
+    url: blackbox-exporter.monitoring.svc:9115

--- a/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
+++ b/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
@@ -57,7 +57,7 @@ Add the Omni Pi endpoints to the cluster's blackbox-exporter probe list as a new
 
   Module choice rationale: `http_2xx` will set `probe_success=0` on `:8100/` (Omni returns 404 there), but `probe_ssl_earliest_cert_expiry` is populated regardless — blackbox-exporter emits it during the TLS handshake, before HTTP status evaluation. The Phase 2 alert keys on the SSL metric, not on `probe_success`.
 
-- [ ] **Step 2: Commit + push + verify ArgoCD sync**
+- [x] **Step 2: Commit + push + verify ArgoCD sync**
 
   ```bash
   git add apps/blackbox-exporter/manifests/vmprobe.yaml
@@ -72,7 +72,7 @@ Add the Omni Pi endpoints to the cluster's blackbox-exporter probe list as a new
   # Expected: Synced
   ```
 
-- [ ] **Step 3: Verify the SSL metric appears in VictoriaMetrics**
+- [x] **Step 3: Verify the SSL metric appears in VictoriaMetrics**
 
   ```bash
   kubectl -n monitoring exec deploy/victoria-metrics-grafana -- \

--- a/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
+++ b/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
@@ -31,7 +31,7 @@ Add the Omni Pi endpoints to the cluster's blackbox-exporter probe list as a new
 
 ### Task 1: Extend `apps/blackbox-exporter/manifests/vmprobe.yaml`
 
-- [ ] **Step 1: Append a second `VMProbe` document for management-plane targets**
+- [x] **Step 1: Append a second `VMProbe` document for management-plane targets**
 
   Edit `apps/blackbox-exporter/manifests/vmprobe.yaml`, append (note the `---` separator):
 

--- a/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
+++ b/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
@@ -1,7 +1,7 @@
 # Obs — Cert-Expiry Alerting Implementation Plan
 
 **Spec:** `docs/superpowers/specs/2026-04-20--obs--pass3-followups-design.md`
-**Status:** Not Started
+**Status:** In Progress
 
 **Goal:** Close the cert-expiry observability gap surfaced by the 2026-05-11 Omni outage. Add cluster-side blackbox probe coverage for the Omni management plane and a global Grafana alert rule keyed on `probe_ssl_earliest_cert_expiry` that pages on Telegram 14 days ahead of expiry for *any* monitored HTTPS endpoint.
 


### PR DESCRIPTION
## Summary

Post-merge bookkeeping for #246 (Phase 1 of `2026-05-11--obs--cert-expiry-alerting.md`).

Ran the PR's "Test plan" checklist against the live cluster after merge:

- ArgoCD `blackbox-exporter` Application synced to merge commit `31c9af9`, Healthy.
- `management-plane-probes` VMProbe reports `operational` (`status.updateStatus`); VictoriaMetrics operator condition `ConfigParsedAndApplied=True`.
- VictoriaMetrics now scrapes the SSL metric for both Omni targets:

  ```
  probe_ssl_earliest_cert_expiry{instance="https://omni.frank.derio.net/"}      → ~46d future
  probe_ssl_earliest_cert_expiry{instance="https://omni.frank.derio.net:8100/"} → ~90d future
  ```

  Two distinct certs — the `/` endpoint serves Traefik's chain, `:8100/` serves the manually-installed Let's Encrypt cert just renewed by `omni-cert-renew.timer` (commits `f161941`, `cf5a501`). Both are now visible to Phase 2's metric-keyed alert.

This ticks `P1.T1.S2` and `P1.T1.S3` in the plan. Phase 1 is functionally complete; Phase 2 (#244) is now unblocked.

## Test plan

- [x] ArgoCD Application synced + Healthy at merge SHA
- [x] VMProbe `management-plane-probes` operational
- [x] `probe_ssl_earliest_cert_expiry` returns 2 series for `omni.frank.derio.net.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)