### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-phase-0 · Phase 2/9 · Visual system

### DIFF
--- a/blog/assets/css/custom.css
+++ b/blog/assets/css/custom.css
@@ -122,3 +122,91 @@
   line-height: 1.5 !important;
   -webkit-line-clamp: unset !important;
 }
+
+/* === The Frank Papers — scoped under .paper-post === */
+
+.paper-post .paper-tldr {
+  background: var(--tw-prose-pre-bg, #1e1e1e);
+  border-left: 4px solid #1f6feb;
+  border-radius: 0.375rem;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.paper-post .paper-pullquote {
+  border-left: 3px solid #30a46c;
+  padding: 0.75rem 1.25rem;
+  margin: 1.5rem 0;
+  font-style: italic;
+  color: var(--tw-prose-body);
+}
+
+.paper-post .paper-pullquote cite {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
+  font-style: normal;
+  opacity: 0.7;
+}
+
+.paper-post .paper-scar {
+  background: rgba(255, 190, 0, 0.08);
+  border: 1px solid rgba(255, 190, 0, 0.3);
+  border-radius: 0.375rem;
+  padding: 0.75rem 1rem;
+  margin: 1.25rem 0;
+  font-size: 0.9rem;
+}
+
+.paper-post .paper-scar-date {
+  font-size: 0.75rem;
+  opacity: 0.6;
+  margin-bottom: 0.25rem;
+  font-family: ui-monospace, monospace;
+}
+
+.paper-post .paper-capability-matrix table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.paper-post .paper-capability-matrix th,
+.paper-post .paper-capability-matrix td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--tw-prose-td-borders, rgba(128,128,128,0.2));
+  text-align: center;
+}
+
+.paper-post .paper-capability-matrix th:first-child,
+.paper-post .paper-capability-matrix td:first-child {
+  text-align: left;
+  font-weight: 500;
+}
+
+.paper-post .paper-dossier-link {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--tw-prose-hr, rgba(128,128,128,0.2));
+  font-size: 0.85rem;
+  opacity: 0.8;
+}
+
+.paper-post .paper-cross-links {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.paper-post .paper-cross-links a {
+  color: #1f6feb;
+  text-decoration: none;
+}
+
+.paper-post .paper-cross-links a:hover {
+  text-decoration: underline;
+}

--- a/blog/assets/js/mermaid-frank.js
+++ b/blog/assets/js/mermaid-frank.js
@@ -1,0 +1,27 @@
+/* Mermaid initializer for The Frank Papers series.
+   Loaded only on pages with series: papers in frontmatter (see head-end.html). */
+(function () {
+  var script = document.createElement('script');
+  script.src = 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js';
+  script.onload = function () {
+    mermaid.initialize({
+      startOnLoad: true,
+      theme: 'base',
+      themeVariables: {
+        background: '#0d1117',
+        primaryColor: '#1e3a5f',
+        primaryTextColor: '#e6edf3',
+        primaryBorderColor: '#1f6feb',
+        lineColor: '#30a46c',
+        secondaryColor: '#161b22',
+        tertiaryColor: '#21262d',
+        edgeLabelBackground: '#0d1117',
+        clusterBkg: '#161b22',
+        titleColor: '#e6edf3',
+        fontFamily: 'ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace',
+        fontSize: '14px',
+      },
+    });
+  };
+  document.head.appendChild(script);
+})();

--- a/blog/layouts/docs/single.html
+++ b/blog/layouts/docs/single.html
@@ -4,7 +4,7 @@
   <div class='hx:mx-auto hx:flex hextra-max-page-width'>
     {{ partial "sidebar.html" (dict "context" .) }}
     {{ partial "toc.html" . }}
-    <article class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]">
+    <article class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]{{ if eq .Params.series "papers" }} paper-post{{ end }}">
       <main id="content" class="hx:w-full hx:min-w-0 hextra-max-content-width hx:px-6 hx:pt-4 hx:md:px-12">
         {{ partial "breadcrumb.html" (dict "page" . "enable" true) }}
         {{ $cover := .Resources.GetMatch "cover.*" }}

--- a/blog/layouts/partials/custom/head-end.html
+++ b/blog/layouts/partials/custom/head-end.html
@@ -6,3 +6,7 @@
 {{- end }}
 {{ $readTracker := resources.Get "js/read-tracker.js" | minify | fingerprint }}
 <script src="{{ $readTracker.RelPermalink }}" defer></script>
+{{- if eq .Params.series "papers" }}
+{{ $mermaidFrank := resources.Get "js/mermaid-frank.js" | minify | fingerprint }}
+<script src="{{ $mermaidFrank.RelPermalink }}" defer></script>
+{{- end }}

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/02.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/02.yaml
@@ -187,22 +187,22 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T06:19:06+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T06:19:06+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T06:19:06+00:00'
       note: null
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T06:19:06+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-18T06:19:07+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  2/9 — Visual system [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/278

---

## Summary

Phase 2/9 — visual system for The Frank Papers series.

- `blog/assets/js/mermaid-frank.js` — Mermaid initializer with Frank's
  brand palette (Hextra doesn't bundle Mermaid, so CDN-loaded on demand).
- `blog/layouts/partials/custom/head-end.html` — loads the Mermaid
  initializer only when `series: papers` is set in frontmatter.
- `blog/assets/css/custom.css` — appended `.paper-post` scoped block
  covering tldr, pullquote, scar, capability-matrix, dossier-link, and
  cross-links.
- `blog/layouts/docs/single.html` — adds `paper-post` body class gated
  on `series: papers` so all `.paper-post *` rules stay off Building and
  Operating pages.

Closes #278.

## Test plan

- [x] `cd blog && hugo` builds clean
- [ ] Verify Mermaid loads only on a future Papers page (series taxonomy
      exists from Phase 1; no Papers content exists yet — visual will be
      exercised when the first Paper renders)
- [ ] Verify Building/Operating pages still render with no `paper-post`
      class and no Mermaid script

🤖 Generated with [Claude Code](https://claude.com/claude-code)