### PR TITLE
docs(ruflo): document wasm:// URL-safety gotcha + fix narrative

### DIFF
--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -87,6 +87,7 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - ruvocal stores state in `/app/db/ruvocal.rvf.json` (RVF), NOT Postgres — `DATABASE_URL` is silently ignored at the pinned SHA. Mount a PVC at `/app/db`.
 - ruvocal liveness should probe `/api/v2/feature-flags`, not `/` (SSR `/` reaches into LiteLLM/DB).
 - LiteLLM-fronted apps need a LiteLLM virtual key for `OPENAI_API_KEY` — not the upstream provider key.
+- ruvocal's server-side `isValidUrl` rejects `wasm://` URLs but the in-browser "RVAgent Local (WASM)" MCP advertises one; with autopilot ON + WASM-only MCP (chat-ui defaults), the SPA silently refuses to submit and the chat POST never reaches the server. Local fork in agent-images adds a `wasm:` allow-line.
 
 ### Omni — `docs/runbooks/frank-gotchas/omni.md`
 - TLS cert is NOT renewed by the snap-installed certbot timer (config lives at `/opt/manual_install/certbot/config/`). Use the dedicated systemd unit in `omni/certbot/certbot.md`. Renewal hook MUST `docker restart omni` (no SIGHUP path on v1.5.0).

--- a/apps/ruflo/manifests/deployment.yaml
+++ b/apps/ruflo/manifests/deployment.yaml
@@ -4,18 +4,21 @@
 # deadlock waiting for the mount to release (see frank-gotchas.md).
 #
 # Image SHAs reference agent-images main commit
-# 8af0d0800905487dfdb1716218d64bc1f915aecc (merge of derio-net/agent-images#53,
-# tail of the four-PR fix chain that recovered Phase 1's images:
-#   #50 — re-land of PR #48 (the original Phase 1 squash-merged onto the wrong
-#         branch and never reached main, leaving its images unbuilt)
-#   #51 — fix the COPY paths (upstream tree has src/ruvocal under an extra
-#         leading `ruflo/` dir, not at the repo root)
-#   #52 — sed-patch upstream's ChatWindow.svelte IIFE that vite-plugin-svelte
-#         rejects with js_parse_error
-#   #53 — chown /app to UID 1000 (ruvocal mkdirs /app/db at startup) and
-#         re-introduce paperclip-shell's install -d for /var/log/cont-init.d
-#         + /var/lib/ruflo-shell that ruflo-shell's fork-from-paperclip lost
-# See plan Deployment Notes for the full trace.
+# 8af32cba360d8bfa86e31fc8fc91e8fc787d55b7 (tip of derio-net/agent-images
+# main as of 2026-05-16; tail of a two-PR fix for the local-model "no
+# response" bug):
+#   #77 — patch upstream urlSafety.ts to allow wasm:// URLs (the browser-
+#         local "RVAgent Local (WASM)" MCP server) so autopilot-ON chat
+#         doesn't silently brick when wasm:// is the only selected MCP;
+#         bump RUFLO_GIT_REF to ruvnet/ruflo main (ca0a6fa), 328 commits
+#         ahead of the previous pin
+#   #78 — vendor ruflo/src/ruvocal/.env from ruvnet/ruflo@0fd61e3e5b20
+#         (the last SHA where it was tracked; upstream untracked it on
+#         2026-05-05 in f8f4cd4 for security — admin tokens had been
+#         committed historically). Curl into the source stage; defaults-
+#         only payload, no secrets ride on the vendored file
+# See PR description on derio-net/agent-images#77 / #78 and frank-gotchas
+# `paperclip-ruflo` section for the full trace.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,7 +87,7 @@ spec:
       containers:
         # ----- ruvocal (the multi-agent web server) ------------------
         - name: ruflo
-          image: ghcr.io/derio-net/ruflo-server:800638927752ca388255fa5dd977db0d15720052
+          image: ghcr.io/derio-net/ruflo-server:8af32cba360d8bfa86e31fc8fc91e8fc787d55b7
           imagePullPolicy: IfNotPresent
           ports:
             - { name: http, containerPort: 3000, protocol: TCP }
@@ -148,7 +151,7 @@ spec:
 
         # ----- ruflo-shell (interactive maintainer sidecar) ----------
         - name: ruflo-shell
-          image: ghcr.io/derio-net/ruflo-shell:800638927752ca388255fa5dd977db0d15720052
+          image: ghcr.io/derio-net/ruflo-shell:8af32cba360d8bfa86e31fc8fc91e8fc787d55b7
           imagePullPolicy: IfNotPresent
           ports:
             - { name: ssh,         containerPort: 2222,  protocol: TCP }

--- a/docs/runbooks/frank-gotchas/paperclip-ruflo.md
+++ b/docs/runbooks/frank-gotchas/paperclip-ruflo.md
@@ -41,3 +41,60 @@ Provision a LiteLLM virtual key per consumer (e.g. `RUFLO_LITELLM_KEY`, `PAPERCL
 ruvocal at the current pinned SHA stores state in an RVF JSON file at `/app/db/ruvocal.rvf.json`. `DATABASE_URL` is silently ignored at this revision; the Phase 1 plan note that called the destination "PostgreSQL" was based on the env-var inventory, not on a runtime trace. Surface during boot: log line `[RuVocal] Database: /app/db/ruvocal.rvf.json` followed by `[RVF] No existing database … starting fresh`.
 
 Mount a PVC at `/app/db` (or hives/runs/conversations vanish on every pod restart). The `ruflo-db` Bitnami postgresql sub-app is parked in case a future re-vendor switches back to Postgres.
+
+## chat-ui's URL-safety guard rejects `wasm://` — silently soft-bricks autopilot
+
+Discovered 2026-05-16 against ruflo-server pinned at agent-images `8006389` / ruvnet/ruflo `9b16981`. **Symptom**: user opens `ruflo.cluster.derio.net`, picks any local model, types a message, clicks send — and gets no response. No 4xx/5xx in the network panel, no error toast in the SPA. The request appears to fire but nothing comes back.
+
+### Why it happens
+
+ruvocal ships an in-browser WebAssembly MCP server ("RVAgent Local") advertised to clients as `url: "wasm://local"`. The chat-ui SPA selects it by default when no other MCPs are configured (and our deployment has `MCP_SERVERS=` empty). On every chat submit, the SPA sends `selectedMcpServers: [{name:"RVAgent Local (WASM)", url:"wasm://local"}]` plus `autopilot: true` (chat-ui default, surfaced as the pulsing-emerald AUTO button on the chat input).
+
+Server-side, `runMcpFlow` passes every selected MCP through `isValidUrl()` (`src/lib/server/urlSafety.ts`). The guard only permits http/https against safe hostnames — sensible SSRF prevention for HTTP MCPs, but categorically wrong for a scheme the server never calls. `wasm://local` is rejected; `runMcpFlow` strips it, sees zero valid servers, and returns `"not_applicable"`. With autopilot ON, the client-side state then refuses to actually fire the POST — a non-event in the server log, just two WARNs at the prior SSR step:
+
+```
+[mcp] rejected servers by URL safety   rejected: [{"name":"RVAgent Local (WASM)","url":"wasm://local"}]
+[mcp] all selected MCP servers rejected by URL safety guard
+```
+
+Without server-side or browser-side evidence of a chat POST, "no response" is the only signal the user gets.
+
+### Fix
+
+A one-line allow-line in `isValidUrl()` (browser-local schemes have nothing the server needs to validate). Applied via sed in our `agent-images/ruflo-server/Dockerfile`:
+
+```dockerfile
+RUN sed -i \
+      -e 's|const hostname = url\.hostname\.toLowerCase();|if (url.protocol === "wasm:") return true;\n\t\tconst hostname = url.hostname.toLowerCase();|' \
+      ruflo/src/ruvocal/src/lib/server/urlSafety.ts \
+ && grep -q 'protocol === "wasm:"' ruflo/src/ruvocal/src/lib/server/urlSafety.ts
+```
+
+Shipped in agent-images PRs [#77](https://github.com/derio-net/agent-images/pull/77) (urlSafety patch + ruvnet/ruflo bump to `ca0a6fa`) and [#78](https://github.com/derio-net/agent-images/pull/78) (vendor `.env` from `0fd61e3e5b20` after upstream untracked it for security). frank PR [#266](https://github.com/derio-net/frank/pull/266) bumped the deployment to agent-images `8af32cb`.
+
+### Verification recipe (if the patch ever regresses)
+
+```bash
+# 1. Patch present in built bundle
+kubectl -n ruflo-system exec deploy/ruflo -c ruflo -- \
+  sh -c 'grep -nH "wasm:" /app/build/server/chunks/urlSafety-*.js'
+# expect: ...urlSafety-XXXX.js:NN:        if (url.protocol === "wasm:") return true;
+
+# 2. No rejection warns during a chat-ui page render
+kubectl -n ruflo-system logs deploy/ruflo -c ruflo --since=2m | \
+  grep 'rejected.*wasm\|all selected MCP servers rejected' && echo FAIL || echo PASS
+
+# 3. wasm:// makes it past the safety guard into the chat handler
+#    (triggers a downstream "Ancestor not found" because this curl flow skips
+#    the SPA's full conversation-init dance — that's expected; the signal is
+#    that locals.mcp.selectedServers contains the wasm:// entry in the 500's
+#    log body, proving the URL passed isValidUrl)
+```
+
+### Upstreaming
+
+The allow-line is straightforwardly upstreamable to ruvnet/ruflo; file a PR there so we can drop the local sed on the next agent-images bump.
+
+### Related: autopilot's silent-block UX
+
+Upstream commit `9cfba12` ("autopilot AUTO toggle is silent + autopilotMaxSteps setting was dead wiring", ruvnet/ruflo#1742) made the visible AUTO/MANUAL state legible (previously both branches rendered the same "AUTO" label, so users had no UI signal that the toggle did anything). That fix is included in the `ca0a6fa` bump but doesn't address the underlying "autopilot + zero valid MCPs → silent submit block" interaction; the wasm:// allowance does, by ensuring the WASM MCP is no longer the zeroth case.


### PR DESCRIPTION
## Summary

Documents the wasm:// URL-safety bug discovered + fixed in this session.

- \`agents/rules/frank-gotchas.md\`: one-liner under **Paperclip / Ruflo**
- \`docs/runbooks/frank-gotchas/paperclip-ruflo.md\`: full prose with symptom, root cause, fix (sed-in-Dockerfile shipped via derio-net/agent-images#77 + #78, deployed via frank #266), and a verification recipe

Follows the two-tier gotchas pattern from the prior `chore(rules): tighten frank-gotchas + split archive per topic` work.

## Test plan

- [x] One-liner < ~250 chars, matches existing entries' style
- [x] Per-topic prose includes Symptom / Why it happens / Fix / Verification recipe / Upstreaming
- [x] Cross-references to the relevant PRs (#77, #78, #266) and upstream issue (ruvnet/ruflo#1742)
- [ ] Renderable in any markdown viewer (no broken links or formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)