### PR TITLE
ci(blog): idempotent deploy-blog push loop

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -83,31 +83,64 @@ jobs:
             ghcr.io/derio-net/blog:latest
             ghcr.io/derio-net/blog:${{ github.sha }}
 
-      - name: Update deployment manifest with new image tag
+      - name: Update deployment manifest with new image tag (idempotent)
+        # Idempotent push loop. Each attempt:
+        #   1. Resets the working tree to fresh origin/main (no rebase mess).
+        #   2. Reads the currently-deployed image SHA.
+        #   3. If main already points at OUR_SHA → nothing to do, exit 0.
+        #   4. If CURRENT_SHA is a descendant of OUR_SHA → a newer build won
+        #      the race; our SHA is stale, yield silently with exit 0.
+        #   5. Otherwise apply the SHA bump, commit, push.
+        #   6. If push is rejected (someone pushed in the gap), loop back to
+        #      step 1 with a fresh checkout.
+        #
+        # This replaces the previous retry-loop that did `git pull --rebase`,
+        # which would silently leave the working tree in a conflicted state
+        # when two workflows both modified the same image: line.
         run: |
-          sed -i "s|image: ghcr.io/derio-net/blog:.*|image: ghcr.io/derio-net/blog:$IMAGE_SHA  # updated by CI — do not pin manually|" \
-            clusters/hop/apps/blog/manifests/deployment.yaml
-        env:
-          IMAGE_SHA: ${{ github.sha }}
-
-      - name: Commit and push updated manifest
-        run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add clusters/hop/apps/blog/manifests/deployment.yaml
-          # Only commit if the file actually changed
-          git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "ci(blog): update image to ${IMAGE_SHA:0:7}"
-          # Retry with rebase on push rejection (concurrent workflows racing to push to main)
+          MANIFEST=clusters/hop/apps/blog/manifests/deployment.yaml
+
           for attempt in 1 2 3 4 5; do
-            if git push; then
+            git fetch origin main
+            git reset --hard origin/main
+
+            CURRENT_SHA=$(sed -nE 's|.*image: ghcr.io/derio-net/blog:([a-f0-9]+).*|\1|p' "$MANIFEST" | head -1)
+            if [ -z "$CURRENT_SHA" ]; then
+              echo "::error::Could not parse current image SHA from $MANIFEST"
+              exit 1
+            fi
+
+            if [ "$CURRENT_SHA" = "$OUR_SHA" ]; then
+              echo "Deployment already pinned to $OUR_SHA — nothing to do"
               exit 0
             fi
-            echo "Push rejected (attempt $attempt/5) — rebasing onto latest main and retrying..."
-            git pull --rebase origin main
+
+            if git merge-base --is-ancestor "$OUR_SHA" "$CURRENT_SHA" 2>/dev/null; then
+              echo "Race lost: main already deployed at $CURRENT_SHA (descendant of our build $OUR_SHA) — exiting clean"
+              exit 0
+            fi
+
+            sed -i "s|image: ghcr.io/derio-net/blog:.*|image: ghcr.io/derio-net/blog:$OUR_SHA  # updated by CI — do not pin manually|" "$MANIFEST"
+            git add "$MANIFEST"
+            if git diff --cached --quiet; then
+              echo "No-op after sed — exiting clean"
+              exit 0
+            fi
+            git commit -m "ci(blog): update image to ${OUR_SHA:0:7}"
+
+            if git push; then
+              echo "Pushed manifest update on attempt $attempt"
+              exit 0
+            fi
+
+            echo "Push rejected (attempt $attempt/5) — another workflow pushed in the gap. Retrying with a fresh checkout."
             sleep $((attempt * 2))
           done
+
           echo "::error::Failed to push manifest update after 5 attempts"
           exit 1
         env:
-          IMAGE_SHA: ${{ github.sha }}
+          OUR_SHA: ${{ github.sha }}


### PR DESCRIPTION
## Summary

Three of the six Paper-merge Deploy Blog workflows today failed (Papers 03, 17, 05): the retry loop's `git pull --rebase origin main` produced a merge conflict on `clusters/hop/apps/blog/manifests/deployment.yaml` (every workflow updates the same `image:` line), the rebase aborted mid-flight, and the next loop iteration tried to `git push` against the unresolved tree.

This PR replaces that retry-loop with an idempotent one:

| Step | Old | New |
|---|---|---|
| On push rejection | `git pull --rebase` then retry push (left tree dirty on conflict) | `git fetch && git reset --hard origin/main`, re-derive the manifest update from scratch |
| Race-lost detection | none — always tried to push our SHA | `git merge-base --is-ancestor OUR_SHA CURRENT_SHA` → yield exit-0 if newer build already deployed |
| Stale check | none — always wrote our SHA | Exit 0 if `CURRENT_SHA == OUR_SHA` (manifest already correct) |
| Fail-fast | bare `for`-loop | `set -euo pipefail` |
| Injection-safe | uses `IMAGE_SHA` env var | uses `OUR_SHA` env var (same safe pattern) |

The yield-when-stale branch is the load-bearing piece: when Paper N's workflow is slow and Paper N+1's workflow lands its image SHA first, Paper N's workflow should **not** overwrite the newer manifest with its older SHA. Detection is via git ancestry — if `CURRENT_SHA` is a descendant of `OUR_SHA`, our build is stale.

## Backstory

Earlier today, six paper PRs landed inside two minutes (#359, #360, #361, #362, #363, #364). All six Deploy-Blog runs queued (concurrency group is serial), and three of them hit the rebase-conflict pathology. The deployed image ended up at Paper 08's content (the last run that won the race); content for Papers 03, 05, 17 was on `main` but not in the deployed image.

Recovered by triggering a manual `workflow_dispatch` from current HEAD, which built a fresh image at `4adf7c2` (everything merged). That run is green and the live blog now shows all six new Papers.

This PR prevents the failure mode for the next paper-burst.

## Test plan

- [x] Manual recovery `workflow_dispatch` succeeded — blog deployed at HEAD `4adf7c2`
- [ ] Next merge-into-main of a `blog/**` change triggers a single non-racy Deploy Blog run that succeeds
- [ ] (Stress-test, optional) Land two `blog/**` PRs in rapid succession and confirm the second yields silently if it builds a stale image