### PR TITLE
[derio-net/frank] 2026-05-16--repo--frank-papers-paper-00 · Phase 6/6 · Post-Deploy Checklist

### DIFF
--- a/blog/content/docs/building/00-overview/index.md
+++ b/blog/content/docs/building/00-overview/index.md
@@ -57,7 +57,7 @@ This post is a **living document**: it gets updated as new technologies and capa
 | **Zot** | OCI container/artifact registry with cert-manager TLS and cosign image signing (`192.168.55.210`) |
 | **agent-images** | Shared base image + per-pod children repo — `agent-base` toolchain + `secure-agent-kali` / `vk-local` children, matrix CI, cross-repo `repository_dispatch`, lockstep bumper PR |
 | **Ruflo (claude-flow + ruvocal)** | Swarm-style AI orchestrator — hybrid pod (ruvocal SSR + agent-shell-base sidecar), LiteLLM-only egress, SSH+Mosh shell on `192.168.55.222`, web UI at `ruflo.cluster.derio.net` |
-| **The Frank Papers** | Third blog series — research-grade landscape reviews framed as decisions; dossier gate (`validate-dossier.py` + pre-commit hook), Mermaid Frank theme, five `papers/` shortcodes, render-time cross-series backlinks |
+| **The Frank Papers** | Third blog series — research-grade landscape reviews framed as decisions; dossier gate (`validate-dossier.py` + pre-commit hook), Mermaid Frank theme, five `papers/` shortcodes, render-time cross-series backlinks. **Prologue published 2026-05-18:** [Why Run Your Own Cluster in 2026?]({{< relref "/docs/papers/00-why-homelab-in-2026" >}}) |
 
 ## Cluster State
 

--- a/blog/layouts/shortcodes/cluster-roadmap.html
+++ b/blog/layouts/shortcodes/cluster-roadmap.html
@@ -630,6 +630,7 @@
         <span class="sub-item">Dossier gate (vendors, sources, gaps, counter-args)</span>
         <span class="sub-item">Mermaid Frank theme + <code>.paper-post</code> CSS scope</span>
         <span class="sub-item">Render-time cross-series backlinks (zero retrofit)</span>
+        <span class="sub-item">Paper 00 prologue published 2026-05-18</span>
       </div>
       <div class="tags">
         <span class="tag">hugo</span>

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/06.yaml
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/06.yaml
@@ -92,34 +92,38 @@ tasks:
 state:
   steps:
     P6.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-18T20:15:06+00:00'
+      note: 'External-verification curl deferred to post-merge: this PR is the publish
+        merge itself; the deploy pipeline runs only on push to main.'
     P6.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T20:15:08+00:00'
       note: null
     P6.T1.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-18T20:15:10+00:00'
+      note: Skip per plan text — Paper 00 IS the publication; phase-0 plan covered
+        the infrastructure building post.
     P6.T1.S4:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-18T20:15:11+00:00'
+      note: Skip per plan text — Papers have no operational commands beyond agents/skills/papers/SKILL.md.
     P6.T1.S5:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-18T20:15:13+00:00'
+      note: README Technology Stack already lists Frank Papers from phase-0; no Paper
+        00-specific row needed — README is a stack snapshot, not a publish log.
     P6.T1.S6:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-18T20:15:15+00:00'
+      note: No manual-operation blocks in this plan — confirmed by grep.
     P6.T1.S7:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T20:15:16+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-18T20:15:18+00:00'
+    note: Post-deploy checklist complete; Paper 00 published; plan status flipped
+      to Complete in _prose.md.
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/_prose.md
+++ b/docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/_prose.md
@@ -1,7 +1,7 @@
 # The Frank Papers — Paper 00: Prologue
 
 **Spec:** `docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md`
-**Status:** Not Started
+**Status:** Complete (2026-05-18) — Paper 00 published; series Phase 1 (capability papers) is now open.
 
 **Prerequisite:** `2026-05-16--repo--frank-papers-phase-0` complete — scripts,
 shortcodes, dossier gate, and `agents/skills/papers/SKILL.md` must be in place.


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00
📐 Spec:   docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
🎯 Phase:  6/6 — Post-Deploy Checklist [manual]
🔗 Issue:  https://github.com/derio-net/frank/issues/291

**Goal (from plan):** Standard post-deploy checklist for a published
Paper — touch the series overviews, update the cluster roadmap, flip
the plan to `Complete`.

---

## Summary

Final phase. **Plan is now Complete.**

### Touched

- **Capability Map row** in `building/00-overview/index.md` — the
  Papers row now points at Paper 00 with an inline relref so anyone
  reading the overview can jump into the prologue.
- **`cluster-roadmap.html` layer-30 card** — added a sub-item
  recording the 2026-05-18 prologue publish.
- **`_prose.md` Status line** — `Not Started → Complete (2026-05-18)`.

### Skipped (with notes in each step)

| Step | Reason |
|---|---|
| S1 external curl | This PR IS the publish merge; deploy pipeline runs only on push to main, so verification belongs post-merge |
| S3 building blog post | Paper 00 IS the publication; phase-0's checklist already covered the *infrastructure* building post |
| S4 operating blog post | Papers have no day-to-day operational surface beyond `agents/skills/papers/SKILL.md` |
| S5 README sync | README Tech Stack already lists Frank Papers from phase-0; the README is a stack snapshot, not a publish log |
| S6 runbook sync | Confirmed no `# manual-operation` blocks in any phase YAML |

### What `vk spec status` will read after merge

```
| The Frank Papers — Phase 0: Tooling & Scaffolding | derio-net/frank | ✅ Complete (9/9 phases) |
| The Frank Papers — Paper 00: Prologue             | derio-net/frank | ✅ Complete (6/6 phases) |
```

## Build verification

- Hugo production build: zero `^ERROR` lines, Paper 00 still at
  `public/docs/papers/00-why-homelab-in-2026/index.html` (169 KB),
  cover served, prologue link in `/docs/papers/index.html`.
- The updated relref in the Capability Map resolves correctly
  (no `REF_NOT_FOUND` warnings).

## Test plan

- [x] Capability Map row links to Paper 00 (relref valid)
- [x] Cluster-roadmap layer-30 card lists prologue publish
- [x] `_prose.md` Status line shows `Complete (2026-05-18)`
- [x] Hugo production build clean
- [x] `vk plan edit --complete-phase 6` accepted
- [ ] Post-merge: `curl https://blog.derio.net/frank/docs/papers/00-why-homelab-in-2026/`
      returns the page (deferred — runs after deploy)

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)