### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-phase-0 · Phase 5/9 · Research tooling

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,3 +17,23 @@ if [ -n "$PLAN_FILES" ]; then
   # shellcheck disable=SC2086
   "$REPO_ROOT/scripts/validate-plans.sh" $PLAN_FILES
 fi
+
+# Dossier gate: any staged Papers index.md requires a passing dossier.
+PAPER_FILES=$(git diff --cached --name-only --diff-filter=ACM \
+  | grep -E '^blog/content/docs/papers/[0-9]+-[^/]+/index\.md$' || true)
+
+if [ -n "$PAPER_FILES" ]; then
+  for PAPER_INDEX in $PAPER_FILES; do
+    # Derive dossier path from paper bundle path
+    # blog/content/docs/papers/NN-slug/index.md -> docs/papers-dossiers/NN-slug/dossier.md
+    PAPER_DIR=$(echo "$PAPER_INDEX" | sed 's|blog/content/docs/papers/||; s|/index\.md||')
+    DOSSIER_PATH="docs/papers-dossiers/${PAPER_DIR}/dossier.md"
+    if [ ! -f "$DOSSIER_PATH" ]; then
+      echo "DOSSIER GATE: no dossier found for staged paper '${PAPER_DIR}'" >&2
+      echo "  Expected: ${DOSSIER_PATH}" >&2
+      echo "  Run: scripts/scaffold-paper.sh <NN> <slug> to create it" >&2
+      exit 1
+    fi
+    "$REPO_ROOT/scripts/validate-dossier.py" "$DOSSIER_PATH"
+  done
+fi

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/05.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/05.yaml
@@ -377,26 +377,27 @@ tasks:
 state:
   steps:
     P5.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-18T09:28:48+00:00'
+      note: validate-dossier.py shipped earlier in commit e68dd36 (Paper 00 Phase
+        2)
     P5.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T09:28:49+00:00'
       note: null
     P5.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T09:28:49+00:00'
       note: null
     P5.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T09:28:49+00:00'
       note: null
     P5.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T09:28:49+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-18T09:28:53+00:00'
     note: null
     observed_prs: []

--- a/scripts/scaffold-paper.sh
+++ b/scripts/scaffold-paper.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# scaffold-paper.sh — create Hugo bundle + dossier for a new Frank Paper.
+# Usage: scripts/scaffold-paper.sh <NN> <slug>
+# Example: scripts/scaffold-paper.sh 10 self-hosted-inference
+set -euo pipefail
+
+NN="${1:?Usage: $0 <NN> <slug>}"
+SLUG="${2:?Usage: $0 <NN> <slug>}"
+PADDED="$(printf '%02d' "$NN")"
+DIR_NAME="${PADDED}-${SLUG}"
+TODAY="$(date +%Y-%m-%d)"
+
+BUNDLE_DIR="blog/content/docs/papers/${DIR_NAME}"
+DOSSIER_DIR="docs/papers-dossiers/${DIR_NAME}"
+
+if [ -e "$BUNDLE_DIR" ] || [ -e "$DOSSIER_DIR" ]; then
+  echo "ERROR: ${DIR_NAME} already exists (bundle or dossier)" >&2
+  exit 1
+fi
+
+mkdir -p "$BUNDLE_DIR/data"
+mkdir -p "$DOSSIER_DIR"
+
+# --- Hugo page bundle ---
+cat > "${BUNDLE_DIR}/index.md" <<FRONTMATTER
+---
+title: "TODO: Paper title"
+date: ${TODAY}
+draft: true
+weight: ${NN}
+series: papers
+layer: TODO
+paper_number: ${NN}
+publish_order: TODO
+status: drafting
+tldr: |
+  TODO: Three-paragraph exec summary, ≤150 words. Write this last.
+tags: ["TODO"]
+capabilities: ["TODO"]
+related_building: ""
+related_operating: ""
+references: []
+---
+
+{{< papers/dossier-link paper="${DIR_NAME}" >}}
+
+## TL;DR
+
+*Write last.*
+
+## §1 — The capability
+
+*200–350 words. 1 Mermaid flowchart LR showing stack position.*
+
+## §2 — The landscape
+
+*400–600 words. 1 quadrantChart + 1 capability-matrix.*
+
+## §3 — How each option handles the hard part
+
+*800–1400 words. 1 architecture diagram per vendor.*
+
+## §4 — What scale changes
+
+*300–600 words. Charts or ≥2 primary-source citations.*
+
+## §5 — Frank's choice, and what happened
+
+*300–600 words. ≥1 scar callout.*
+
+## §6 — When Frank's answer doesn't generalize
+
+*200–400 words. 1 decision flowchart ≤4 leaves.*
+
+## §7 — Roadmap & where this space is going
+
+*200–400 words.*
+
+## References
+
+*Auto-rendered from frontmatter by Hugo taxonomy.*
+FRONTMATTER
+
+# --- Research dossier ---
+cat > "${DOSSIER_DIR}/dossier.md" <<DOSSIER
+---
+paper: ${DIR_NAME}
+status: draft
+---
+
+## Vendors in scope (≥3, typically 4–6)
+- name: TODO
+  positioning: "one-line claim from their own marketing"
+  primary_url: "https://TODO"
+
+## Primary sources (≥5, ≥3 distinct type values)
+- title: "TODO"
+  type: vendor-docs
+  url: "https://TODO"
+  quoted_passages: []
+  relevance: "one sentence"
+
+## Frank artefacts (≥3, ≥2 distinct kind values)
+- kind: yaml
+  path_or_url: "TODO"
+  date: ${TODAY}
+  demonstrates: "one sentence"
+
+## Diagrams planned
+- landscape:
+    x_axis: "TODO ↔ TODO"
+    y_axis: "TODO ↔ TODO"
+    vendors_plotted: []
+- architecture_comparison:
+    vendors: []
+- decision_tree:
+    leaves: 4
+
+## Named gaps (≥1)
+- "TODO: gap description"
+
+## Counter-arguments considered (≥1)
+- "TODO: counter-argument"
+DOSSIER
+
+echo "Scaffolded Paper ${NN}:"
+echo "  Hugo bundle:  ${BUNDLE_DIR}/"
+echo "  Dossier:      ${DOSSIER_DIR}/dossier.md"
+echo ""
+echo "Next steps:"
+echo "  1. Edit ${DOSSIER_DIR}/dossier.md — fill vendors, sources, artefacts"
+echo "  2. python scripts/validate-dossier.py ${DOSSIER_DIR}/dossier.md"
+echo "  3. Draft ${BUNDLE_DIR}/index.md"


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  5/9 — Research tooling [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/281

**Goal (from plan):** Ship the Papers research toolchain — `scripts/validate-dossier.py`, `scripts/scaffold-paper.sh`, and the pre-commit dossier gate — so no Paper can land without a passing dossier.

## Summary

- `scripts/scaffold-paper.sh` — creates a Hugo page bundle + research dossier from templates (`scaffold-paper.sh <NN> <slug>`), with idempotency guard
- `.githooks/pre-commit` — new dossier gate that fires when any `blog/content/docs/papers/NN-*/index.md` is staged; blocks the commit if `docs/papers-dossiers/NN-*/dossier.md` is missing or fails validation
- `scripts/validate-dossier.py` — already shipped in commit e68dd36 as part of Paper 00 Phase 2; reused unchanged (the validator was lifted directly from this plan's spec). Step P5.T1.S1 ticked with a note pointing at the prior commit.

## Test plan

- [x] `validate-dossier.py` smoke-tested against `docs/papers-dossiers/00-why-homelab-in-2026/dossier.md` → PASSED, exit 0
- [x] `validate-dossier.py` smoke-tested against missing path → exit 1, `ERROR: ... not found`
- [x] `scaffold-paper.sh 99 test-dummy` creates both the bundle and dossier; second invocation errors with `already exists`
- [x] Pre-commit gate fail-case: staging a `blog/content/docs/papers/99-test-dummy/index.md` without the dossier blocks the commit with the expected `DOSSIER GATE: no dossier found` message and exit 1
- [x] Pre-commit gate pass-case: staging the same alongside a valid dossier commits cleanly

Closes #281
