### PR TITLE
fix(blog): correct /docs/operating relref target

### DIFF
--- a/blog/content/docs/building/30-frank-papers/index.md
+++ b/blog/content/docs/building/30-frank-papers/index.md
@@ -7,7 +7,7 @@ summary: "A third blog series — research-grade landscape reviews framed as dec
 weight: 31
 ---
 
-The cluster has two voices already. The [Building series]({{< relref "/docs/building/00-overview" >}}) answers *how* — step by step, with the manifests and the gotchas. The [Operating series]({{< relref "/docs/operating/00-overview" >}}) answers *how to run* — day-to-day commands, the wrong things to type, what to check first when the page goes red. Neither answers *why this and not the other twelve options*. That's the gap the third series fills.
+The cluster has two voices already. The [Building series]({{< relref "/docs/building/00-overview" >}}) answers *how* — step by step, with the manifests and the gotchas. The [Operating series]({{< relref "/docs/operating" >}}) answers *how to run* — day-to-day commands, the wrong things to type, what to check first when the page goes red. Neither answers *why this and not the other twelve options*. That's the gap the third series fills.
 
 **The Frank Papers** are research-grade landscape reviews. Each paper maps the vendor space for one capability, grades the options against criteria a staff engineer or CTO actually brings to the table, then returns to Frank's choice as a worked case study — honest about where that choice wouldn't generalize. Every paper carries a ≤150-word TL;DR up front, so an engineering manager reading over a shoulder gets the conclusion without scrolling.
 


### PR DESCRIPTION
## Summary

Second hotfix for the live blog deploy. The escape-syntax fix in #314 unblocked Hugo's shortcode parse stage, but the next stage surfaced a second bug in the same line of `building/30-frank-papers/index.md`:

```
ERROR [en] REF_NOT_FOUND: Ref "/docs/operating/00-overview":
  blog/content/docs/building/30-frank-papers/index.md:10:195": page not found
```

Operating has no `00-overview/` directory — only `blog/content/docs/operating/_index.md` at the section root. Changed line 10's `{{< relref "/docs/operating/00-overview" >}}` to `{{< relref "/docs/operating" >}}`, which Hugo resolves to the section's `_index.md`.

Affected `deploy-blog.yml` run: https://github.com/derio-net/frank/actions/runs/26044152061 (failure after #314 merge).

Local existence check confirmed all other relrefs in the two Phase 9 posts resolve:
- `/docs/operating` → ✓ (_index.md)
- `/docs/building/00-overview` → ✓
- `/docs/building/30-frank-papers` → ✓
- `/docs/operating/25-frank-papers` → ✓

## Test plan

- [ ] CI on this PR builds clean
- [ ] After merge: `deploy-blog.yml` succeeds on main
- [ ] `clusters/hop/apps/blog/manifests/deployment.yaml` auto-bumped past `a6a83cb`
- [ ] Hop cluster ArgoCD picks up the new image
- [ ] `curl -sI https://blog.derio.net/frank/docs/building/30-frank-papers/` returns 200 with current `last-modified`

🤖 Generated with [Claude Code](https://claude.com/claude-code)