### PR TITLE
agents: Phase 5 soak complete — dial back vk-local limit 8Gi→4Gi (gh#156)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,7 +5,8 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
 # Collect staged plan files
-PLAN_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^docs/superpowers/(plans|archived-plans)/.*\.md$' || true)
+# Only match top-level .md files; skip v2 folder components (_prose.md, NN.yaml, _meta.yaml in subdirs).
+PLAN_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^docs/superpowers/(plans|archived-plans)/[^/]+\.md$' || true)
 AGENT_CONFIG_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(AGENTS\.md|CLAUDE\.md|GEMINI\.md|agents/|\.claude/settings\.json|\.claude/launch\.json|scripts/hooks/|scripts/validate-agent-config\.sh|docs/runbooks/)' || true)
 
 if [ -n "$AGENT_CONFIG_FILES" ]; then

--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -163,7 +163,7 @@ spec:
               cpu: "200m"
               memory: 512Mi
             limits:
-              memory: 8Gi
+              memory: 3Gi
           readinessProbe:
             httpGet:
               path: /api/health

--- a/apps/secure-agent-pod/manifests/deployment.yaml
+++ b/apps/secure-agent-pod/manifests/deployment.yaml
@@ -163,7 +163,7 @@ spec:
               cpu: "200m"
               memory: 512Mi
             limits:
-              memory: 3Gi
+              memory: 4Gi
           readinessProbe:
             httpGet:
               path: /api/health

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/05.yaml
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/05.yaml
@@ -66,9 +66,9 @@ state:
     P5.T2.S1:
       state: x
       ticked_at: '2026-05-16'
-      note: "Outcome (b): dial back to 3 Gi. vk-local limits.memory: 8Gi → 3Gi (PR #264). 14-day p99 peaked 2.95 GiB; 3 Gi covers it with ~5% headroom. Zero OOMKills, zero restarts across the full window."
+      note: "Outcome (b): dial back to 4 Gi. vk-local limits.memory: 8Gi → 4Gi (PR #264). 14-day p99 peaked 2.95 GiB; 4 Gi provides ~35% headroom as a buffer given low workload activity during the soak window. Zero OOMKills, zero restarts across the full window."
   completion:
     at: '2026-05-16'
-    note: Phase 5 soak complete. Outcome (b) implemented in PR #264.
+    note: Phase 5 soak complete. Outcome (b) implemented in PR #264 (4 Gi with buffer).
     observed_prs:
     - https://github.com/derio-net/frank/pull/264

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/05.yaml
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/05.yaml
@@ -56,18 +56,19 @@ tasks:
 state:
   steps:
     P5.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-16'
+      note: Auto-collected by scripts/phase5-soak-daily.sh via supercronic (0 8 * * * UTC, kali sibling container). 14 days, zero OOMKills, zero container restarts.
     P5.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-16'
+      note: Soak log recorded in _prose.md. p99 RSS peaked 2.95 GiB (Day 2, queue=3); median ~1.1 GiB; Day 14 = 0.19 GiB.
     P5.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-16'
+      note: "Outcome (b): dial back to 3 Gi. vk-local limits.memory: 8Gi → 3Gi (PR #264). 14-day p99 peaked 2.95 GiB; 3 Gi covers it with ~5% headroom. Zero OOMKills, zero restarts across the full window."
   completion:
-    at: null
-    note: null
-    observed_prs: []
+    at: '2026-05-16'
+    note: Phase 5 soak complete. Outcome (b) implemented in PR #264.
+    observed_prs:
+    - https://github.com/derio-net/frank/pull/264

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/_meta.yaml
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/_meta.yaml
@@ -1,6 +1,8 @@
 schema_version: 2
 plan: 2026-04-30--agents--vk-local-oom-remediation
 spec: docs/superpowers/specs/2026-04-30--agents--vk-local-oom-remediation-design.md
-target_repo: derio-net/superpowers-for-vk
+target_repo: derio-net/frank
 vk_version: '>=1.0.0,<3.0.0'
 created: '2026-04-30'
+status: Deployed
+completed: '2026-05-16'

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/_prose.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/_prose.md
@@ -102,6 +102,35 @@
 
 - P5.T2.S1: After 14 days, choose one outcome and document the rationale:
 
+  **Outcome: (b) Dial back to 3 Gi** — `vk-local limits.memory: 8Gi → 3Gi` (PR #264).
+
+---
+
+## Soak Log (Phase 5)
+
+**Soak window:** 2026-05-03 → 2026-05-16 (14 days from Phase 4 Task 2 merge at `c88b755`).
+
+Auto-filled by `scripts/phase5-soak-daily.sh` via supercronic (`0 8 * * *` UTC, kali sibling container).
+
+| Day | Date (UTC) | `restartCount` | OOMKills since soak start | p99 working-set (24 h) | Peak `vibekanban_queued_executions` (24 h) | Notes |
+|-----|------------|----------------|---------------------------|------------------------|---------------------------------------------|-------|
+| 1 | 2026-05-03 | 0 | 0 | ~2.35 GiB (cadvisor) / ~2.53 GiB (resource) | 0 | Soak start. Phase 4 image `8af0d080` live, `VK_MAX_CONCURRENT_EXECUTIONS=4` confirmed. |
+| 2 | 2026-05-04 | 0 | 0 | 2.95 GiB | 3 | pod=secure-agent-pod-c976f9946-rqdqc |
+| 3 | 2026-05-05 | 0 | 0 | 0.74 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
+| 4 | 2026-05-06 | 0 | 0 | 0.97 GiB | 0 | pod=secure-agent-pod-c976f9946-rqdqc |
+| 5 | 2026-05-07 | 0 | 0 | 1.05 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
+| 6 | 2026-05-08 | 0 | 0 | 0.24 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
+| 7 | 2026-05-09 | 0 | 0 | 0.38 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
+| 8 | 2026-05-10 | 0 | 0 | 1.11 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
+| 9 | 2026-05-11 | 0 | 0 | 0.99 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
+| 10 | 2026-05-12 | 0 | 0 | 1.56 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
+| 11 | 2026-05-13 | 0 | 0 | 1.73 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
+| 12 | 2026-05-14 | 0 | 0 | 1.90 GiB | 0 | pod=secure-agent-pod-5c46cb8f7b-9765c |
+| 13 | 2026-05-15 | 0 | 0 | 1.66 GiB | 0 | pod=secure-agent-pod-fc9585b8b-jn2rx (pod replaced — node eviction, not OOM) |
+| 14 | 2026-05-16 | 0 | 0 | 0.19 GiB | 0 | pod=secure-agent-pod-548744b988-dngfj (pod replaced again) |
+
+**Decision rationale:** 14 days, zero OOMKills, zero container restarts. p99 RSS peaked at 2.95 GiB on Day 2 (the only day with queue depth > 0). All other days 0.19–1.90 GiB. The 8 Gi limit was a conservative post-OOM placeholder; 3 Gi covers the p99 peak with ~5 % headroom. `vk-local limits.memory` dialled back to 3 Gi in PR #264.
+
 ## Phase 6: File tracking issues for B2, B3, R
 
 ### Task 1: File B2 tracking issue

--- a/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/_prose.md
+++ b/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation/_prose.md
@@ -102,7 +102,7 @@
 
 - P5.T2.S1: After 14 days, choose one outcome and document the rationale:
 
-  **Outcome: (b) Dial back to 3 Gi** — `vk-local limits.memory: 8Gi → 3Gi` (PR #264).
+  **Outcome: (b) Dial back to 4 Gi** — `vk-local limits.memory: 8Gi → 4Gi` (PR #264). 4 Gi chosen over the data-minimum 3 Gi as a buffer, given low workload activity during the soak window.
 
 ---
 
@@ -129,7 +129,7 @@ Auto-filled by `scripts/phase5-soak-daily.sh` via supercronic (`0 8 * * *` UTC, 
 | 13 | 2026-05-15 | 0 | 0 | 1.66 GiB | 0 | pod=secure-agent-pod-fc9585b8b-jn2rx (pod replaced — node eviction, not OOM) |
 | 14 | 2026-05-16 | 0 | 0 | 0.19 GiB | 0 | pod=secure-agent-pod-548744b988-dngfj (pod replaced again) |
 
-**Decision rationale:** 14 days, zero OOMKills, zero container restarts. p99 RSS peaked at 2.95 GiB on Day 2 (the only day with queue depth > 0). All other days 0.19–1.90 GiB. The 8 Gi limit was a conservative post-OOM placeholder; 3 Gi covers the p99 peak with ~5 % headroom. `vk-local limits.memory` dialled back to 3 Gi in PR #264.
+**Decision rationale:** 14 days, zero OOMKills, zero container restarts. p99 RSS peaked at 2.95 GiB on Day 2 (the only day with queue depth > 0). All other days 0.19–1.90 GiB. The soak window was not particularly busy; 4 Gi chosen over the data-minimum 3 Gi to provide a comfortable buffer against busier-than-soak workloads. `vk-local limits.memory` dialled back to 4 Gi in PR #264.
 
 ## Phase 6: File tracking issues for B2, B3, R
 

--- a/scripts/hooks/plan-validate-check.sh
+++ b/scripts/hooks/plan-validate-check.sh
@@ -6,8 +6,15 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$(cd "$(dirname 
 INPUT=$(cat)
 FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_response.filePath // empty')
 
-# Only care about plan files
+# Only care about legacy flat/phased plan .md files.
+# Skip v2 folder components (_prose.md, _meta.yaml, NN.yaml inside a plan dir).
 case "$FILE_PATH" in
+  *docs/superpowers/plans/*/_prose.md|\
+  *docs/superpowers/plans/*/_meta.yaml|\
+  *docs/superpowers/plans/*/*.yaml|\
+  *docs/superpowers/archived-plans/*/_prose.md|\
+  *docs/superpowers/archived-plans/*/_meta.yaml|\
+  *docs/superpowers/archived-plans/*/*.yaml) exit 0 ;;
   *docs/superpowers/plans/*.md|*docs/superpowers/archived-plans/*.md) ;;
   *) exit 0 ;;
 esac


### PR DESCRIPTION
## Summary

14-day Phase 5 soak complete (2026-05-03 → 2026-05-16). Data supports **outcome (b): dial back `vk-local limits.memory` from `8Gi` to `4Gi`** (4 Gi over the data-minimum 3 Gi as a buffer given low workload activity during the soak window).

| Metric | Result |
|--------|--------|
| OOMKills | 0 |
| Container restarts | 0 |
| p99 RSS peak | **2.95 GiB** (Day 2 — queue depth 3, the only queuing event) |
| p99 RSS median | ~1.1 GiB |
| p99 RSS Day 14 | 0.19 GiB |

Pod identity changed on Days 13–14 (node eviction, not OOM). `restartCount` and OOMKill counter both remained at 0 throughout.

## Changes

- `apps/secure-agent-pod/manifests/deployment.yaml`: `vk-local limits.memory: 8Gi → 4Gi` (OOM ceiling; kali's scheduling request unchanged)
- `docs/superpowers/plans/…/05.yaml`: Phase 5 steps marked complete, decision rationale recorded (v2 format)
- `docs/superpowers/plans/…/_prose.md`: Full 14-day soak log table + decision rationale (v2 format)
- `docs/superpowers/plans/…/_meta.yaml`: status=Deployed, completed=2026-05-16
- `.githooks/pre-commit` + `scripts/hooks/plan-validate-check.sh`: Fix v2 folder component exclusion — glob/regex was matching `_prose.md` inside plan subdirectories as if it were a legacy plan file

## Test plan

- [ ] ArgoCD syncs cleanly (SSA, no rollingUpdate conflict)
- [ ] Pod scheduled successfully (4 Gi well within node capacity)
- [ ] `restartCount` remains 0 after rollout
- [ ] Grafana memory panel shows new pod's RSS within expected range

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)