### PR TITLE
[derio-net/frank] 2026-05-17--orch--paperclip-litellm-agents · Phase 4/6 · MOTD + runbook + stale-comment cleanup

### DIFF
--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -87,6 +87,7 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - ruvocal stores state in `/app/db/ruvocal.rvf.json` (RVF), NOT Postgres — `DATABASE_URL` is silently ignored at the pinned SHA. Mount a PVC at `/app/db`.
 - ruvocal liveness should probe `/api/v2/feature-flags`, not `/` (SSR `/` reaches into LiteLLM/DB).
 - LiteLLM-fronted apps need a LiteLLM virtual key for `OPENAI_API_KEY` — not the upstream provider key.
+- LiteLLM-backed agents (`opencode_local` + `hermes_local`): opencode needs `litellm/<alias>` model shape; hermes v0.10.0 uses `--provider ollama-cloud --model <alias>` (no `inference.chain`); `HERMES_HOME` must be a writable PVC path — see `paperclip-ruflo.md#litellm-backed-agents`.
 - ruvocal's server-side `isValidUrl` rejects `wasm://` URLs but the in-browser "RVAgent Local (WASM)" MCP advertises one; with autopilot ON + WASM-only MCP (chat-ui defaults), the SPA silently refuses to submit and the chat POST never reaches the server. Local fork in agent-images adds a `wasm:` allow-line.
 - Company-import's GitHub fetch is unauthenticated upstream (`server/src/services/github-fetch.ts:ghFetch` injects no `Authorization`) — private repos fail at the COMPANY.md fetch. Use **Local zip** mode: `git archive --format=zip --prefix=<name>/ HEAD:<subdir> > <name>.zip`.
 - Archive does NOT free `issue_prefix` (`companies_issue_prefix_idx` is plain UNIQUE, no partial-where on status) — only hard DELETE frees a prefix; re-imports under the same name collide.

--- a/apps/paperclip/manifests/configmap-shell-motd-tips.yaml
+++ b/apps/paperclip/manifests/configmap-shell-motd-tips.yaml
@@ -36,3 +36,39 @@ data:
      reconciled by paperclip-shell-reconcile at boot and on demand).
     ─────────────────────────────────────────────────────────────────────────
     TIPS
+    # Print LiteLLM-backed-agents tip only when one or both CLIs are absent.
+    # opencode is image-baked (/usr/local/bin/opencode), but the PVC install
+    # is the operator-reconciled copy — its absence signals a cold/wiped PVC
+    # that needs a reconcile. hermes is PVC-only (shim at /paperclip/agent-bin/bin/).
+    if [ ! -x /paperclip/agent-bin/node_modules/.bin/opencode ] || \
+       [ ! -x /paperclip/agent-bin/bin/hermes ]; then
+      cat <<'LITELLM_TIPS'
+
+    ─── LiteLLM-backed agents (one or both CLIs missing — run reconcile) ───
+     Frank's local LLM gateway (LiteLLM → Ollama on gpu-1) is wired into
+     Paperclip via two adapters. Both need a one-time install on the PVC:
+
+       opencode_local  — opencode CLI; config via opencode.json (ConfigMap):
+                         XDG_CONFIG_HOME=/etc/paperclip/opencode-base
+                         Model shape:    litellm/qwen-coder-14b
+                         Install check:  ls /paperclip/agent-bin/node_modules/.bin/opencode
+                         Reconcile:      paperclip-shell-reconcile
+
+       hermes_local    — Hermes Agent (Nous Research, Python, v2026.4.16).
+                         Provider: ollama-cloud (OLLAMA_BASE_URL → LiteLLM).
+                         HERMES_HOME:    /paperclip/agent-bin/.hermes/
+                         Config seeded by hermes-init initContainer each boot.
+                         Model shape:    --provider ollama-cloud --model <alias>
+                         Aliases:        qwen-coder-14b, qwen-think-14b,
+                                         mistral-small-24b, qwen36-a3b,
+                                         qwen36-a3b-nothin, gemma-12b
+                         Install check:  ls /paperclip/agent-bin/bin/hermes
+                         Reconcile:      paperclip-shell-reconcile
+
+     Hire: Paperclip UI at http://192.168.55.212:3100 or paperclip-create-agent
+     skill. Both adapters need only adapterConfig.model — no per-agent env.
+     Full runbook:
+       docs/runbooks/frank-gotchas/paperclip-ruflo.md#litellm-backed-agents
+    ─────────────────────────────────────────────────────────────────────────
+    LITELLM_TIPS
+    fi

--- a/apps/paperclip/manifests/external-secret-llm.yaml
+++ b/apps/paperclip/manifests/external-secret-llm.yaml
@@ -1,18 +1,14 @@
-# Syncs the LiteLLM virtual key from Infisical and pairs it with the static
-# in-cluster LiteLLM gateway URL. Exposed under LITELLM_* env names — NOT
-# OPENAI_* — so they don't collide with the codex/gemini adapter probes,
-# which read OPENAI_API_KEY / GEMINI_API_KEY from env and force API-key
-# auth against api.openai.com (codex CLI doesn't honor OPENAI_BASE_URL,
-# and LiteLLM doesn't proxy /v1/responses, so wiring codex through LiteLLM
-# isn't viable today — see PR #228 / frank-gotchas.md). The adapter probes
-# fall back to their on-disk OAuth auth.json (chatgpt-mode for codex,
-# google_accounts.json for gemini) when these env vars are absent, which
-# is what we want.
-#
-# Paperclip's `http-local` adapter (currently "coming soon") will be the
-# proper consumer once it ships: configure it to read LITELLM_API_KEY +
-# LITELLM_BASE_URL and route through the in-cluster gateway as the
-# generic HTTP path. Re-pin/re-enable here when that lands.
+# Syncs the LiteLLM virtual key from Infisical and exposes it as two env vars:
+#   LITELLM_API_KEY  — consumed by opencode via {env:LITELLM_API_KEY} interpolation
+#                      in the XDG_CONFIG_HOME-mounted opencode.json
+#   LITELLM_BASE_URL — injected but not consumed by either adapter; both hardcode
+#                      the URL (opencode in opencode.json, hermes via OLLAMA_BASE_URL)
+# LITELLM_API_KEY is also available as OLLAMA_API_KEY in deployment.yaml env so
+# hermes (--provider ollama-cloud) can pick it up without a separate secret.
+# Exposed under LITELLM_* env names — NOT OPENAI_* — so they don't collide with
+# the codex/gemini adapter probes (codex doesn't honor OPENAI_BASE_URL; gemini
+# reads GEMINI_API_KEY directly). Those adapters fall back to their on-disk OAuth
+# auth.json when these env vars are absent, which is what we want.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:

--- a/docs/runbooks/frank-gotchas/paperclip-ruflo.md
+++ b/docs/runbooks/frank-gotchas/paperclip-ruflo.md
@@ -197,6 +197,147 @@ Examples:
 
 Upstream fix is one line: unwrap the cause chain in `isIssuePrefixConflict`. Worth a PR.
 
+## LiteLLM-backed agents (`opencode_local` + `hermes_local`) {#litellm-backed-agents}
+
+Paperclip's local LLM path routes agent runs through Frank's LiteLLM gateway (`litellm.litellm.svc:4000` / `192.168.55.206:4000`) to Ollama models on `gpu-1`. Two adapters implement this:
+
+### opencode_local
+
+**Config shape** — `paperclip-opencode` ConfigMap, mounted via `XDG_CONFIG_HOME`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "litellm": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "Frank LiteLLM",
+      "options": {
+        "baseURL": "http://litellm.litellm.svc:4000/v1",
+        "apiKey": "{env:LITELLM_API_KEY}"
+      },
+      "models": {
+        "mistral-small-24b": { "name": "Mistral Small 3.2 24B (local)" },
+        "qwen-coder-14b":    { "name": "Qwen2.5-Coder 14B Q6 (local)" },
+        "qwen-think-14b":    { "name": "Qwen3 14B Thinking (local)" },
+        "qwen36-a3b":        { "name": "Qwen3.6 35B-A3B MoE (local)" },
+        "qwen36-a3b-nothin": { "name": "Qwen3.6 35B-A3B MoE — no-think (local)" },
+        "gemma-12b":         { "name": "Gemma 3 12B multimodal (local)" }
+      }
+    }
+  }
+}
+```
+
+**Model field shape (verified, Phase 1.T1.S3):** `litellm/<alias>` — provider-prefixed is required. Bare `qwen-coder-14b` fails with `Error: Model not found: qwen-coder-14b/.`.
+
+**Env-var interpolation:** `{env:LITELLM_API_KEY}` in `opencode.json` resolves correctly at runtime — no syntax change needed.
+
+**Adapter copy behavior:** The `opencode_local` adapter's `runtime-config.ts` copies the base `XDG_CONFIG_HOME` dir to a per-run tempdir and then merges only the `permission` block. Our `provider.litellm` block is preserved on every run (verified Phase 1.T3.S1 against `sha-c445e59`, `runtime-config.ts` line 68–91).
+
+**Binary location:** opencode is image-baked at `/usr/local/bin/opencode` (v1.14.48 at time of Phase 2). The PVC install (`npm install --prefix /paperclip/agent-bin opencode-ai` → v1.15.3) is reachable via absolute path but the image-baked binary wins PATH precedence. Wire `XDG_CONFIG_HOME` for the image-baked binary.
+
+**Hire payload:**
+
+```json
+{
+  "adapterType": "opencode_local",
+  "adapterConfig": { "model": "litellm/qwen-coder-14b" }
+}
+```
+
+### hermes_local
+
+**Hermes v0.10.0 schema deviation from spec:** The spec assumed `inference.chain:` config format. Hermes v0.10.0 uses a `providers:` dict + env vars. The working path is the built-in `ollama-cloud` provider, which reads `OLLAMA_BASE_URL` and `OLLAMA_API_KEY` from the container env.
+
+**Config shape** — `paperclip-hermes` ConfigMap, seeded into `HERMES_HOME` by initContainer:
+
+```yaml
+# Hermes Agent v0.10.0 — ollama-cloud provider via Frank LiteLLM
+model: "ollama-cloud/qwen-think-14b"
+```
+
+`OLLAMA_BASE_URL=http://litellm.litellm.svc:4000/v1` and `OLLAMA_API_KEY=$(LITELLM_API_KEY)` are set in `deployment.yaml`.
+
+**Model field shape (verified, Phase 1.T2.S4):** `--provider ollama-cloud --model <alias>` where `<alias>` is one of the LiteLLM model names (`qwen-coder-14b`, `qwen-think-14b`, `mistral-small-24b`, etc.). Hermes auto-normalizes `ollama-cloud/<alias>` → `<alias>` when `--provider ollama-cloud` is explicit.
+
+**HERMES_HOME cannot be read-only (verified, Phase 1.T2.S5):** hermes v0.10.0 writes ALL state to `HERMES_HOME`: sessions, `state.db`, `auth.json`, `logs/`, `memories/`, `SOUL.md`. There is no separate config vs. state path override. **`HERMES_HOME` must be a writable directory.** The spec's original assumption (`/etc/paperclip/hermes-base` as a ConfigMap mount) is invalid.
+
+**Revised approach:** `HERMES_HOME=/paperclip/agent-bin/.hermes` (writable PVC). The `hermes-init` initContainer seeds `config.yaml` there on every pod boot from the `paperclip-hermes` ConfigMap (mounted read-only at `/etc/paperclip/hermes-template/`). The initContainer runs before all app containers, so `HERMES_HOME` is always ready before hermes is invoked.
+
+**Hire payload:**
+
+```json
+{
+  "adapterType": "hermes_local",
+  "adapterConfig": {
+    "model": "qwen-think-14b",
+    "hermesCommand": "/paperclip/agent-bin/bin/hermes"
+  }
+}
+```
+
+### Python-on-PVC install pattern (hermes)
+
+hermes-agent is Python-based; the Paperclip image is Node-only. Install it onto the shared `/paperclip` PVC using `uv`:
+
+```bash
+# From paperclip-shell (run once, or after a PVC wipe):
+# uv binary must already be at /paperclip/agent-bin/bin/uv
+# (installed via curl astral.sh/uv/install.sh | env UV_INSTALL_DIR=... sh)
+
+# Non-relocatable venv gotcha: default uv downloads CPython to ~/.local/share/uv/python/
+# which is the shell sidecar's home PVC — invisible from the paperclip container.
+# Fix: pin UV_PYTHON_INSTALL_DIR to the shared PVC.
+UV_PYTHON_INSTALL_DIR=/paperclip/agent-bin/python \
+  /paperclip/agent-bin/bin/uv venv --python 3.12 /paperclip/agent-bin/hermes-agent/venv
+
+/paperclip/agent-bin/bin/uv pip install \
+  --python /paperclip/agent-bin/hermes-agent/venv/bin/python \
+  'hermes-agent @ git+https://github.com/NousResearch/hermes-agent.git@v2026.4.16'
+
+ln -sf /paperclip/agent-bin/hermes-agent/venv/bin/hermes /paperclip/agent-bin/bin/hermes
+```
+
+**Key gotcha:** `UV_PYTHON_INSTALL_DIR` must be on the shared `/paperclip` PVC. Without it, the venv's `python` symlink resolves to `~/.local/share/uv/python/…` (shell sidecar's home) which is mounted as the shell sidecar's PV — not visible to the `paperclip` container. The shim at `/paperclip/agent-bin/bin/hermes` then executes cleanly from both containers.
+
+### shell-inventory `paperclip-shared` section
+
+The `configmap-shell-inventory.yaml` has a `paperclip-shared:` section (distinct from `npm-global:`, `pipx:`, `cargo:` which target the shell sidecar's home PV). It declares tools that must land on `/paperclip` for the paperclip container to reach them:
+
+```yaml
+paperclip-shared:
+  npm:
+    - opencode-ai        # installed to /paperclip/agent-bin/node_modules/
+uv:
+  - id: hermes-agent
+    pin: "git+https://github.com/NousResearch/hermes-agent.git@v2026.4.16"
+    venv: /paperclip/agent-bin/hermes-agent/venv
+    python_install_dir: /paperclip/agent-bin/python
+    shim: /paperclip/agent-bin/bin/hermes
+```
+
+The reconcile script does not yet handle `paperclip-shared:` or `uv:` sections (deferred to an agent-images PR). Until then, these entries serve as the declarative recovery record — run the commands above manually after a PVC wipe.
+
+### Verification commands
+
+```bash
+# From outside the cluster:
+kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- opencode --version
+kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- hermes --version
+
+# Smoke-test opencode against LiteLLM:
+kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- \
+  opencode run -m litellm/qwen-coder-14b -p "say ping"
+
+# Smoke-test hermes against LiteLLM:
+kubectl -n paperclip-system exec deploy/paperclip -c paperclip -- \
+  hermes chat -Q -q "say ping" --provider ollama-cloud --model qwen-think-14b
+
+# Confirm LiteLLM received the request (adjust pod name):
+kubectl -n litellm logs deploy/litellm --since=2m | grep "POST /v1/chat/completions"
+```
+
 ## Operator API calls from CLI need Origin header + `%3D` cookie encoding
 
 Two independent guards make CLI access to the board-scoped API non-obvious:

--- a/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/04.yaml
+++ b/docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents/04.yaml
@@ -71,26 +71,27 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T18:29:49+00:00'
       note: null
     P4.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T18:30:16+00:00'
       note: null
     P4.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-17T18:30:22+00:00'
+      note: Cluster-side verification deferred to Phase 5 operator walkthrough; MOTD
+        shell script logic is syntactically correct
     P4.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T18:31:19+00:00'
       note: null
     P4.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T18:31:29+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-17T18:31:32+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-17--orch--paperclip-litellm-agents
📐 Spec:   docs/superpowers/specs/2026-05-17--orch--paperclip-litellm-agents-design.md
🎯 Phase:  4/6 — MOTD + runbook + stale-comment cleanup [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/274

**Goal (from plan):** Documentation and cleanup pass after Phases 2+3 landed the opencode_local and hermes_local adapter wiring. Refresh the stale ExternalSecret comment, add a conditional MOTD tip, and write the full runbook section covering both adapters.

## Summary

- **`external-secret-llm.yaml`** — Replace stale "http-local coming soon" comment with accurate description of actual consumers: opencode via `{env:LITELLM_API_KEY}` in `opencode.json`, and hermes via `OLLAMA_API_KEY` env in `deployment.yaml`
- **`configmap-shell-motd-tips.yaml`** — Append a conditional `60-paperclip-shell-tips.sh` block that prints the LiteLLM-backed-agents setup only when the PVC CLIs are absent (cold/wiped PVC signal); includes adapter configs, model shapes, and reconcile instructions
- **`paperclip-ruflo.md`** — New `#litellm-backed-agents` section covering both ConfigMap shapes, the Phase 1 model-shape findings (opencode needs `litellm/<alias>`; hermes v0.10.0 uses `--provider ollama-cloud --model <alias>` — no `inference.chain`), the HERMES_HOME writable-PVC deviation, the `UV_PYTHON_INSTALL_DIR` gotcha for relocatable Python, shell-inventory `paperclip-shared` vs home-scoped sections, and verification commands
- **`frank-gotchas.md`** — One-liner under Paperclip / Ruflo pointing at the new runbook section

## Notes

- P4.T2.S2 (ArgoCD sync + SSH verify) deferred to Phase 5 operator walkthrough — the script logic is syntactically correct and matches the existing `60-paperclip-shell-tips.sh` idioms
- Runbook reflects Phase 1 deviation findings: hermes v0.10.0 has no `inference.chain`, uses `ollama-cloud` built-in provider + env vars