### PR TITLE
fix(cicd): use 'resources' not 'computeResources' in pipelinerun-ttl-gc CronJob

### DIFF
--- a/apps/tekton/manifests/pipelinerun-ttl-gc.yaml
+++ b/apps/tekton/manifests/pipelinerun-ttl-gc.yaml
@@ -68,7 +68,10 @@ spec:
                 runAsUser: 1001
                 capabilities: { drop: ["ALL"] }
                 seccompProfile: { type: RuntimeDefault }
-              computeResources:
+              # Native K8s containers use `resources` (Tekton CRDs use
+              # `computeResources` — see frank-gotchas.md). This is a
+              # CronJob/batch.v1, not a Tekton Task, so plain `resources`.
+              resources:
                 requests: { cpu: 50m, memory: 64Mi }
                 limits:   { memory: 128Mi }
               command: ["/bin/bash", "-eu", "-o", "pipefail", "-c"]


### PR DESCRIPTION
## Summary

One-line follow-up to #255. The CronJob manifest used \`computeResources\` (Tekton Task CRD field) instead of \`resources\` (native K8s container field). ArgoCD sync caught it after #255 merged:

\`\`\`
failed to create typed patch object (tekton-pipelines/pipelinerun-ttl-gc; batch/v1, Kind=CronJob):
.spec.jobTemplate.spec.template.spec.containers[name="gc"].computeResources: field not declared in schema
\`\`\`

The SA + Role + RoleBinding from the same manifest landed correctly in the #255 sync; only the CronJob itself failed. After this merges + syncs, the CronJob materializes and the daily 04:30 UTC sweep starts.

\`frank-gotchas.md\` already documents the Tekton-specific field name. Added a comment in the manifest pointing at it so the next contributor doesn't repeat the confusion.

## Test plan

- [ ] Sync \`tekton-extras\` → \`kubectl get cronjob -n tekton-pipelines pipelinerun-ttl-gc\` returns the CronJob
- [ ] No more \`SyncFailed\` on tekton-extras Application

🤖 Generated with [Claude Code](https://claude.com/claude-code)