### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-phase-0 · Phase 4/9 · Cross-series partials

### DIFF
--- a/blog/layouts/docs/single.html
+++ b/blog/layouts/docs/single.html
@@ -22,6 +22,12 @@
           {{ end }}
           {{ .Content }}
         </div>
+        {{- if eq .Params.series "papers" }}
+          {{- partial "papers-forwardlinks.html" . }}
+          {{- partial "papers/dossier-link.html" . }}
+        {{- else if and (ne .Params.series "papers") (not (eq .Section "")) }}
+          {{- partial "papers-backlink.html" . }}
+        {{- end }}
         {{ partial "components/last-updated.html" . }}
         {{- if (site.Params.page.displayPagination | default true) -}}
           {{- partial "components/pager.html" . -}}

--- a/blog/layouts/partials/papers-backlink.html
+++ b/blog/layouts/partials/papers-backlink.html
@@ -1,0 +1,20 @@
+{{/* papers-backlink.html — included in single.html for non-Papers docs pages.
+     Finds any Paper whose related_building or related_operating matches
+     the current page's relative path, and renders a chip. */}}
+{{ $currentPath := .RelPermalink | strings.TrimSuffix "/" }}
+{{ $matchedPaper := false }}
+{{ range where .Site.Pages "Params.series" "papers" }}
+  {{ $buildingRef := .Params.related_building | default "" }}
+  {{ $operatingRef := .Params.related_operating | default "" }}
+  {{ if or (strings.Contains $currentPath $buildingRef) (strings.Contains $currentPath $operatingRef) }}
+    {{ if $buildingRef | or $operatingRef }}
+      {{ $matchedPaper = . }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+{{ with $matchedPaper }}
+<div class="paper-cross-links">
+  <span>🔬 Decision-level view:</span>
+  <a href="{{ .RelPermalink }}">Paper {{ .Params.paper_number | printf "%02d" }} — {{ .Title }}</a>
+</div>
+{{ end }}

--- a/blog/layouts/partials/papers-forwardlinks.html
+++ b/blog/layouts/partials/papers-forwardlinks.html
@@ -1,0 +1,22 @@
+{{/* papers-forwardlinks.html — included in single.html for Papers pages.
+     Renders forward links to related Building and Operating posts from
+     Paper frontmatter. */}}
+{{ $buildingRef := .Params.related_building | default "" }}
+{{ $operatingRef := .Params.related_operating | default "" }}
+{{ if or $buildingRef $operatingRef }}
+<div class="paper-cross-links">
+  <span>🔧 Hands-on:</span>
+  {{ with $buildingRef }}
+    {{ $page := $.Site.GetPage . }}
+    {{ with $page }}
+    <a href="{{ .RelPermalink }}">Building — {{ .Title }}</a>
+    {{ end }}
+  {{ end }}
+  {{ with $operatingRef }}
+    {{ $page := $.Site.GetPage . }}
+    {{ with $page }}
+    <a href="{{ .RelPermalink }}">Operating — {{ .Title }}</a>
+    {{ end }}
+  {{ end }}
+</div>
+{{ end }}

--- a/blog/layouts/partials/papers/dossier-link.html
+++ b/blog/layouts/partials/papers/dossier-link.html
@@ -1,0 +1,20 @@
+{{/* papers/dossier-link.html — automatic footer chip for Papers pages.
+     Reads the dossier directory from the page bundle's folder name
+     (e.g., `00-why-homelab-in-2026`). Mirrors the inline shortcode
+     `papers/dossier-link.html`; do NOT use both inline and automatic
+     injection in the same Paper or the chip renders twice. */}}
+{{ $dir := "" }}
+{{ with .File }}
+  {{ $dir = path.Base .Dir }}
+{{ end }}
+{{ with $dir }}
+{{ $baseURL := "https://github.com/derio-net/frank/blob/main/docs/papers-dossiers" }}
+<div class="paper-dossier-link">
+  📋 <strong>Research dossier:</strong>
+  <a href="{{ $baseURL }}/{{ . }}/dossier.md" target="_blank" rel="noopener">
+    docs/papers-dossiers/{{ . }}/dossier.md
+  </a>
+  — primary sources, Frank artefacts, named gaps, and counter-arguments
+  reviewed before this paper was drafted.
+</div>
+{{ end }}

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/04.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/04.yaml
@@ -130,22 +130,26 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T09:30:25+00:00'
       note: null
     P4.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T09:30:25+00:00'
       note: null
     P4.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T09:30:25+00:00'
       note: null
     P4.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-18T09:30:25+00:00'
+      note: 'Verified via ''hugo --buildDrafts'' + curl on built HTML; /docs/building/10-local-inference
+        renders 0 cross-links (expected); /docs/building/01-introduction renders the
+        Paper 00 backlink chip. Dev server is blocked by a pre-existing Hextra opengraph
+        bug (''series: papers'' string vs. list expected) in Paper 00''s frontmatter
+        — out of Phase 4 scope.'
   completion:
-    at: null
+    at: '2026-05-18T09:30:29+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  4/9 — Cross-series partials [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/280

**Goal (from plan):** Wire Papers ↔ Building/Operating posts at render time, without writing back to existing content.

---

## Summary

- Adds `blog/layouts/partials/papers-backlink.html` — renders a "🔬 Decision-level view" chip on Building/Operating pages that a Paper points at via `related_building` / `related_operating`. Pure read-time query over `.Site.Pages` filtered by `series: papers`; no edits to existing posts.
- Adds `blog/layouts/partials/papers-forwardlinks.html` — renders "🔧 Hands-on" chips on Paper pages linking to the matching Building/Operating posts.
- Adds `blog/layouts/partials/papers/dossier-link.html` — automatic footer chip that derives the dossier directory from the page bundle's folder name. Mirrors the inline shortcode `papers/dossier-link.html`; using both inline AND automatic injection on the same Paper renders the chip twice. (The "document this in `agents/rules/repo-papers.md`" note from the plan is intentionally deferred — Phase 7 creates that file.)
- Wires all three into `blog/layouts/docs/single.html`: forwardlinks + dossier on Papers, backlink on non-Papers section pages.

## Test plan

- [x] `hugo --buildDrafts` succeeds for non-Papers pages.
- [x] `/docs/building/10-local-inference/` (no Paper points here) → 0 cross-links rendered.
- [x] `/docs/building/01-introduction/` (Paper 00's `related_building`) → renders the Paper 00 backlink chip exactly once.
- [ ] Verify forwardlinks + dossier render on the Papers page itself — currently blocked by a pre-existing Hextra opengraph bug in Paper 00's frontmatter (`series: papers` is a string, but Hextra's `_partials/opengraph.html` does `range $name := .` over it). Reproducible on `origin/main` with this PR's changes stashed. Out of Phase 4 scope; suggested fix is to change `series: papers` → `series: [papers]` in Paper 00's frontmatter in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)