### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-phase-0 · Phase 3/9 · Hugo shortcodes

### DIFF
--- a/blog/layouts/shortcodes/papers/capability-matrix.html
+++ b/blog/layouts/shortcodes/papers/capability-matrix.html
@@ -1,0 +1,33 @@
+{{ $dataFile := .Get "data" | default "vendors" }}
+{{ $vendors := .Page.Resources.GetMatch (printf "data/%s.yaml" $dataFile) }}
+{{ if $vendors }}
+  {{ $data := $vendors.Content | transform.Unmarshal }}
+  {{ if and $data $data.features $data.vendors }}
+  <div class="paper-capability-matrix">
+    <table>
+      <thead>
+        <tr>
+          <th>Feature</th>
+          {{ range $data.vendors }}<th>{{ .name }}</th>{{ end }}
+        </tr>
+      </thead>
+      <tbody>
+        {{ range $data.features }}
+        {{ $feature := .key }}
+        <tr>
+          <td>{{ .label }}</td>
+          {{ range $data.vendors }}
+            {{ $val := index .features $feature | default "—" }}
+            <td>{{ if eq $val "yes" }}✅{{ else if eq $val "partial" }}🟡{{ else if eq $val "no" }}❌{{ else }}{{ $val }}{{ end }}</td>
+          {{ end }}
+        </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  </div>
+  {{ else }}
+  <p><em>vendors.yaml missing required <code>features</code> and <code>vendors</code> keys.</em></p>
+  {{ end }}
+{{ else }}
+<p><em>No <code>data/{{ $dataFile }}.yaml</code> found in page bundle.</em></p>
+{{ end }}

--- a/blog/layouts/shortcodes/papers/dossier-link.html
+++ b/blog/layouts/shortcodes/papers/dossier-link.html
@@ -1,0 +1,10 @@
+{{ $paper := .Get "paper" }}
+{{ $baseURL := "https://github.com/derio-net/frank/blob/main/docs/papers-dossiers" }}
+<div class="paper-dossier-link">
+  📋 <strong>Research dossier:</strong>
+  <a href="{{ $baseURL }}/{{ $paper }}/dossier.md" target="_blank" rel="noopener">
+    docs/papers-dossiers/{{ $paper }}/dossier.md
+  </a>
+  — primary sources, Frank artefacts, named gaps, and counter-arguments
+  reviewed before this paper was drafted.
+</div>

--- a/blog/layouts/shortcodes/papers/landscape.html
+++ b/blog/layouts/shortcodes/papers/landscape.html
@@ -1,0 +1,7 @@
+<div class="paper-landscape">
+  {{ with .Get "title" }}<p class="paper-landscape-title"><strong>{{ . }}</strong></p>{{ end }}
+  <pre class="mermaid">
+quadrantChart
+    {{ .Inner }}
+  </pre>
+</div>

--- a/blog/layouts/shortcodes/papers/pullquote.html
+++ b/blog/layouts/shortcodes/papers/pullquote.html
@@ -1,0 +1,10 @@
+<div class="paper-pullquote">
+  <blockquote>{{ .Inner | markdownify }}</blockquote>
+  {{ with .Get "source" }}
+  <cite>
+    {{ if $.Get "url" }}<a href="{{ $.Get "url" }}" target="_blank" rel="noopener">{{ end }}
+    {{ . }}
+    {{ if $.Get "url" }}</a>{{ end }}
+  </cite>
+  {{ end }}
+</div>

--- a/blog/layouts/shortcodes/papers/scar.html
+++ b/blog/layouts/shortcodes/papers/scar.html
@@ -1,0 +1,4 @@
+<div class="paper-scar">
+  {{ with .Get "date" }}<div class="paper-scar-date">🩹 {{ . }}</div>{{ end }}
+  <div>{{ .Inner | markdownify }}</div>
+</div>

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/03.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/03.yaml
@@ -185,30 +185,30 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T07:13:59+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T07:13:59+00:00'
       note: null
     P3.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T07:14:00+00:00'
       note: null
     P3.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T07:14:00+00:00'
       note: null
     P3.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T07:14:00+00:00'
       note: null
     P3.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T07:14:00+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-18T07:14:03+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  3/9 — Hugo shortcodes [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/279

**Goal (from plan):** Ship the five Papers-only shortcodes so Paper drafts can use them.

## Summary

Adds `blog/layouts/shortcodes/papers/` with the five shortcodes the Papers series needs:

- `pullquote.html` — cited block quote, optional URL
- `scar.html` — dated correction box ("here's what we got wrong")
- `capability-matrix.html` — vendor/feature table sourced from a page-bundle `data/<name>.yaml`
- `landscape.html` — Mermaid `quadrantChart` wrapper with consistent Frank styling
- `dossier-link.html` — footer link to the committed dossier on GitHub

## Verification

- Hugo smoke test: `cd blog && hugo --buildDrafts --quiet` reports **Clean build** (no shortcode parse errors).
- Shortcodes don't render anywhere yet because Paper content using them lands in later phases — expected.

## Test plan

- [x] Hugo `--buildDrafts` clean
- [ ] Render check deferred to phases that author Paper content (`{{< papers/pullquote >}}` etc.)

Closes via `vk apply` once merged.