### PR TITLE
feat(papers): Paper 11 — Phase 2/6: Gate validation

### DIFF
--- a/docs/papers-dossiers/11-identity-heterogeneous-stack/dossier.md
+++ b/docs/papers-dossiers/11-identity-heterogeneous-stack/dossier.md
@@ -1,6 +1,6 @@
 ---
 paper: 11-identity-heterogeneous-stack
-status: draft
+status: ready
 ---
 
 ## Vendors in scope (≥3, typically 4–6)
@@ -59,9 +59,9 @@ status: draft
     - "This lets dex defer authentication to LDAP servers, SAML providers, or established identity providers like GitHub, Google, and Active Directory."
   relevance: "Defines the 'federation-only' position in the §2 landscape — Dex deliberately does not store users, only proxies authentication. Explains why projects that adopted Dex (ArgoCD's bundled provider) end up adding a 'real' IdP behind it as soon as they want password policies, MFA enrolment, or admin UI."
 
-- title: "TechnoTim — Authelia + Authentik + Traefik for self-hosted SSO"
+- title: "TechnoTim — 2 Factor Auth and Single Sign on with Authelia (Traefik forward-auth)"
   type: talk
-  url: "https://docs.techno.tim/docs/authelia-traefik"
+  url: "https://docs.technotim.com/posts/authelia-traefik/"
   quoted_passages:
     - "Authelia is an open-source authentication and authorization server providing two-factor authentication and single sign-on (SSO) for your applications via a web portal."
     - "It acts as a companion of reverse proxies like nginx, Traefik or HAProxy to let them know whether requests should either be allowed or redirected to Authelia's portal for authentication."

--- a/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-11/02.yaml
+++ b/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-11/02.yaml
@@ -72,18 +72,19 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-19T03:41:55+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-19T03:41:56+00:00'
       note: null
     P2.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-19T03:41:58+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-19T03:42:06+00:00'
+    note: 'Validator exits 0; dossier marked status: ready by agent acting as gate-keeper.
+      TechnoTim URL swapped to current canonical.'
     observed_prs: []


### PR DESCRIPTION
## Summary

Phase 2 of 6 for **Paper 11: Identity for a Heterogeneous Stack**.

`validate-dossier.py` passes; dossier marked `status: ready` by agent acting as the gate-keeper. TechnoTim URL replaced (dead `docs.techno.tim/docs/authelia-traefik` → canonical `docs.technotim.com/posts/authelia-traefik/`); existing quoted passages match the canonical page verbatim, so only the URL and title were touched.

## Test plan

- [x] `python scripts/validate-dossier.py docs/papers-dossiers/11-identity-heterogeneous-stack/dossier.md` exits 0