### PR TITLE
docs(repo): Paper 04 post-deploy checklist — Phase 6/6 (Complete)

### DIFF
--- a/blog/content/docs/papers/_index.md
+++ b/blog/content/docs/papers/_index.md
@@ -14,4 +14,6 @@ Start with the prologue: **[Why Run Your Own Cluster in 2026?](/docs/papers/00-w
 
 Then the first capability paper: **[Self-Hosted Inference & the LLM Gateway Pattern](/docs/papers/10-self-hosted-inference/)**.
 
+Followed by: **[Distributed Storage on Bare Metal](/docs/papers/04-distributed-storage/)** — the six contenders for PVCs that survive a node loss, and why Frank trades the unified data plane for a per-volume mirror.
+
 The auth landscape paper: **[Identity for a Heterogeneous Stack](/docs/papers/11-identity-heterogeneous-stack/)**.

--- a/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/06.yaml
+++ b/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/06.yaml
@@ -153,38 +153,51 @@ tasks:
 state:
   steps:
     P6.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-19T04:30:15+00:00'
+      note: Skip — Paper 04 publishes on existing public blog at blog.derio.net/frank;
+        no new IngressRoute. URL liveness check deferred to post-deploy CI.
     P6.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-19T04:30:16+00:00'
+      note: Cross-series chip backlink verification deferred to merge-time Hugo CI
+        build (same posture as Paper 10 Phase 6). Hugo build green locally; partial
+        logic pre-existing, out of scope for this phase.
     P6.T1.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-19T04:30:18+00:00'
+      note: 'Updated blog/content/docs/papers/_index.md: appended Paper 04 link below
+        Paper 10 (publish order 00 → 10 → 04).'
     P6.T1.S4:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-19T04:30:33+00:00'
+      note: Skip — Building 03-storage and Operating 02-storage-backups exist; cross-series
+        chip auto-renders from Paper 04 frontmatter. No series-overview 'Further reading'
+        section in current building/operating/00-overview pages.
     P6.T1.S5:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-19T04:30:35+00:00'
+      note: Skip — Papers reference existing Building/Operating posts via frontmatter;
+        no new posts needed (Paper 04 is decision-level companion).
     P6.T1.S6:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-19T04:30:37+00:00'
+      note: Skip — README references Papers series from Paper 00; Paper 04 is content
+        addition, not a stack change. Same posture as Paper 10 Phase 6.
     P6.T1.S7:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-19T04:30:39+00:00'
+      note: 'Skip — no # manual-operation blocks in plan.'
     P6.T1.S8:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-19T04:30:48+00:00'
+      note: _prose.md Status flipped to Complete (2026-05-19). Spec Implementation
+        Plans table row updated to 'Complete (2026-05-19) — published'. vk 2.2.4 has
+        no spec-index subcommand; used direct Edit on the spec table row.
   completion:
-    at: null
-    note: null
+    at: '2026-05-19T04:30:56+00:00'
+    note: Papers landing updated to link Paper 04. Plan status flipped to Complete
+      in _prose.md and the spec's Implementation Plans table row. Building/Operating
+      retro-edits not needed (cross-series chip auto-renders from Paper 04 frontmatter
+      at Hugo build time).
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/_prose.md
+++ b/docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/_prose.md
@@ -1,7 +1,7 @@
 # The Frank Papers — Paper 04: Distributed Storage on Bare Metal
 
 **Spec:** `docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md`
-**Status:** Not Started
+**Status:** Complete (2026-05-19) — Paper 04 published as the second capability paper after Paper 10; series Phase 1 continues.
 
 **Prerequisite:** `2026-05-16--repo--frank-papers-phase-0` complete (scripts,
 shortcodes, dossier gate, `agents/skills/papers/SKILL.md`). Paper 00 published

--- a/docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
+++ b/docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
@@ -389,5 +389,5 @@ Phase 0 done → Paper 00 dossier → Paper 00 draft → publish → Phase 1 ope
 | The Frank Papers — Phase 0: Tooling & Scaffolding | derio-net/frank | `docs/superpowers/plans/2026-05-16--repo--frank-papers-phase-0/` | — |
 | The Frank Papers — Paper 00: Prologue | derio-net/frank | `docs/superpowers/plans/2026-05-16--repo--frank-papers-paper-00/` | Phase 0 complete |
 | The Frank Papers — Paper 10: Self-Hosted Inference & the LLM Gateway Pattern | derio-net/frank | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-10/` | Complete (2026-05-19) — published |
-| The Frank Papers — Paper 04: Distributed Storage on Bare Metal | derio-net/frank | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/` | Phase 0 complete; Paper 00 published |
+| The Frank Papers — Paper 04: Distributed Storage on Bare Metal | derio-net/frank | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-04/` | Complete (2026-05-19) — published |
 | The Frank Papers — Paper 11: Identity for a Heterogeneous Stack | derio-net/frank | `docs/superpowers/plans/2026-05-18--repo--frank-papers-paper-11/` | Complete (2026-05-19) — published |


### PR DESCRIPTION
## Summary

Phase 6 of 6 for **Paper 04: Distributed Storage on Bare Metal** — final phase. Plan now marked Complete.

- Papers landing page now links Paper 04 in publish order (00 → 10 → 04).
- `_prose.md` Status flipped to `Complete (2026-05-19) — Paper 04 published`.
- Spec Implementation Plans table row updated to `Complete (2026-05-19) — published`.
- Skips, with notes: external exposure (already public via existing blog), Building/Operating posts (companions exist; cross-series chip auto-renders from frontmatter), README (no stack change), runbook (no manual-operation blocks).

## Test plan

- [x] `cd blog && hugo --minify` exits 0
- [x] Sidebar links to Paper 04 present on Building 03-storage and Operating 02-storage-backups via Hextra docs/single.html
- [x] Plan _prose.md status updated
- [x] Cross-series chip rendering deferred to merge-time Hugo CI build (same posture as Paper 10 Phase 6 PR #341)