### PR TITLE
fix(blog): escape Hugo shortcode references in Phase 9 prose

### DIFF
--- a/blog/content/docs/building/30-frank-papers/index.md
+++ b/blog/content/docs/building/30-frank-papers/index.md
@@ -136,7 +136,7 @@ The Hextra theme's section system is per-directory; `blog/content/docs/papers/` 
 
 The Papers nav entry sits between Operating and the GitHub link, weight 3, no submenu. Section landing lives at `/docs/papers/_index.md` with a title, a one-sentence positioning statement, and (when paginated) a list of papers by `paper_number`. Right now it says "First paper coming soon." in production. That's the truthful state.
 
-The site-root `_index.md` was rewritten from a custom `frank-series-cards` shortcode block to native Hextra `{{< cards >}}` / `{{< card >}}` shortcodes — three cards instead of two, with the Papers card pointing at `/docs/papers/`. This was a quiet rebase of the spec, written when the landing was still on a bespoke shortcode. The blog had been refactored to Hextra-native cards in the interim, so Phase 0 followed the new pattern instead of preserving the old one.
+The site-root `_index.md` was rewritten from a custom `frank-series-cards` shortcode block to native Hextra `{{</* cards */>}}` / `{{</* card */>}}` shortcodes — three cards instead of two, with the Papers card pointing at `/docs/papers/`. This was a quiet rebase of the spec, written when the landing was still on a bespoke shortcode. The blog had been refactored to Hextra-native cards in the interim, so Phase 0 followed the new pattern instead of preserving the old one.
 
 ## Visual System — Mermaid Frank Theme and the `.paper-post` Scope
 
@@ -165,7 +165,7 @@ That theme only applies on pages with the `paper-post` body class. The class is 
 <body class="{{ if $isPaper }}paper-post{{ end }}">
 ```
 
-Same gate carries the matching CSS scope. `.paper-post` rules in `blog/assets/css/custom.css` give Papers slightly tighter type, denser tables, a different blockquote treatment for `{{< papers/pullquote >}}`, and the visual styling for `{{< papers/scar >}}` callouts. Building and Operating posts don't inherit any of it — `body.paper-post` only matches Papers pages.
+Same gate carries the matching CSS scope. `.paper-post` rules in `blog/assets/css/custom.css` give Papers slightly tighter type, denser tables, a different blockquote treatment for `{{</* papers/pullquote */>}}`, and the visual styling for `{{</* papers/scar */>}}` callouts. Building and Operating posts don't inherit any of it — `body.paper-post` only matches Papers pages.
 
 The point is *consistency across the corpus, isolation from the rest of the site*. The day a reader lands on Paper 04 from a search result, every other Paper they click feels familiar. The day they navigate to a Building post from a Paper, the visual language returns to the build-journal voice without bleed-through.
 
@@ -312,7 +312,7 @@ The lesson is small and old: a paper can't depend on infrastructure that isn't y
 Two quiet rebases between the spec (2026-04-15) and Phase 0 (2026-05-16):
 
 - The blog was refactored in the interim. Rules now live in `agents/rules/` (not `.claude/rules/`); skills now live in `agents/skills/` (not `.claude/skills/`). The spec's references to those paths were translated as Phase 0 went in.
-- The landing-page cards were rewritten to native Hextra `{{< cards >}}` / `{{< card >}}` shortcodes. The spec had assumed a custom `frank-series-cards` block. Phase 0 followed the new convention, three cards under the same `{{< cards >}}` parent.
+- The landing-page cards were rewritten to native Hextra `{{</* cards */>}}` / `{{</* card */>}}` shortcodes. The spec had assumed a custom `frank-series-cards` block. Phase 0 followed the new convention, three cards under the same `{{</* cards */>}}` parent.
 
 Neither rebase changed the *what* — three series, dossier gate, cross-series linking, Mermaid Frank theme. They changed where the files landed and which shortcode wrapper the cards used. Both are noted at the top of `_prose.md` so future re-readers of the plan see the deltas immediately.
 
@@ -326,8 +326,8 @@ The cluster will, as ever, have opinions. Now it has the format for them.
 
 ## References
 
-- [Spec — The Frank Papers]({{< ref "" >}}) — `docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md`
-- [Plan — Phase 0 Tooling]({{< ref "" >}}) — `docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/`
+- **Spec — The Frank Papers** — `docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md`
+- **Plan — Phase 0 Tooling** — `docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/`
 - [Hextra theme](https://imfing.github.io/hextra/) — taxonomies, cards, custom CSS scoping
 - [Mermaid theming guide](https://mermaid.js.org/config/theming.html) — `themeVariables` schema
 - [Operating The Frank Papers]({{< relref "/docs/operating/25-frank-papers" >}}) — companion operating post (research-and-publish workflow)

--- a/blog/content/docs/operating/25-frank-papers/index.md
+++ b/blog/content/docs/operating/25-frank-papers/index.md
@@ -41,7 +41,7 @@ The Hugo bundle lands with:
 - Frontmatter pre-populated (`title:`, `paper_number: 4`, `series: papers`, `status: draft`, empty `tldr`, empty `tags`, empty `capabilities`, empty `references`).
 - §1 Stack position, §2 Vendor landscape, §3 Architecture comparison, §4 Operational evidence, §5 Decision rubric, §6 Return to Frank's choice — each with a placeholder paragraph.
 - Mermaid diagram placeholders in the sections that need them (§1 `flowchart LR`, §2 the `landscape` shortcode, §3 per-vendor `flowchart TD`, §6 the decision tree).
-- A `{{< papers/dossier-link >}}` placeholder — **commented out by default**, because `single.html` injects one automatically (see *Don't render the dossier chip twice* below).
+- A `{{</* papers/dossier-link */>}}` placeholder — **commented out by default**, because `single.html` injects one automatically (see *Don't render the dossier chip twice* below).
 
 The dossier lands with the six required section headers and stub entries:
 
@@ -154,12 +154,12 @@ The diagram types by section live in `agents/rules/repo-papers.md`. Use the righ
 
 ## Don't Render the Dossier Chip Twice
 
-`single.html` automatically injects a footer chip pointing to the paper's dossier on every Papers page. **If you also use `{{< papers/dossier-link >}}` inline in the body, the chip renders twice.**
+`single.html` automatically injects a footer chip pointing to the paper's dossier on every Papers page. **If you also use `{{</* papers/dossier-link */>}}` inline in the body, the chip renders twice.**
 
 Two patterns, pick one:
 
 - **Default (recommended):** rely on the auto-injected footer chip. Leave the inline shortcode commented out in `index.md`.
-- **Inline:** use `{{< papers/dossier-link >}}` near §1 to make the dossier discoverable above the fold. If you do this, **remove the auto-injection** for this paper by setting `dossier_link_auto: false` in frontmatter (it overrides the default `single.html` behaviour for this page only).
+- **Inline:** use `{{</* papers/dossier-link */>}}` near §1 to make the dossier discoverable above the fold. If you do this, **remove the auto-injection** for this paper by setting `dossier_link_auto: false` in frontmatter (it overrides the default `single.html` behaviour for this page only).
 
 This is captured in `agents/rules/repo-papers.md` and is the most common authoring footgun.
 
@@ -250,7 +250,7 @@ cd blog && hugo --buildDrafts 2>&1 | tee /tmp/hugo-build.log | tail -10
 grep -cE "^ERROR" /tmp/hugo-build.log
 ```
 
-Expected: zero errors. The most common Phase 0 break was a malformed shortcode call — `{{< papers/landscape title="…" axes="…" >}}` with mismatched quotes inside the `vendors` argument. Fix the quote escaping; rerun.
+Expected: zero errors. The most common Phase 0 break was a malformed shortcode call — `{{</* papers/landscape title="…" axes="…" */>}}` with mismatched quotes inside the `vendors` argument. Fix the quote escaping; rerun.
 
 ## Publishing
 


### PR DESCRIPTION
## Summary

Hotfix for the live blog deploy. The Phase 9 merge (#313 as 9d41736) broke `deploy-blog.yml` on main: Hugo parses `{{< ... >}}` tokens as live shortcodes regardless of whether they're inside markdown backticks. The build failed on `building/30-frank-papers/index.md:139` with:

```
ERROR error building site: assemble: failed to create page from pageMetaSource
  /docs/building/30-frank-papers:
  shortcode "cards" must be closed or self-closed
```

Affected `deploy-blog.yml` run: https://github.com/derio-net/frank/actions/runs/26040999046 (failure on the merge commit). Production blog is currently on the pre-Phase-9 image (`ghcr.io/derio-net/blog:a6a83cb...`), so Building 30 / Operating 25 / the new banner-papers / refreshed favicon are all not yet live.

## Fix

Applied the Hugo escape syntax `{{</* ... */>}}` to every *illustrative* shortcode reference in the Phase 9 posts:

**building/30-frank-papers/index.md**
- L139: `{{< cards >}}` / `{{< card >}}`
- L168: `{{< papers/pullquote >}}` / `{{< papers/scar >}}`
- L315: `{{< cards >}}` / `{{< card >}}` (×3)
- L329–330: removed `[…]({{< ref "" >}})` markdown links — the referenced specs/plans live outside `blog/content/` so Hugo can't resolve them anyway; demoted to plain bold + backticked path.

**operating/25-frank-papers/index.md**
- L44, L157, L162: `{{< papers/dossier-link >}}`
- L253: `{{< papers/landscape … >}}`

Legitimate `{{< relref "/docs/…" >}}` calls (used to render actual working links between Phase 9 posts) are unchanged.

## Test plan

- [x] grep for any remaining unescaped `{{< [^/]` patterns in the two posts — only `relref` to existing pages remain
- [ ] CI on this PR builds clean
- [ ] After merge: `deploy-blog.yml` succeeds on main; manifest at `clusters/hop/apps/blog/manifests/deployment.yaml` gets auto-bumped past `a6a83cb`
- [ ] Hop cluster ArgoCD syncs the new image
- [ ] `curl -sI https://blog.derio.net/frank/docs/building/30-frank-papers/` returns 200 with current `last-modified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)