### PR TITLE
feat(papers): Paper 04 — Phase 2/6: Gate validation

### DIFF
--- a/docs/papers-dossiers/04-distributed-storage/dossier.md
+++ b/docs/papers-dossiers/04-distributed-storage/dossier.md
@@ -1,6 +1,6 @@
 ---
 paper: 04-distributed-storage
-status: draft
+status: ready
 ---
 
 ## Vendors in scope (≥3, typically 4–6)
@@ -42,7 +42,7 @@ status: draft
 
 - title: "Ceph: A Scalable, High-Performance Distributed File System (Weil et al., OSDI '06)"
   type: paper
-  url: "https://www.ssrc.ucsc.edu/Papers/weil-osdi06.pdf"
+  url: "https://www.usenix.org/legacy/event/osdi06/tech/full_papers/weil/weil.pdf"
   quoted_passages:
     - "We have designed and implemented Ceph, a distributed file system that provides excellent performance, reliability, and scalability."
     - "Ceph maximizes the separation between data and metadata management by replacing allocation tables with a pseudo-random data distribution function (CRUSH) designed for heterogeneous and dynamic clusters of unreliable object storage devices (OSDs)."

--- a/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/02.yaml
+++ b/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/02.yaml
@@ -66,18 +66,18 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-19T03:39:25+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-19T03:39:26+00:00'
       note: null
     P2.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-19T03:39:28+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-19T03:39:38+00:00'
+    note: 'Validator exits 0; dossier marked status: ready by agent acting as gate-keeper.'
     observed_prs: []


### PR DESCRIPTION
## Summary

Phase 2 of 6 for **Paper 04: Distributed Storage on Bare Metal**.

`validate-dossier.py` passes; dossier marked `status: ready` by agent acting as the gate-keeper. URL fix: Ceph OSDI '06 paper (Weil et al.) moved from `ssrc.ucsc.edu` (now 404) to USENIX-hosted PDF.

## Test plan

- [x] `python scripts/validate-dossier.py docs/papers-dossiers/04-distributed-storage/dossier.md` exits 0