### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-phase-0 · Phase 1/9 · Hugo foundation

### DIFF
--- a/blog/content/_index.md
+++ b/blog/content/_index.md
@@ -15,17 +15,17 @@ layout: hextra-home
 
 <div class="hx-mb-12">
 {{< hextra/hero-subtitle >}}
-  Tutorial series on building and operating an AI-hybrid Kubernetes homelab
-  with Talos Linux, Cilium, Longhorn, ArgoCD, and GPU compute.
+  Building, operating, and deciding: an AI-hybrid Kubernetes homelab with
+  Talos Linux, Cilium, Longhorn, ArgoCD, and GPU compute.
 {{< /hextra/hero-subtitle >}}
 </div>
 
 <div class="blog-series-cards">
-{{< cards cols="2" >}}
+{{< cards cols="3" >}}
   {{< card
     link="docs/building/"
     title="Building Frank"
-    subtitle="26 posts — from bare metal to a fully operational AI-hybrid cluster."
+    subtitle="29 posts — from bare metal to a fully operational AI-hybrid cluster."
     image="/images/tile-building.png"
   >}}
   {{< card
@@ -33,6 +33,12 @@ layout: hextra-home
     title="Operating on Frank"
     subtitle="20 posts — day-to-day commands, health checks, and debugging guides."
     image="/images/tile-operating.png"
+  >}}
+  {{< card
+    link="docs/papers/"
+    title="The Frank Papers"
+    subtitle="Research-grade decision reviews for every capability on the cluster."
+    image="/images/banner-papers.png"
   >}}
 {{< /cards >}}
 </div>

--- a/blog/content/docs/papers/_index.md
+++ b/blog/content/docs/papers/_index.md
@@ -1,0 +1,13 @@
+---
+title: "The Frank Papers"
+weight: 3
+sidebar:
+  open: true
+---
+
+Research-grade landscape reviews for every capability on the cluster. Each
+Paper maps the vendor space, grades options against a decision-maker rubric,
+and returns to Frank's choice as a worked case study — honest about where
+that choice would not generalize.
+
+*First paper coming soon.*

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -36,17 +36,27 @@ title = "Frank, the Talos Cluster"
   weight = 2
 
 [[menu.main]]
-  name = "Search"
+  name = "Papers"
+  pageRef = "/docs/papers"
   weight = 3
+
+[[menu.main]]
+  name = "Search"
+  weight = 4
   [menu.main.params]
     type = "search"
 
 [[menu.main]]
   name = "GitHub"
   url = "https://github.com/derio-net/frank"
-  weight = 4
+  weight = 5
   [menu.main.params]
     icon = "github"
+
+[taxonomies]
+  series = "series"
+  capabilities = "capabilities"
+  references = "references"
 
 [markup]
   [markup.goldmark]

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -7,7 +7,7 @@ title = "Frank, the Talos Cluster"
     path = "github.com/imfing/hextra"
 
 [params]
-  description = "Tutorial series on building and operating an AI-hybrid Kubernetes homelab"
+  description = "Building, operating, and deciding: an AI-hybrid Kubernetes homelab with Talos Linux, Cilium, Longhorn, ArgoCD, and GPU compute"
 
   [params.navbar]
     displayTitle = true
@@ -53,11 +53,6 @@ title = "Frank, the Talos Cluster"
   [menu.main.params]
     icon = "github"
 
-[taxonomies]
-  series = "series"
-  capabilities = "capabilities"
-  references = "references"
-
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]
@@ -66,6 +61,11 @@ title = "Frank, the Talos Cluster"
     codeFences = true
     lineNos = false
     style = "monokai"
+
+[taxonomies]
+  series = "series"
+  capabilities = "capabilities"
+  references = "references"
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/01.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/01.yaml
@@ -162,26 +162,26 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T20:32:18+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T20:32:22+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T20:32:22+00:00'
       note: null
     P1.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T20:32:22+00:00'
       note: null
     P1.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-17T20:32:22+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-17T20:32:25+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  1/9 — Hugo foundation [agentic]
🔗 Issue:  #277

**Goal (from plan):** Wire the Hugo site so the Papers series has a home — taxonomies registered, nav entry in place, section landing page live, and a third card on the homepage.

---

## Summary

- Added `series`, `capabilities`, `references` taxonomies to `blog/hugo.toml`
- Inserted Papers nav entry at weight 3 (Search shifted to 4, GitHub to 5)
- Created `blog/content/docs/papers/_index.md` — Papers section landing page with "First paper coming soon" stub
- Added third Papers card to `blog/content/_index.md`, updated hero subtitle to mention three series
- Ticked all plan steps P1.T1.S1–P1.T3.S2 and marked Phase 1 complete

## Test plan

- [x] Hugo builds with `--buildDrafts --quiet` — 0 errors
- [x] New taxonomy pages (`/series/`, `/capabilities/`, `/references/`) created automatically by Hugo
- [x] Papers section at `/docs/papers/` renders with stub content
- [x] Landing page shows 3 cards (Papers image slot will be empty until Phase 6 — expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)