### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-phase-0 · Phase 7/9 · Agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Agent-neutral rules live in `agents/rules/`:
 - `repo-architecture.md`
 - `repo-blog.md`
 - `repo-manual-ops.md`
+- `repo-papers.md`
 - `repo-principles.md`
 - `repo-workflows.md`
 - `third-party-privacy.md`
@@ -50,6 +51,7 @@ read that skill's `SKILL.md` before acting.
 - `blog-post`: `agents/skills/blog-post/SKILL.md`
 - `deploy-app`: `agents/skills/deploy-app/SKILL.md`
 - `media`: `agents/skills/media/SKILL.md`
+- `papers`: `agents/skills/papers/SKILL.md`
 - `sync-runbook`: `agents/skills/sync-runbook/SKILL.md`
 - `update-readme`: `agents/skills/update-readme/SKILL.md`
 

--- a/agents/rules/repo-papers.md
+++ b/agents/rules/repo-papers.md
@@ -1,0 +1,81 @@
+## The Frank Papers — Series Rules
+
+Papers live at `blog/content/docs/papers/NN-slug/` (Hugo page bundles).
+Research dossiers live at `docs/papers-dossiers/NN-slug/dossier.md`.
+
+### Paper lifecycle
+
+1. **Scaffold** — `scripts/scaffold-paper.sh <NN> <slug>`
+   Creates the Hugo bundle skeleton and a dossier template.
+2. **Fill dossier** — edit `docs/papers-dossiers/NN-slug/dossier.md`
+   until `scripts/validate-dossier.py` passes (≥3 vendors, ≥5 sources,
+   ≥3 artefacts, ≥1 gap, ≥1 counter-argument).
+3. **Author dossier** (human gate) — user reviews named gaps and
+   counter-arguments; marks dossier `status: ready`.
+4. **Draft** — fill every `§` section of the Hugo `index.md`.
+5. **Media** — Mermaid diagrams + cover image (use `/media` skill).
+   Cover prompt: `"Frank examining [domain object] with a
+   decision-maker expression, wearing his thin black tie and round
+   reading glasses."` Add prompt to `blog/prompt_for_images.yaml`
+   under `# --- Papers Series Covers ---` section; generate with
+   `scripts/generate-all-images.py --only <key>`.
+6. **Review** — voice pass, TL;DR ≤150 words, dossier-link renders.
+7. **Publish** — set `draft: false`, set `status: published`.
+
+### Frontmatter schema
+
+Required fields: `title`, `date`, `draft`, `weight`, `series: papers`,
+`layer`, `paper_number`, `publish_order`, `status`, `tldr`, `tags`,
+`capabilities`, `related_building`, `related_operating`, `references`.
+
+### Cross-linking (bidirectional, zero retrofit)
+
+The Paper's frontmatter is the single source of truth:
+- `related_building: "docs/building/10-local-inference"` — path
+  relative to `blog/content/`
+- `related_operating: "docs/operating/07-inference"` — same
+
+`papers-backlink.html` renders a chip on Building/Operating posts at
+Hugo build time, querying pages with `series: papers`. No edits to
+existing posts needed.
+
+### Dossier format
+
+Sections (YAML blocks under `##` headers):
+- `## Vendors in scope` — list with `name`, `positioning`, `primary_url`
+- `## Primary sources` — list with `title`, `type`, `url`, `quoted_passages`, `relevance`
+- `## Frank artefacts` — list with `kind`, `path_or_url`, `date`, `demonstrates`
+- `## Diagrams planned`
+- `## Named gaps`
+- `## Counter-arguments considered`
+
+Valid source `type` values: `vendor-docs`, `paper`, `postmortem`, `talk`,
+`benchmark`.
+Valid artefact `kind` values: `grafana-screenshot`, `asciinema`, `yaml`,
+`commit`, `incident`.
+
+### Dossier vs. shortcode: avoid double-render
+
+`papers-forwardlinks.html` and a footer dossier chip are automatically
+injected by `single.html`. Do NOT also use `{{< papers/dossier-link >}}`
+inline in a Paper that relies on the automatic injection — it will render
+twice. Use the shortcode inline OR rely on automatic injection, not both.
+
+### Diagram types by section
+
+| Section | Mermaid type |
+|---------|-------------|
+| §1 stack position | `flowchart LR` |
+| §2 vendor landscape | `quadrantChart` via `{{< papers/landscape >}}` |
+| §2 capability matrix | `{{< papers/capability-matrix >}}` |
+| §3 architecture comparison | `flowchart TD` per vendor |
+| §6 decision tree | `flowchart TD` ≤4 leaves |
+
+### Commands
+
+```bash
+scripts/scaffold-paper.sh <NN> <slug>         # scaffold bundle + dossier
+python scripts/validate-dossier.py <dossier>  # gate check (exit 0 = pass)
+cd blog && hugo server --buildDrafts           # preview
+hugo --minify                                  # production build
+```

--- a/agents/skills/papers/SKILL.md
+++ b/agents/skills/papers/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: papers
+description: Write or continue a Frank Paper — enforces the dossier gate, scaffold commands, and section skeleton.
+user-invocable: true
+disable-model-invocation: false
+arguments:
+  - name: number
+    description: "Paper number (e.g. 02)"
+    required: true
+  - name: slug
+    description: "URL slug (kebab-case, e.g. local-inference)"
+    required: true
+---
+
+# papers — Write a Frank Paper
+
+Use this skill when writing or continuing a Frank Paper. Enforces the
+dossier gate and correct section skeleton.
+
+## When to use
+
+- Scaffolding a new paper (`scripts/scaffold-paper.sh`)
+- Filling a research dossier
+- Drafting paper sections
+- Generating per-paper cover image
+- Publishing (setting draft: false)
+
+## Procedure
+
+1. **Check paper number and slug** — confirm they match the TOC in the spec
+   (`docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md`).
+
+2. **Scaffold if not yet created:**
+   ```bash
+   scripts/scaffold-paper.sh <NN> <slug>
+   ```
+
+3. **Fill dossier** (`docs/papers-dossiers/NN-slug/dossier.md`):
+   - ≥3 vendors in scope
+   - ≥5 primary sources, ≥3 distinct type values
+   - All URLs reachable
+   - ≥3 Frank artefacts, ≥2 distinct kind values
+   - ≥1 named gap
+   - ≥1 counter-argument
+
+4. **Gate:** `python scripts/validate-dossier.py docs/papers-dossiers/NN-slug/dossier.md`
+   Must exit 0 before drafting begins.
+
+5. **Human gate:** Author reviews named gaps + counter-arguments.
+   Mark dossier `status: ready` when satisfied.
+
+6. **Draft** — fill every `§` section in `blog/content/docs/papers/NN-slug/index.md`.
+   Section budgets:
+   - TL;DR: ≤150 words (write last)
+   - §1: 200–350 words + 1 `flowchart LR`
+   - §2: 400–600 words + `{{< papers/landscape >}}` + `{{< papers/capability-matrix >}}`
+   - §3: 800–1400 words + 1 `flowchart TD` per vendor
+   - §4: 300–600 words + charts or ≥2 citations
+   - §5: 300–600 words + ≥1 `{{< papers/scar >}}`
+   - §6: 200–400 words + `flowchart TD` ≤4 leaves
+   - §7: 200–400 words
+
+7. **Cover image** — add prompt to `blog/prompt_for_images.yaml` under
+   `# --- Papers Series Covers ---`. Template:
+   `"Frank examining [domain object] with a decision-maker expression
+   (curious / skeptical / weighing), wearing his thin black tie and
+   round reading glasses."`
+   Generate: `scripts/generate-all-images.py --only <key>`
+
+8. **Review** — verify TL;DR ≤150 words, voice pass, dossier-link renders.
+
+9. **Publish** — set `draft: false`, `status: published`.
+   ```bash
+   cd blog && hugo --minify
+   git add blog/content/docs/papers/NN-slug/ docs/papers-dossiers/NN-slug/
+   git commit -m "docs(repo): publish Paper NN — <title>"
+   ```
+
+## Rules
+
+- TL;DR is written last, after the body has stabilized.
+- Scar callouts (`{{< papers/scar >}}`) are used 1–3× per paper.
+- `{{< papers/dossier-link >}}` inline OR automatic injection — not both.
+- `related_building` and `related_operating` use paths relative to
+  `blog/content/` (e.g., `docs/building/10-local-inference`).

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/07.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/07.yaml
@@ -217,22 +217,22 @@ tasks:
 state:
   steps:
     P7.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T08:10:32+00:00'
       note: null
     P7.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T08:11:01+00:00'
       note: null
     P7.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T08:11:40+00:00'
       note: null
     P7.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T08:11:58+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-18T08:12:05+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  7/9 — Agent docs [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/283

---

## Summary

Adds the agent-facing surface for the Frank Papers series so future
agents can pick up paper authoring without re-deriving the contract:

- `agents/rules/repo-papers.md` — series rules (lifecycle, frontmatter
  schema, cross-linking, dossier format, diagram-types-by-section,
  commands). Mirrors `repo-blog.md` but scoped to Papers.
- `agents/skills/papers/SKILL.md` — slash-command skill enforcing the
  dossier gate, scaffold/validate commands, and per-section budgets.
  Mirrors `agents/skills/blog-post/SKILL.md` shape with appropriate
  frontmatter for slash-command registration.
- `AGENTS.md` — registers `repo-papers.md` in the Shared Rule Registry
  and `papers` in the Shared Skills section.

## Test plan

- [x] `scripts/validate-agent-config.sh` passes
- [x] `scripts/validate-plans.sh` passes
- [x] Skill is discoverable (appears in Claude Code skill list as `papers`)
- [x] Plan steps P7.T1.S1, P7.T1.S2, P7.T2.S1, P7.T2.S2 ticked
- [x] Phase 7 marked complete via `vk plan edit --complete-phase 7`

Closes gh#283

🤖 Generated with [Claude Code](https://claude.com/claude-code)