### PR TITLE
feat(papers): Paper 10 — Phase 2/6: gate validation

### DIFF
--- a/docs/papers-dossiers/10-self-hosted-inference/dossier.md
+++ b/docs/papers-dossiers/10-self-hosted-inference/dossier.md
@@ -1,6 +1,6 @@
 ---
 paper: 10-self-hosted-inference
-status: draft
+status: ready
 ---
 
 ## Vendors in scope (≥3, typically 4–6)

--- a/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-10/02.yaml
+++ b/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-10/02.yaml
@@ -67,18 +67,19 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T22:05:35+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-18T22:05:37+00:00'
+      note: 'Reviewed: small-scale benchmark gap and ''just use the OpenAI API'' counter-argument
+        both survive scrutiny; dossier status flipped to ready.'
     P2.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-18T22:05:38+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-18T22:05:40+00:00'
+    note: 'validate-dossier.py exits 0; dossier status: ready; human gate review complete.'
     observed_prs: []


### PR DESCRIPTION
## Summary

Phase 2 of 6 for **Paper 10: Self-Hosted Inference & the LLM Gateway Pattern**.

`scripts/validate-dossier.py` passes; dossier `status: ready`. Author gate reviewed the named gaps (no published small-scale Ollama/vLLM/llama.cpp benchmark at ≤2 concurrent users on a single consumer GPU; LiteLLM OSS emits no `litellm_*` Prometheus metrics) and confirmed the "just use the OpenAI API" counter-argument is framed honestly (Frank chose self-hosted to pay the learning tax in full).

## Test plan

- [x] `.venv/bin/python scripts/validate-dossier.py docs/papers-dossiers/10-self-hosted-inference/dossier.md` exits 0
- [x] Dossier frontmatter `status: ready`
- [x] Phase 2 marked complete via `vk plan edit --complete-phase 2`