### PR TITLE
[derio-net/frank] obs--cert-expiry-alerting · Phase 2/3 · Global cert-expiry alert rule

### DIFF
--- a/apps/grafana-alerting/manifests/alert-rules-cm.yaml
+++ b/apps/grafana-alerting/manifests/alert-rules-cm.yaml
@@ -1168,9 +1168,8 @@ data:
             annotations:
               summary: "L17 Edge: probe {{ $labels.instance }} failing — Hop cluster or Caddy down"
               runbook: "source .env_hop; kubectl -n blog get pods; talosctl -n $HOP_IP health"
-              # DEFERRED (Pass 3+): extend with Headscale peer count + cert expiry + Hetzner API.
+              # DEFERRED (Pass 3+): extend with Headscale peer count + Hetzner API.
               # Headscale: headscale_peer_count from a sidecar scrape (needs exporter).
-              # Cert expiry: probe_ssl_earliest_cert_expiry - time() < 7*86400.
               # Hetzner API: needs hetzner_server_status exporter — file a follow-up.
 
       # --- Layer 19 — Progressive Delivery / Argo Rollouts (frank-ops#19) ---
@@ -1299,3 +1298,86 @@ data:
             annotations:
               summary: "L25 CI/CD: {{ $labels.namespace }}/{{ $labels.pod }} NotReady"
               runbook: "kubectl -n {{ $labels.namespace }} describe pod {{ $labels.pod }}"
+
+      # =====================================================================
+      # GLOBAL TLS CERT-EXPIRY
+      # Triggered by 2026-05-11 Omni outage — see
+      # docs/investigations/2026-05-11--omni--cert-expiry-incident.md.
+      # Fires on ANY blackbox probe target with cert <14d (warning) or <7d
+      # (critical) remaining. Wires to telegram via existing severity-based
+      # notification policy.
+      # =====================================================================
+      - orgId: 1
+        name: tls-cert-expiry-1h
+        folder: feature-health
+        interval: 1h
+        rules:
+          - uid: tls-cert-expiring-14d
+            title: TLS cert expiring within 14 days
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: P4169E866C3094E38
+                model:
+                  refId: A
+                  expr: 'probe_ssl_earliest_cert_expiry - time()'
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+              - refId: B
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: __expr__
+                model: { refId: B, type: reduce, expression: A, reducer: last, settings: { mode: dropNN } }
+              - refId: C
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: lt, params: [1209600] }
+            noDataState: OK
+            execErrState: Error
+            for: 1h
+            labels:
+              severity: warning
+            annotations:
+              summary: "TLS cert for {{ $labels.instance }} expires in <14 days ({{ humanizeDuration $value }} remaining)"
+              runbook: "See docs/investigations/2026-05-11--omni--cert-expiry-incident.md for renewal procedure."
+
+          - uid: tls-cert-expiring-7d
+            title: TLS cert expiring within 7 days
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: P4169E866C3094E38
+                model:
+                  refId: A
+                  expr: 'probe_ssl_earliest_cert_expiry - time()'
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+              - refId: B
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: __expr__
+                model: { refId: B, type: reduce, expression: A, reducer: last, settings: { mode: dropNN } }
+              - refId: C
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: lt, params: [604800] }
+            noDataState: OK
+            execErrState: Error
+            for: 1h
+            labels:
+              severity: critical
+            annotations:
+              summary: "TLS cert for {{ $labels.instance }} expires in <7 days ({{ humanizeDuration $value }} remaining)"
+              runbook: "See docs/investigations/2026-05-11--omni--cert-expiry-incident.md for renewal procedure."

--- a/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
+++ b/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
@@ -92,7 +92,7 @@ Add a rule that keys on the *metric*, not on any specific `instance`, so the ale
 
 ### Task 1: Add rule group to `apps/grafana-alerting/manifests/alert-rules-cm.yaml`
 
-- [ ] **Step 1: Delete the deferred-comment line at L1173**
+- [x] **Step 1: Delete the deferred-comment line at L1173**
 
   Find:
 
@@ -102,7 +102,7 @@ Add a rule that keys on the *metric*, not on any specific `instance`, so the ale
 
   Delete only that single line (keep the Headscale and Hetzner deferred comments — they're separate follow-ups).
 
-- [ ] **Step 2: Append a new rule group**
+- [x] **Step 2: Append a new rule group**
 
   At the end of the existing `groups:` list (after the last `- orgId: 1, name: layer-...` block), append:
 


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
📐 Spec:   docs/superpowers/specs/2026-04-20--obs--pass3-followups-design.md
🎯 Phase:  2/3 — Global cert-expiry alert rule [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/244

**Goal (from plan):** Close the cert-expiry observability gap surfaced by the 2026-05-11 Omni outage. Add cluster-side blackbox probe coverage for the Omni management plane and a global Grafana alert rule keyed on `probe_ssl_earliest_cert_expiry` that pages on Telegram 14 days ahead of expiry for *any* monitored HTTPS endpoint.

## Summary

- Adds a new `tls-cert-expiry-1h` rule group to `apps/grafana-alerting/manifests/alert-rules-cm.yaml` with two rules:
  - `tls-cert-expiring-14d` — `severity: warning`, threshold `lt 1209600` (14d)
  - `tls-cert-expiring-7d` — `severity: critical`, threshold `lt 604800` (7d)
- Both rules use the mandatory Grafana 12.x SSE A→B→C three-step format (per `frank-gotchas.md`) and key on the metric, not on any specific `instance` — so every endpoint blackbox-exporter probes inherits cert-expiry coverage automatically.
- Removes the now-superseded `# Cert expiry: probe_ssl_earliest_cert_expiry - time() < 7*86400.` deferral comment from the Layer 17 edge block (Headscale + Hetzner deferrals kept — separate follow-ups).
- Plan: `P2.T1.S1` (delete deferred comment) and `P2.T1.S2` (append rule group) ticked. `S3` (post-merge ArgoCD sync + Grafana pod restart) and `S4` (verify rules loaded via Grafana provisioning API) remain unticked — they happen on `main` after merge, mirroring how Phase 1 logged its sync/verify in a follow-up `tick + post-merge verification` commit.

## Verification (pre-merge)

YAML parses cleanly via `yaml.safe_load`, and the new group sits where expected:

```
group count: 27
tls rules: ['tls-cert-expiring-14d', 'tls-cert-expiring-7d']
severities: {'critical', 'warning'}
```

End-to-end alert delivery via `expired.badssl.com` is Phase 3's gate (#245).

## Test plan

- [ ] Merge → ArgoCD syncs `grafana-alerting` (auto)
- [ ] Restart Grafana pod (`kubectl delete pod -n monitoring -l app.kubernetes.io/name=grafana`) — file-provisioning is read at boot, not watched
- [ ] Confirm rules via `/api/v1/provisioning/alert-rules` (expect both `tls-cert-expiring-14d` and `tls-cert-expiring-7d` UIDs)
- [ ] Tick `P2.T1.S3` and `P2.T1.S4` in a follow-up commit on `main`
- [ ] Phase 3 (#245) drives end-to-end alert delivery via `expired.badssl.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)