### PR TITLE
spec+plan(orch): Paperclip LiteLLM-backed agents (opencode + hermes)

### DIFF
--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/01.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/01.yaml
@@ -1,0 +1,300 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Plan-time verifications + one-shot install
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Install opencode-ai and probe behavior against LiteLLM
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      SSH into paperclip-shell and install opencode-ai onto the shared `/paperclip` PVC. Operator-imperative for now; persistence comes in Phase 2.
+
+      ```bash
+      ssh paperclip-shell
+      npm install --prefix /paperclip/agent-bin opencode-ai
+      ls -la /paperclip/agent-bin/node_modules/.bin/opencode
+      ```
+
+      Expected: `/paperclip/agent-bin/node_modules/.bin/opencode` exists and is executable.
+  - id: P1.T1.S2
+    text: |-
+      Verify opencode is reachable from the paperclip main container — that container's PATH already includes `/paperclip/agent-bin/node_modules/.bin` (`deployment.yaml:96`), so this should succeed without any wiring change.
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- which opencode
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- opencode --version
+      ```
+
+      Expected: `which` resolves to `/paperclip/agent-bin/node_modules/.bin/opencode`; `--version` prints. If either fails, the cause is most likely either a npm-prefix install layout surprise or a stale paperclip pod that needs `rollout restart` to pick up the new PVC contents — record as a deviation.
+
+      The shell sidecar's PATH does NOT necessarily include that directory, so subsequent shell-sidecar steps in this phase use the absolute path `/paperclip/agent-bin/node_modules/.bin/opencode`.
+  - id: P1.T1.S3
+    text: |-
+      Author a probe `opencode.json` under a temp `XDG_CONFIG_HOME` and run opencode against LiteLLM to discover the working `model` field shape. Run from inside the paperclip main container — that's where `$LITELLM_API_KEY` is injected (the shell sidecar doesn't have it).
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- sh -eu <<'PROBE'
+      mkdir -p /tmp/oc-probe/opencode
+      cat > /tmp/oc-probe/opencode/opencode.json <<'JSON'
+      {
+        "$schema": "https://opencode.ai/config.json",
+        "provider": {
+          "litellm": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "Frank LiteLLM",
+            "options": {
+              "baseURL": "http://litellm.litellm.svc:4000/v1",
+              "apiKey": "{env:LITELLM_API_KEY}"
+            },
+            "models": {
+              "qwen-coder-14b": { "name": "Qwen Coder 14B" }
+            }
+          }
+        }
+      }
+      JSON
+
+      echo '--- Shape A: provider-prefixed ---'
+      XDG_CONFIG_HOME=/tmp/oc-probe opencode run -m litellm/qwen-coder-14b -p 'say ping' || echo 'shape A failed'
+
+      echo '--- Shape B: bare model name ---'
+      XDG_CONFIG_HOME=/tmp/oc-probe opencode run -m qwen-coder-14b -p 'say ping' || echo 'shape B failed'
+      PROBE
+      ```
+
+      Record which form succeeded. Capture also: did opencode read `{env:LITELLM_API_KEY}` correctly, or did it pass the literal string through? (If literal, look up the right interpolation syntax in opencode docs.) Note: `kubectl exec` with stdin heredoc requires no `-it` flag for non-interactive runs; if your kubectl version misbehaves, fall back to dropping the heredoc into a file via `kubectl cp` and exec-ing the file path.
+  - id: P1.T1.S4
+    text: |-
+      Verify the call landed on LiteLLM (not somewhere else). Grep the LiteLLM pod logs for the request.
+
+      ```bash
+      kubectl -n litellm logs -l app.kubernetes.io/name=litellm --tail=200 | grep -E 'POST|/chat/completions|qwen-coder' | tail -20
+      ```
+
+      Expected: a `POST /chat/completions` entry with `model=qwen-coder-14b` (or the working form discovered in S3) and `200 OK`.
+  - id: P1.T1.S5
+    text: |-
+      Record findings in this plan's `_prose.md` under the "Plan-time verification log — opencode" section: working model shape, env-interpolation behavior, anything surprising. P1.T2.S7 will clean up the `/tmp/oc-probe` dir alongside the hermes probe.
+- number: 2
+  title: Install Hermes via uv and probe behavior against LiteLLM
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      From paperclip-shell, install `uv` (the relocatable Python installer) into `/paperclip/agent-bin/bin`:
+
+      ```bash
+      curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/paperclip/agent-bin/bin sh
+      /paperclip/agent-bin/bin/uv --version
+      ```
+
+      Expected: uv installs and reports a version.
+  - id: P1.T2.S2
+    text: |-
+      Install Hermes Agent (`v2026.4.16`) into a relocatable venv on the shared PVC. NOTE: PyPI's `hermes-agent` is a different package (`0.13.0` at this writing); the Nous Research agent is installed from the upstream git tag.
+
+      ```bash
+      cd /paperclip/agent-bin
+      /paperclip/agent-bin/bin/uv venv --python 3.12 /paperclip/agent-bin/hermes-agent/venv
+      /paperclip/agent-bin/bin/uv pip install --python /paperclip/agent-bin/hermes-agent/venv/bin/python \
+          'hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@v2026.4.16'
+
+      # Shim onto agent-bin/bin
+      mkdir -p /paperclip/agent-bin/bin
+      ln -sf /paperclip/agent-bin/hermes-agent/venv/bin/hermes /paperclip/agent-bin/bin/hermes
+      /paperclip/agent-bin/bin/hermes --version
+      ```
+
+      Expected: hermes reports a version matching the tag. If the git ref doesn't resolve (tag renamed / repo moved), check `https://github.com/NousResearch/hermes-agent/tags` for the closest stable tag and update the pin everywhere (`_prose.md` verification log + the shell-inventory entry in Phase 3 + the spec's pin).
+  - id: P1.T2.S3
+    text: |-
+      Verify hermes is reachable from BOTH containers. The paperclip container's PATH does NOT currently include `/paperclip/agent-bin/bin` — record that finding; Phase 3 widens it.
+
+      ```bash
+      # Shell sidecar — should work if /paperclip/agent-bin/bin is on PATH
+      /paperclip/agent-bin/bin/hermes --version
+
+      # Paperclip container — direct path; PATH widening is Phase 3 work
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- /paperclip/agent-bin/bin/hermes --version
+      ```
+
+      Expected: both report the same Hermes version. If the second call fails with a shebang / interpreter error, the uv venv isn't relocatable from that container's mount view — escalate to spec deviation.
+  - id: P1.T2.S4
+    text: |-
+      Author a probe `$HERMES_HOME/config.yml` and run hermes against LiteLLM to discover the working `--model` field shape. Run from inside the paperclip main container so `$LITELLM_API_KEY` is in scope (the shell sidecar doesn't have it).
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- sh -eu <<'PROBE'
+      mkdir -p /tmp/hermes-probe
+      cat > /tmp/hermes-probe/config.yml <<'YAML'
+      inference:
+        chain:
+          - name: frank-litellm-reasoner
+            type: openai
+            base_url: http://litellm.litellm.svc:4000/v1
+            model: qwen-think-14b
+            api_key_env: LITELLM_API_KEY
+      YAML
+
+      export HERMES_HOME=/tmp/hermes-probe
+      HERMES=/paperclip/agent-bin/bin/hermes
+
+      echo '--- Shape A: backend name ---'
+      "$HERMES" chat -q --model frank-litellm-reasoner 'say ping' || echo 'shape A failed'
+
+      echo '--- Shape B: provider/model ---'
+      "$HERMES" chat -q --model openai/qwen-think-14b 'say ping' || echo 'shape B failed'
+
+      echo '--- Shape C: bare model name ---'
+      "$HERMES" chat -q --model qwen-think-14b 'say ping' || echo 'shape C failed'
+      PROBE
+      ```
+
+      Record which form succeeded — this drives the agent-hire payload shape in Phase 5.
+  - id: P1.T2.S5
+    text: |-
+      Verify hermes wrote its session state somewhere writable, and find the path. Critical: in Phase 3 the `$HERMES_HOME` mount will be read-only (ConfigMap), so hermes must NOT default its session DB to `$HERMES_HOME`. Run from the paperclip main container.
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- sh -eu <<'PROBE'
+      export HERMES_HOME=/tmp/hermes-probe
+      /paperclip/agent-bin/bin/hermes chat -q --model <SHAPE_FROM_S4> 'remember this number: 42'
+      find /tmp/hermes-probe /root/.hermes /home /paperclip -newer /tmp/hermes-probe/config.yml -type f 2>/dev/null | head -30
+      PROBE
+      ```
+
+      Replace `<SHAPE_FROM_S4>` with the working form from the previous step. Record the session-DB location. If under `$HERMES_HOME` by default, look up the override option in `config.yml` (likely `tools.memory.path` or `session.database_path` — confirm exact key against the installed Hermes version's docs) and document the override syntax — Phase 3 will set it to `/paperclip/agent-bin/.hermes/`.
+  - id: P1.T2.S6
+    text: |-
+      Verify the hermes call landed on LiteLLM.
+
+      ```bash
+      kubectl -n litellm logs -l app.kubernetes.io/name=litellm --tail=200 | grep -E 'POST|/chat/completions|qwen-think' | tail -20
+      ```
+
+      Expected: `POST /chat/completions` with `model=qwen-think-14b`, `200 OK`.
+  - id: P1.T2.S7
+    text: |-
+      Record findings in `_prose.md` under "Plan-time verification log — hermes": working model shape, session-DB default path + override syntax, any quirks. Clean up the probe dirs in BOTH containers (the opencode probe wrote to `/tmp` in the paperclip container; the hermes probe also wrote there):
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- rm -rf /tmp/oc-probe /tmp/hermes-probe
+      ```
+- number: 3
+  title: Verify opencode_local adapter's per-run config-copy preserves our blocks
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      Per the spec's constraint 7, the `opencode_local` adapter constructs a temporary `XDG_CONFIG_HOME` per run and copies our base `opencode.json` into it. Verify by reading the adapter source for v2026.512.0 (the image we run) — confirm the `fs.cp(..., recursive: true)` is in place and the only mutating write only adds `permission.external_directory: allow` without re-authoring the rest of the file.
+
+      ```bash
+      env -u GITHUB_TOKEN gh api repos/paperclipai/paperclip/contents/packages/adapters/opencode-local/src/server/runtime-config.ts --jq '.content' \
+        | base64 -d \
+        | grep -nE 'fs\.cp|fs\.copyFile|writeFile|JSON\.stringify|recursive'
+      ```
+
+      Expected output (line numbers may drift across releases):
+
+      - one line like `await fs.cp(sourceConfigDir, runtimeConfigDir, {`
+      - one line like `await fs.writeFile(runtimeConfigPath, ...JSON.stringify(nextConfig, ...))`
+      - the `recursive: true` flag visible on the `fs.cp` options
+
+      If the source re-authors `opencode.json` from scratch (i.e., writes the file without first having `cp`'d the source dir), escalate as a spec deviation — our `provider`/`models` blocks would be lost on every run.
+  - id: P1.T3.S2
+    text: |-
+      Smoke test the adapter's copy behavior end-to-end: drop a stub agent through Paperclip's API that uses `opencode_local`, run it once, and verify our `provider.litellm` block survived into the per-run temp dir.
+
+      Optional — defer to Phase 5 if API access is the gating factor. Record the verification path chosen.
+- number: 4
+  title: Decide PATH-widening and stale comment cleanups
+  steps:
+  - id: P1.T4.S1
+    text: |-
+      Based on Phase 1.T1/T2 findings, draft the exact `deployment.yaml` env / PATH edits needed:
+
+      - `PATH` extension: add `/paperclip/agent-bin/bin` (for the hermes shim + uv binary)
+      - New env: `XDG_CONFIG_HOME=/etc/paperclip/opencode-base`
+      - New env: `HERMES_HOME=/etc/paperclip/hermes-base`
+
+      Record the exact diff in `_prose.md`; Phase 2/3 apply it.
+  - id: P1.T4.S2
+    text: |-
+      Draft the refreshed `apps/paperclip/manifests/external-secret-llm.yaml` header comment based on what we learned:
+
+      - opencode reads `LITELLM_API_KEY` via `{env:...}` interpolation in `opencode.json`
+      - hermes reads `LITELLM_API_KEY` via `api_key_env:` in `config.yml`
+
+      The old "http-local coming soon" paragraph is removed entirely. Record the new comment in `_prose.md`; Phase 4 applies it.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S5:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S5:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S6:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S7:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/02.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/02.yaml
@@ -1,0 +1,175 @@
+schema_version: 2
+phase:
+  number: 2
+  title: opencode_local — declarative wiring
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Create the opencode ConfigMap
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Write `apps/paperclip/manifests/configmap-opencode.yaml` containing the validated `opencode.json` (from Phase 1.T1).
+
+      BEGIN_FILE apps/paperclip/manifests/configmap-opencode.yaml
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: paperclip-opencode
+        namespace: paperclip-system
+      data:
+        opencode.json: |
+          {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+              "litellm": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "Frank LiteLLM",
+                "options": {
+                  "baseURL": "http://litellm.litellm.svc:4000/v1",
+                  "apiKey": "{env:LITELLM_API_KEY}"
+                },
+                "models": {
+                  "mistral-small-24b": { "name": "Mistral Small 3.2 24B (local)" },
+                  "qwen-coder-14b":    { "name": "Qwen2.5-Coder 14B Q6 (local)" },
+                  "qwen-think-14b":    { "name": "Qwen3 14B Thinking (local)" },
+                  "qwen36-a3b":        { "name": "Qwen3.6 35B-A3B MoE (local)" },
+                  "qwen36-a3b-nothin": { "name": "Qwen3.6 35B-A3B MoE — no-think (local)" },
+                  "gemma-12b":         { "name": "Gemma 3 12B multimodal (local)" }
+                }
+              }
+            }
+          }
+      END_FILE
+  - id: P2.T1.S2
+    text: |-
+      Verify the file parses as YAML and the embedded JSON is well-formed.
+
+      ```bash
+      yq '.data."opencode.json"' apps/paperclip/manifests/configmap-opencode.yaml | python3 -c 'import json,sys; json.load(sys.stdin); print("OK")'
+      ```
+- number: 2
+  title: Mount the ConfigMap and set XDG_CONFIG_HOME
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      Edit `apps/paperclip/manifests/deployment.yaml` to add a new volume + volumeMount for the opencode ConfigMap.
+
+      Add to `spec.template.spec.volumes` (sibling of the existing `data` volume):
+
+      ```yaml
+      - name: opencode-config
+        configMap:
+          name: paperclip-opencode
+      ```
+
+      Add to the `paperclip` container's `volumeMounts`:
+
+      ```yaml
+      - name: opencode-config
+        mountPath: /etc/paperclip/opencode-base/opencode/opencode.json
+        subPath: opencode.json
+        readOnly: true
+      ```
+  - id: P2.T2.S2
+    text: |-
+      Add `XDG_CONFIG_HOME` to the paperclip container's `env:` block (alongside the existing `PATH` env at `deployment.yaml:95-96`):
+
+      ```yaml
+      - name: XDG_CONFIG_HOME
+        value: /etc/paperclip/opencode-base
+      ```
+- number: 3
+  title: Persist opencode-ai install via shell-inventory
+  steps:
+  - id: P2.T3.S1
+    text: |-
+      Edit `apps/paperclip/manifests/configmap-shell-inventory.yaml`. Extend the inventory schema with a new `paperclip-shared` section (or amend the comment block to clarify that future entries land on `/paperclip/agent-bin` not on the shell home PVC). Add `opencode-ai` so the reconcile re-installs it after a PVC wipe.
+
+      ```yaml
+      paperclip-shared:
+        npm:
+          - opencode-ai
+      ```
+
+      Note: this requires the shell-sidecar's reconcile script to grow handling for the new section. If that's an `agent-images` change (out of scope here), document as a deviation and keep the operator-imperative install from Phase 1 as the working installer for now.
+- number: 4
+  title: Ship via ArgoCD and smoke-test
+  steps:
+  - id: P2.T4.S1
+    text: |-
+      Commit the manifest changes on a branch, push, open PR. Once merged, force ArgoCD sync:
+
+      ```bash
+      argocd app sync paperclip --port-forward --port-forward-namespace argocd
+      kubectl -n paperclip-system rollout status deploy/paperclip --timeout=2m
+      ```
+
+      Expected: paperclip pod restarts with new env and ConfigMap mounted (`strategy: Recreate` is already in place).
+  - id: P2.T4.S2
+    text: |-
+      Verify the ConfigMap is mounted in the running pod:
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- cat /etc/paperclip/opencode-base/opencode/opencode.json | head -5
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- printenv XDG_CONFIG_HOME
+      ```
+
+      Expected: file contents match git, `XDG_CONFIG_HOME=/etc/paperclip/opencode-base`.
+  - id: P2.T4.S3
+    text: |-
+      End-to-end smoke test from inside the paperclip container, using the model shape validated in Phase 1.T1:
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- \
+        opencode run -m <working-shape> -p 'say ping'
+      ```
+
+      Then verify LiteLLM saw the call:
+
+      ```bash
+      kubectl -n litellm logs -l app.kubernetes.io/name=litellm --tail=50 | grep qwen-coder
+      ```
+
+      Expected: opencode prints a model response; LiteLLM log shows a 200 against `qwen-coder-14b` from the Paperclip virtual key.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T4.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T4.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/03.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/03.yaml
@@ -1,0 +1,210 @@
+schema_version: 2
+phase:
+  number: 3
+  title: hermes_local — declarative wiring
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Create the hermes ConfigMap
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      Write `apps/paperclip/manifests/configmap-hermes.yaml` containing the validated Hermes `config.yml` (inference chain from spec, plus the session-DB override path discovered in Phase 1.T2.S5).
+
+      BEGIN_FILE apps/paperclip/manifests/configmap-hermes.yaml
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: paperclip-hermes
+        namespace: paperclip-system
+      data:
+        config.yml: |
+          inference:
+            chain:
+              - name: frank-litellm-coder
+                type: openai
+                base_url: http://litellm.litellm.svc:4000/v1
+                model: qwen-coder-14b
+                api_key_env: LITELLM_API_KEY
+              - name: frank-litellm-reasoner
+                type: openai
+                base_url: http://litellm.litellm.svc:4000/v1
+                model: qwen-think-14b
+                api_key_env: LITELLM_API_KEY
+              - name: frank-litellm-default
+                type: openai
+                base_url: http://litellm.litellm.svc:4000/v1
+                model: mistral-small-24b
+                api_key_env: LITELLM_API_KEY
+
+          # Session DB override — $HERMES_HOME is read-only (ConfigMap mount),
+          # so write session state under /paperclip/agent-bin/.hermes/.
+          # PLACEHOLDER: replace in P3.T1.S2 with the actual override key
+          # discovered in P1.T2.S5. Do NOT commit this file with the
+          # marker `SESSION_DB_OVERRIDE_PLACEHOLDER` still present.
+          # SESSION_DB_OVERRIDE_PLACEHOLDER
+
+          tools:
+            filesystem:
+              read_roots:
+                - /paperclip
+              write_roots: []
+            shell:
+              enabled: false
+      END_FILE
+  - id: P3.T1.S2
+    text: |-
+      Replace the `SESSION_DB_OVERRIDE_PLACEHOLDER` marker line in `configmap-hermes.yaml` with the exact override discovered in P1.T2.S5. Example shape (verify the key name against Hermes docs):
+
+      ```yaml
+              session:
+                database_path: /paperclip/agent-bin/.hermes/sessions.db
+      ```
+
+      Or `tools.memory.path: /paperclip/agent-bin/.hermes/`, depending on which key Phase 1 found. If Phase 1 found Hermes already writes outside `$HERMES_HOME` by default, delete the placeholder + the comment block entirely and leave a one-line comment explaining no override is needed.
+
+      Sanity check: `grep SESSION_DB_OVERRIDE_PLACEHOLDER apps/paperclip/manifests/configmap-hermes.yaml` returns nothing. Add this grep to the pre-commit check if a recurring footgun.
+  - id: P3.T1.S3
+    text: |-
+      Sanity-check the YAML:
+
+      ```bash
+      yq '.data."config.yml"' apps/paperclip/manifests/configmap-hermes.yaml | yq -P >/dev/null && echo OK
+      ```
+- number: 2
+  title: Mount the ConfigMap, set HERMES_HOME, widen PATH
+  steps:
+  - id: P3.T2.S1
+    text: |-
+      Edit `apps/paperclip/manifests/deployment.yaml`:
+
+      Add to `spec.template.spec.volumes`:
+
+      ```yaml
+      - name: hermes-config
+        configMap:
+          name: paperclip-hermes
+      ```
+
+      Add to the `paperclip` container's `volumeMounts`:
+
+      ```yaml
+      - name: hermes-config
+        mountPath: /etc/paperclip/hermes-base/config.yml
+        subPath: config.yml
+        readOnly: true
+      ```
+  - id: P3.T2.S2
+    text: |-
+      Add `HERMES_HOME` to the paperclip container's `env:` block, and extend `PATH` to include `/paperclip/agent-bin/bin`:
+
+      ```yaml
+      - name: PATH
+        value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/paperclip/agent-bin/node_modules/.bin:/paperclip/agent-bin/bin"
+      - name: HERMES_HOME
+        value: /etc/paperclip/hermes-base
+      ```
+
+      Update the comment block at `deployment.yaml:81-94` to mention hermes alongside the existing codex/gemini/opencode notes.
+- number: 3
+  title: Persist hermes install via shell-inventory
+  steps:
+  - id: P3.T3.S1
+    text: |-
+      Extend `paperclip-shared` in `configmap-shell-inventory.yaml` with a uv-based entry for hermes-agent. If a `uv:` section type doesn't exist yet, define one (or use a generic `commands:` list that captures the install steps from Phase 1.T2.S1-S2). Pin `v2026.4.16`.
+
+      Same caveat as P2.T3.S1: the reconcile-script-side handling for this section type may need to grow in `agent-images`. If it doesn't exist yet, capture as a deviation and rely on the Phase 1 operator-imperative install.
+- number: 4
+  title: Ship via ArgoCD and smoke-test
+  steps:
+  - id: P3.T4.S1
+    text: |-
+      Commit + push + sync (same pattern as P2.T4.S1).
+
+      ```bash
+      argocd app sync paperclip --port-forward --port-forward-namespace argocd
+      kubectl -n paperclip-system rollout status deploy/paperclip --timeout=2m
+      ```
+  - id: P3.T4.S2
+    text: |-
+      Verify mount + env:
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- cat /etc/paperclip/hermes-base/config.yml | head -10
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- printenv HERMES_HOME PATH
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- which hermes
+      ```
+
+      Expected: config rendered, `HERMES_HOME=/etc/paperclip/hermes-base`, PATH ends with `agent-bin/bin`, `which hermes` resolves.
+  - id: P3.T4.S3
+    text: |-
+      End-to-end smoke test using the model shape validated in P1.T2.S4:
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- \
+        hermes chat -q --model frank-litellm-reasoner 'say ping'
+      ```
+
+      Verify in LiteLLM logs:
+
+      ```bash
+      kubectl -n litellm logs -l app.kubernetes.io/name=litellm --tail=50 | grep qwen-think
+      ```
+
+      Expected: hermes prints a response; LiteLLM log shows a 200 against `qwen-think-14b`.
+  - id: P3.T4.S4
+    text: |-
+      Verify session state writes to the configured path (the override from P3.T1.S2). Re-run hermes once and confirm a file appeared under `/paperclip/agent-bin/.hermes/`:
+
+      ```bash
+      kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- ls -la /paperclip/agent-bin/.hermes/ 2>&1 | head -20
+      ```
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T4.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T4.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T4.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/04.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/04.yaml
@@ -1,0 +1,96 @@
+schema_version: 2
+phase:
+  number: 4
+  title: MOTD + runbook + stale-comment cleanup
+  tag: agentic
+  depends_on:
+  - 2
+  - 3
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Refresh external-secret-llm.yaml header comment
+  steps:
+  - id: P4.T1.S1
+    text: |-
+      Replace the stale "http-local coming soon" comment block in `apps/paperclip/manifests/external-secret-llm.yaml` with the wording drafted in P1.T4.S2. The new comment names both consumers: opencode (via `opencode.json` + `{env:LITELLM_API_KEY}`) and hermes (via `config.yml` + `api_key_env: LITELLM_API_KEY`).
+- number: 2
+  title: Add "LiteLLM-backed agents" section to MOTD
+  steps:
+  - id: P4.T2.S1
+    text: |-
+      Edit `apps/paperclip/manifests/configmap-shell-motd-tips.yaml`. Append a new conditional section to the `60-paperclip-shell-tips.sh` script that prints the spec-defined block (per the spec's "paperclip-shell MOTD" section).
+
+      Two design choices to make at edit time:
+
+      1. **Conditional or unconditional?** The MOTD prints on every interactive SSH login to paperclip-shell; many of those are routine. Three options:
+         a. Always print (simple, can become noise).
+         b. Print only if `/paperclip/agent-bin/node_modules/.bin/opencode` or `/paperclip/agent-bin/bin/hermes` is missing (helpful on cold PVs).
+         c. Print until the operator acks via touching `~/.config/paperclip-shell/litellm-tips-seen`.
+
+         Recommended: option (b). It uses absolute paths on the shared `/paperclip` PVC, so the existence check works from the shell-sidecar's filesystem view directly — no `kubectl exec` cross-container probe needed.
+
+      2. **Match the existing script's helper style.** Read `apps/paperclip/manifests/configmap-shell-motd-tips.yaml` first to see what idioms (`tput`, color codes, divider chars) the existing tips use, and match.
+
+      Sketch:
+
+      ```bash
+      if [ ! -x /paperclip/agent-bin/node_modules/.bin/opencode ] || \
+         [ ! -x /paperclip/agent-bin/bin/hermes ]; then
+        cat <<'TIPS'
+        <the LiteLLM-backed agents block from the spec, verbatim>
+      TIPS
+      fi
+      ```
+
+      Verbatim block = the text under "## paperclip-shell MOTD" in the design spec.
+  - id: P4.T2.S2
+    text: |-
+      ArgoCD sync; SSH into paperclip-shell to confirm the new tip prints on login (and is suppressed when both CLIs exist — flip a binary off temporarily to test the on-path).
+
+      ```bash
+      argocd app sync paperclip --port-forward --port-forward-namespace argocd
+      ssh paperclip-shell  # observe the MOTD
+      ```
+- number: 3
+  title: Document in the runbook
+  steps:
+  - id: P4.T3.S1
+    text: |-
+      Add a new "LiteLLM-backed agents" section to `docs/runbooks/frank-gotchas/paperclip-ruflo.md` covering:
+
+      - Both ConfigMap shapes (`opencode.json` provider block, hermes `config.yml` inference chain)
+      - The uv-based Python install pattern for hermes
+      - The session-DB override (from Phase 1.T2.S5)
+      - The shell-inventory `paperclip-shared` section vs the shell-home-scoped sections
+      - The model-name shape findings from Phase 1.T1 / T2
+      - Any gotchas surfaced during execution (e.g., adapter-copy quirks, env-interpolation behavior)
+  - id: P4.T3.S2
+    text: |-
+      Add a one-liner pointing at the new section to `agents/rules/frank-gotchas.md` under the existing `Paperclip / Ruflo` section.
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/05.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/05.yaml
@@ -1,0 +1,109 @@
+schema_version: 2
+phase:
+  number: 5
+  title: Hire LiteLLM-backed agents — end-to-end
+  tag: manual
+  depends_on:
+  - 4
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Hire one opencode_local agent
+  steps:
+  - id: P5.T1.S1
+    text: |-
+      Two paths to hire — **prefer the UI**:
+
+      - **UI (recommended):** http://192.168.55.212:3100 → board hire form. Sidesteps the board-mutation CSRF gotcha in `docs/runbooks/frank-gotchas/paperclip-ruflo.md` (which requires the `Origin` header + `%3D`-encoded cookie). The UI does that wiring for you.
+      - **API via `paperclip-create-agent` skill:** Works from the dev box when you have `$PAPERCLIP_API_KEY` + `$PAPERCLIP_COMPANY_ID` set. Honor the runbook's CSRF + cookie-encoding rules; the skill does this correctly.
+
+      Payload template (drop into UI form or skill `adapterConfig`):
+
+      ```json
+      {
+        "name": "Local Coder",
+        "role": "engineer",
+        "title": "Local Engineer (opencode)",
+        "icon": "wrench",
+        "adapterType": "opencode_local",
+        "adapterConfig": {
+          "model": "<working-shape-from-P1.T1>"
+        }
+      }
+      ```
+  - id: P5.T1.S2
+    text: |-
+      Assign a trivial issue (e.g. "Reply 'ack' as a comment"). Watch the run in Paperclip's UI: transcript completes, no errors, comment posted.
+- number: 2
+  title: Hire one hermes_local agent
+  steps:
+  - id: P5.T2.S1
+    text: |-
+      Same UI-vs-skill choice as P5.T1.S1; same CSRF caveats on the skill path. Payload:
+
+      ```json
+      {
+        "name": "Local Reasoner",
+        "role": "engineer",
+        "title": "Local Reasoner (Hermes)",
+        "icon": "brain",
+        "adapterType": "hermes_local",
+        "adapterConfig": {
+          "model": "<working-shape-from-P1.T2>",
+          "hermesCommand": "/paperclip/agent-bin/bin/hermes",
+          "toolsets": "terminal,file,web",
+          "persistSession": true
+        }
+      }
+      ```
+
+      Note: `hermesCommand` is set explicitly to the absolute path even though Phase 3 widens PATH to include `/paperclip/agent-bin/bin`. Belt-and-braces against future PATH drift.
+  - id: P5.T2.S2
+    text: |-
+      Assign a second trivial issue. Watch the transcript flow back as structured tool cards (hermes-paperclip-adapter parses Hermes's stdout into typed entries).
+- number: 3
+  title: Cross-verify on LiteLLM
+  steps:
+  - id: P5.T3.S1
+    text: |-
+      Confirm both calls landed on LiteLLM and routed to Ollama (not OpenRouter).
+
+      ```bash
+      kubectl -n litellm logs -l app.kubernetes.io/name=litellm --tail=200 \
+        | grep -E 'ollama/(qwen2.5-coder|qwen3:14b|mistral-small)' | tail -10
+      ```
+
+      Expected: both agents' calls appear with model=`qwen-coder-14b` (opencode) and `qwen-think-14b` (hermes).
+  - id: P5.T3.S2
+    text: |-
+      Pod-restart resilience: restart the paperclip pod (`kubectl rollout restart`), wait for it to come back, and rerun a heartbeat on the hermes agent. Confirm it resumes its session via `--resume` (no fresh-start banner).
+state:
+  steps:
+    P5.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/06.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/06.yaml
@@ -1,0 +1,47 @@
+schema_version: 2
+phase:
+  number: 6
+  title: Post-Deploy Checklist
+  tag: manual
+  depends_on:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+tasks:
+- number: 1
+  title: (unstructured content)
+  steps:
+  - id: P6.T1.S1
+    text: |-
+      Post-Deploy Checklist [manual]
+      **Depends on:** Phase 1, Phase 2, Phase 3, Phase 4, Phase 5
+
+      This is a fix/extension of the existing `orch`/paperclip layer (not a new layer), so per `agents/rules/repo-workflows.md` and `agents/rules/plan-post-deploy-checklist.md` most steps are skipped or redirected to retroactive updates of the existing layer's posts.
+
+      - [-] **Step 1: Expose externally** — *(skipped — no new IngressRoute, no new homepage tile; this is a Paperclip-internal capability extension)*
+      - [-] **Step 2: Write building blog post** — *(skipped — fix/extension; update the existing paperclip building post instead, see Step 4 below)*
+      - [-] **Step 3: Write operating blog post** — *(skipped — same; update the existing operating post in Step 4)*
+      - [ ] **Step 4: Update existing paperclip blog posts retroactively**
+            - Building post: add a new section covering the two LiteLLM-backed adapters (opencode + hermes), the `XDG_CONFIG_HOME` / `HERMES_HOME` declarative-config pattern, and any non-obvious findings from Phase 1's verification log
+            - Operating post: add the new operational commands (`opencode run …`, `hermes chat -q --model …`, the LiteLLM-log grep) and the MOTD setup flow for cold PVs
+            - Locate the existing posts under `blog/content/docs/building/` and `blog/content/docs/operating/` (the paperclip layer post — look for the slug matching the existing 2026-03-14 paperclip work, plus the 2026-05-02 paperclip-shell-sidecar follow-up)
+      - [ ] **Step 5: Update gotchas one-liner** — Append a short row to `agents/rules/frank-gotchas.md` under `Paperclip / Ruflo` pointing at the new section in `docs/runbooks/frank-gotchas/paperclip-ruflo.md` (the prose section was added in Phase 4, so this is just the one-line index entry)
+      - [-] **Step 6: Update README** — *(skipped unless a new user-facing service was exposed; this plan added neither)*
+      - [ ] **Step 7: Sync runbook** — Run `/sync-runbook` to pick up the three `# manual-operation` blocks declared in the spec (`orch-paperclip-reconcile-shared-agent-clis`, `orch-paperclip-hire-opencode-litellm-agent`, `orch-paperclip-hire-hermes-litellm-agent`)
+      - [ ] **Step 8: Update plan status** — Once Phase 5 transcripts are observed end-to-end and LiteLLM logs confirm both adapters routed to Ollama, set the spec's `**Status:**` line to `Deployed` (cluster workload). Note in the spec the date and the two agent IDs created.
+
+      ---
+
+      ## Deployment Deviations
+
+      To be populated during execution. Format: each entry names the phase + step where the deviation surfaced, what was observed, and the resolution (or the open question). Phase 1's verification-log entries in `_prose.md` already capture findings; this section captures *deviations* (something didn't go as the spec predicted) so a future reader can map plan → reality.
+state:
+  steps:
+    P6.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/_meta.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-05-17--orch--paperclip-litellm-agents
+spec: docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-05-17'

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/_prose.md
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/_prose.md
@@ -1,0 +1,75 @@
+# Paperclip via LiteLLM (opencode + hermes adapters) — Implementation Plan
+
+**Spec:** `docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md`
+**Status:** Not Started
+**Layer:** `orch` (fix/extension of existing Paperclip deployment)
+
+## Narrative
+
+The spec laid out the design; this plan implements it in five working phases plus the auto-appended post-deploy checklist. The shape mirrors the spec's structure but front-loads all the plan-time-only verifications into a single Phase 1 so risks surface before any manifest change lands. The two adapter wirings (opencode in Phase 2, hermes in Phase 3) are independent — they can execute in parallel after Phase 1 — and the MOTD / runbook / stale-comment cleanup waits for both before documenting them in Phase 4. Phase 5 is the only manual phase: hiring agents through Paperclip's UI to satisfy the cluster rule that a layer isn't "Deployed" until its workflow has run end-to-end.
+
+### Why Phase 1 exists as a standalone phase
+
+Three open assumptions from the spec must be resolved before manifest commits:
+
+1. **opencode `model` field shape.** Whether opencode wants `litellm/qwen-coder-14b` or bare `qwen-coder-14b` once `provider.litellm` is declared. Different opencode versions disagree.
+2. **Hermes `--model <name>` argument shape.** Whether Hermes accepts a backend `name` from the inference chain (the most ergonomic choice), or whether it always expects `provider/model` or a bare model ID.
+3. **Hermes session-DB write path.** `$HERMES_HOME` will be a read-only ConfigMap mount in Phase 3, so Hermes must NOT default its session DB to that location. The override key in `config.yml` must be identified at plan time, otherwise hermes will fail on first write.
+
+Each of these is a CLI-behavior observation, not a Paperclip-side change — they're cheaper to discover by running the CLIs against LiteLLM from the shell sidecar than by guessing in YAML and bouncing the pod three times.
+
+### Phase 1 doubles as the bootstrap install
+
+Verifying CLI behavior requires installing the CLIs first. Phase 1's installs land on the shared `/paperclip` PVC in the same locations Phases 2 and 3 will rely on (`/paperclip/agent-bin/node_modules/.bin/opencode`, `/paperclip/agent-bin/bin/hermes`). The wiring phases then add the declarative inventory entry so the install survives PVC wipes — but the wiring phases never have to re-install, which keeps them fast and PR-shaped.
+
+### Phase 2 and 3 are independent verticals
+
+Each phase delivers one fully-wired adapter end-to-end: ConfigMap → mount → env → smoke test against LiteLLM. If hermes turns out harder than opencode (likely — Python on a Node-only container is the non-trivial part), opencode still lands on its own merits and provides a working LiteLLM-backed adapter for Phase 5's hire.
+
+### Phase 4 is docs-first
+
+External docs (MOTD, runbook, stale comment) are batched because they document things readers compare in one place — if a reader needs to know "how do I hire a LiteLLM-backed agent," they want both adapters covered in one location, not two PRs of context they have to merge in their head.
+
+### Phase 5 is the real success criterion
+
+Per `agents/rules/frank-gotchas.md`:
+
+> A layer is not "Deployed" until its workflow has been triggered + observed end-to-end. ArgoCD Synced/Healthy proves artifacts exist; not that they work.
+
+So Phase 5 is non-skippable: hire one agent of each adapter type, assign each a trivial issue, watch the transcripts complete, and confirm in LiteLLM's logs that the calls were routed to Ollama. Only then does Phase 6 (post-deploy) run.
+
+## Plan-time verification log
+
+To be populated as Phase 1 executes. Each entry: timestamp, finding, evidence (command output excerpt or LiteLLM log line).
+
+### opencode
+
+- _(P1.T1.S3 — working model shape)_
+- _(P1.T1.S3 — env interpolation behavior)_
+- _(P1.T1.S4 — LiteLLM route confirmation)_
+- _(P1.T3.S1 — runtime-config-copy verification)_
+
+### hermes
+
+- _(P1.T2.S2 — install + relocatable venv verification)_
+- _(P1.T2.S3 — both-containers reachability)_
+- _(P1.T2.S4 — working `--model` shape)_
+- _(P1.T2.S5 — session-DB default + override syntax)_
+- _(P1.T2.S6 — LiteLLM route confirmation)_
+
+### Resolutions for Phase 2/3/4
+
+- _(P1.T4.S1 — exact deployment.yaml diff drafted)_
+- _(P1.T4.S2 — exact external-secret-llm.yaml comment drafted)_
+
+## Deployment Deviations
+
+To be populated during execution. Each entry: phase + step, observed deviation, decision, links.
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md`
+- Frank gotchas process rule: `agents/rules/frank-gotchas.md` (#process / practice)
+- Post-deploy checklist rule: `agents/rules/plan-post-deploy-checklist.md`
+- Paperclip deployment manifest: `apps/paperclip/manifests/deployment.yaml`
+- LiteLLM values + model aliases: `apps/litellm/values.yaml`

--- a/docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
+++ b/docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
@@ -1,0 +1,419 @@
+# Paperclip via LiteLLM (opencode + hermes adapters) — Design
+
+**Status:** Draft
+**Layer:** `orch`
+**Spec date:** 2026-05-17
+
+## Goal
+
+Let Paperclip hire and run agents backed by Frank's local LLM stack — Ollama on `gpu-1`, fronted by the LiteLLM gateway at `litellm.litellm.svc:4000`. Concretely, install and wire **two** new adapters by default:
+
+1. **`opencode_local`** — opencode-ai CLI, talks to LiteLLM as a custom OpenAI-compatible provider declared in `opencode.json`.
+2. **`hermes_local`** — Nous Research's Hermes Agent (Python-based, multi-tool), pointed at LiteLLM via an `$HERMES_HOME/config.yml` inference chain.
+
+Both default to one of the LiteLLM model aliases (`mistral-small-24b`, `qwen-coder-14b`, `qwen-think-14b`, `qwen36-a3b-nothin`, etc.). The paperclip-shell sidecar's MOTD documents the setup so operators know how to install, verify, and hire.
+
+This is a **layer extension** of the existing `paperclip` deployment (layer `orch`), not a new layer.
+
+## Motivation
+
+Two halves of the wiring already exist:
+
+1. **LiteLLM serves Ollama models with friendly names.** `apps/litellm/values.yaml` already exposes the local lineup at `192.168.55.206:4000` / `litellm.litellm.svc:4000` with virtual-key auth. See `2026-03-09--infer--ollama-litellm-design.md`.
+2. **Paperclip already gets `LITELLM_API_KEY` and `LITELLM_BASE_URL` injected** from Infisical via `apps/paperclip/manifests/external-secret-llm.yaml`.
+
+What's missing is the *consumer*: nothing inside Paperclip reads those env vars. The comment in `external-secret-llm.yaml` says Paperclip's "`http-local` adapter (currently 'coming soon')" will be the consumer — that comment is now **stale**. What shipped upstream is the `http` adapter, but it's a generic webhook adapter (POSTs `{agentId, runId, context}` to a URL), **not** an OpenAI-compatible LLM adapter. There is no first-class "point Paperclip at an OpenAI-compatible gateway" path.
+
+The remaining adapters wrap specific agentic CLIs (`claude-code`, `codex`, `gemini`, `opencode`, `cursor`, etc.), each authenticated through that CLI's own provider plumbing. `codex_local` is already known unusable (LiteLLM doesn't proxy `/v1/responses` — see `frank-gotchas.md`), and `gemini_local` talks to Google directly.
+
+Two adapters are clean matches, both with **declarative, config-file-driven** provider setup (so neither relies on container-wide `OPENAI_*` env vars that would re-create the PR #228 codex/gemini auth-clobber regression):
+
+- **`opencode_local`** — opencode-ai's config declares custom OpenAI-compatible providers via `@ai-sdk/openai-compatible`, with `{env:VAR}` substitution for the API key. Configured globally via `opencode.json` shipped in a ConfigMap mounted under `$XDG_CONFIG_HOME`.
+- **`hermes_local`** — Hermes Agent has its own `config.yml` with an `inference.chain:` block. Backends use `type: openai`, `base_url: <litellm>`, `api_key_env: LITELLM_API_KEY` (key referenced by env var name, read from the container-wide secret that ESO already injects). Mounted under `$HERMES_HOME`. This config shape has been pre-validated in a separate, simpler deployment hitting Frank's LiteLLM gateway, so we're porting a known-working chain rather than designing one from scratch.
+
+Both run from the existing single Paperclip pod. The deliverable is an end-to-end run from at least one agent of each type — work routed through LiteLLM to Ollama on `gpu-1`, with no traffic leaving the cluster.
+
+## Current state (audit)
+
+| Piece | Status | Notes |
+|---|---|---|
+| LiteLLM gateway up | ✅ | `litellm.litellm.svc:4000`, master key + virtual keys via Infisical |
+| LiteLLM Ollama model aliases | ✅ | `mistral-small-24b`, `gemma-12b`, `qwen-vl-7b`, `qwen-coder-14b`, `qwen-think-14b`, `qwen36-a3b`, `qwen36-a3b-nothin` |
+| LiteLLM virtual key for Paperclip in Infisical (`PAPERCLIP_LITELLM_KEY`) | ✅ | Synced via ExternalSecret to `paperclip-llm-key` |
+| `LITELLM_API_KEY` + `LITELLM_BASE_URL` env on paperclip container | ✅ | But nothing reads them today |
+| `http-local` Paperclip adapter referenced in `external-secret-llm.yaml` comment | ❌ | Does not exist upstream; shipped `http` is a webhook adapter, not an LLM adapter |
+| `opencode-ai` CLI on paperclip container's PATH | ❌ | Not in the upstream Paperclip image; only `codex` and `claude-code` are |
+| `opencode.json` provider config | ❌ | Needs to be authored + delivered |
+| `XDG_CONFIG_HOME` set on paperclip container | ❌ | Currently unset; defaults to `$HOME/.config` which is unusable on read-only image |
+| `hermes` CLI on paperclip container's PATH | ❌ | Hermes is Python-based; Paperclip image is Node-only. Needs a Python interpreter and venv reachable from the paperclip container's filesystem. |
+| `$HERMES_HOME/config.yml` provider config | ❌ | Inference chain with `type: openai` backends pointed at `litellm.litellm.svc:4000` |
+| `HERMES_HOME` env on paperclip container | ❌ | Currently unset; needs to point at the ConfigMap mount path |
+| Hired Paperclip agents using `opencode_local` / `hermes_local` adapters | ❌ | Manual step via paperclip-create-agent skill or UI once wiring lands |
+| paperclip-shell MOTD documents setup | ❌ | The existing `60-paperclip-shell-tips.sh` ConfigMap doesn't mention either install step |
+
+## Constraints
+
+1. **Paperclip image untouched.** Same upstream image (`ghcr.io/paperclipai/paperclip:sha-c445e59`); install opencode-ai and hermes-agent onto the shared `/paperclip` PVC, not into the image.
+2. **Match existing PVC-as-toolchain pattern.** PR #224 already installs `gemini` to `/paperclip/agent-bin/node_modules/.bin` and adds that path to PATH on the paperclip container. opencode-ai follows the same npm-on-PVC shape; hermes needs a Python-on-PVC variant since it's `pip install`.
+3. **Declarative for both adapters.** `opencode.json` (under `$XDG_CONFIG_HOME/opencode/`) configures all opencode agents globally. Hermes's `config.yml` (under `$HERMES_HOME/`) configures all hermes agents globally, pointed at the in-cluster LiteLLM service URL. No per-agent env blocks; `adapterConfig` only nominates `model`.
+4. **No new services.** All traffic flows through the existing LiteLLM Service. No webhook proxy, no per-Paperclip adapter package.
+5. **Operator API mutations need the documented Origin header + `%3D` cookie encoding gotcha** when an agent is hired via curl (per `paperclip-ruflo.md`); hiring through the Paperclip UI sidesteps that.
+6. **Single-model default per adapter; not single-model overall.** Both adapters point at the same LiteLLM gateway and can use any of the LiteLLM aliases; the *default* hire payload nominates one (`qwen-coder-14b` for opencode's coding-leaning agents, `qwen-think-14b` for hermes's reasoning-leaning agents). Operators are free to override per hire.
+7. **Adapter-internal behavior must be verified at plan time:**
+   - `opencode_local`: the adapter constructs a temporary `XDG_CONFIG_HOME` per run and copies our base `opencode.json` into it; rely on that copy preserving the `provider`/`models` blocks. (Per upstream `packages/adapters/opencode-local/src/server/runtime-config.ts`.)
+   - `hermes_local`: the adapter's `normalizeHermesConfig` passes through process env (including `HERMES_HOME` and `LITELLM_API_KEY`) and merges in `adapterConfig.env` if set. We do not need the env-merge path; the config-file path is sufficient.
+8. **Python on shared PVC via `uv`.** Install hermes-agent with `uv python install` plus `uv pip install hermes-agent==v2026.4.16` onto `/paperclip/agent-bin/hermes-agent/venv`, with the entry-point shim at `/paperclip/agent-bin/bin/hermes`. uv produces a self-contained, relocatable Python install — the venv's shebang resolves to a path that exists in both the shell sidecar and the paperclip container's filesystem because both mount the same `/paperclip` PVC. (`v2026.4.16` is the pinned upstream Hermes release used here because it's the one already exercised against Frank's LiteLLM elsewhere.)
+
+## Architecture
+
+```
+                                    paperclip-system namespace
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                                                                              │
+│  ┌────────────────────────┐   ┌────────────────────────┐   ┌──────────────┐  │
+│  │ ConfigMap              │   │ ConfigMap              │   │ ConfigMap    │  │
+│  │ paperclip-opencode     │   │ paperclip-hermes       │   │ paperclip-   │  │
+│  │ (NEW)                  │   │ (NEW)                  │   │ shell-motd-  │  │
+│  │ opencode.json          │   │ config.yml (inference  │   │ tips (EDIT)  │  │
+│  │ (provider=litellm)     │   │  chain → litellm)      │   │              │  │
+│  └─────────┬──────────────┘   └────────┬───────────────┘   └──────┬───────┘  │
+│            │                           │                          │          │
+│            │ mount (paperclip ctr):    │ mount (paperclip ctr):   │ (shell)  │
+│            │ /etc/paperclip/opencode-  │ /etc/paperclip/hermes-   │          │
+│            │   base/opencode/          │   base/config.yml        │          │
+│            │     opencode.json         │                          │          │
+│            ▼                           ▼                          ▼          │
+│  ┌────────────────────────────────────────────────────────────────────────┐  │
+│  │ Deployment: paperclip                                                  │  │
+│  │  Volumes shared: paperclip-data PVC → /paperclip in both containers    │  │
+│  │                                                                        │  │
+│  │  container: paperclip                container: paperclip-shell        │  │
+│  │    env:                                (SSH + Mosh entry, sidecar)     │  │
+│  │      XDG_CONFIG_HOME=                  reconcile writes to /paperclip: │  │
+│  │        /etc/paperclip/opencode-base      /paperclip/agent-bin/         │  │
+│  │      HERMES_HOME=                          node_modules/.bin/opencode  │  │
+│  │        /etc/paperclip/hermes-base          hermes-agent/venv/...       │  │
+│  │      LITELLM_API_KEY  (existing ESO)       bin/hermes  (shim)          │  │
+│  │      LITELLM_BASE_URL (existing ESO)                                   │  │
+│  │      (NO container-wide OPENAI_*)                                      │  │
+│  │                                                                        │  │
+│  │    PATH includes                                                       │  │
+│  │      /paperclip/agent-bin/node_modules/.bin                            │  │
+│  │      /paperclip/agent-bin/bin                                          │  │
+│  │                                                                        │  │
+│  │    spawns CLI per agent run:                                           │  │
+│  │      • opencode → reads opencode.json (provider=litellm)               │  │
+│  │      • hermes   → reads $HERMES_HOME/config.yml                        │  │
+│  │                   (type=openai, base_url=litellm,                      │  │
+│  │                    api_key_env=LITELLM_API_KEY)                        │  │
+│  └──────────────────────────────────────┬─────────────────────────────────┘  │
+│                                         │                                    │
+│            POST /v1/chat/completions    │                                    │
+│            Authorization: Bearer …      │                                    │
+│                                         ▼                                    │
+│  ┌──────────────────────────────────────────────────────────────────────┐    │
+│  │ litellm.litellm.svc:4000 → Ollama (gpu-1) → mistral / qwen / gemma   │    │
+│  └──────────────────────────────────────────────────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Hermes `config.yml` (provider config delivered via ConfigMap)
+
+The Hermes-side schema uses `type: openai` for any OpenAI-protocol-compatible endpoint — LiteLLM speaks that protocol natively. This shape (with `type: openai` + `base_url` + `api_key_env`) has been confirmed working against the Frank LiteLLM gateway in a separate small deployment, which is why we're transplanting it rather than designing it from scratch.
+
+```yaml
+# Mounted at $HERMES_HOME/config.yml = /etc/paperclip/hermes-base/config.yml
+inference:
+  chain:
+    - name: frank-litellm-coder
+      type: openai
+      base_url: http://litellm.litellm.svc:4000/v1
+      model: qwen-coder-14b
+      api_key_env: LITELLM_API_KEY
+    - name: frank-litellm-reasoner
+      type: openai
+      base_url: http://litellm.litellm.svc:4000/v1
+      model: qwen-think-14b
+      api_key_env: LITELLM_API_KEY
+    - name: frank-litellm-default
+      type: openai
+      base_url: http://litellm.litellm.svc:4000/v1
+      model: mistral-small-24b
+      api_key_env: LITELLM_API_KEY
+
+tools:
+  filesystem:
+    read_roots:
+      - /paperclip
+    write_roots: []
+  shell:
+    enabled: false
+```
+
+`api_key_env: LITELLM_API_KEY` tells Hermes to read the env var **by name** (not value), so the existing container-wide `LITELLM_API_KEY` from the ExternalSecret is picked up without any per-agent wiring. The `inference.chain` is ordered preference — Hermes selects the first entry whose `name` matches the agent's `adapterConfig.model`, or falls through to the default.
+
+### opencode.json (provider config delivered via ConfigMap)
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Frank LiteLLM",
+      "options": {
+        "baseURL": "http://litellm.litellm.svc:4000/v1",
+        "apiKey": "{env:LITELLM_API_KEY}"
+      },
+      "models": {
+        "mistral-small-24b": { "name": "Mistral Small 3.2 24B (local)" },
+        "qwen-coder-14b":    { "name": "Qwen2.5-Coder 14B Q6 (local)" },
+        "qwen-think-14b":    { "name": "Qwen3 14B Thinking (local)" },
+        "qwen36-a3b":        { "name": "Qwen3.6 35B-A3B MoE (local)" },
+        "qwen36-a3b-nothin": { "name": "Qwen3.6 35B-A3B MoE — no-think (local)" },
+        "gemma-12b":         { "name": "Gemma 3 12B multimodal (local)" }
+      }
+    }
+  }
+}
+```
+
+### Agent hire payloads (initial agents — one per adapter)
+
+Used through the paperclip-create-agent skill or Paperclip UI:
+
+**opencode_local** — provider config is global (from `opencode.json`), so the hire payload just nominates the model:
+
+```json
+{
+  "name": "Local Coder",
+  "role": "engineer",
+  "title": "Local Engineer",
+  "icon": "wrench",
+  "adapterType": "opencode_local",
+  "adapterConfig": {
+    "model": "litellm/qwen-coder-14b",
+    "promptTemplate": "<role-specific prompt>"
+  },
+  "runtimeConfig": { "heartbeat": { "enabled": false } }
+}
+```
+
+**hermes_local** — provider config is global (from `$HERMES_HOME/config.yml`), so the hire payload just nominates a backend `name` from the inference chain via the `model` field:
+
+```json
+{
+  "name": "Local Reasoner",
+  "role": "engineer",
+  "title": "Local Reasoner (Hermes)",
+  "icon": "brain",
+  "adapterType": "hermes_local",
+  "adapterConfig": {
+    "model": "frank-litellm-reasoner",
+    "hermesCommand": "/paperclip/agent-bin/bin/hermes",
+    "toolsets": "terminal,file,web",
+    "persistSession": true,
+    "promptTemplate": "<role-specific prompt>"
+  },
+  "runtimeConfig": { "heartbeat": { "enabled": false } }
+}
+```
+
+The exact `model` field shape — whether Hermes wants the backend `name` from the inference chain, a `provider/model` tuple, or a bare model ID — is verified in the plan phase against Hermes `v2026.4.16`. The fallback is to flatten the inference chain to one backend named `default` and let Hermes pick it.
+
+The exact `model` field shape for opencode (`litellm/qwen-coder-14b` vs bare `qwen-coder-14b`) is verified in the plan phase against the installed opencode-ai version.
+
+## Components touched
+
+| File | Change | Why |
+|---|---|---|
+| `apps/paperclip/manifests/configmap-opencode.yaml` | **New** | Holds `opencode.json` with the LiteLLM provider block |
+| `apps/paperclip/manifests/configmap-hermes.yaml` | **New** | Holds `config.yml` (Hermes inference chain) with `type: openai` backends pointed at `litellm.litellm.svc:4000`. |
+| `apps/paperclip/manifests/deployment.yaml` | **Edit** | Mount both new ConfigMaps; set `XDG_CONFIG_HOME` and `HERMES_HOME`; extend `PATH` with `/paperclip/agent-bin/bin` so the hermes shim is visible; consider an initContainer or post-start hook that runs the reconcile so cold PVs install opencode + hermes without manual SSH |
+| `apps/paperclip/manifests/configmap-shell-inventory.yaml` | **Edit** | Extend the inventory schema with a new `paperclip-shared` section (or equivalent) for tools that must land on `/paperclip` not on the shell's home PV. Entries: `opencode-ai` (npm, into `/paperclip/agent-bin/node_modules/`), `hermes-agent` pinned to `v2026.4.16` (Python via uv into `/paperclip/agent-bin/hermes-agent/venv`). The existing `npm-global` / `pipx` / `cargo` lists stay shell-home-scoped. |
+| `apps/paperclip/manifests/configmap-shell-motd-tips.yaml` | **Edit** | New "LiteLLM-backed agents" section with: (a) install commands for opencode + hermes, (b) the model-name → backend-name map for hires, (c) verification one-liners, (d) link to the runbook |
+| `apps/paperclip/manifests/external-secret-llm.yaml` | **Edit** | Replace the stale "`http-local` coming soon" comment with the actual wiring (opencode reads `{env:LITELLM_API_KEY}` from `opencode.json`; hermes reads `LITELLM_API_KEY` via `api_key_env:` in `config.yml`) |
+| `docs/runbooks/frank-gotchas/paperclip-ruflo.md` (new "LiteLLM-backed agents" section) | **Edit** | Both ConfigMap shapes, the Python-on-PVC pattern (uv-based install), the hermes inference-chain naming convention, and any new gotchas surfaced during plan/execute (e.g., `model` field shape per CLI version) |
+| `agents/rules/frank-gotchas.md` | **Edit** | One-liner pointing at the new runbook section |
+
+No changes to `apps/litellm/` (the gateway), `apps/ollama/` (the runtime), `apps/paperclip/manifests/configmap.yaml` (PAPERCLIP_HOME etc. unchanged), or `secrets/paperclip/` (the SOPS bootstrap).
+
+## Data flow (per agent run)
+
+**opencode_local agent:**
+
+1. Paperclip scheduler decides to run agent `Local Coder`.
+2. `opencode_local` adapter (`packages/adapters/opencode-local/src/server/execute.ts`) constructs a fresh per-run XDG dir, copying our base `opencode.json` into it.
+3. Adapter spawns `opencode run -m litellm/qwen-coder-14b --prompt "<task>"` (exact CLI shape verified in plan).
+4. opencode reads its merged config, resolves `apiKey` from `LITELLM_API_KEY` env (container-wide), and POSTs `/v1/chat/completions` to `litellm.litellm.svc:4000` with model `qwen-coder-14b`.
+5. LiteLLM routes to `ollama/qwen2.5-coder:14b-instruct-q6_K` on `gpu-1`.
+6. Streamed completion flows back through opencode → Paperclip transcript.
+7. Paperclip records the run, transcript, and exit code.
+
+**hermes_local agent:**
+
+1. Paperclip scheduler decides to run agent `Local Reasoner`.
+2. `hermes_local` adapter (`hermes-paperclip-adapter/server`) calls `normalizeHermesConfig` and spawns the hermes CLI. The container env already has `HERMES_HOME=/etc/paperclip/hermes-base` and `LITELLM_API_KEY=<value>`, so hermes auto-discovers our `config.yml` on launch.
+3. Adapter spawns `hermes chat -q --model frank-litellm-reasoner "<task>"` (exact CLI shape verified in plan).
+4. Hermes reads `config.yml`, selects the `frank-litellm-reasoner` backend (`type: openai`, `base_url: …`), resolves `api_key_env: LITELLM_API_KEY` from process env, and POSTs `/v1/chat/completions` to LiteLLM.
+5. LiteLLM routes to `ollama/qwen3:14b` on `gpu-1`.
+6. Streamed completion → hermes structured transcript → Paperclip adapter parses into `TranscriptEntry` objects (tool cards) → Paperclip UI/run history.
+7. Hermes session state lives under `$HERMES_HOME/sessions/` — but `$HERMES_HOME` is a read-only ConfigMap mount. Plan-phase task: set the session DB path explicitly via `config.yml` to a writable path under `/paperclip/agent-bin/.hermes/` so `--resume` survives pod restarts.
+
+## Failure modes
+
+| Failure | Symptom | Handling |
+|---|---|---|
+| Virtual key revoked / rotated | opencode/hermes 401 from `/v1/chat/completions` | Paperclip surfaces adapter failure; rotate `PAPERCLIP_LITELLM_KEY` in Infisical; ESO re-syncs within 5m |
+| LiteLLM pod down | Connection refused | Existing LiteLLM canary/Rollout health story applies; Paperclip retries per its own scheduler |
+| Ollama model swap evicts hot model | First request slow, may timeout if model is large (qwen36-a3b cold-load is ~20s) | Default agents pin an always-warm model (`mistral-small-24b` for opencode, `qwen-think-14b` for hermes); document `OLLAMA_KEEP_ALIVE=24h` gotcha for cold MoE loads |
+| opencode CLI missing from PVC after wipe | `opencode: command not found` | Declarative-install via initContainer (preferred), or operator runs the reconcile from the shell sidecar — surfaced in the MOTD instructions |
+| hermes CLI missing from PVC after wipe | `hermes: command not found` | Same as opencode — the shared `paperclip-shared` inventory section drives reconcile; MOTD points at it |
+| opencode runtime-config-copy strips provider block | Agent run fails with unknown provider | Plan-time verification of the copy behavior; if it strips, fall back to setting `XDG_CONFIG_HOME` to the ConfigMap mount and rely on the adapter's directory-copy without per-run overwrites |
+| hermes ignores `HERMES_HOME` or reads a different filename | Hermes falls back to defaults or errors on "no config" | Plan-time check: confirm `v2026.4.16` honors `HERMES_HOME` for `config.yml` discovery. Low-risk (the prior validated deployment relies on this behavior) but verify at our pinned version. |
+| `model` field maps to a backend `name` not present in our inference chain | hermes error "unknown model" / falls through to next chain entry | Plan-time verification: hire one agent with each named backend (`frank-litellm-coder`, `-reasoner`, `-default`) and confirm the call lands on the expected LiteLLM model |
+| Hermes session DB written under read-only `$HERMES_HOME` mount | `--resume` fails or hermes can't write | Override session/database paths in `config.yml` to point under `/paperclip/agent-bin/.hermes/`. Plan-phase task. |
+| Python interpreter on PVC has wrong arch / libc | `hermes: cannot execute binary file` on Paperclip container | Plan-time validation: install via `uv python install` — uv produces a relocatable Python compatible with any glibc-compatible Linux — and exec it from both the shell and the paperclip containers before declaring `Deployed` |
+| Hermes SELinux relabel needed (Fedora hosts only) | systemd `203/EXEC` if the install path is `var_lib_t` | Not applicable — paperclip-system pods run unconfined inside the cluster; no SELinux denial path here. |
+| `model` field shape mismatch (opencode) | opencode error "unknown model" | Plan-time verification of `litellm/<name>` vs bare `<name>` per opencode-ai version |
+
+## Verification — "Deployed" gate
+
+Per `agents/rules/frank-gotchas.md` ("Process / practice — a layer is not Deployed until its workflow has been triggered + observed end-to-end"):
+
+**opencode_local path:**
+
+1. `opencode` CLI present on PATH inside paperclip container (single `kubectl exec ... -- which opencode`).
+2. `kubectl exec paperclip-… -c paperclip -- opencode run -m litellm/qwen-coder-14b -p "say ping"` resolves to a successful completion **and the request shows up in LiteLLM's request log** (admin UI, filtered by the Paperclip virtual key).
+3. Through the Paperclip UI: hire one `opencode_local` agent, assign a trivial issue, watch the run complete with transcript.
+
+**hermes_local path:**
+
+4. `hermes` CLI present on PATH inside paperclip container; `hermes --version` succeeds; `cat $HERMES_HOME/config.yml` shows the LiteLLM inference chain.
+5. `kubectl exec paperclip-… -c paperclip -- hermes chat -q --model frank-litellm-reasoner "say ping"` completes and the request appears in LiteLLM's log (model = `qwen-think-14b`).
+6. Through the Paperclip UI: hire one `hermes_local` agent with `adapterConfig.model: "frank-litellm-reasoner"`, assign a trivial issue, watch the transcript flow back as structured tool cards.
+
+**Cross-path:**
+
+7. Confirm with LiteLLM logs that both adapters' calls routed to Ollama (not OpenRouter).
+8. Confirm both agents survive a Paperclip pod restart (`strategy: Recreate`) — the PVC-resident CLIs persist; the hermes session resumes from `--resume`.
+
+Only after step 6 succeeds end-to-end (both adapters, both via Paperclip UI) is the spec status promoted to `Deployed`.
+
+## Out of scope
+
+- Wiring the *other* hermes providers (`openrouter`, `nous`, `zai`, `kimi-coding`, `minimax`, …). LiteLLM-via-`openai` covers our local + free-cloud needs since LiteLLM itself fronts OpenRouter; cluttering hermes with overlapping providers is YAGNI.
+- A third adapter beyond opencode and hermes (e.g. `claude_local` against LiteLLM's Anthropic-compat surface, `pi_local`, `acpx_local`). Those are pre-vetted as possible but not part of this scope.
+- Cloud-fallback policy inside agents — the gateway already does that. Agents pick a LiteLLM model name; LiteLLM decides where the call lands.
+- Replacing the existing `claude_local` / `codex_local` agents in Paperclip; this is purely additive.
+- Authentik SSO for the LiteLLM admin UI (separate concern).
+- Per-agent virtual keys + spend limits in LiteLLM (one shared Paperclip key for now; revisit if multiple agents start churning quota).
+- Declarative initContainer install of opencode-ai + hermes-agent. Surfaced as a follow-up if PVC wipes start happening often enough to justify it.
+
+## paperclip-shell MOTD (`60-paperclip-shell-tips.sh` addition)
+
+The shell sidecar prints `/etc/profile.d/60-paperclip-shell-tips.sh` on interactive SSH login. A new "LiteLLM-backed agents" section is appended (rendered conditionally — only if `opencode` or `hermes` aren't already on the paperclip container's PATH). Indicative shape:
+
+```text
+─── LiteLLM-backed agents ──────────────────────────────────────────
+ LiteLLM (Frank's local LLM gateway) is wired into Paperclip via:
+
+   opencode_local  — opencode CLI, provider declared globally in
+                     /etc/paperclip/opencode-base/opencode/opencode.json
+                     Default model:  litellm/qwen-coder-14b
+                     Install once:   paperclip-shell-reconcile
+                     Verify:         kubectl exec ... -- opencode --version
+
+   hermes_local    — Hermes Agent (Nous Research, Python). Inference
+                     chain declared globally in
+                     $HERMES_HOME/config.yml (mounted from ConfigMap).
+                     Pick a backend by name in adapterConfig.model:
+                       • frank-litellm-coder    → qwen-coder-14b
+                       • frank-litellm-reasoner → qwen-think-14b
+                       • frank-litellm-default  → mistral-small-24b
+                     Install once:   paperclip-shell-reconcile
+                     Verify:         kubectl exec ... -- hermes --version
+
+ Hire flow: use the paperclip-create-agent skill from your dev box, or
+ the Paperclip UI at http://192.168.55.212:3100. Both adapters need
+ only adapterConfig.model — no per-agent env blocks. Full runbook:
+ docs/runbooks/frank-gotchas/paperclip-ruflo.md#litellm-backed-agents
+────────────────────────────────────────────────────────────────────
+```
+
+The MOTD's reconcile suggestion (`paperclip-shell-reconcile`) is the existing helper from the shell-sidecar layer; the spec adds the new install items into the inventory so the same reconcile picks them up. The MOTD intentionally **does not** print secrets — only the `{env:...}` placeholder.
+
+## Manual operations
+
+```yaml
+# manual-operation
+id: orch-paperclip-reconcile-shared-agent-clis
+layer: orch
+app: paperclip
+plan: docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
+when: "After the inventory ConfigMap is synced and on every fresh /paperclip PV"
+why_manual: "PVC-resident tools are installed by the shell sidecar's reconcile, not by ArgoCD. Declarative-initContainer is the long-term home; for now this stays operator-imperative + idempotent."
+commands:
+  - "SSH into paperclip-shell: ssh paperclip-shell"
+  - "Run reconcile: paperclip-shell-reconcile  # installs opencode-ai + hermes-agent onto /paperclip/agent-bin"
+  - "Verify from paperclip container: kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- which opencode hermes"
+verify:
+  - "Both `opencode --version` and `hermes --version` succeed when exec'd in the paperclip container"
+status: pending
+```
+
+```yaml
+# manual-operation
+id: orch-paperclip-hire-opencode-litellm-agent
+layer: orch
+app: paperclip
+plan: docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
+when: "After the reconcile op above has installed opencode on the PVC"
+why_manual: "Agent hire is a board-level operator action through Paperclip's API; not declarative"
+commands:
+  - "Smoke test: kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- opencode run -m litellm/qwen-coder-14b -p 'say ping'"
+  - "Hire agent through Paperclip UI or via paperclip-create-agent skill with adapterType=opencode_local"
+  - "Assign a trivial issue and confirm transcript completes"
+verify:
+  - "LiteLLM admin UI request log shows the call from the Paperclip virtual key against model=qwen-coder-14b"
+  - "Paperclip run history shows successful completion with non-empty transcript"
+status: pending
+```
+
+```yaml
+# manual-operation
+id: orch-paperclip-hire-hermes-litellm-agent
+layer: orch
+app: paperclip
+plan: docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
+when: "After the reconcile op above has installed hermes on the PVC"
+why_manual: "Agent hire is a board-level operator action; hermes inference chain is global via config.yml so the hire payload only needs adapterConfig.model"
+commands:
+  - "Smoke test: kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- hermes chat -q --model frank-litellm-reasoner 'say ping'"
+  - "Hire agent through Paperclip UI or via paperclip-create-agent skill with adapterType=hermes_local, adapterConfig.model=frank-litellm-reasoner"
+  - "Assign a trivial issue and confirm transcript completes with structured tool cards"
+verify:
+  - "LiteLLM admin UI request log shows the call from the Paperclip virtual key against model=qwen-think-14b"
+  - "Paperclip run history shows successful completion; hermes session ID is captured for --resume continuity"
+status: pending
+```
+
+(If a declarative initContainer install lands, `orch-paperclip-reconcile-shared-agent-clis` becomes belt-and-braces rather than load-bearing.)
+
+## References
+
+- Existing Paperclip design: `docs/superpowers/specs/2026-03-14--orch--paperclip-design.md`
+- Paperclip shell sidecar design: `docs/superpowers/specs/2026-05-02--orch--paperclip-shell-sidecar-design.md`
+- Ollama+LiteLLM design: `docs/superpowers/specs/2026-03-09--infer--ollama-litellm-design.md`
+- LiteLLM values + model aliases: `apps/litellm/values.yaml`
+- Paperclip LiteLLM ExternalSecret: `apps/paperclip/manifests/external-secret-llm.yaml`
+- Paperclip deployment: `apps/paperclip/manifests/deployment.yaml`
+- Paperclip MOTD ConfigMap: `apps/paperclip/manifests/configmap-shell-motd-tips.yaml`
+- Paperclip shell-sidecar inventory: `apps/paperclip/manifests/configmap-shell-inventory.yaml`
+- Paperclip-Ruflo gotchas (codex `/v1/responses` issue, board-mutation CSRF gotcha): `docs/runbooks/frank-gotchas/paperclip-ruflo.md`
+- Upstream `opencode_local` adapter package: `paperclipai/paperclip` → `packages/adapters/opencode-local/`
+- opencode.ai provider docs (custom OpenAI-compatible providers + `{env:VAR}` substitution): `https://opencode.ai/docs/providers`, `https://opencode.ai/docs/config`
+- Upstream `hermes_local` adapter package: `NousResearch/hermes-paperclip-adapter`
+- Hermes Agent itself: `NousResearch/hermes-agent` (we pin `v2026.4.16`)
+- Hermes env-variables reference: `https://hermes-agent.nousresearch.com/docs/reference/environment-variables`
+- `uv` for relocatable Python on the shared PVC: `https://github.com/astral-sh/uv`

--- a/docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
+++ b/docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
@@ -62,7 +62,7 @@ Both run from the existing single Paperclip pod. The deliverable is an end-to-en
 7. **Adapter-internal behavior must be verified at plan time:**
    - `opencode_local`: the adapter constructs a temporary `XDG_CONFIG_HOME` per run and copies our base `opencode.json` into it; rely on that copy preserving the `provider`/`models` blocks. (Per upstream `packages/adapters/opencode-local/src/server/runtime-config.ts`.)
    - `hermes_local`: the adapter's `normalizeHermesConfig` passes through process env (including `HERMES_HOME` and `LITELLM_API_KEY`) and merges in `adapterConfig.env` if set. We do not need the env-merge path; the config-file path is sufficient.
-8. **Python on shared PVC via `uv`.** Install hermes-agent with `uv python install` plus `uv pip install hermes-agent==v2026.4.16` onto `/paperclip/agent-bin/hermes-agent/venv`, with the entry-point shim at `/paperclip/agent-bin/bin/hermes`. uv produces a self-contained, relocatable Python install — the venv's shebang resolves to a path that exists in both the shell sidecar and the paperclip container's filesystem because both mount the same `/paperclip` PVC. (`v2026.4.16` is the pinned upstream Hermes release used here because it's the one already exercised against Frank's LiteLLM elsewhere.)
+8. **Python on shared PVC via `uv`.** Install hermes-agent with `uv python install` plus `uv pip install 'hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@v2026.4.16'` onto `/paperclip/agent-bin/hermes-agent/venv`, with the entry-point shim at `/paperclip/agent-bin/bin/hermes`. (PyPI has a different `hermes-agent` package; we install from the upstream git tag.) uv produces a self-contained, relocatable Python install — the venv's shebang resolves to a path that exists in both the shell sidecar and the paperclip container's filesystem because both mount the same `/paperclip` PVC. (`v2026.4.16` is the pinned upstream Hermes release used here because it's the one already exercised against Frank's LiteLLM elsewhere.)
 
 ## Architecture
 
@@ -399,6 +399,12 @@ status: pending
 ```
 
 (If a declarative initContainer install lands, `orch-paperclip-reconcile-shared-agent-clis` becomes belt-and-braces rather than load-bearing.)
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| Paperclip LiteLLM-Backed Agents Implementation Plan |  | `docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/` | — |
 
 ## References
 


### PR DESCRIPTION
## Summary

Brings Paperclip onto Frank's local LLM stack (Ollama on gpu-1 via LiteLLM) by adding two new CLI-backed adapters and the declarative ConfigMaps that point them at the in-cluster LiteLLM gateway. Neither adapter uses container-wide `OPENAI_*` env (avoiding the PR #228 codex/gemini auth-clobber).

Two commits:

1. **Spec** (`ec87053`) — design doc at `docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md`. Covers both adapters' config-file-driven provider setup (opencode → `opencode.json`, hermes → `$HERMES_HOME/config.yml`), the relocatable-Python install via uv, MOTD setup notes, and the rationale for per-adapter declarative config over per-agent env injection.
2. **Plan** (`625d38d`) — six-phase implementation plan under `docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/`.

## Plan shape (v2 plan-as-folder)

| Phase | Tag | Depends on | What |
|---|---|---|---|
| 1 | agentic | — | Plan-time verifications + one-shot install on shared PVC |
| 2 | agentic | 1 | opencode_local wiring (ConfigMap, mount, `XDG_CONFIG_HOME`, inventory) |
| 3 | agentic | 1 | hermes_local wiring (ConfigMap, mount, `HERMES_HOME`, PATH widen, inventory) |
| 4 | agentic | 2, 3 | MOTD setup tip + runbook prose + stale-comment refresh |
| 5 | manual | 4 | Hire one agent per adapter, end-to-end via Paperclip UI |
| 6 | manual | 1-5 | Post-deploy checklist (fix/extension shape) |

`vk plan self-review` passes.

## Notable design choices

- **Phase 1 up-front.** Settles three open assumptions (opencode/hermes `model` field shape, hermes session-DB write path, opencode runtime-config-copy behavior) before any manifest change lands.
- **Per-adapter declarative config, not per-agent env.** Both adapters get a global ConfigMap-mounted provider file. Agent-hire payloads only nominate `model`. The hermes path uses `api_key_env: LITELLM_API_KEY` so the existing ESO-injected secret is read by env-var name without per-agent wiring.
- **Hermes install via git-tag, not PyPI.** Audit caught that the PyPI `hermes-agent` package is an unrelated project — Nous Research's Hermes Agent is installed via `uv pip install 'hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@v2026.4.16'`.
- **Fix/extension layer.** Treated as an extension of the existing `orch`/paperclip layer per `repo-workflows.md` — no new homepage tile, no new blog post; Phase 6 retroactively updates the existing paperclip building/operating posts.

## Test plan

- [ ] Phase 1 verifications produce concrete answers for all three open assumptions (model shape × 2, session DB path).
- [ ] Phase 2 / 3 ArgoCD syncs leave the paperclip pod healthy with both ConfigMaps mounted (`kubectl exec ... cat /etc/paperclip/opencode-base/opencode/opencode.json` and `cat /etc/paperclip/hermes-base/config.yml` return git contents).
- [ ] Phase 4 MOTD prints the new tip block on SSH login when either CLI is missing from the shared PVC.
- [ ] Phase 5 end-to-end: one opencode-backed agent + one hermes-backed agent each complete a trivial assigned issue, transcripts visible in Paperclip UI, LiteLLM logs show both calls routed to Ollama (not OpenRouter).
- [ ] Phase 6 retroactive blog updates + `/sync-runbook` + spec **Status:** → Deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)