### PR TITLE
docs(repo): normalise Papers 10 & 11 rows in spec Implementation Plans table

### DIFF
--- a/docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
+++ b/docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
@@ -388,6 +388,6 @@ Phase 0 done → Paper 00 dossier → Paper 00 draft → publish → Phase 1 ope
 |------|------|------|------------|
 | The Frank Papers — Phase 0: Tooling & Scaffolding | derio-net/frank | `docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/` | — |
 | The Frank Papers — Paper 00: Prologue | derio-net/frank | `docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/` | Phase 0 complete |
-| 2026-05-18--repo--frank-papers-paper-10 | `derio-net/frank` | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-10/` | — |
+| The Frank Papers — Paper 10: Self-Hosted Inference & the LLM Gateway Pattern | derio-net/frank | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-10/` | Phase 0 complete; Paper 00 published |
 | The Frank Papers — Paper 04: Distributed Storage on Bare Metal | derio-net/frank | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/` | Phase 0 complete; Paper 00 published |
-| 2026-05-18--repo--frank-papers-paper-11 | `derio-net/frank` | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-11/` | — |
+| The Frank Papers — Paper 11: Identity for a Heterogeneous Stack | derio-net/frank | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-11/` | Phase 0 complete; Paper 00 published |


### PR DESCRIPTION
## Summary

Both rows for Papers 10 and 11 were inserted by `vk plan create` with the raw plan slug as the human-readable plan name and backticked repo value. This brings them in line with the pattern used by Phase 0, Paper 00, and Paper 04: human-readable title, no backticks on the repo column, and the standard "Phase 0 complete; Paper 00 published" dependency note.

Cosmetic only — no plan content changes.

## Test plan

- [x] Diff is a 2-line change