### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-paper-00 · Phase 4/6 · Media fill

### DIFF
--- a/blog/content/docs/papers/00-why-homelab-in-2026/index.md
+++ b/blog/content/docs/papers/00-why-homelab-in-2026/index.md
@@ -3,7 +3,7 @@ title: "Why Run Your Own Cluster in 2026?"
 date: 2026-05-18
 draft: true
 weight: 0
-series: papers
+series: ["papers"]
 layer: repo
 paper_number: 0
 publish_order: 1

--- a/blog/prompt_for_images.yaml
+++ b/blog/prompt_for_images.yaml
@@ -169,6 +169,23 @@ images:
       - resize: {target: "blog/static/apple-touch-icon.png", size: 180}
       - ico: {target: "blog/static/favicon.ico", size: 32}
 
+  # --- Papers Series Covers --------------------------------------------------
+
+  - key: paper-00-cover
+    output: blog/content/docs/papers/00-why-homelab-in-2026/cover.png
+    description: Paper 00 cover — Frank at whiteboard with "2026?" written on it, skeptical expression
+    prompt: >-
+      Frank the server-hardware Frankenstein monster stands at a whiteboard,
+      one hand on his chin in a skeptical "weighing" expression. On the
+      whiteboard behind him: "2026?" written in large chalk letters, with
+      three branching arrows below it — one labeled "cloud", one labeled
+      "managed", one labeled "DIY". He wears thin round reading glasses
+      resting low on his nose and a thin black necktie. His posture is
+      thoughtful, not triumphant — the question is genuinely open. Warm
+      overhead lamp. Dark background. RJ45 neck bolts, green skin, messy
+      black hair, rack-mount torso. No other text in the image besides
+      what is written on the whiteboard by Frank.
+
   # --- Post Covers ------------------------------------------------------------
 
   - key: building-00-overview

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/04.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/04.yaml
@@ -97,9 +97,11 @@ state:
       ticked_at: '2026-05-18T08:10:44+00:00'
       note: null
     P4.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-18T08:22:33+00:00'
+      note: 'Deferred: Gemini gemini-3-pro-image-preview returning 503 UNAVAILABLE
+        on 7+ retries with backoff. Prompt is in place; rerun ''.venv/bin/python scripts/generate-all-images.py
+        -r blog/static/images/reference.png --only paper-00-cover'' once API is healthy.'
     P4.T2.S1:
       state: x
       ticked_at: '2026-05-18T08:12:04+00:00'
@@ -109,6 +111,8 @@ state:
       ticked_at: '2026-05-18T08:13:12+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-18T08:22:38+00:00'
+    note: 'Cover prompt added and Mermaid validation complete; cover image generation
+      deferred — Gemini image model 503 UNAVAILABLE through 7+ retries with up to
+      90s backoff. Followup task needed: rerun image gen script when API recovers.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/04.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/04.yaml
@@ -93,20 +93,20 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T08:10:44+00:00'
       note: null
     P4.T1.S2:
       state: ' '
       ticked_at: null
       note: null
     P4.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T08:12:04+00:00'
       note: null
     P4.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T08:13:12+00:00'
       note: null
   completion:
     at: null


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  4/6 — Media fill [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/289

Closes #289

**Goal (from plan):** Per-paper cover image (Frank at a whiteboard with "2026?", reading glasses + tie, skeptical) and Mermaid diagram validation across the §1 three-branch flowchart and §4 decision tree.

---

## Summary

- **P4.T1.S1 ✅** Added `paper-00-cover` entry to `blog/prompt_for_images.yaml` under a new `# --- Papers Series Covers ---` section, placed before `# --- Post Covers ---` (the natural cousin section; the plan's referenced `banner-papers-thin` / `# --- Building Series Covers ---` anchors don't yet exist in the file).
- **P4.T1.S2 ⏸ deferred** Cover image generation could not be completed: `gemini-3-pro-image-preview` returned `503 UNAVAILABLE` on **7+ attempts** with up to 90s backoff between retries. This is not a transient spike — the model is in an extended capacity outage. Rerun once the API recovers:
  ```bash
  .venv/bin/python scripts/generate-all-images.py \
    -r blog/static/images/reference.png --only paper-00-cover
  ```
- **P4.T2.S1 ✅** No `TODO:` placeholders remain in the draft.
- **P4.T2.S2 ✅** Hugo dev server renders `/docs/papers/00-why-homelab-in-2026/` with HTTP 200. Both Mermaid blocks are emitted (`<pre class="mermaid">` × 2 for the §1 three-branch flowchart and the §4 decision tree). Mermaid script tag is loaded.

## Drive-by fix

The Paper 00 frontmatter had `series: papers` (a scalar string). Hextra's `_partials/opengraph.html:82` does `{{ range $name := . }}` over `.Params.series`, which fails with `range can't iterate over papers` on a string. Fixed by changing to `series: ["papers"]`.

## Test plan

- [x] `grep -n "TODO:" blog/content/docs/papers/00-why-homelab-in-2026/index.md` returns 0 matches
- [x] `hugo server --buildDrafts` builds without errors
- [x] `curl /frank/docs/papers/00-why-homelab-in-2026/` returns HTTP 200 with two `<pre class="mermaid">` blocks and the Hextra Mermaid initializer script
- [ ] Spot-check the generated cover image once the API recovers (deferred)

## Follow-up

A small follow-up task should rerun the image-gen script. Suggested issue title: *"Paper 00: regenerate cover image once Gemini image API recovers"*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)