### PR TITLE
plan(obs): tick Phase 2 T1.S3/T1.S4 + log post-merge verification

### DIFF
--- a/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
+++ b/docs/superpowers/plans/2026-05-11--obs--cert-expiry-alerting.md
@@ -197,7 +197,7 @@ Add a rule that keys on the *metric*, not on any specific `instance`, so the ale
   - The Prometheus `datasourceUid: P4169E866C3094E38` matches the existing rules in the same file — copy-paste consistent.
   - No `github_issue` label here: this is a generalized rule, not tied to one Layer tracker. Add one later if a tracker is wanted.
 
-- [ ] **Step 3: Commit + push + sync + restart Grafana**
+- [x] **Step 3: Commit + push + sync + restart Grafana**
 
   ```bash
   git add apps/grafana-alerting/manifests/alert-rules-cm.yaml
@@ -213,21 +213,29 @@ Add a rule that keys on the *metric*, not on any specific `instance`, so the ale
   kubectl delete pod -n monitoring -l app.kubernetes.io/name=grafana
   ```
 
-- [ ] **Step 4: Verify rules are loaded**
+- [x] **Step 4: Verify rules are loaded**
+
+  The provisioning API path needs Grafana admin auth, but the chart-managed Secret drifts from the PVC-backed `grafana.db` (frank-gotcha: "Grafana Helm chart regenerates admin password Secret on re-render — PVC-backed database retains old password"), so the documented `wget --user/--password` path returns `401`. Two no-auth alternatives that confirm provisioning without resetting the admin password:
 
   ```bash
-  GRAFANA_PASS=$(kubectl -n monitoring get secret victoria-metrics-grafana -o jsonpath='{.data.admin-password}' | base64 -d)
+  # (a) Confirm Grafana parsed the provisioning file with no SSE/parse errors.
+  kubectl -n monitoring logs deploy/victoria-metrics-grafana --tail=400 \
+    | grep -iE 'provisioning.alerting|parseError|sse\.parse'
+  # Expect: "starting to provision alerting" → "finished to provision alerting"
+  # with no parseError / sse.parse lines in between.
+
+  # (b) Confirm both rules made it into grafana.db (sqlite3 isn't in the image —
+  #     grep the raw db for our UIDs instead).
   kubectl -n monitoring exec deploy/victoria-metrics-grafana -- \
-    wget -qO- --user=admin --password="$GRAFANA_PASS" \
-    'http://localhost:3000/api/v1/provisioning/alert-rules' \
-    | grep -oE '"uid":"tls-cert-expiring-[0-9]+d"'
+    sh -c 'strings /var/lib/grafana/grafana.db | grep -E "^tls-cert-expir" | sort -u'
+  # Expect: both `tls-cert-expiring-14d` and `tls-cert-expiring-7d` appear,
+  # each with their full A→B→C JSON inlined (thresholds 1209600 and 604800).
   ```
 
-  Expected output:
-  ```
-  "uid":"tls-cert-expiring-14d"
-  "uid":"tls-cert-expiring-7d"
-  ```
+  (Note: busybox `wget` inside the Grafana image does not understand
+  `--user`/`--password` flags — basic-auth has to come via an
+  `Authorization: Basic …` header. With the chart-secret password mismatch above
+  that path is moot anyway; the two checks above are the working verification.)
 
 ---
 


### PR DESCRIPTION
## Summary

Follow-up to #248 (Phase 2 — Global cert-expiry alert rule). Ticks `P2.T1.S3` (deploy: ArgoCD sync + Grafana restart) and `P2.T1.S4` (verify rules are loaded) on `main`, mirroring the Phase 1 tick PR (#247).

Also fixes `S4`'s documented verification command so the next operator running this against a live Grafana doesn't hit a wall:

- The original `wget --user=admin --password="$GRAFANA_PASS"` fails because the Grafana image ships busybox `wget` (no `--user`/`--password` flags).
- Even with `Authorization: Basic …`, the chart-managed `victoria-metrics-grafana` Secret drifts from the PVC-backed `grafana.db` (existing frank-gotcha), so the provisioning API returns `401` with the chart-secret value.
- Replaced with two no-auth checks: (a) `provisioning.alerting` log scan for `starting/finished … to provision alerting` with no `parseError`, and (b) `strings /var/lib/grafana/grafana.db | grep ^tls-cert-expir` to confirm the rules made it into the DB with their full A→B→C JSON.

## Post-merge verification log

- ArgoCD `grafana-alerting` synced to `2b3ac48` after a hard refresh — Synced/Healthy.
- ConfigMap `grafana-alerting-rules` carries the new `tls-cert-expiry-1h` group with both UIDs.
- Grafana pod restarted (`kubectl delete pod -n monitoring -l app.kubernetes.io/name=grafana`); rollout completed.
- Provisioning logs: `starting to provision alerting` → `finished to provision alerting`, no `parseError`/`sse.parse*` lines.
- `grafana.db` contains both rules with the full inline A→B→C JSON (thresholds `1209600` for 14d, `604800` for 7d).

End-to-end alert delivery is the gate for Phase 3 (#245), not for this PR.

## Test plan

- [x] Phase 2 artifact (alert rules) loaded into Grafana — verified above
- [ ] Phase 3 (#245) drives end-to-end alert delivery via `expired.badssl.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)