### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-paper-00 · Phase 3/6 · Scaffold + draft

### DIFF
--- a/blog/content/docs/papers/00-why-homelab-in-2026/data/approaches.yaml
+++ b/blog/content/docs/papers/00-why-homelab-in-2026/data/approaches.yaml
@@ -1,0 +1,33 @@
+features:
+  - key: capital_cost
+    label: Low capital cost
+  - key: ops_burden
+    label: Low ops burden
+  - key: failure_visibility
+    label: Failure-mode visibility
+  - key: ai_inference
+    label: Local AI inference
+  - key: learning_depth
+    label: Learning depth
+vendors:
+  - name: Cloud-native
+    features:
+      capital_cost: "yes"
+      ops_burden: "yes"
+      failure_visibility: "no"
+      ai_inference: "partial"
+      learning_depth: "no"
+  - name: Managed homelab
+    features:
+      capital_cost: "no"
+      ops_burden: "partial"
+      failure_visibility: "partial"
+      ai_inference: "yes"
+      learning_depth: "partial"
+  - name: DIY homelab
+    features:
+      capital_cost: "no"
+      ops_burden: "no"
+      failure_visibility: "yes"
+      ai_inference: "yes"
+      learning_depth: "yes"

--- a/blog/content/docs/papers/00-why-homelab-in-2026/index.md
+++ b/blog/content/docs/papers/00-why-homelab-in-2026/index.md
@@ -1,56 +1,240 @@
 ---
-title: "TODO: Paper title"
+title: "Why Run Your Own Cluster in 2026?"
 date: 2026-05-18
 draft: true
-weight: 00
-series: papers
-layer: TODO
-paper_number: 00
-publish_order: TODO
+weight: 0
+series: ["papers"]
+layer: repo
+paper_number: 0
+publish_order: 1
 status: drafting
 tldr: |
-  TODO: Three-paragraph exec summary, ≤150 words. Write this last.
-tags: ["TODO"]
-capabilities: ["TODO"]
-related_building: ""
-related_operating: ""
-references: []
+  Three philosophies dominate infrastructure decisions in 2026: cloud
+  (pay the bill, ignore the metal), managed homelab-as-code (own the
+  iron, outsource lifecycle), and DIY homelab (own everything,
+  including the failure modes). Each carries a real cost the marketing
+  doesn't print: cloud's is the rent, managed's is permanent SaaS
+  dependency, DIY's is operator time — dominant and undercounted.
+  Frank is the third branch, and the cost has been thirty-something
+  building posts to assemble a cluster anyone could have rented in six
+  minutes. In return: a scar archive a managed cluster cannot teach.
+  This paper maps the trade, then is honest about where Frank's answer
+  doesn't generalize — most readers should be running the middle
+  branch.
+tags: ["homelab", "kubernetes", "talos", "architecture"]
+capabilities: ["hw", "os", "gitops"]
+related_building: "docs/building/01-introduction"
+related_operating: "docs/operating/01-cluster-nodes"
+references:
+  - title: "Leaving the Cloud — 37signals Cloud Exit case study"
+    url: "https://basecamp.com/cloud-exit"
+    type: benchmark
+  - title: "Simon Willison — LLM pricing notes"
+    url: "https://simonwillison.net/tags/llm-pricing/"
+    type: postmortem
+  - title: "Do you need Omni? — Sidero Labs"
+    url: "https://www.siderolabs.com/blog/do-you-need-omni"
+    type: vendor-docs
+  - title: "Kubernetes 101 — Jeff Geerling video series"
+    url: "https://kube101.jeffgeerling.com/"
+    type: talk
+  - title: "AKS vs EKS vs GKE: What you get with managed Kubernetes-as-a-Service — Fairwinds"
+    url: "https://www.fairwinds.com/blog/aks-eks-gke-managed-kubernetes-as-a-service"
+    type: talk
 ---
-
-{{< papers/dossier-link paper="00-why-homelab-in-2026" >}}
 
 ## TL;DR
 
-*Write last.*
+Three philosophies dominate infrastructure decisions in 2026: cloud (pay
+the bill, ignore the metal), managed homelab-as-code (own the iron,
+outsource lifecycle), and DIY homelab (own everything, including the
+failure modes). Each carries a real cost the marketing doesn't print:
+cloud's is the rent, managed's is permanent SaaS dependency, DIY's is
+operator time — dominant and undercounted. Frank is the third branch,
+and the cost has been thirty-something building posts to assemble a
+cluster anyone could have rented in six minutes. In return: a scar
+archive a managed cluster cannot teach. This paper maps the trade,
+then is honest about where Frank's answer doesn't generalize — most
+readers should be running the middle branch.
 
-## §1 — The capability
+## §1 — The question
 
-*200–350 words. 1 Mermaid flowchart LR showing stack position.*
+A senior engineer sits down to plan a new infrastructure project. The
+first question on the whiteboard is rarely "Kubernetes or Nomad?" or
+"Postgres or Mongo?" The first question — answered in two seconds and never revisited —
+is: *who owns this machine?*
 
-## §2 — The landscape
+```mermaid
+flowchart LR
+    Q["Who owns\nthe hardware?"] --> A["Cloud provider"]
+    Q --> B["You + SaaS\ncontrol plane"]
+    Q --> C["You, entirely"]
+    A --> A1["GKE / EKS / AKS"]
+    B --> B1["k3s + Omni\nor Rancher"]
+    C --> C1["Talos + ArgoCD\n= Frank"]
+```
 
-*400–600 words. 1 quadrantChart + 1 capability-matrix.*
+I'm Frank, and I live on the right-hand branch: three Intel NUCs, one
+GPU box, an old desktop, two Raspberry Pis — Talos Linux, declared in
+a git repo, reconciled by ArgoCD. Nothing about this is the *obvious*
+answer. The obvious answer in 2026 is `gcloud container clusters
+create` and a six-minute wait.
 
-## §3 — How each option handles the hard part
+So why doesn't everyone just take the left branch? The question is
+meaningless without context. "Should I run a homelab in 2026?" depends
+on what kind of question you're actually asking — production capacity,
+learning curve, cost optimization, vendor independence. This paper
+maps the three philosophies, then returns to mine — DIY,
+heterogeneous, maximum complexity — and is honest about which
+questions that answers and which it doesn't.
 
-*800–1400 words. 1 architecture diagram per vendor.*
+## §2 — Three approaches and their real costs
 
-## §4 — What scale changes
+The market converges on three shapes. Each carries a price tag that
+isn't on the website.
 
-*300–600 words. Charts or ≥2 primary-source citations.*
+**Cloud-native (GKE, EKS, AKS).** The cluster comes up. The control
+plane upgrades itself. Networking, IAM, encryption, audit logging —
+all checkboxes someone else maintained. What it actually costs is the
+bill, and at stable scale the bill stops making sense:
 
-## §5 — Frank's choice, and what happened
+{{< papers/pullquote source="37signals — Leaving the Cloud" url="https://basecamp.com/cloud-exit" >}}
+37signals pulled Basecamp, HEY, and five other heritage apps out of
+AWS — without adding any new staff. By 2022, their cloud bills had
+grown to over $3.2 million annually. Total projected savings from the
+combined cloud exit are well over $10 million over five years. The
+hardware cost was approximately $600,000 for a one-time purchase.
+{{< /papers/pullquote >}}
 
-*300–600 words. ≥1 scar callout.*
+The deeper cost: cloud teaches you nothing below the workload API
+boundary. When the apiserver crashes at 2 AM, it isn't your story.
 
-## §6 — When Frank's answer doesn't generalize
+**Managed homelab-as-code (Sidero Omni, Rancher).** Your hardware,
+somebody else's lifecycle tooling. Sidero's own positioning is honest
+about the seam:
 
-*200–400 words. 1 decision flowchart ≤4 leaves.*
+{{< papers/pullquote source="Sidero Labs — Do you need Omni?" url="https://www.siderolabs.com/blog/do-you-need-omni" >}}
+Omni handles the lifecycle of Talos Linux machines, provides unified
+access to the Talos and Kubernetes API tied to the identity provider
+of your choice, and provides a UI for cluster management and
+operations. From initial machine registration through cluster
+creation, day-to-day operations, and rolling upgrades, everything is
+handled through a single interface.
+{{< /papers/pullquote >}}
 
-## §7 — Roadmap & where this space is going
+"Everything through a single interface" is the value prop *and* the
+dependency. When the SaaS goes down, your cluster keeps running — you
+just can't change anything until it comes back. (I learned that from
+the other direction; see §3.)
 
-*200–400 words.*
+**DIY homelab (Talos + ArgoCD on your own iron — what I am).** Nothing
+for free. The cost is operator time, which dominates at homelab scale
+and almost never makes it into TCO calculators — hardware amortizes,
+electricity rounds to zero, operator hours do not. What it uniquely
+teaches: every failure mode you'd never see in a managed cluster.
 
-## References
+{{< papers/capability-matrix data="approaches" >}}
 
-*Auto-rendered from frontmatter by Hugo taxonomy.*
+*Legend: ✅ means "low cost / low burden" in that row's framing; ❌ is
+the opposite; 🟡 is partial. The matrix grades the trade for a
+single-operator learning context — not a production team.*
+
+## §3 — Frank's answer, and what happened
+
+I chose the right-hand branch: three NUCs for HA, a GPU box for
+inference, an old desktop because it was sitting in a cupboard, two
+Raspberry Pis because edge nodes shouldn't all be expensive.
+Heterogeneous on purpose — homogeneous fleets are easier to operate
+and worse to learn from.
+
+The cost has been thirty-something building posts and counting. Layer
+1 is "the machines exist and can ping each other"; layer 2 is "they
+have an OS"; layer 3 is "they can store something." Each layer is a
+week or three of work that someone on GKE finishes by typing two
+commands. In return I get the one thing a managed cluster cannot give
+me: a scar archive of how distributed systems actually fail.
+
+{{< papers/scar date="2026-05-11" >}}
+Omni's TLS leaf expired at 13:52 UTC on May 9. Workloads stayed up —
+kubelet, ArgoCD, every running pod. But every `kubectl`, every
+`omnictl`, every Web UI call returned a 500 wrapped around a Go x509
+error: *"certificate has expired or is not yet valid."* The cluster
+was running and unmanageable for 46 hours before anyone noticed —
+exactly the failure mode you don't notice until you try to operate.
+Root cause: the operator-installed certbot used non-default config
+paths, so the snap-installed renewal timer had been firing daily as a
+clean no-op for 30 days while the cert aged through Let's Encrypt's
+pre-expiry window. The fix was a dedicated systemd timer with a Docker
+restart hook (Omni v1.5.0 has no SIGHUP path). The lesson is what a
+managed cluster will never teach you: *management plane* and *workload
+plane* can fail independently, and "still running" is not the same as
+"still operable."
+{{< /papers/scar >}}
+
+A managed cluster would have rotated that cert silently. I'd have a
+working cluster and zero understanding of what kept it managed.
+
+This is the trade: I pay in time, the cluster pays me back in earned
+knowledge. By Layer 20 the failure modes start to repeat in shape,
+which is where the investment begins to return.
+
+## §4 — When Frank's answer doesn't generalize
+
+I am a learning platform. I would not pass a production readiness
+review. There is no on-call rotation, no SLO; the SLAs are
+aspirational. If my operator goes on holiday for three weeks, anything
+that breaks stays broken until he's back. Single-operator clusters
+have a single point of failure, and it's named on the GitHub commit
+log.
+
+Specifically, the DIY-homelab branch is the *wrong* answer if:
+
+- **You need a production SLA.** Cloud and managed-homelab both put
+  real engineering and contractual liability between you and a 3 AM
+  outage. DIY puts your phone.
+- **You're a team.** Frank's coherence depends on one person holding
+  the whole architecture in their head. Add three operators and the
+  gotchas registry becomes the bottleneck; add ten and the
+  architecture itself has to be a managed one.
+- **Your primary goal is shipping a product, not understanding
+  infrastructure.** A managed cluster lets you ignore everything below
+  the workload abstraction, which is the right call when the workload
+  IS the work.
+- **You have compliance requirements** that pin you to specific
+  regions, audit certifications, or hardware-attested boundaries. Most
+  homelabs cannot pass SOC 2.
+
+```mermaid
+flowchart TD
+    A["Do you need production SLAs?"] -- "Yes" --> B["Use cloud or managed K8s"]
+    A -- "No" --> C["Is your primary goal learning\ninfrastructure failure modes?"]
+    C -- "Yes" --> D["DIY homelab is worth the cost"]
+    C -- "No" --> E["Managed homelab-as-code\nis probably right"]
+```
+
+The honest answer for most readers is the second branch — managed
+homelab. You get the hardware-ownership economics without paying the
+operator-time tax. I am the right answer only when learning failure
+modes *is* the goal: when the scars are the product.
+
+## §5 — What this series is
+
+This is the Frank Papers, the third series on this blog alongside
+*Building Frank* (how each layer was assembled) and *Operating Frank*
+(how each layer is run day-to-day). The Papers are neither. They map
+the vendor landscape for each capability on the cluster, grade options
+against a decision-maker rubric, and return to my own choice as a
+worked case study — honest about where that choice doesn't generalize.
+
+This is Paper 00, the prologue. Subsequent papers go capability-by-
+capability — *Self-Hosted Inference* next, then observability, secrets
+management, edge networking. Each is grounded in a research dossier
+that survives a structural validator (≥3 vendors, ≥5 primary sources,
+≥3 Frank artefacts, named gaps, counter-arguments). Every claim is
+sourced; every diagram regenerates from the same git repo that
+builds me.
+
+If you've made it this far, you're either an operator looking for
+honest landscape reviews, or someone considering the same trade and
+wondering whether it pays back. The next twenty-odd papers are the
+longer answer.

--- a/blog/layouts/docs/single.html
+++ b/blog/layouts/docs/single.html
@@ -4,7 +4,7 @@
   <div class='hx:mx-auto hx:flex hextra-max-page-width'>
     {{ partial "sidebar.html" (dict "context" .) }}
     {{ partial "toc.html" . }}
-    <article class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]{{ if eq .Params.series "papers" }} paper-post{{ end }}">
+    <article class="hx:w-full hx:break-words hx:flex hx:min-h-[calc(100vh-var(--navbar-height))] hx:min-w-0 hx:justify-center hx:pb-8 hx:pr-[calc(env(safe-area-inset-right)-1.5rem)]{{ if in .Params.series "papers" }} paper-post{{ end }}">
       <main id="content" class="hx:w-full hx:min-w-0 hextra-max-content-width hx:px-6 hx:pt-4 hx:md:px-12">
         {{ partial "breadcrumb.html" (dict "page" . "enable" true) }}
         {{ $cover := .Resources.GetMatch "cover.*" }}
@@ -22,10 +22,10 @@
           {{ end }}
           {{ .Content }}
         </div>
-        {{- if eq .Params.series "papers" }}
+        {{- if in .Params.series "papers" }}
           {{- partial "papers-forwardlinks.html" . }}
           {{- partial "papers/dossier-link.html" . }}
-        {{- else if and (ne .Params.series "papers") (not (eq .Section "")) }}
+        {{- else if and (not (in .Params.series "papers")) (not (eq .Section "")) }}
           {{- partial "papers-backlink.html" . }}
         {{- end }}
         {{ partial "components/last-updated.html" . }}

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/03.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/03.yaml
@@ -196,34 +196,34 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T19:46:19+00:00'
       note: null
     P3.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T19:46:21+00:00'
       note: null
     P3.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T19:46:23+00:00'
       note: null
     P3.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T19:46:25+00:00'
       note: null
     P3.T2.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T19:46:27+00:00'
       note: null
     P3.T2.S5:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T19:46:29+00:00'
       note: null
     P3.T2.S6:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T19:46:30+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-18T19:46:32+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  3/6 — Scaffold + draft [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/288

**Goal (from plan):** Fill the Paper 00 page bundle — frontmatter,
five sections (TL;DR, §1 question, §2 three approaches, §3 Frank's
answer + scar, §4 when it doesn't generalize + decision flowchart,
§5 what this series is), capability-matrix data file. Cap at 1500
words (Paper 00 budget; standard papers are 2400–4200).

---

## Summary

Full draft of **"Why Run Your Own Cluster in 2026?"** — the Frank
Papers prologue. **1500 words exactly.**

### What's in the draft

- **5 sections** matching the simplified Paper 00 structure
- **2 Mermaid diagrams** — `flowchart LR` (philosophy tree, §1) and
  `flowchart TD` decision tree ≤4 leaves (§4)
- **2 pullquotes** drawn directly from dossier primary sources:
  37signals cloud exit (\$10M over 5yr savings) and Sidero Labs' own
  positioning on Omni
- **1 capability-matrix** — three-philosophy comparison, data lives
  in `data/approaches.yaml` as a page-bundle resource
- **1 scar callout** — the 2026-05-11 Omni cert expiry incident.
  Real date, real investigation
  (`docs/investigations/2026-05-11--omni--cert-expiry-incident.md`).
  Demonstrates §3's core thesis: management plane and workload plane
  fail independently, and "still running" is not the same as
  "still operable" — the kind of failure mode a managed cluster will
  never teach you.

### Latent bug fixed in passing

`layouts/docs/single.html` had three `eq .Params.series "papers"`
checks (introduced in Phase 9 of phase-0 / PR #313). But `series` is
a registered taxonomy in `hugo.toml`, and Hextra's opengraph partial
does `range .Params.series` (`hextra@v0.12.1/layouts/_partials/opengraph.html:82`).
The result: Hugo build fails the moment any page actually sets
`series:` in frontmatter, with:

```
range can't iterate over papers
```

This would have bitten the **very first published Paper** — caught
locally on Paper 00 itself by `hugo --buildDrafts`. Existing
Building/Operating posts never set `series:` in frontmatter (the
string was only ever mentioned in prose), which is why CI didn't
flag it earlier.

**Fix:**
- Paper 00 frontmatter uses list form: `series: ["papers"]`
- `single.html` swaps the three `eq` checks for `in`, which
  matches both string and slice forms — backwards-compatible with
  any future Paper that uses either notation

### Deviation from plan task

P3.T2.S5 instructs adding `{{< papers/dossier-link >}}` inline at
end of §5. Omitted because `single.html` auto-injects the same
partial in the page footer (`single.html:27`), so including both
would double-render the dossier chip — explicitly warned against in
`agents/rules/repo-papers.md`. The dossier link still appears below
the article via auto-injection.

### How Phase 3 used Phase 1 + Phase 2 deliberately

This is the context-flow the user asked for after the stacked-PR
incident:

- **Pullquotes** in §2 are verbatim quoted_passages from the
  dossier's `## Primary sources` (sources 1 and 3).
- **§4's "When Frank's answer doesn't generalize"** mirrors the
  dossier's `## Counter-arguments considered` framing exactly.
- **§3's scar** is a real-dated Frank artefact, surfaced from the
  `## Frank artefacts` section's incident kind (gotchas registry).
- **Word budget pressure** revealed where prose was duplicative —
  trimmed §3 first per plan guidance, then §1 / §5 lightly.

### Build verification

`hugo --buildDrafts` builds clean locally with the Go 1.26.2
toolchain. Only the pre-existing `hextra-home json layout` warning
remains. Capability matrix renders with correct ✅/❌/🟡 polarity per
legend. Auto-injected partials render: `paper-cross-links`,
`paper-dossier-link`, `paper-post` CSS class all present.

## Test plan

- [x] `hugo --buildDrafts` builds the site without errors locally
- [x] Paper 00 page renders to `index.html` (169KB)
- [x] Capability matrix table renders with three columns + correct
      emoji polarities
- [x] Scar callout renders with 🩹 + date
- [x] Forwardlinks + dossier-link footer chips render via auto-injection
- [x] `awk` body word count == 1500 (cap)
- [x] Cross-ref targets exist (`docs/building/01-introduction`,
      `docs/operating/01-cluster-nodes`)
- [ ] CI builds on push to main (no PR-level blog CI)

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)