### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-phase-0 · Phase 8/9 · Validation & completion

### DIFF
--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/08.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/08.yaml
@@ -140,30 +140,31 @@ tasks:
 state:
   steps:
     P8.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T10:17:14+00:00'
       note: null
     P8.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T10:17:14+00:00'
       note: null
     P8.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T10:17:14+00:00'
       note: null
     P8.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T10:17:14+00:00'
       note: null
     P8.T3.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-18T10:17:14+00:00'
+      note: vk plan spec-index subcommand does not exist; spec table already populated
+        by vk plan create
     P8.T3.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T10:17:28+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-18T10:17:28+00:00'
     note: null
     observed_prs: []

--- a/scripts/validate-dossier.py
+++ b/scripts/validate-dossier.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate a Frank Papers research dossier against the gate rules.
+
+Usage: python scripts/validate-dossier.py <dossier.md>
+
+Exit 0 = pass. Exit 1 = fail (prints specific failures).
+"""
+import sys
+import re
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML required. Run: pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+
+def check_url(url: str) -> bool:
+    try:
+        req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "vk-dossier-validator/1.0"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status < 400
+    except Exception:
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": "vk-dossier-validator/1.0"})
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                return resp.status < 400
+        except Exception:
+            return False
+
+
+def validate(path: Path) -> list[str]:
+    text = path.read_text()
+    # Strip YAML frontmatter if present
+    fm_match = re.match(r'^---\n(.*?)\n---\n', text, re.DOTALL)
+    if fm_match:
+        text = text[fm_match.end():]
+
+    # Parse sections as YAML blocks delimited by ## headers
+    # Each ## section becomes a top-level key
+    sections: dict = {}
+    current_key = None
+    current_lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## "):
+            if current_key:
+                try:
+                    sections[current_key] = yaml.safe_load("\n".join(current_lines)) or []
+                except yaml.YAMLError:
+                    sections[current_key] = current_lines
+            current_key = line[3:].strip().lower().replace(" ", "_").replace("(", "").replace(")", "")
+            current_lines = []
+        elif current_key is not None:
+            current_lines.append(line)
+    if current_key:
+        try:
+            sections[current_key] = yaml.safe_load("\n".join(current_lines)) or []
+        except yaml.YAMLError:
+            sections[current_key] = current_lines
+
+    failures: list[str] = []
+
+    # Rule 1: vendors_in_scope >= 3
+    vendors = sections.get("vendors_in_scope_≥3,_typically_4–6", sections.get("vendors_in_scope", []))
+    if not isinstance(vendors, list) or len(vendors) < 3:
+        failures.append(f"vendors_in_scope: need ≥3, got {len(vendors) if isinstance(vendors, list) else 0}")
+
+    # Rule 2: primary_sources >= 5, spanning >= 3 distinct type values
+    sources = sections.get("primary_sources_≥5,_≥3_distinct_type_values", sections.get("primary_sources", []))
+    if not isinstance(sources, list) or len(sources) < 5:
+        failures.append(f"primary_sources: need ≥5, got {len(sources) if isinstance(sources, list) else 0}")
+    else:
+        types = set()
+        for s in sources:
+            if isinstance(s, dict):
+                types.add(s.get("type", ""))
+        if len(types) < 3:
+            failures.append(f"primary_sources: need ≥3 distinct type values, got {len(types)}: {types}")
+
+    # Rule 3: all primary_sources[].url return HTTP 200
+    if isinstance(sources, list):
+        for s in sources:
+            if isinstance(s, dict):
+                url = s.get("url", "")
+                if url and not check_url(url):
+                    failures.append(f"primary_sources URL not reachable (non-200): {url}")
+
+    # Rule 4: frank_artefacts >= 3, spanning >= 2 distinct kind values
+    artefacts = sections.get("frank_artefacts_≥3,_≥2_distinct_kind_values", sections.get("frank_artefacts", []))
+    if not isinstance(artefacts, list) or len(artefacts) < 3:
+        failures.append(f"frank_artefacts: need ≥3, got {len(artefacts) if isinstance(artefacts, list) else 0}")
+    else:
+        kinds = set()
+        for a in artefacts:
+            if isinstance(a, dict):
+                kinds.add(a.get("kind", ""))
+        if len(kinds) < 2:
+            failures.append(f"frank_artefacts: need ≥2 distinct kind values, got {len(kinds)}: {kinds}")
+
+    # Rule 5: named_gaps >= 1
+    gaps = sections.get("named_gaps_≥1", sections.get("named_gaps", []))
+    if not isinstance(gaps, list) or len(gaps) < 1:
+        failures.append("named_gaps: need ≥1")
+
+    # Rule 6: counter_arguments_considered >= 1
+    counters = sections.get("counter-arguments_considered_≥1", sections.get("counter-arguments_considered", []))
+    if not isinstance(counters, list) or len(counters) < 1:
+        failures.append("counter-arguments_considered: need ≥1")
+
+    return failures
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <dossier.md>", file=sys.stderr)
+        sys.exit(1)
+    dossier_path = Path(sys.argv[1])
+    if not dossier_path.exists():
+        print(f"ERROR: {dossier_path} not found", file=sys.stderr)
+        sys.exit(1)
+    failures = validate(dossier_path)
+    if failures:
+        print(f"DOSSIER GATE FAILED: {dossier_path}", file=sys.stderr)
+        for f in failures:
+            print(f"  ✗ {f}", file=sys.stderr)
+        sys.exit(1)
+    print(f"DOSSIER GATE PASSED: {dossier_path}")
+    sys.exit(0)


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  8/9 — Validation & completion [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/284

**Goal (from plan):** Hugo build clean, pre-commit hook test, vk plan spec-index, final commit. Depends on all prior phases.

---

## Summary

Phase 8 validates the toolchain delivered by phases 1–7 of frank-papers-phase-0.

- ✅ **P8.T1.S1** — `hugo --buildDrafts` produces 0 `ERROR` lines (72 pages built)
- ✅ **P8.T1.S2** — Papers section + landing page spot-checks pass (title, 10 cards ≥ 3, nav entry present)
- ✅ **P8.T2.S1** — Pre-commit dossier gate correctly blocks the scaffolded stub paper (all three `_in_scope` counts flagged)
- ✅ **P8.T3.S1** — `validate-agent-config.sh` exits 0
- ⏭ **P8.T3.S2** — `vk plan spec-index` subcommand does not exist in current `vk` build; the spec's Implementation Plans table was already populated when `vk plan create` scaffolded this plan, so the intent is satisfied
- ✅ **P8.T3.S3** — This commit

## Restored `scripts/validate-dossier.py`

The validator was originally shipped in commit `e68dd36` (Paper 00 Phase 2 — gate validation) and silently lost in the Paper 00 revert (`3cd2f78`). Phase 5's commit message (`8cffaca`) explicitly assumed the script would persist:

> Companion validate-dossier.py was already shipped in commit e68dd36 (Paper 00 Phase 2) and is reused unchanged.

…but the revert removed the script alongside the Paper 00 content. Without it, the pre-commit hook's dossier gate exits with `ERROR: PyYAML required` (because the script can't even start) — and worse, with a missing interpreter would fail with `No such file`, not a clean gate failure. This PR restores the file byte-identical to `e68dd36`; only its provenance moves into Phase 0 where it belongs.

## Test plan

- [x] `cd blog && hugo --buildDrafts` — clean
- [x] Hugo server spot-checks (Papers landing, card count, nav)
- [x] Scaffold + stage stub paper → pre-commit hook fails with `DOSSIER GATE FAILED`
- [x] `scripts/validate-agent-config.sh` exits 0
- [x] `vk plan edit … --complete-phase 8` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)