### PR TITLE
[derio-net/frank] 2026-05-17--orch--paperclip-litellm-agents · Phase 3/6 · hermes_local — declarative wiring

### DIFF
--- a/apps/paperclip/manifests/configmap-hermes.yaml
+++ b/apps/paperclip/manifests/configmap-hermes.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: paperclip-hermes
+  namespace: paperclip-system
+data:
+  # Deviation from spec (P1.T2.S4): hermes v0.10.0 does not use inference.chain.
+  # It uses built-in provider overlays + env vars. ollama-cloud is the built-in
+  # provider that reads OLLAMA_BASE_URL + OLLAMA_API_KEY, both set in deployment.yaml
+  # to point at litellm.litellm.svc:4000.
+  #
+  # Deviation from spec (P1.T2.S5): no session-DB override key needed.
+  # hermes v0.10.0 has no config/state path split — all state (sessions, state.db,
+  # memory, logs) writes to HERMES_HOME. The spec's read-only ConfigMap mount at
+  # HERMES_HOME is therefore invalid. Revised: HERMES_HOME=/paperclip/agent-bin/.hermes
+  # (writable PVC); this ConfigMap is mounted as a template at
+  # /etc/paperclip/hermes-template/ and seeded into HERMES_HOME by an initContainer
+  # on every pod start.
+  config.yaml: |
+    # Hermes Agent v0.10.0 — ollama-cloud provider via Frank LiteLLM
+    # Built-in ollama-cloud transport reads OLLAMA_BASE_URL + OLLAMA_API_KEY
+    # from the container env (both set in deployment.yaml, pointing at LiteLLM).
+    # Default model for operator convenience; hermes_local adapter passes
+    # --provider ollama-cloud --model <model> at invocation time.
+    model: "ollama-cloud/qwen-think-14b"

--- a/apps/paperclip/manifests/configmap-shell-inventory.yaml
+++ b/apps/paperclip/manifests/configmap-shell-inventory.yaml
@@ -47,3 +47,22 @@ data:
       npm-global: []
       pipx: []
       cargo: []
+    # uv-based installs — reconcile script does not yet handle the 'uv' section;
+    # these entries document the install steps for hermes-agent and serve as
+    # the declarative record for PVC-wipe recovery. Run manually from paperclip-shell
+    # until derio-net/agent-images adds reconcile-script support for this section.
+    # Deviation captured in plan 2026-05-17--orch--paperclip-litellm-agents P3.T3.S1.
+    #
+    # Install commands (run from paperclip-shell):
+    #   UV_PYTHON_INSTALL_DIR=/paperclip/agent-bin/python \
+    #     /paperclip/agent-bin/bin/uv venv --python 3.12 /paperclip/agent-bin/hermes-agent/venv
+    #   /paperclip/agent-bin/bin/uv pip install \
+    #     --python /paperclip/agent-bin/hermes-agent/venv/bin/python \
+    #     'hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@v2026.4.16'
+    #   ln -sf /paperclip/agent-bin/hermes-agent/venv/bin/hermes /paperclip/agent-bin/bin/hermes
+    uv:
+      - id: hermes-agent
+        pin: "git+https://github.com/NousResearch/hermes-agent.git@v2026.4.16"
+        venv: /paperclip/agent-bin/hermes-agent/venv
+        python_install_dir: /paperclip/agent-bin/python
+        shim: /paperclip/agent-bin/bin/hermes

--- a/apps/paperclip/manifests/deployment.yaml
+++ b/apps/paperclip/manifests/deployment.yaml
@@ -47,6 +47,26 @@ spec:
       # made (see PR #196): we forgo the cross-container `ps` for a working
       # sshd; the shell still gets full visibility into `/paperclip` (the
       # actual debugging surface) via the shared PVC.
+      initContainers:
+        # Seeds HERMES_HOME from the paperclip-hermes ConfigMap on every pod start.
+        # Required because hermes v0.10.0 writes ALL state (sessions, memory, state.db)
+        # to HERMES_HOME — a read-only ConfigMap mount at that path is not viable.
+        # HERMES_HOME=/paperclip/agent-bin/.hermes (writable PVC); this initContainer
+        # ensures a fresh config.yaml lands there before the main container starts,
+        # keeping the ConfigMap as the declarative source of truth.
+        - name: hermes-init
+          image: busybox:1
+          command:
+            - sh
+            - -c
+            - "mkdir -p /paperclip/agent-bin/.hermes && cp /etc/paperclip/hermes-template/config.yaml /paperclip/agent-bin/.hermes/config.yaml"
+          volumeMounts:
+            - name: data
+              mountPath: /paperclip
+            - name: hermes-config
+              mountPath: /etc/paperclip/hermes-template/config.yaml
+              subPath: config.yaml
+              readOnly: true
       containers:
         - name: paperclip
           # Upstream public image. Pinned by digest-equivalent sha tag.
@@ -92,8 +112,26 @@ spec:
             # codex stays authoritative; we only fill gaps (gemini).
             # TODO: lift this install from operator-imperative to a
             # declarative initContainer so PVC wipe regenerates state.
+            #
+            # hermes is installed on the PVC at /paperclip/agent-bin/bin/hermes
+            # (uv venv, seeded in Phase 1). PATH extended here so the paperclip
+            # container can invoke it directly. HERMES_HOME points at a writable
+            # PVC subdirectory — hermes v0.10.0 has no config/state split, so
+            # a read-only ConfigMap mount is not viable; config.yaml is seeded
+            # from paperclip-hermes ConfigMap by the hermes-init initContainer
+            # on every pod start. OLLAMA_BASE_URL/OLLAMA_API_KEY route hermes
+            # through LiteLLM (discovered working shape in P1.T2.S4).
             - name: PATH
-              value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/paperclip/agent-bin/node_modules/.bin"
+              value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/paperclip/agent-bin/node_modules/.bin:/paperclip/agent-bin/bin"
+            - name: HERMES_HOME
+              value: /paperclip/agent-bin/.hermes
+            - name: OLLAMA_BASE_URL
+              value: "http://litellm.litellm.svc:4000/v1"
+            - name: OLLAMA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: paperclip-llm-key
+                  key: LITELLM_API_KEY
             - name: PG_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -104,6 +142,12 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /paperclip
+            # hermes config template — mounted read-only; hermes-init initContainer
+            # copies this into HERMES_HOME (/paperclip/agent-bin/.hermes/) on boot.
+            - name: hermes-config
+              mountPath: /etc/paperclip/hermes-template/config.yaml
+              subPath: config.yaml
+              readOnly: true
           resources:
             requests:
               memory: 512Mi
@@ -227,3 +271,6 @@ spec:
           configMap:
             name: paperclip-shell-motd-tips
             defaultMode: 0644
+        - name: hermes-config
+          configMap:
+            name: paperclip-hermes

--- a/apps/paperclip/manifests/deployment.yaml
+++ b/apps/paperclip/manifests/deployment.yaml
@@ -55,7 +55,7 @@ spec:
         # ensures a fresh config.yaml lands there before the main container starts,
         # keeping the ConfigMap as the declarative source of truth.
         - name: hermes-init
-          image: busybox:1
+          image: busybox:1.37
           command:
             - sh
             - -c
@@ -67,6 +67,12 @@ spec:
               mountPath: /etc/paperclip/hermes-template/config.yaml
               subPath: config.yaml
               readOnly: true
+          resources:
+            requests:
+              cpu: 1m
+              memory: 8Mi
+            limits:
+              memory: 32Mi
       containers:
         - name: paperclip
           # Upstream public image. Pinned by digest-equivalent sha tag.

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/03.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/03.yaml
@@ -165,46 +165,64 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T13:06:23+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-17T13:06:23+00:00'
+      note: No session-DB override key exists in hermes v0.10.0; placeholder removed.
+        HERMES_HOME must be writable — revised to /paperclip/agent-bin/.hermes (PVC),
+        seeded by initContainer.
     P3.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T13:06:23+00:00'
       note: null
     P3.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-17T13:06:29+00:00'
+      note: ConfigMap mounted at /etc/paperclip/hermes-template/config.yaml (read-only);
+        initContainer hermes-init seeds HERMES_HOME from this template on pod start.
+        Spec's /etc/paperclip/hermes-base mount invalid — HERMES_HOME must be writable.
     P3.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-17T13:06:29+00:00'
+      note: HERMES_HOME=/paperclip/agent-bin/.hermes (not /etc/paperclip/hermes-base).
+        Added OLLAMA_BASE_URL + OLLAMA_API_KEY for ollama-cloud transport (P1.T2.S4
+        working shape). PATH extended with /paperclip/agent-bin/bin.
     P3.T3.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-17T13:06:35+00:00'
+      note: 'Added uv: section to configmap-shell-inventory.yaml documenting hermes
+        install steps. Reconcile script (paperclip-shell-reconcile) does not yet handle
+        uv: sections — deviation captured, relies on Phase 1 operator-imperative install
+        for now.'
     P3.T4.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-17T13:06:40+00:00'
+      note: Committed + pushed. ArgoCD syncs from main — manual apply+validate done
+        on feature branch per ArgoCD gotcha pattern (suspend selfHeal, apply, test,
+        restore).
     P3.T4.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-17T13:06:40+00:00'
+      note: 'Verified: /etc/paperclip/hermes-template/config.yaml mounted, HERMES_HOME=/paperclip/agent-bin/.hermes,
+        PATH ends with agent-bin/bin, which hermes → /paperclip/agent-bin/bin/hermes.
+        initContainer seeded config.yaml into HERMES_HOME.'
     P3.T4.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-17T13:06:47+00:00'
+      note: 'Smoke test: hermes chat -Q --provider ollama-cloud --model qwen-think-14b
+        -q ''say ping''. LiteLLM log: POST /v1/chat/completions HTTP/1.1 200 OK from
+        10.244.10.16 (paperclip pod). HERMES_HOME sessions, state.db, logs, memories
+        all created.'
     P3.T4.S4:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-17T13:06:47+00:00'
+      note: 'ls -la /paperclip/agent-bin/.hermes/ shows: config.yaml, SOUL.md, auth.json,
+        auth.lock, state.db, sessions/, logs/, memories/, cron/, sandboxes/ — full
+        state tree written correctly.'
   completion:
-    at: null
+    at: '2026-05-17T13:06:50+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents
📐 Spec:   docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
🎯 Phase:  3/6 — hermes_local — declarative wiring [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/273

**Goal (from plan):** Wire hermes v0.10.0 onto the paperclip container declaratively: ConfigMap + initContainer + env vars + PATH extension + shell-inventory entry for PVC-wipe recovery.

---

## Summary

- **`configmap-hermes.yaml`** (new): Hermes config template using the v0.10.0 schema (`model: "ollama-cloud/qwen-think-14b"`). Built-in `ollama-cloud` transport reads `OLLAMA_BASE_URL` + `OLLAMA_API_KEY` from the container env; no custom providers block needed.
- **`deployment.yaml`**: Added `hermes-init` initContainer (busybox) that seeds `HERMES_HOME` from the ConfigMap template on every pod start. Set `HERMES_HOME=/paperclip/agent-bin/.hermes` (writable PVC), `OLLAMA_BASE_URL`, `OLLAMA_API_KEY` (from existing `paperclip-llm-key` secret). Extended `PATH` to include `/paperclip/agent-bin/bin`.
- **`configmap-shell-inventory.yaml`**: Added `uv:` section documenting the hermes install steps for PVC-wipe recovery (reconcile-script support pending `agent-images`).

## Key Deviations from Plan Template (driven by Phase 1 findings)

| Deviation | Finding | Adaptation |
|---|---|---|
| `inference.chain` config schema | hermes v0.10.0 uses `providers:` dict + env vars, not `inference.chain` | Config uses `model: ollama-cloud/qwen-think-14b`; built-in `ollama-cloud` provider |
| `HERMES_HOME` read-only ConfigMap mount | No config/state path split in v0.10.0 — all state writes to `HERMES_HOME` | `HERMES_HOME=/paperclip/agent-bin/.hermes` (writable PVC) + `hermes-init` initContainer seeds config |
| No `OLLAMA_*` env vars in spec | Working invocation requires `OLLAMA_BASE_URL` + `OLLAMA_API_KEY` (P1.T2.S4) | Both env vars added to deployment |
| `uv:` shell-inventory section | Reconcile script does not handle `uv:` sections yet | Added as documentation; noted as deviation |

## Test Plan

- [x] `yq` sanity-check: `configmap-hermes.yaml` YAML valid, no `SESSION_DB_OVERRIDE_PLACEHOLDER` marker
- [x] `kubectl apply --dry-run=server` passes for all 3 manifests
- [x] Live rollout: `kubectl rollout status deploy/paperclip` completed successfully
- [x] Mount verified: `/etc/paperclip/hermes-template/config.yaml` readable in container
- [x] Env verified: `HERMES_HOME=/paperclip/agent-bin/.hermes`, PATH ends with `agent-bin/bin`, `OLLAMA_BASE_URL` set
- [x] `which hermes` → `/paperclip/agent-bin/bin/hermes`
- [x] initContainer seeded `config.yaml` into `HERMES_HOME` before main container started
- [x] Smoke test: `hermes chat -Q --provider ollama-cloud --model qwen-think-14b -q 'say ping'` → LiteLLM log `POST /v1/chat/completions HTTP/1.1" 200 OK` from paperclip pod IP
- [x] Session state written: `state.db`, `sessions/`, `memories/`, `logs/`, `SOUL.md` all created under `/paperclip/agent-bin/.hermes/`
- [x] ArgoCD restored: selfHeal re-enabled, resync to `main` Synced/Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)