### PR TITLE
feat(repo): paper bibliography rendering — dossier → §8

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -45,7 +45,12 @@ DOSSIER_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^docs
 if [ -n "$DOSSIER_FILES" ]; then
   for dossier in $DOSSIER_FILES; do
     slug=$(basename "$(dirname "$dossier")")
-    python "$REPO_ROOT/scripts/sync-dossier-to-data.py" "$slug"
+    if ! python "$REPO_ROOT/scripts/sync-dossier-to-data.py" "$slug"; then
+      echo "ERROR: sync-dossier-to-data.py failed for slug '$slug'." >&2
+      echo "Fix the dossier YAML, re-stage, and retry the commit." >&2
+      echo "(Run manually: python scripts/sync-dossier-to-data.py $slug)" >&2
+      exit 1
+    fi
     git add "$REPO_ROOT/blog/data/papers/${slug}.yaml"
   done
 fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -37,3 +37,15 @@ if [ -n "$PAPER_FILES" ]; then
     "$REPO_ROOT/scripts/validate-dossier.py" "$DOSSIER_PATH"
   done
 fi
+
+# Dossier → data file sync: regenerate matching blog/data/papers/<slug>.yaml
+# for any staged docs/papers-dossiers/<slug>/dossier.md, and stage the result.
+DOSSIER_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^docs/papers-dossiers/[^/]+/dossier\.md$' || true)
+
+if [ -n "$DOSSIER_FILES" ]; then
+  for dossier in $DOSSIER_FILES; do
+    slug=$(basename "$(dirname "$dossier")")
+    python "$REPO_ROOT/scripts/sync-dossier-to-data.py" "$slug"
+    git add "$REPO_ROOT/blog/data/papers/${slug}.yaml"
+  done
+fi

--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -32,6 +32,17 @@ jobs:
           hugo-version: "0.157.0"
           extended: true
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dossier-sync deps
+        run: pip install pyyaml
+
+      - name: Check dossier ↔ blog/data/papers sync
+        run: python scripts/sync-dossier-to-data.py --check
+
       - name: Build
         working-directory: blog
         run: |

--- a/agents/rules/repo-papers.md
+++ b/agents/rules/repo-papers.md
@@ -26,7 +26,7 @@ Research dossiers live at `docs/papers-dossiers/NN-slug/dossier.md`.
 
 Required fields: `title`, `date`, `draft`, `weight`, `series: papers`,
 `layer`, `paper_number`, `publish_order`, `status`, `tldr`, `tags`,
-`capabilities`, `related_building`, `related_operating`, `references`.
+`capabilities`, `related_building`, `related_operating`.
 
 ### Cross-linking (bidirectional, zero retrofit)
 

--- a/blog/assets/css/custom.css
+++ b/blog/assets/css/custom.css
@@ -526,3 +526,59 @@
     align-items: flex-start;
   }
 }
+
+/* Frank Papers — §8 References + cross-series index */
+
+.paper-post .paper-references {
+  margin-top: 3rem;
+  border-top: 1px solid var(--border-color, #2a2a2a);
+  padding-top: 1.5rem;
+}
+.paper-post .paper-references ol {
+  list-style: decimal;
+  padding-left: 1.5rem;
+}
+.paper-post .paper-references li {
+  margin-bottom: 1.25rem;
+}
+.paper-post .paper-references blockquote,
+.papers-references-index blockquote {
+  border-left: 3px solid var(--accent-color, #888);
+  padding-left: 0.75rem;
+  margin: 0.5rem 0;
+  font-style: normal;
+  color: var(--text-muted, #aaa);
+}
+.paper-reference-relevance {
+  margin-top: 0.5rem;
+  opacity: 0.85;
+}
+.paper-reference-chip {
+  display: inline-block;
+  padding: 0.1rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin-right: 0.5rem;
+  background: var(--chip-bg, #2a2a2a);
+  color: var(--chip-fg, #ddd);
+}
+.paper-reference-chip--vendor-docs { background: #1e3a5f; color: #cfe2ff; }
+.paper-reference-chip--paper       { background: #2e1e5f; color: #d4c7ff; }
+.paper-reference-chip--postmortem  { background: #5f1e1e; color: #ffcccc; }
+.paper-reference-chip--talk        { background: #1e5f3a; color: #c7ffd4; }
+.paper-reference-chip--benchmark   { background: #5f4e1e; color: #ffe9b3; }
+
+.papers-references-index h2 {
+  margin-top: 2.5rem;
+  text-transform: lowercase;
+  font-variant: small-caps;
+}
+.papers-references-index .paper-reference-citations {
+  margin-top: 0.5rem;
+  font-size: 0.9rem;
+}
+.papers-references-index .paper-reference-citations ul {
+  list-style: none;
+  padding-left: 1rem;
+}

--- a/blog/content/docs/papers/00-why-homelab-in-2026/index.md
+++ b/blog/content/docs/papers/00-why-homelab-in-2026/index.md
@@ -29,22 +29,6 @@ tags: ["homelab", "kubernetes", "talos", "architecture"]
 capabilities: ["hw", "os", "gitops"]
 related_building: "docs/building/01-introduction"
 related_operating: "docs/operating/01-cluster-nodes"
-references:
-  - title: "Leaving the Cloud — 37signals Cloud Exit case study"
-    url: "https://basecamp.com/cloud-exit"
-    type: benchmark
-  - title: "Simon Willison — LLM pricing notes"
-    url: "https://simonwillison.net/tags/llm-pricing/"
-    type: postmortem
-  - title: "Do you need Omni? — Sidero Labs"
-    url: "https://www.siderolabs.com/blog/do-you-need-omni"
-    type: vendor-docs
-  - title: "Kubernetes 101 — Jeff Geerling video series"
-    url: "https://kube101.jeffgeerling.com/"
-    type: talk
-  - title: "AKS vs EKS vs GKE: What you get with managed Kubernetes-as-a-Service — Fairwinds"
-    url: "https://www.fairwinds.com/blog/aks-eks-gke-managed-kubernetes-as-a-service"
-    type: talk
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/01-heterogeneous-hardware/index.md
+++ b/blog/content/docs/papers/01-heterogeneous-hardware/index.md
@@ -30,28 +30,6 @@ tags: ["hardware", "heterogeneous", "node-pools", "kubernetes", "talos", "raspbe
 capabilities: ["hw"]
 related_building: "docs/building/01-introduction"
 related_operating: "docs/operating/01-cluster-nodes"
-references:
-  - title: "Kubernetes docs — Assigning Pods to Nodes"
-    url: "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/"
-    type: vendor-docs
-  - title: "Karpenter docs — NodePools and NodeClasses"
-    url: "https://karpenter.sh/docs/concepts/nodepools/"
-    type: vendor-docs
-  - title: "Cluster API — Concepts (MachineDeployments)"
-    url: "https://cluster-api.sigs.k8s.io/user/concepts"
-    type: vendor-docs
-  - title: "Talos Linux v1.10 — Managing Kubernetes nodes"
-    url: "https://www.talos.dev/v1.10/kubernetes-guides/configuration/managing-nodes/"
-    type: vendor-docs
-  - title: "Raspberry Pi Cluster Episode 3 — Installing K3s on the Turing Pi (Geerling, 2020)"
-    url: "https://www.jeffgeerling.com/blog/2020/installing-k3s-kubernetes-on-turing-pi-raspberry-pi-cluster-episode-3/"
-    type: benchmark
-  - title: "Frank cluster gotcha registry (frank-gotchas.md)"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
-  - title: "pc-1 reboot investigation (2026-05-11)"
-    url: "https://github.com/derio-net/frank/blob/main/docs/investigations/2026-05-11--hw--pc-1-reboot-investigation.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/02-immutable-os/index.md
+++ b/blog/content/docs/papers/02-immutable-os/index.md
@@ -30,25 +30,6 @@ tags: ["os", "talos", "immutable", "kubernetes", "homelab"]
 capabilities: ["os"]
 related_building: "docs/building/02-foundation"
 related_operating: "docs/operating/01-cluster-nodes"
-references:
-  - title: "Talos Linux — Concepts"
-    url: "https://www.talos.dev/v1.11/learn-more/concepts/"
-    type: vendor-docs
-  - title: "Fedora CoreOS — Documentation"
-    url: "https://docs.fedoraproject.org/en-US/fedora-coreos/"
-    type: vendor-docs
-  - title: "Ignition (CoreOS) — Specification"
-    url: "https://coreos.github.io/ignition/"
-    type: vendor-docs
-  - title: "Bottlerocket: A special-purpose container operating system (AWS blog)"
-    url: "https://aws.amazon.com/blogs/containers/bottlerocket-a-special-purpose-container-operating-system/"
-    type: paper
-  - title: "ImmutableServer (Martin Fowler / ThoughtWorks)"
-    url: "https://martinfowler.com/bliki/ImmutableServer.html"
-    type: paper
-  - title: "Frank — OS / Talos / Hop gotchas (postmortem registry)"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/hop-gotchas.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/03-ebpf-networking/index.md
+++ b/blog/content/docs/papers/03-ebpf-networking/index.md
@@ -605,6 +605,3 @@ into Gateway API.
 The space is not done evolving. Frank will revisit this paper when
 the answers change.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/03-ebpf-networking/index.md
+++ b/blog/content/docs/papers/03-ebpf-networking/index.md
@@ -27,25 +27,6 @@ tags: ["cilium", "ebpf", "kubernetes", "service-mesh", "networking"]
 capabilities: ["net"]
 related_building: "docs/building/02-foundation"
 related_operating: "docs/operating/01-cluster-nodes"
-references:
-  - title: "Cilium — Component Overview"
-    url: "https://docs.cilium.io/en/stable/overview/component-overview/"
-    type: vendor-docs
-  - title: "Cilium 1.17 release blog (Isovalent)"
-    url: "https://isovalent.com/blog/post/cilium-1-17/"
-    type: vendor-docs
-  - title: "Liz Rice — eBPF: A New Frontier (KubeCon NA 2021)"
-    url: "https://kccncna2021.sched.com/event/lV3T"
-    type: talk
-  - title: "CNI Benchmark — Cilium vs Calico vs Kube-router (Cilium)"
-    url: "https://cilium.io/blog/2021/05/11/cni-benchmark/"
-    type: benchmark
-  - title: "Frank — Cilium gotchas"
-    url: "https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/networking.md"
-    type: postmortem
-  - title: "Amazon VPC CNI — Pod networking"
-    url: "https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html"
-    type: vendor-docs
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/04-distributed-storage/index.md
+++ b/blog/content/docs/papers/04-distributed-storage/index.md
@@ -30,22 +30,6 @@ tags: ["storage", "longhorn", "ceph", "kubernetes", "homelab"]
 capabilities: ["stor"]
 related_building: "docs/building/03-storage"
 related_operating: "docs/operating/02-storage-backups"
-references:
-  - title: "Longhorn — Architecture and Concepts"
-    url: "https://longhorn.io/docs/"
-    type: vendor-docs
-  - title: "Rook — Architecture overview"
-    url: "https://rook.io/docs/rook/latest-release/Getting-Started/intro/"
-    type: vendor-docs
-  - title: "Ceph: A Scalable, High-Performance Distributed File System (Weil et al., OSDI '06)"
-    url: "https://www.usenix.org/legacy/event/osdi06/tech/full_papers/weil/weil.pdf"
-    type: paper
-  - title: "Longhorn vs Ceph (Rook) — r/kubernetes practitioner thread"
-    url: "https://www.reddit.com/r/kubernetes/comments/15h0sw5/longhorn_vs_ceph/"
-    type: benchmark
-  - title: "Frank — Storage / Secrets / SSA gotchas"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/05-gpu-scheduling/index.md
+++ b/blog/content/docs/papers/05-gpu-scheduling/index.md
@@ -632,6 +632,3 @@ allocation and management UI.
 The space is not done evolving. Frank will revisit this paper when the
 answers change.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/05-gpu-scheduling/index.md
+++ b/blog/content/docs/papers/05-gpu-scheduling/index.md
@@ -30,25 +30,6 @@ tags: ["gpu", "nvidia", "intel", "dra", "kubernetes"]
 capabilities: ["gpu"]
 related_building: "docs/building/04-gpu-compute"
 related_operating: "docs/operating/04-gpu-compute"
-references:
-  - title: "NVIDIA GPU Operator — Overview"
-    url: "https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/overview.html"
-    type: vendor-docs
-  - title: "Kubernetes — Dynamic Resource Allocation"
-    url: "https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/"
-    type: vendor-docs
-  - title: "NVIDIA Multi-Instance GPU (MIG) User Guide"
-    url: "https://docs.nvidia.com/datacenter/tesla/mig-user-guide/"
-    type: vendor-docs
-  - title: "Volcano — A Cloud Native Batch System"
-    url: "https://volcano.sh/en/docs/"
-    type: paper
-  - title: "Intel Resource Drivers for Kubernetes"
-    url: "https://github.com/intel/intel-resource-drivers-for-kubernetes"
-    type: vendor-docs
-  - title: "Frank — gpu-1 specifics gotchas"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/06-gitops-at-small-scale/index.md
+++ b/blog/content/docs/papers/06-gitops-at-small-scale/index.md
@@ -27,25 +27,6 @@ tags: ["gitops", "argocd", "flux", "kubernetes", "homelab"]
 capabilities: ["gitops"]
 related_building: "docs/building/05-gitops"
 related_operating: "docs/operating/03-gitops"
-references:
-  - title: "Argo CD — Architecture"
-    url: "https://argo-cd.readthedocs.io/en/stable/operator-manual/architecture/"
-    type: vendor-docs
-  - title: "Flux — Core Concepts"
-    url: "https://fluxcd.io/flux/concepts/"
-    type: vendor-docs
-  - title: "OpenGitOps Principles v1.0.0"
-    url: "https://opengitops.dev/"
-    type: paper
-  - title: "GitOps — Operations by Pull Request (Alexis Richardson, Weaveworks, 2017)"
-    url: "https://www.weave.works/blog/gitops-operations-by-pull-request"
-    type: talk
-  - title: "Frank — ArgoCD gotcha registry"
-    url: "https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/argocd.md"
-    type: postmortem
-  - title: "ArgoCD vs FluxCD — r/kubernetes practitioner thread"
-    url: "https://www.reddit.com/r/kubernetes/comments/16dj9lr/argocd_vs_fluxcd_which_one_did_you_choose_and_why/"
-    type: benchmark
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/07-observability-honestly/index.md
+++ b/blog/content/docs/papers/07-observability-honestly/index.md
@@ -30,28 +30,6 @@ tags: ["observability", "grafana", "prometheus", "loki", "victoriametrics", "kub
 capabilities: ["obs"]
 related_building: "docs/building/07-observability"
 related_operating: "docs/operating/05-observability"
-references:
-  - title: "Prometheus Operator — Getting Started"
-    url: "https://prometheus-operator.dev/docs/getting-started/introduction/"
-    type: vendor-docs
-  - title: "VictoriaMetrics — Overview & Architecture"
-    url: "https://docs.victoriametrics.com/"
-    type: vendor-docs
-  - title: "Google SRE Book — Monitoring Distributed Systems"
-    url: "https://sre.google/sre-book/monitoring-distributed-systems/"
-    type: paper
-  - title: "Grafana Alerting — Documentation"
-    url: "https://grafana.com/docs/grafana/latest/alerting/"
-    type: vendor-docs
-  - title: "SigNoz — Loki vs Elasticsearch"
-    url: "https://signoz.io/blog/loki-vs-elasticsearch/"
-    type: postmortem
-  - title: "VictoriaMetrics — Benchmarking Prometheus-compatible time series databases"
-    url: "https://victoriametrics.com/blog/remote-write-benchmark/"
-    type: benchmark
-  - title: "Frank — Grafana gotchas"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/08-backup-dr/index.md
+++ b/blog/content/docs/papers/08-backup-dr/index.md
@@ -650,6 +650,3 @@ git" is strengthening. Frank is the early version of that posture.
 The space is not done evolving. Frank will revisit this paper when the
 answers change.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/08-backup-dr/index.md
+++ b/blog/content/docs/papers/08-backup-dr/index.md
@@ -30,28 +30,6 @@ tags: ["backup", "disaster-recovery", "velero", "longhorn", "kasten", "kubernete
 capabilities: ["backup"]
 related_building: "docs/building/08-backup"
 related_operating: "docs/operating/02-storage-backups"
-references:
-  - title: "Velero — How Velero Works"
-    url: "https://velero.io/docs/main/how-velero-works/"
-    type: vendor-docs
-  - title: "Longhorn — Concepts: Backups and Secondary Storage"
-    url: "https://longhorn.io/docs/latest/concepts/"
-    type: vendor-docs
-  - title: "Kubernetes blog — Kubernetes 1.20: Volume Snapshot Moves to GA"
-    url: "https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/"
-    type: paper
-  - title: "restic — Design and References"
-    url: "https://restic.readthedocs.io/en/stable/100_references.html"
-    type: vendor-docs
-  - title: "Frank — Longhorn backup gotchas"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
-  - title: "Longhorn issue #11412 — NFS BackupTarget mount-string bug"
-    url: "https://github.com/longhorn/longhorn/issues/11412"
-    type: postmortem
-  - title: "Longhorn issue #11392 — RecurringJob lacks backupTargetName"
-    url: "https://github.com/longhorn/longhorn/issues/11392"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/09-secrets-bootstrap/index.md
+++ b/blog/content/docs/papers/09-secrets-bootstrap/index.md
@@ -678,6 +678,3 @@ the answers change — most likely when the OIDC-trusted-identity story
 matures enough that the bootstrap loop becomes a Kubernetes-native
 operation rather than an out-of-band one.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/09-secrets-bootstrap/index.md
+++ b/blog/content/docs/papers/09-secrets-bootstrap/index.md
@@ -28,34 +28,6 @@ tags: ["secrets", "infisical", "external-secrets", "sops", "vault", "kubernetes"
 capabilities: ["secrets"]
 related_building: "docs/building/09-secrets"
 related_operating: "docs/operating/06-secrets"
-references:
-  - title: "External Secrets Operator — ClusterSecretStore API"
-    url: "https://external-secrets.io/latest/api/clustersecretstore/"
-    type: vendor-docs
-  - title: "Infisical — Self-hosting overview"
-    url: "https://infisical.com/docs/self-hosting/overview"
-    type: vendor-docs
-  - title: "HashiCorp Vault — Architecture"
-    url: "https://developer.hashicorp.com/vault/docs/internals/architecture"
-    type: paper
-  - title: "Mozilla SOPS — README and design"
-    url: "https://github.com/getsops/sops"
-    type: vendor-docs
-  - title: "Frank — Storage / Secrets / SSA gotcha registry"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
-  - title: "Secrets Store CSI Driver — Overview"
-    url: "https://secrets-store-csi-driver.sigs.k8s.io/"
-    type: vendor-docs
-  - title: "External Secrets Operator — GitHub repo"
-    url: "https://github.com/external-secrets/external-secrets"
-    type: vendor-docs
-  - title: "GitGuardian — The State of Secrets Sprawl 2024"
-    url: "https://blog.gitguardian.com/the-state-of-secrets-sprawl-2024/"
-    type: benchmark
-  - title: "KubeCon NA 2022 — The State of Kubernetes Secrets Management"
-    url: "https://kccncna2022.sched.com/event/182PB/the-state-of-kubernetes-secrets-management"
-    type: talk
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/10-self-hosted-inference/index.md
+++ b/blog/content/docs/papers/10-self-hosted-inference/index.md
@@ -460,6 +460,3 @@ small-scale benchmark that the literature has not yet published. The
 dossier names that gap; it is mine to either fill or admit I never
 filled.
 
-## References
-
-*See frontmatter — auto-rendered.*

--- a/blog/content/docs/papers/10-self-hosted-inference/index.md
+++ b/blog/content/docs/papers/10-self-hosted-inference/index.md
@@ -28,22 +28,6 @@ tags: ["inference", "llm", "gpu", "gateway", "litellm", "ollama", "vllm"]
 capabilities: ["infer", "gpu"]
 related_building: "docs/building/10-local-inference"
 related_operating: "docs/operating/07-inference"
-references:
-  - title: "Efficient Memory Management for LLM Serving with PagedAttention (Kwon et al. 2023)"
-    url: "https://arxiv.org/abs/2309.06180"
-    type: paper
-  - title: "Ollama README & Modelfile reference"
-    url: "https://github.com/ollama/ollama"
-    type: vendor-docs
-  - title: "LiteLLM virtual keys, budgets & rate limits"
-    url: "https://docs.litellm.ai/docs/proxy/virtual_keys"
-    type: vendor-docs
-  - title: "vLLM v0.6.0: 2.7× Throughput Improvement and 5× Latency Reduction"
-    url: "https://blog.vllm.ai/2024/09/05/perf-update.html"
-    type: benchmark
-  - title: "Simon Willison — Notes on running LLMs locally"
-    url: "https://simonwillison.net/tags/llm-pricing/"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/11-identity-heterogeneous-stack/index.md
+++ b/blog/content/docs/papers/11-identity-heterogeneous-stack/index.md
@@ -31,25 +31,6 @@ tags: ["authentik", "identity", "sso", "forward-auth", "oidc"]
 capabilities: ["auth"]
 related_building: "docs/building/13-unified-auth"
 related_operating: "docs/operating/08-auth"
-references:
-  - title: "BeyondCorp: A New Approach to Enterprise Security (Ward & Beyer, 2014)"
-    url: "https://research.google/pubs/beyondcorp-a-new-approach-to-enterprise-security/"
-    type: paper
-  - title: "Authentik docs — Forward auth (Proxy provider)"
-    url: "https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/forward_auth/"
-    type: vendor-docs
-  - title: "Keycloak docs — Server Administration Guide"
-    url: "https://www.keycloak.org/docs/latest/server_admin/index.html"
-    type: vendor-docs
-  - title: "Dex docs — A federated OpenID Connect provider"
-    url: "https://dexidp.io/docs/"
-    type: vendor-docs
-  - title: "TechnoTim — 2 Factor Auth and Single Sign on with Authelia"
-    url: "https://docs.technotim.com/posts/authelia-traefik/"
-    type: talk
-  - title: "Authentik — Release notes and breaking-change archive"
-    url: "https://docs.goauthentik.io/docs/releases"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/13-self-hosted-cicd/index.md
+++ b/blog/content/docs/papers/13-self-hosted-cicd/index.md
@@ -559,6 +559,3 @@ several already exist in alpha.
 The space is not done evolving. Frank will revisit this paper when
 the answers change.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/13-self-hosted-cicd/index.md
+++ b/blog/content/docs/papers/13-self-hosted-cicd/index.md
@@ -29,25 +29,6 @@ tags: ["ci-cd", "tekton", "gitea", "zot", "kubernetes"]
 capabilities: ["cicd"]
 related_building: "docs/building/27-cicd-platform"
 related_operating: "docs/operating/22-cicd-platform"
-references:
-  - title: "Tekton — Concepts"
-    url: "https://tekton.dev/docs/concepts/"
-    type: vendor-docs
-  - title: "Tekton Triggers — Interceptors"
-    url: "https://github.com/tektoncd/triggers/blob/main/docs/interceptors.md"
-    type: vendor-docs
-  - title: "Gitea — Webhooks documentation"
-    url: "https://docs.gitea.com/usage/webhooks"
-    type: vendor-docs
-  - title: "Zot — Architecture overview"
-    url: "https://zotregistry.dev/v2.1.0/general/architecture/"
-    type: vendor-docs
-  - title: "GitHub Actions now supports CI/CD"
-    url: "https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/"
-    type: paper
-  - title: "Frank — Tekton / Gitea / Zot gotchas"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/14-progressive-delivery/index.md
+++ b/blog/content/docs/papers/14-progressive-delivery/index.md
@@ -607,6 +607,3 @@ the Cilium tax is much smaller.
 The space is not done evolving. Frank will revisit this paper when
 the answers change.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/14-progressive-delivery/index.md
+++ b/blog/content/docs/papers/14-progressive-delivery/index.md
@@ -30,22 +30,6 @@ tags: ["progressive-delivery", "argo-rollouts", "flagger", "service-mesh", "kube
 capabilities: ["deploy"]
 related_building: "docs/building/19-progressive-delivery"
 related_operating: "docs/operating/12-progressive-delivery"
-references:
-  - title: "Argo Rollouts — Canary strategy"
-    url: "https://argo-rollouts.readthedocs.io/en/stable/features/canary/"
-    type: vendor-docs
-  - title: "Flagger — How it works"
-    url: "https://docs.flagger.app/usage/how-it-works"
-    type: vendor-docs
-  - title: "Introducing Kayenta — Google Cloud + Netflix"
-    url: "https://cloud.google.com/blog/products/gcp/introducing-kayenta-an-open-automated-canary-analysis-tool-from-google-and-netflix"
-    type: paper
-  - title: "Flagger vs Argo Rollouts vs service meshes (CNCF / Buoyant)"
-    url: "https://www.cncf.io/blog/2024/02/27/flagger-vs-argo-rollouts-vs-service-meshes-a-guide-to-progressive-delivery-in-kubernetes/"
-    type: benchmark
-  - title: "Frank — Argo Rollouts gotchas"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/15-ingress-and-service-catalog/index.md
+++ b/blog/content/docs/papers/15-ingress-and-service-catalog/index.md
@@ -611,6 +611,3 @@ label gets a tile" — and at that point the catalogue collapses back
 into the cluster's own resource model, where it arguably should have
 lived from the start.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/15-ingress-and-service-catalog/index.md
+++ b/blog/content/docs/papers/15-ingress-and-service-catalog/index.md
@@ -28,34 +28,6 @@ tags: ["ingress", "traefik", "authentik", "forward-auth", "homepage", "service-c
 capabilities: ["net", "auth"]
 related_building: "docs/building/24-in-cluster-ingress"
 related_operating: "docs/operating/17-ingress"
-references:
-  - title: "Traefik v3.5 — ForwardAuth middleware"
-    url: "https://doc.traefik.io/traefik/v3.5/middlewares/http/forwardauth/"
-    type: vendor-docs
-  - title: "Authentik — Proxy provider documentation"
-    url: "https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/"
-    type: vendor-docs
-  - title: "Kubernetes — Ingress Controllers (project recommendation)"
-    url: "https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/"
-    type: vendor-docs
-  - title: "Kubernetes Gateway API"
-    url: "https://gateway-api.sigs.k8s.io/"
-    type: paper
-  - title: "oauth2-proxy — reverse-proxy authentication"
-    url: "https://oauth2-proxy.github.io/oauth2-proxy/"
-    type: vendor-docs
-  - title: "Contour — Ingress controller built on Envoy"
-    url: "https://projectcontour.io/docs/"
-    type: vendor-docs
-  - title: "gethomepage.dev — Services configuration"
-    url: "https://gethomepage.dev/configs/services/"
-    type: vendor-docs
-  - title: "Frank — gotcha registry (operational lessons)"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
-  - title: "Frank — Authentik per-topic runbook"
-    url: "https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/authentik.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/17-agentic-orchestration/index.md
+++ b/blog/content/docs/papers/17-agentic-orchestration/index.md
@@ -30,28 +30,6 @@ tags: ["agents", "orchestration", "secure-workstation", "vibekanban", "paperclip
 capabilities: ["orch"]
 related_building: "docs/building/21-secure-agent-pod"
 related_operating: "docs/operating/14-secure-agent-pod"
-references:
-  - title: "s6-overlay — README and architecture"
-    url: "https://github.com/just-containers/s6-overlay"
-    type: vendor-docs
-  - title: "Coder.com — Platform documentation"
-    url: "https://coder.com/docs"
-    type: vendor-docs
-  - title: "Development Containers Specification (containers.dev)"
-    url: "https://containers.dev/implementors/spec/"
-    type: vendor-docs
-  - title: "Model Context Protocol — Introduction"
-    url: "https://modelcontextprotocol.io/introduction"
-    type: paper
-  - title: "Claude Code — Security and isolation"
-    url: "https://docs.anthropic.com/en/docs/claude-code/security"
-    type: vendor-docs
-  - title: "Agentic Misalignment — Anthropic Research"
-    url: "https://www.anthropic.com/research/agentic-misalignment"
-    type: paper
-  - title: "Frank — Agent shells + Paperclip/Ruflo gotchas registry"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md"
-    type: postmortem
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/17-agentic-orchestration/index.md
+++ b/blog/content/docs/papers/17-agentic-orchestration/index.md
@@ -626,6 +626,3 @@ namespace with a NetworkPolicy".
 The space is not done evolving. Frank will revisit this paper when
 the answers change.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/20-edge-clusters-public-exposure/index.md
+++ b/blog/content/docs/papers/20-edge-clusters-public-exposure/index.md
@@ -31,40 +31,6 @@ tags: ["edge", "headscale", "cloudflare-tunnel", "tailscale", "talos", "caddy", 
 capabilities: ["edge"]
 related_building: "docs/building/17-public-edge"
 related_operating: "docs/operating/11-public-edge"
-references:
-  - title: "Cloudflare Tunnel — Connect networks"
-    url: "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/"
-    type: vendor-docs
-  - title: "How Tailscale Works (Tailscale blog)"
-    url: "https://tailscale.com/blog/how-tailscale-works"
-    type: vendor-docs
-  - title: "Tailscale Funnel"
-    url: "https://tailscale.com/kb/1223/funnel"
-    type: vendor-docs
-  - title: "Headscale — self-hosted Tailscale control server"
-    url: "https://github.com/juanfont/headscale"
-    type: vendor-docs
-  - title: "Talos Linux on Hetzner Cloud"
-    url: "https://docs.siderolabs.com/talos/v1.10/platform-specific-installations/cloud-platforms/hetzner"
-    type: vendor-docs
-  - title: "How NAT traversal works (Tailscale blog)"
-    url: "https://tailscale.com/blog/how-nat-traversal-works"
-    type: paper
-  - title: "awesome-tunneling (anderspitman)"
-    url: "https://github.com/anderspitman/awesome-tunneling"
-    type: postmortem
-  - title: "Frank — Hop cluster gotchas"
-    url: "https://github.com/derio-net/frank/blob/main/agents/rules/hop-gotchas.md"
-    type: postmortem
-  - title: "Cloudflare network — sub-50ms to 95% of users"
-    url: "https://www.cloudflare.com/network/"
-    type: benchmark
-  - title: "inlets.dev — self-hosted HTTP and TCP tunnels"
-    url: "https://inlets.dev/"
-    type: vendor-docs
-  - title: "Rancher Fleet — multi-cluster GitOps"
-    url: "https://fleet.rancher.io/0.15/"
-    type: vendor-docs
 ---
 
 ## TL;DR

--- a/blog/content/docs/papers/20-edge-clusters-public-exposure/index.md
+++ b/blog/content/docs/papers/20-edge-clusters-public-exposure/index.md
@@ -502,6 +502,3 @@ CPU, more storage) or split into two — a public-facing edge cluster
 and a separate mesh-coordination cluster — once the agentic workload
 shape stops fitting on one VPS.
 
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*

--- a/blog/content/docs/papers/references/_index.md
+++ b/blog/content/docs/papers/references/_index.md
@@ -1,0 +1,7 @@
+---
+title: "References"
+weight: 999
+series: ["references"]
+---
+
+{{< papers/references-index >}}

--- a/blog/data/papers/00-why-homelab-in-2026.yaml
+++ b/blog/data/papers/00-why-homelab-in-2026.yaml
@@ -1,0 +1,37 @@
+primary_sources:
+- title: Leaving the Cloud — 37signals Cloud Exit case study
+  type: benchmark
+  url: https://basecamp.com/cloud-exit
+  quoted_passages:
+  - 37signals pulled Basecamp, HEY, and five other heritage apps out of AWS and onto their own hardware — without adding any new staff. By 2022, their cloud bills had grown to over $3.2 million annually.
+  - Performance improved dramatically, with database queries running 3-5x faster and page load times improving 30-50%.
+  - Total projected savings from the combined cloud exit are well over $10 million over five years. The hardware cost was approximately $600,000 for a one-time purchase.
+  relevance: Canonical real-world cost benchmark of cloud-vs-self-hosted for a stable, predictable workload at small-org scale. Provides hard numbers other practitioners cite. Most directly supports §2 of Paper 00 (real costs of the three approaches).
+- title: Simon Willison — LLM pricing notes
+  type: postmortem
+  url: https://simonwillison.net/tags/llm-pricing/
+  quoted_passages:
+  - One of the most notable trends from 2024 was the total collapse in terms of LLM pricing — the API models are absurdly inexpensive now.
+  - Generating captions for 68,000 photos using Gemini 1.5 Flash 8B costs $1.68.
+  relevance: Running practitioner log of frontier LLM API price collapse. Critical counterweight to the assumption that 'self-host because cloud inference is expensive' — at most scales the API is now cheaper by an order of magnitude. Supports the counter-argument in §3.
+- title: Do you need Omni? — Sidero Labs
+  type: vendor-docs
+  url: https://www.siderolabs.com/blog/do-you-need-omni
+  quoted_passages:
+  - Omni handles the lifecycle of Talos Linux machines, provides unified access to the Talos and Kubernetes API tied to the identity provider of your choice, and provides a UI for cluster management and operations.
+  - From initial machine registration through cluster creation, day-to-day operations, and rolling upgrades, everything is handled through a single interface.
+  relevance: Vendor's own articulation of where the managed homelab-as-code seam sits. Defines what 'managed control-plane on owned hardware' actually means in practice and what it costs in operational autonomy.
+- title: Kubernetes 101 — Jeff Geerling video series
+  type: talk
+  url: https://kube101.jeffgeerling.com/
+  quoted_passages:
+  - A YouTube streaming series on Kubernetes and container-based infrastructure by Jeff Geerling.
+  - Everything on his site is being served from a Drupal site, which used to run on a Kubernetes cluster of Raspberry Pis in Jeff Geerling's basement.
+  relevance: Highest-visibility practitioner positioning of the DIY-homelab-for-learning thesis. Anchors the framing that real-world clusters built from cheap hardware teach skills that paid courses don't.
+- title: 'AKS vs EKS vs GKE: What you get with managed Kubernetes-as-a-Service — Fairwinds'
+  type: talk
+  url: https://www.fairwinds.com/blog/aks-eks-gke-managed-kubernetes-as-a-service
+  quoted_passages:
+  - Managed Kubernetes services take the complexities of managing Kubernetes clusters and relieve organizations of the underlying infrastructure management tasks. These services automatically handle the installation, configuration, and maintenance of Kubernetes.
+  - When you run Kubernetes yourself, you have to manage everything such as servers, networking, upgrades, and security, which adds significant operational overhead.
+  relevance: Counter-position arguing for cloud defaults. The strongest case for 'why not just use a managed cluster?' that Paper 00 must engage with honestly rather than dismiss.

--- a/blog/data/papers/01-heterogeneous-hardware.yaml
+++ b/blog/data/papers/01-heterogeneous-hardware.yaml
@@ -1,0 +1,51 @@
+primary_sources:
+- title: Kubernetes docs — Assigning Pods to Nodes (nodeSelector, taints, tolerations, affinity)
+  type: vendor-docs
+  url: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+  quoted_passages:
+  - You can constrain a Pod so that it is restricted to run on particular node(s), or to prefer to run on particular nodes.
+  - Taints are the opposite — they allow a node to repel a set of pods. Tolerations are applied to pods. Tolerations allow the scheduler to schedule pods with matching taints. Tolerations allow scheduling but don't guarantee scheduling.
+  relevance: The canonical vocabulary for expressing 'these pods run on these node classes' — every heterogeneous fleet uses this surface, whether the labels come from per-node Talos patches (Frank), Karpenter NodeClaim provisioning, or Cluster API MachineDeployment template inheritance. §1 and §3 anchor on this primitive.
+- title: Karpenter docs — NodePools and NodeClasses
+  type: vendor-docs
+  url: https://karpenter.sh/docs/concepts/nodepools/
+  quoted_passages:
+  - NodePools set constraints on the nodes that can be created by Karpenter and the pods that can run on those nodes.
+  - It is recommended to create NodePools that are mutually exclusive. So no Pod should match multiple NodePools. If multiple NodePools are matched, Karpenter will use the NodePool with the highest weight.
+  - Karpenter recommends using as few NodePools as possible to keep your configuration simple and manageable.
+  relevance: Karpenter's own doc explicitly couples heterogeneity to operator cost — 'as few NodePools as possible'. That's the cloud-managed-fleet analogue of Frank's tax-on-classes argument; §4 cites this directly when characterising the per-node-class operator cost that the literature implies but does not measure.
+- title: Cluster API — Concepts (MachineDeployments, MachineSets, Machines)
+  type: vendor-docs
+  url: https://cluster-api.sigs.k8s.io/user/concepts
+  quoted_passages:
+  - A 'machine' is the declarative spec for an infrastructure component hosting a Kubernetes Node (for example, a VM).
+  - A MachineDeployment provides declarative updates for Machines and MachineSets.
+  relevance: The other major CRD-based heterogeneity surface. Cluster API's MachineDeployment-per-class pattern is what the bare-metal world converges on as it grows past the talosctl-per-node regime. §3 contrasts it with Frank's per-node Talos patches and Karpenter's NodePool CRDs as three points on the same 'declare your node classes' axis.
+- title: Talos Linux v1.10 — Managing Kubernetes nodes via Talos machine config
+  type: vendor-docs
+  url: https://www.talos.dev/v1.10/kubernetes-guides/configuration/managing-nodes/
+  quoted_passages:
+  - Talos provides built-in support for managing Kubernetes node labels, annotations, and taints via Talos machine configuration.
+  - Node labels, annotations and taints managed via Talos take precedence over the values set on the node directly. They are reconciled to the desired state on each Talos restart.
+  relevance: The mechanism that Frank actually uses to declare its seven-node, four-hardware-class fleet — one machine-config patch per node under `patches/phase01-node-config/`. Demonstrates that the heterogeneous-bare-metal shape doesn't require Cluster API or Karpenter at small N; the OS can carry the role/zone/hardware label schema.
+- title: Raspberry Pi Cluster Episode 3 — Installing K3s Kubernetes on the Turing Pi (Geerling, 2020)
+  type: benchmark
+  url: https://www.jeffgeerling.com/blog/2020/installing-k3s-kubernetes-on-turing-pi-raspberry-pi-cluster-episode-3/
+  quoted_passages:
+  - K3s is purpose-built for low-power, small-form-factor compute clusters like the Turing Pi, since it is lighter than the full-fat K8s, requires much less in the way of resources to operate, and was easier to set up.
+  - I'm able to deploy K3s to the cluster, and it works well enough... but there are still some quirks I'd like to iron out, especially when it comes to the slower Pi 3 B+ compute modules I'm using on this Turing Pi.
+  relevance: The reference work for the all-RPi homelab fleet shape — including the candid 'works well enough … some quirks' note that anchors the §2 claim about what the all-Pi fleet teaches and what it cannot. The 'slower Pi 3 B+ … some quirks' admission is itself an argument for why even the ostensibly-homogeneous Pi fleet pays a tax on the day one Pi differs from the others.
+- title: Frank cluster gotcha registry (frank-gotchas.md)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - kubectl port-forward flakes regularly with CNI-netns errors on gpu-1 pods only — use `kubectl get application -n argocd -o wide` for argocd-cli replacements; use `kubectl exec ... wget -qO-` for in-pod metrics.
+  - 'Pin GPU workloads with `nodeSelector: kubernetes.io/hostname: gpu-1` + defensive `nvidia.com/gpu:NoSchedule` toleration (insurance against driver re-validation re-asserting the taint).'
+  relevance: Frank's own running ledger of per-node-class failure modes — the gpu-1-only port-forward flake, the defensive NoSchedule toleration pattern, the Ollama-cgroup-memory pitfall. Every entry is direct evidence that a heterogeneous fleet pays a per-class operator tax that a homogeneous fleet wouldn't; §3 and §5 cite this for the scar callouts.
+- title: pc-1 reboot investigation (2026-05-11) — 245-line root-cause writeup
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/docs/investigations/2026-05-11--hw--pc-1-reboot-investigation.md
+  quoted_passages:
+  - 'pc-1 has rebooted 7 times in the last 33 days (window: 2026-04-04 → 2026-05-07), with no kernel panic, no OOM kill, no watchdog event, and no thermal trip recorded.'
+  - 'Verdict: hardware-class fault. Best-fit single-cause hypothesis is a deteriorating 2013-era ATX PSU (Corsair / OCZ-era unit, well past typical 7–10 year capacitor service life) browning out under transient CPU load.'
+  relevance: The canonical pc-1 scar — and the structural argument for keeping it in the fleet despite the failure. A homogeneous fleet of 2025-vintage mini-PCs would never have surfaced a 'silent reset faster than printk' failure mode; the heterogeneous fleet did, and the investigation that resulted is itself a deliverable. §5's first scar callout is this incident.

--- a/blog/data/papers/02-immutable-os.yaml
+++ b/blog/data/papers/02-immutable-os.yaml
@@ -1,0 +1,47 @@
+primary_sources:
+- title: Talos Linux — Concepts
+  type: vendor-docs
+  url: https://www.talos.dev/v1.11/learn-more/concepts/
+  quoted_passages:
+  - Talos is a modern OS designed to be secure, immutable, and minimal.
+  - Talos is configured exclusively through an API; there is no SSH access or interactive shell.
+  - 'Machine configuration is the source of truth: applying a new config replaces the existing one.'
+  relevance: Vendor's canonical articulation of Talos's API-only management model and the 'no SSH, no shell' posture. Defines the model Frank actually runs on all seven nodes and grounds the architecture diagram in the vendor's own authoritative description.
+- title: Fedora CoreOS — Documentation
+  type: vendor-docs
+  url: https://docs.fedoraproject.org/en-US/fedora-coreos/
+  quoted_passages:
+  - Fedora CoreOS is an automatically-updating, minimal operating system for running containerized workloads securely and at scale.
+  - It is the successor to CoreOS Container Linux and Atomic Host, combining the provisioning tools, automatic update model, and philosophy of CoreOS Container Linux with the packaging technology, OCI support, and SELinux security of Atomic Host.
+  - Provisioning is performed by Ignition, which runs only on the first boot.
+  relevance: Vendor's own description of the Fedora CoreOS model — first-boot Ignition + rpm-ostree A/B updates. Anchors the Fedora CoreOS architecture diagram and supports the quadrant placement (immutable + Ignition-bootstrapped, not API-driven the way Talos and Bottlerocket are).
+- title: Ignition (CoreOS) — Specification
+  type: vendor-docs
+  url: https://coreos.github.io/ignition/
+  quoted_passages:
+  - Ignition is a provisioning utility designed specifically for CoreOS-like OSes that reads its configuration from the system's firmware and applies it during the initramfs.
+  - Ignition runs only once on the first boot.
+  relevance: The Ignition spec underpins both Fedora CoreOS and Flatcar. Used to explain the shared 'image-based, Ignition-bootstrapped' family of immutable OSes that sits between Talos and the mutable baseline.
+- title: 'Bottlerocket: A special-purpose container operating system (AWS blog)'
+  type: paper
+  url: https://aws.amazon.com/blogs/containers/bottlerocket-a-special-purpose-container-operating-system/
+  quoted_passages:
+  - Bottlerocket is a Linux-based open-source operating system that we built from the ground up to run containers.
+  - We've removed everything that's not needed to run containers, which reduces the attack surface area and the resources used.
+  - All software changes are applied via image-based updates, which enable faster, more reliable updates that can be quickly rolled back if necessary.
+  relevance: AWS's own design rationale for Bottlerocket — purpose-built, image-based updates, minimal surface area. The canonical AWS articulation referenced by every Bottlerocket-vs-X comparison. Used in landscape positioning, architecture diagram, and the ASG-coordinated update story.
+- title: ImmutableServer (Martin Fowler / ThoughtWorks)
+  type: paper
+  url: https://martinfowler.com/bliki/ImmutableServer.html
+  quoted_passages:
+  - An ImmutableServer is one that, once instantiated, is never modified. Updates and fixes occur not by changing the existing server, but by creating a new one.
+  - 'Phoenix servers go further: they are also re-created from scratch regularly, regardless of need.'
+  relevance: The canonical framing essay that names the immutable-server pattern and contrasts it with traditional mutable infrastructure. Used to anchor the capability question and to draw the philosophical line between Frank's choice (immutable) and the mutable baseline.
+- title: Frank — OS / Talos / Hop gotchas (postmortem registry)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/hop-gotchas.md
+  quoted_passages:
+  - talosctl apply-config --config-patch patches the base file, not the running config — all patches must be combined in one invocation.
+  - 'Talos control-plane taint must be removed for single-node cluster (allowSchedulingOnControlPlanes: true in Talos config).'
+  - 'PodSecurity namespaces must be labeled pod-security.kubernetes.io/enforce: privileged for hostPort/privileged pods.'
+  relevance: Frank's own running postmortem registry — concrete operational scars accumulated across two clusters (Frank, Hop) while running Talos in production for this learning platform. Provides the source-of-truth dates and recovery commands for the scar callouts and underwrites the decision-tree branches.

--- a/blog/data/papers/03-ebpf-networking.yaml
+++ b/blog/data/papers/03-ebpf-networking.yaml
@@ -1,0 +1,44 @@
+primary_sources:
+- title: Cilium — Component Overview
+  type: vendor-docs
+  url: https://docs.cilium.io/en/stable/overview/component-overview/
+  quoted_passages:
+  - Cilium agent (cilium-agent) runs on each node in the cluster. At a high-level, the agent accepts configuration via Kubernetes or APIs that describes networking, service load-balancing, network policies, and visibility & monitoring requirements.
+  - The Cilium agent compiles configuration into eBPF programs that are loaded into the kernel and runs the related management tasks like updating BPF maps.
+  relevance: 'Vendor''s authoritative description of Cilium''s data-plane model — eBPF programs compiled by the per-node agent and loaded into the kernel via BPF maps. Grounds the §3 Cilium architecture diagram and the §5 description of Frank''s `kubeProxyReplacement: true` configuration.'
+- title: Cilium 1.17 release blog (Isovalent)
+  type: vendor-docs
+  url: https://isovalent.com/blog/post/cilium-1-17/
+  quoted_passages:
+  - Cilium 1.17 introduces Service Mesh enhancements with L7 traffic management and BGP advancements for L3 routing.
+  - Cilium continues to push eBPF as the foundational dataplane for cloud-native networking, with new features in routing, load balancing, and observability.
+  relevance: The version Frank actually runs. Anchors the §1 / §3 claims about feature scope and the §5 LBIPAM and MixedProtocolLBService observations to a specific release rather than a generic 'Cilium does this'.
+- title: 'Liz Rice — eBPF: A New Frontier for Performance Tooling (KubeCon NA 2021)'
+  type: talk
+  url: https://kccncna2021.sched.com/event/lV3T
+  quoted_passages:
+  - eBPF is the kernel's universal programmability layer — it lets you load sandboxed programs into the kernel that run on every packet, every syscall, every scheduler tick.
+  - Cilium is the largest eBPF application in production today; it replaced kube-proxy at GitLab, Adobe, Bell, and a half-dozen other multi-thousand-node Kubernetes deployments.
+  relevance: The canonical introduction of eBPF-as-data-plane to the Kubernetes operator audience. Underwrites the §2 axis 'userspace ↔ kernel/eBPF' and the §7 roadmap claim that the iptables-kube-proxy default is on its way out.
+- title: CNI Benchmark — Cilium vs Calico vs Kube-router (Cilium)
+  type: benchmark
+  url: https://cilium.io/blog/2021/05/11/cni-benchmark/
+  quoted_passages:
+  - Cilium with eBPF kube-proxy replacement reduces latency by 30% in our benchmark vs iptables-mode kube-proxy at 5,000 Services.
+  - iptables rule-evaluation cost is O(N) in the number of Services — at 10,000 Services, kube-proxy resync takes minutes; the eBPF map-lookup is O(1).
+  relevance: Vendor-published benchmark (acknowledged biased toward Cilium, but methodology is open) covering throughput, latency, and rule-evaluation cost at small-to-mid Service counts. Source for the §4 'scale changes' claims about kube-proxy degradation and eBPF map-lookup constancy. The named-gap section in this dossier specifically calls out that this benchmark does not measure the bundled operational tax.
+- title: Frank — Cilium gotchas (FQDN stale BPF, LBIPAM sharing-key, MixedProtocolLBService)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/networking.md
+  quoted_passages:
+  - Stale BPF egress rules persist even after deleting the CiliumNetworkPolicy — must also restart the Cilium agent to clear them.
+  - 'Annotating both Services with the same `lbipam.cilium.io/ips: "<addr>"` does NOT cause Cilium L2 IPAM to coordinate the allocation. IPAM treats each annotation as an independent request, gives the IP to whichever Service it processes first, and leaves the other at `EXTERNAL-IP <pending>` indefinitely with no error event.'
+  - MixedProtocolLBService — TCP/22 + UDP/60000–60015 on a single Cilium L2 LB IP works on Cilium 1.17 + K8s 1.35. No feature gate flip, no annotation, no per-protocol service split.
+  relevance: Frank's own running postmortem registry — concrete operational scars accumulated while running Cilium 1.17 in production on Talos. Provides source-of-truth dates and recovery commands for the §5 scar callouts and underwrites the §6 decision-tree branches.
+- title: Amazon VPC CNI — Pod networking
+  type: vendor-docs
+  url: https://docs.aws.amazon.com/eks/latest/userguide/pod-networking.html
+  quoted_passages:
+  - The Amazon VPC CNI plugin for Kubernetes is the networking plugin for pod networking in Amazon EKS clusters. The plugin is responsible for allocating VPC IP addresses to Kubernetes nodes and configuring the necessary networking for pods on each node.
+  - Each pod receives an IP address from the VPC CIDR and is fully routable on the VPC.
+  relevance: The cloud-managed leaf of the §6 decision tree. Vendor's own description that VPC CNI delegates the data plane to AWS — explicit support for the §6 'AWS-native → VPC CNI' branch and the counter-argument that for that geometry Cilium is overkill.

--- a/blog/data/papers/04-distributed-storage.yaml
+++ b/blog/data/papers/04-distributed-storage.yaml
@@ -1,0 +1,37 @@
+primary_sources:
+- title: Longhorn — Architecture and Concepts
+  type: vendor-docs
+  url: https://longhorn.io/docs/
+  quoted_passages:
+  - Longhorn creates a dedicated storage controller for each volume and synchronously replicates the volume across multiple replicas stored on multiple nodes.
+  - The default replica count is 3. Each replica is placed on a different node based on the configured replica scheduling policy.
+  relevance: Vendor's own articulation of Longhorn's per-volume-engine architecture. Defines the model Frank actually runs (engine pod + N replica pods per volume) and grounds the §3 architecture comparison in Longhorn's authoritative description.
+- title: Rook — Architecture overview
+  type: vendor-docs
+  url: https://rook.io/docs/rook/latest-release/Getting-Started/intro/
+  quoted_passages:
+  - Rook is an open source cloud-native storage orchestrator, providing the platform, framework, and support for Ceph storage to natively integrate with cloud-native environments.
+  - Rook automates deployment, bootstrapping, configuration, provisioning, scaling, upgrading, migration, disaster recovery, monitoring, and resource management.
+  relevance: Definitive description of the operator-driven Ceph deployment model. Anchors the §3 architecture diagram for Rook-Ceph and the §4 'CRUSH wants ≥5 OSD hosts' rule.
+- title: 'Ceph: A Scalable, High-Performance Distributed File System (Weil et al., OSDI ''06)'
+  type: paper
+  url: https://www.usenix.org/legacy/event/osdi06/tech/full_papers/weil/weil.pdf
+  quoted_passages:
+  - We have designed and implemented Ceph, a distributed file system that provides excellent performance, reliability, and scalability.
+  - Ceph maximizes the separation between data and metadata management by replacing allocation tables with a pseudo-random data distribution function (CRUSH) designed for heterogeneous and dynamic clusters of unreliable object storage devices (OSDs).
+  relevance: Foundational academic paper that introduces the CRUSH placement algorithm, the same machinery Rook still deploys twenty years later. Used in §2 and §3 to anchor the centralized-storage definition and explain why Ceph's minimum-host count is what it is.
+- title: Longhorn vs Ceph (Rook) — Reddit r/kubernetes practitioner thread
+  type: benchmark
+  url: https://www.reddit.com/r/kubernetes/comments/15h0sw5/longhorn_vs_ceph/
+  quoted_passages:
+  - Longhorn is much simpler to set up and operate. Ceph is more powerful but requires more nodes and more tuning to perform well.
+  - I run Longhorn on a 3-node cluster with NVMe drives and it just works.
+  relevance: Practitioner-level head-to-head with reproducible setup notes — explicitly names the 'Ceph needs more nodes to perform' rule of thumb cited in §4. Not a controlled benchmark, but the closest thing the community has to one at homelab scale, and representative of the consensus.
+- title: Frank — Storage / Secrets / SSA gotchas (RWO PVC + RollingUpdate deadlock, ESO empty-data rejection)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - 'RWO PVC + RollingUpdate deadlocks; use strategy: Recreate. Switching strategy via Helm needs a one-time kubectl patch to clear the orphan rollingUpdate: block.'
+  - 'ESO: empty data: [] is rejected; delete the ExternalSecret if all keys are removed.'
+  - SOPS-encrypted secrets must NOT be ArgoCD-managed; apply out-of-band from secrets/.
+  relevance: Frank's own running postmortem registry — concrete operational scars accumulated while running Longhorn in production for this learning platform. Provides the source-of-truth dates and recovery commands for §5 scar callouts and underwrites the §6 decision-tree branches.

--- a/blog/data/papers/05-gpu-scheduling.yaml
+++ b/blog/data/papers/05-gpu-scheduling.yaml
@@ -1,0 +1,44 @@
+primary_sources:
+- title: NVIDIA GPU Operator — Overview
+  type: vendor-docs
+  url: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/overview.html
+  quoted_passages:
+  - The NVIDIA GPU Operator uses the operator framework within Kubernetes to automate the management of all NVIDIA software components needed to provision GPU.
+  - These components include the NVIDIA drivers (to enable CUDA), Kubernetes device plugin for GPUs, the NVIDIA Container Toolkit, automatic node labeling using GFD, DCGM based monitoring and others.
+  relevance: Vendor's authoritative description of what the Operator does — five lifecycle components bundled into a single operator. Grounds the §3 NVIDIA architecture diagram and underwrites the §5 description of Frank's driver.enabled false Talos workaround (driver is the one component the Operator does NOT manage on Frank, because Talos system extensions already provide it).
+- title: Kubernetes — Dynamic Resource Allocation
+  type: vendor-docs
+  url: https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/
+  quoted_passages:
+  - DRA is a Kubernetes feature that lets you request and share resources among Pods. These resources are often attached devices like hardware accelerators.
+  - These benefits provide significant improvements in the device allocation workflow when compared to device plugins, which require per-container device requests, dont support device sharing, and dont support expression-based device filtering.
+  relevance: Upstream Kubernetes definition of DRA and the explicit contrast with the legacy device-plugin model. Anchors the §2 axis device plugin (legacy) ↔ DRA (KEP-4381) and the §7 roadmap claim that DRA is eating the device-plugin API.
+- title: NVIDIA Multi-Instance GPU (MIG) User Guide
+  type: vendor-docs
+  url: https://docs.nvidia.com/datacenter/tesla/mig-user-guide/
+  quoted_passages:
+  - The Multi-Instance GPU (MIG) User Guide explains how to partition supported NVIDIA GPUs into multiple isolated instances, each with dedicated compute and memory resources.
+  - MIG enables efficient GPU utilization across multiple users or workloads with guaranteed performance.
+  relevance: Vendor's authoritative description of MIG — hardware-level partitioning of a single physical GPU into isolated instances. Source for the §3 MIG/MPS architecture diagram, the §4 fragmentation-cost discussion, and the §6 decision-tree leaf multi-tenant on a single big card.
+- title: Volcano — A Cloud Native Batch System
+  type: paper
+  url: https://volcano.sh/en/docs/
+  quoted_passages:
+  - Volcano is a cloud native system for high-performance workloads, which has been accepted by Cloud Native Computing Foundation (CNCF) as its first and only official container batch scheduling project.
+  - Ensure all tasks of a job start simultaneously, suitable for distributed training and big data scenarios
+  relevance: CNCF Incubating projects own positioning statement and the gang-scheduling definition. Source for the §3 Volcano architecture diagram and the §6 decision-tree branch multi-tenant batch workloads. Counters the assumption that gang scheduling requires Run.AIs commercial product.
+- title: Intel Resource Drivers for Kubernetes
+  type: vendor-docs
+  url: https://github.com/intel/intel-resource-drivers-for-kubernetes
+  quoted_passages:
+  - Intel resource drivers for Kubernetes is an alternative for Intel device plugins, facilitating workload offloading by providing accelerator access on Kubernetes cluster worker nodes.
+  - The resource drivers are based on Dynamic Resource Allocation (DRA) framework in Kubernetes
+  relevance: Vendors authoritative positioning of the DRA replacement path for Intel hardware. Underwrites the §3 architecture diagram for the Intel iGPUs on Franks mini-1/2/3 and the §5 case-study claim that DRA is the path Intel has taken first.
+- title: Frank — gpu-1 specifics gotchas (Talos extension dance, NVIDIA taint re-assertion, OLLAMA_KEEP_ALIVE cgroup-RAM, port-forward CNI-netns flakes)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - Pin GPU workloads with nodeSelector kubernetes.io/hostname gpu-1 plus defensive nvidia.com/gpu NoSchedule toleration (insurance against driver re-validation re-asserting the taint).
+  - Ollama system memory errors mean container cgroup RAM (not VRAM) — OLLAMA_KEEP_ALIVE page cache pins the cgroup near resources.limits.memory.
+  - kubectl port-forward flakes regularly with CNI-netns errors on gpu-1 pods only — use kubectl get application -n argocd -o wide for argocd-cli replacements; use kubectl exec ... wget -qO- for in-pod metrics.
+  relevance: Franks own running postmortem registry — concrete operational scars accumulated while running the NVIDIA GPU Operator + Intel GPU Resource Driver pair in production for this learning platform. Provides source-of-truth dates and recovery commands for the §5 scar callouts and underwrites the §6 decision-tree branches.

--- a/blog/data/papers/06-gitops-at-small-scale.yaml
+++ b/blog/data/papers/06-gitops-at-small-scale.yaml
@@ -1,0 +1,46 @@
+primary_sources:
+- title: Argo CD — Architecture
+  type: vendor-docs
+  url: https://argo-cd.readthedocs.io/en/stable/operator-manual/architecture/
+  quoted_passages:
+  - Argo CD is implemented as a Kubernetes controller which continuously monitors running applications and compares the current, live state against the desired target state (as specified in the Git repo).
+  - The application controller is a Kubernetes controller which continuously monitors running applications and compares the current, live state against the desired target state. It detects OutOfSync application state and optionally takes corrective action.
+  relevance: Vendor's own articulation of ArgoCD's reconciliation model — pull-mode controller that compares declared state against live state continuously. Anchors the §3 architecture diagram for ArgoCD and underwrites the §1 capability definition.
+- title: Flux — Core Concepts
+  type: vendor-docs
+  url: https://fluxcd.io/flux/concepts/
+  quoted_passages:
+  - Flux is a tool for keeping Kubernetes clusters in sync with sources of configuration (like Git repositories and OCI artifacts), and automating updates to configuration when there is new code to deploy.
+  - Flux is constructed with the GitOps Toolkit, a set of composable APIs and specialized tools for building Continuous Delivery on top of Kubernetes.
+  relevance: Definitive description of the GitOps Toolkit composition model — Flux is unbundled by design, where ArgoCD ships as a single application. Anchors the §2 axis (unbundled vs opinionated) and the §3 Flux architecture diagram.
+- title: OpenGitOps Principles v1.0.0
+  type: paper
+  url: https://opengitops.dev/
+  quoted_passages:
+  - 'Declarative: A system managed by GitOps must have its desired state expressed declaratively.'
+  - 'Versioned and Immutable: Desired state is stored in a way that enforces immutability, versioning and retains a complete version history.'
+  - 'Pulled Automatically: Software agents automatically pull the desired state declarations from the source.'
+  - 'Continuously Reconciled: Software agents continuously observe actual system state and attempt to apply the desired state.'
+  relevance: The CNCF/OpenGitOps working-group definition of what GitOps actually is. The four principles are load-bearing for §1 (the capability definition) and §6 (the decision-tree leaf where the 'just bash + kubectl' option fails Principle 3 and 4).
+- title: GitOps — Operations by Pull Request (Alexis Richardson, Weaveworks, 2017)
+  type: talk
+  url: https://www.weave.works/blog/gitops-operations-by-pull-request
+  quoted_passages:
+  - By using Git as our source of truth and operations toolkit, we can keep declarative descriptions of all of our infrastructure and applications under version control.
+  - Our Git repository is the source of truth for what we want our system to look like. Our diff tools and convergence operators are how we get there.
+  relevance: The original Weaveworks blog post that named the practice. Cited as the historical origin of the GitOps label (the term predates both ArgoCD and Flux v2). Used in §1 to ground the capability in its 2017 articulation.
+- title: Frank — ArgoCD gotcha registry (symlink ComparisonError, manual-syncOptions-inheritance, root re-templating)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/argocd.md
+  quoted_passages:
+  - ArgoCD's repo-server refuses to generate manifests for any source in a repo that contains a symlink resolving above the repo root. Self-heal can't fire because comparison itself fails, so the cluster silently runs on the last-known-good cache indefinitely.
+  - 'Manually-triggered syncs do NOT inherit spec.syncPolicy.syncOptions ... any chart-bundled CM larger than ~250KB ... fails with metadata.annotations: Too long: may not be more than 262144 bytes.'
+  - Root App-of-Apps re-templates leaf Application specs on every sync. Any live mutation to a leaf is reverted within the root's sync window.
+  relevance: Frank's running postmortem registry for ArgoCD — concrete operational scars accumulated while running the App-of-Apps pattern in production for this learning platform. Provides the source-of-truth dates and recovery commands for the §5 scar callouts and underwrites the §6 decision-tree branches with real failure modes.
+- title: ArgoCD vs FluxCD — r/kubernetes practitioner thread
+  type: benchmark
+  url: https://www.reddit.com/r/kubernetes/comments/16dj9lr/argocd_vs_fluxcd_which_one_did_you_choose_and_why/
+  quoted_passages:
+  - ArgoCD has the better UI by far. Flux is more modular and feels more Kubernetes-native, but the UI gap is real.
+  - We picked Flux because we wanted everything to be a CR and we didn't want a separate UI service running. We picked ArgoCD because we wanted the UI and the App-of-Apps pattern.
+  relevance: Practitioner-level head-to-head capturing the community consensus on the trade Frank made. Not a controlled benchmark, but representative of the decision shape for the ≤10-node single-cluster case the paper actually addresses.

--- a/blog/data/papers/07-observability-honestly.yaml
+++ b/blog/data/papers/07-observability-honestly.yaml
@@ -1,0 +1,51 @@
+primary_sources:
+- title: Prometheus Operator — Getting Started
+  type: vendor-docs
+  url: https://prometheus-operator.dev/docs/getting-started/introduction/
+  quoted_passages:
+  - The Prometheus Operator provides Kubernetes native deployment and management of Prometheus and related monitoring components.
+  - ServiceMonitor, which declaratively specifies how groups of Kubernetes services should be monitored. The Operator automatically generates Prometheus scrape configuration based on the current configuration of the API objects.
+  relevance: Anchors the §3 architecture diagram for the LGTM stack — defines the ServiceMonitor model Frank actually uses for in-cluster discovery and the operator-managed reconciliation loop that produces the live Prometheus scrape config.
+- title: VictoriaMetrics — Overview & Architecture
+  type: vendor-docs
+  url: https://docs.victoriametrics.com/
+  quoted_passages:
+  - VictoriaMetrics is a fast, cost-effective and scalable monitoring solution and time series database.
+  - It is optimized for storage with high-latency IO and low IOPS (HDD and network storage in AWS, GCP, Azure, etc.) compared to other solutions.
+  relevance: Vendor's own articulation of the small-cluster wins — low IOPS, low RAM, Prometheus wire-compatible. Anchors the §2 vendor positioning and the §4 'metric cardinality' callout that drives Frank's choice of VM over a stock Prometheus TSDB.
+- title: Google SRE Book — Monitoring Distributed Systems (Chapter 6)
+  type: paper
+  url: https://sre.google/sre-book/monitoring-distributed-systems/
+  quoted_passages:
+  - Monitoring a very complex application is a significant engineering endeavor in and of itself. Even with substantial existing infrastructure for instrumentation, collection, display, and alerting in place, a Google SRE team with 10–12 members typically has one or sometimes two members whose primary assignment is to build and maintain monitoring systems for their service.
+  - 'Your monitoring system should address two questions: what''s broken, and why? The ''what''s broken'' indicates the symptom; the ''why'' indicates a (possibly intermediate) cause.'
+  relevance: The foundational text on what an observability system is FOR — symptom vs cause, the four golden signals, the cost of monitoring as engineering effort. Cited in §1 to frame the capability and in §5 to ground Frank's choice to provision alerts from code, not click-ops.
+- title: Grafana Alerting — Documentation
+  type: vendor-docs
+  url: https://grafana.com/docs/grafana/latest/alerting/
+  quoted_passages:
+  - Grafana Alerting is a unified alerting system, where alerts are managed in a single location for all your data sources.
+  - 'Alert rules: Define the conditions that trigger alerts. Each rule consists of one or more queries and expressions, a condition that needs to be met, and an interval at which the rule should be evaluated.'
+  relevance: Underwrites §3 (alerting architecture diagram) and §5 (the 12.x SSE alert rules need a 3-step A→B→C — the classic-condition format that worked in Grafana 11 breaks with sse.parseError on 12.x). Vendor's authoritative description of the alert-rule shape Frank's alerts must conform to.
+- title: SigNoz — Loki vs Elasticsearch (practitioner comparison)
+  type: postmortem
+  url: https://signoz.io/blog/loki-vs-elasticsearch/
+  quoted_passages:
+  - Loki indexes only metadata (labels) for log entries, while Elasticsearch indexes the full content of logs. This fundamental design choice has significant implications for storage costs, query performance, and use cases.
+  - Loki is significantly more cost-effective for storing large volumes of logs because of its index-light design and use of object storage backends like S3, GCS, or local filesystems.
+  relevance: Practitioner-level head-to-head with concrete trade-offs on the index-at-write vs index-at-query split. Used in §3 to explain why Loki's log model is structurally different from OpenSearch/Elastic, and in §4 to ground the log-volume-vs-query-cost callout.
+- title: VictoriaMetrics — Benchmarking Prometheus-compatible time series databases
+  type: benchmark
+  url: https://victoriametrics.com/blog/remote-write-benchmark/
+  quoted_passages:
+  - vmagent uses 3.2x/1.6x less CPU and 2.7x/3.0x less memory than competing scrape agents (OpenTelemetry Collector and Prometheus 3.x).
+  - VictoriaMetrics uses 5x-10x less RAM than Prometheus for the same data.
+  relevance: Vendor-published benchmark — biased but reproducible. Anchors the §4 cardinality / resource-cost callout that justifies Frank's swap from stock Prometheus to VictoriaMetrics on a small-cluster footprint.
+- title: Frank — Grafana gotchas (file-provisioned alerts, SSE alert format, ALERTS{} in VM)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - File-provisioned alerts/dashboards in apps/grafana-alerting/manifests/ are read-only in UI; edit ConfigMap, push, restart pod (provisioning files are read at boot, not watched).
+  - 12.x SSE alert rules need 3-step A→B→C; classic-condition format fails with sse.parseError.
+  - ALERTS{} does NOT exist in VM for Grafana-managed alerts — use alertlist panel type.
+  relevance: Frank's own running postmortem registry — concrete operational scars accumulated while running the Grafana stack against VictoriaMetrics. Provides the source-of-truth one-liners and recovery commands for §5 scar callouts.

--- a/blog/data/papers/08-backup-dr.yaml
+++ b/blog/data/papers/08-backup-dr.yaml
@@ -1,0 +1,50 @@
+primary_sources:
+- title: Velero — How Velero Works
+  type: vendor-docs
+  url: https://velero.io/docs/main/how-velero-works/
+  quoted_passages:
+  - Each Velero operation – on-demand backup, scheduled backup, restore – is a custom resource, defined with a Kubernetes Custom Resource Definition (CRD) and stored in etcd.
+  - Velero also includes controllers that process the custom resources to perform backups, restores, and all related operations.
+  relevance: Vendor's authoritative description of Velero's architecture as a controller-driven backup system that captures Kubernetes API objects via CRDs and stores them alongside volume snapshots. Grounds the §3 architecture diagram for Velero and the §5 'why Frank skips Velero' framing — every operation Velero captures is also captured by ArgoCD + git, leaving only PVC data to handle.
+- title: 'Longhorn — Concepts: Backups and Secondary Storage'
+  type: vendor-docs
+  url: https://longhorn.io/docs/latest/concepts/
+  quoted_passages:
+  - A backup is a snapshot copy that is stored in a secondary storage (NFS or S3-compatible object store) outside of the Longhorn cluster. Backups are designed for the disaster recovery purpose.
+  - Longhorn uses a unique mechanism to construct each backup at the block level. Each backup consists of a metadata file and the data blocks. If a data block is already saved in the secondary storage, this data block will not be transferred again.
+  relevance: Definitive statement that Longhorn's backup model is block-level, deduplicated against the BackupStore, and lives outside the Longhorn cluster on S3 or NFS. This is the architectural fork that distinguishes Longhorn-native from Velero+restic — the dedup is at the volume-block layer, owned by the storage driver, not bolted on by a separate backup controller. Underwrites the §2 capability matrix, the §3 Longhorn diagram, and the §5 'no extra control plane' claim.
+- title: 'Kubernetes blog — Kubernetes 1.20: Volume Snapshot Moves to GA'
+  type: paper
+  url: https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/
+  quoted_passages:
+  - The Kubernetes Volume Snapshot feature is now GA in Kubernetes v1.20. It was introduced as alpha in Kubernetes v1.12, followed by a second alpha with breaking changes in Kubernetes v1.13, and promotion to beta in Kubernetes v1.17.
+  - Volume snapshots provide Kubernetes users with a standardized way to copy a volume's contents at a particular point in time without creating an entirely new volume. This functionality enables, for example, database administrators to backup databases before performing edit or delete modifications.
+  relevance: Canonical announcement that the CSI VolumeSnapshot API graduated to GA — the cross-vendor primitive every modern backup tool now consumes. Anchors the §2 axis 'volume-only ↔ application-aware' and the §7 roadmap claim that CSI VolumeSnapshot is becoming the lingua franca and that the divide between storage-native backup (Longhorn) and storage-agnostic backup (Velero, Kasten) is narrowing.
+- title: restic — Design and References
+  type: vendor-docs
+  url: https://restic.readthedocs.io/en/stable/100_references.html
+  quoted_passages:
+  - restic uses content-defined chunking and deduplication. Each file is split into variable-sized chunks and the SHA-256 hash of each chunk is used to identify it; identical chunks are stored only once.
+  - The repository's data is stored encrypted using AES-256 in counter mode. The encryption keys are derived from a user-provided password using scrypt.
+  relevance: Vendor description of restic's content-addressed, deduplicated, encrypted-at-rest data model — the design that Velero's File-System Backup mode inherits and that determines why §4 calls out deduplication ratios as a load-bearing scale axis. Underwrites the §3 restic diagram and the §6 'offline-resilient / paranoid' decision-tree leaf.
+- title: Frank — Longhorn backup gotchas (NFS mount-string bug, RecurringJob schema, SOPS-secrets-out-of-band)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - SOPS-encrypted secrets must NOT be ArgoCD-managed; apply out-of-band from `secrets/`.
+  - 'RWO PVC + RollingUpdate deadlocks; use `strategy: Recreate`.'
+  - 'ESO: empty `data: []` is rejected; delete the ExternalSecret if all keys are removed.'
+  relevance: Frank's own running postmortem registry — concrete operational scars accumulated while running Longhorn-native backup to Cloudflare R2 in production for this learning platform. Provides source-of-truth dates and recovery commands for the §5 scar callouts on the SOPS-out-of-band requirement, the RWO restore-order constraint, and the dependency-ordering load-bearing for any DR runbook.
+- title: 'Longhorn issue #11412 — NFS BackupTarget generates host/path instead of host:/path'
+  type: postmortem
+  url: https://github.com/longhorn/longhorn/issues/11412
+  quoted_passages:
+  - remote share not in 'host:dir' format
+  - Fix targeted for Longhorn v1.13.0.
+  relevance: 'Upstream bug report and triage thread for the Longhorn 1.11 NFS mount-string defect that disabled Frank''s local-first restore path. Provides the canonical incident reference for §5 Scar 2 and the §7 roadmap claim that the NAS-target axis is gated on Longhorn v1.13.0 shipping. Type: postmortem, since it documents a confirmed defect, its triage, and its fix-version commitment.'
+- title: 'Longhorn issue #11392 — RecurringJob has no spec.backupTargetName field'
+  type: postmortem
+  url: https://github.com/longhorn/longhorn/issues/11392
+  quoted_passages:
+  - '.spec.backupTargetName: field not declared in schema'
+  relevance: Upstream issue documenting the Longhorn 1.11 CRD schema gap that prevents per-RecurringJob target selection. All RecurringJobs in 1.11 target the `default` BackupTarget; there is no per-job routing. Anchors the §5 Scar 3 callout and the §7 roadmap note that Frank's manifests keep the original two-target names (`daily-nas` / `weekly-r2`) as documentation of intent.

--- a/blog/data/papers/09-secrets-bootstrap.yaml
+++ b/blog/data/papers/09-secrets-bootstrap.yaml
@@ -1,0 +1,65 @@
+primary_sources:
+- title: External Secrets Operator — ClusterSecretStore API
+  type: vendor-docs
+  url: https://external-secrets.io/latest/api/clustersecretstore/
+  quoted_passages:
+  - The ClusterSecretStore is a cluster scoped SecretStore that can be referenced by all ExternalSecrets from all namespaces.
+  - It defines how the operator authenticates against the secret provider — for Infisical, via universalAuthCredentials referencing a clientId and clientSecret stored in Kubernetes Secrets.
+  relevance: Definitive vendor documentation of the ClusterSecretStore CR Frank actually deploys. Grounds the §3 architecture comparison in ESO's own model and underwrites the §5 description of `apps/infisical/manifests/cluster-secret-store.yaml`.
+- title: Infisical — Self-hosting overview
+  type: vendor-docs
+  url: https://infisical.com/docs/self-hosting/overview
+  quoted_passages:
+  - Infisical is an open-source platform for managing secrets, certificates, and configurations across teams and infrastructure.
+  - You can self-host Infisical on your own infrastructure using Docker, Kubernetes, or any other container-orchestration platform.
+  relevance: Vendor's authoritative statement of Infisical's self-hosting model and the projects/environments/identities architecture. Anchors §3's Infisical diagram and the §5 narrative of why a UI-first secret store earns its operational cost at small homelab scale.
+- title: HashiCorp Vault — Architecture
+  type: paper
+  url: https://developer.hashicorp.com/vault/docs/internals/architecture
+  quoted_passages:
+  - Vault is a complex system that has many different pieces. To help both users and developers of Vault build a mental model of how it works, this page documents the system architecture.
+  - The storage backend is untrusted, and is used only to durably store encrypted data.
+  relevance: Canonical architecture document for the heavyweight in the space. Anchors §2's 'self-hosted · dynamic-credentials' quadrant and the §4 scale claim that Vault's storage-backend-is-untrusted model is what enables the audit-log + transit + PKI feature surface that compliance teams pay for.
+- title: Mozilla SOPS — README and design
+  type: vendor-docs
+  url: https://github.com/getsops/sops
+  quoted_passages:
+  - sops is an editor of encrypted files that supports YAML, JSON, ENV, INI and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault, age, and PGP.
+  - Only the values are encrypted, the keys are still readable. That allows you to do diffs that are meaningful and preserve the structure of your file.
+  relevance: Vendor design document for SOPS — the only sane way to ship encrypted bootstrap secrets in Git. Anchors the §3 SOPS-in-Git architecture diagram and the §5 explanation of why `secrets/` is applied out-of-band before Infisical exists.
+- title: Frank — Storage / Secrets / SSA gotcha registry
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - SOPS-encrypted secrets must NOT be ArgoCD-managed; apply out-of-band from `secrets/`.
+  - 'ESO: empty `data: []` is rejected; delete the ExternalSecret if all keys are removed.'
+  - '`envFrom.secretRef` without `optional: true` blocks rolling updates when the Secret is missing.'
+  relevance: Frank's own running incident catalogue, codified as one-liner gotchas with per-topic prose under `docs/runbooks/frank-gotchas/storage-secrets-ssa.md`. Direct evidence for the §5 scar callouts; also the load-bearing claim that every scar in Paper 09 came from a real incident, not a hypothetical.
+- title: Secrets Store CSI Driver — Overview
+  type: vendor-docs
+  url: https://secrets-store-csi-driver.sigs.k8s.io/
+  quoted_passages:
+  - Secrets Store CSI Driver for Kubernetes Secrets — Integrates secrets stores with Kubernetes via a CSI volume.
+  - The Secrets Store CSI Driver secrets-store.csi.k8s.io allows Kubernetes to mount multiple secrets, keys, and certs stored in enterprise-grade external secrets stores into their pods as a volume.
+  relevance: Vendor docs for the CSI-driver alternative to ESO. Anchors the §7 roadmap claim about 'CSI driver vs ESO is the architectural fork to watch' and the §3 architecture diagram for AWS Secrets Manager + CSI.
+- title: External Secrets Operator — GitHub repo
+  type: vendor-docs
+  url: https://github.com/external-secrets/external-secrets
+  quoted_passages:
+  - External Secrets Operator is a Kubernetes operator that integrates external secret management systems like AWS Secrets Manager, HashiCorp Vault, Google Secrets Manager, Azure Key Vault, IBM Cloud Secrets Manager, Akeyless, CyberArk Conjur, Pulumi ESC, and many more.
+  - The operator reads information from external APIs and automatically injects the values into a Kubernetes Secret.
+  relevance: The canonical project repo. Anchors the §2 'ESO + SOPS-in-Git' placement on the landscape and the §3 architecture flow for how ESO sync into native K8s Secret resources is the same regardless of upstream store.
+- title: GitGuardian — The State of Secrets Sprawl 2024
+  type: benchmark
+  url: https://blog.gitguardian.com/the-state-of-secrets-sprawl-2024/
+  quoted_passages:
+  - In 2023, we detected 12.8 million secrets exposed in public GitHub commits — a 28% increase over 2022.
+  - Generic high-entropy strings, generic passwords, and Google API keys remain the top three leak types.
+  relevance: 'The closest thing to an industry-wide benchmark on the cost of NOT running a secret-store: 12.8M leaks in public Git in one year, the empirical pricetag of ''plaintext in Git''. Anchors §4''s scale claim that the rotation-cadence axis flips the ranking when secret count grows past a single human''s mental cache, and provides the headline number for §6''s argument that the null-hypothesis leaf is not safe at any scale where you ship code from more than one machine.'
+- title: KubeCon NA 2022 — The State of Kubernetes Secrets Management
+  type: talk
+  url: https://kccncna2022.sched.com/event/182PB/the-state-of-kubernetes-secrets-management
+  quoted_passages:
+  - There is no single 'right' way to manage secrets in Kubernetes — the right answer depends on whether you trust your cluster API, your storage backend, your CI system, and your operators, and the answer to each is rarely the same.
+  - The trade-off between encrypt-in-Git (Sealed Secrets, SOPS) and sync-from-external-store (ESO, CSI) is fundamentally an axis of where you put the trust boundary.
+  relevance: A community talk that frames the entire space as a trust-boundary decision, which is exactly the framing §6's decision-tree adopts. Cited as the canonical 'there is no single right answer' source — useful when the Paper resists the temptation to declare one vendor universally correct.

--- a/blog/data/papers/10-self-hosted-inference.yaml
+++ b/blog/data/papers/10-self-hosted-inference.yaml
@@ -1,0 +1,41 @@
+primary_sources:
+- title: Efficient Memory Management for Large Language Model Serving with PagedAttention
+  type: paper
+  url: https://arxiv.org/abs/2309.06180
+  quoted_passages:
+  - We propose PagedAttention, an attention algorithm inspired by the classical virtual memory and paging techniques in operating systems.
+  - On top of it, we build vLLM, an LLM serving system that achieves (1) near-zero waste in KV cache memory and (2) flexible sharing of KV cache within and across requests to further reduce memory usage.
+  - Evaluations on various models and workloads show that vLLM improves the throughput of popular LLMs by 2-4× compared with the state-of-the-art systems, such as FasterTransformer and Orca, with the same level of latency.
+  relevance: Foundational paper for vLLM. Defines why PagedAttention beats naive KV-cache layouts under batched workloads — the load-bearing throughput argument for §3 and §4 of the paper. Anchors the 'why are SaaS providers running vLLM' claim.
+- title: Ollama README & Modelfile reference
+  type: vendor-docs
+  url: https://github.com/ollama/ollama
+  quoted_passages:
+  - Get up and running with large language models locally.
+  - Ollama provides the simplest way to run large language models on your own hardware. It packages model weights, configuration, and data into a single Modelfile.
+  - 'OLLAMA_KEEP_ALIVE — Set the duration that models stay loaded in memory (default: 5m, e.g. ''24h'' to keep loaded indefinitely).'
+  relevance: Vendor's own articulation of what Ollama actually is — a llama.cpp wrapper with a Modelfile abstraction and an OpenAI-shaped API. Pairs with the dated Frank incident in §5 where OLLAMA_KEEP_ALIVE pinned the cgroup RAM ceiling and made VRAM look like the bottleneck.
+- title: LiteLLM virtual keys, budgets & rate limits
+  type: vendor-docs
+  url: https://docs.litellm.ai/docs/proxy/virtual_keys
+  quoted_passages:
+  - Track Spend, set budgets and create virtual keys for the proxy.
+  - Maintain different rate limits per user/key/team.
+  - 'Prometheus Metrics — Available on Enterprise. Track LiteLLM usage metrics, with: Total spend on a per-user, model, team basis. Token usage per user, model, team. Rate limit errors.'
+  relevance: 'Vendor''s articulation of the gateway pattern as Frank uses it: virtual keys, cost tracking, OpenAI-compatible routing. Critically, the page itself documents that Prometheus metrics are an Enterprise feature — the load-bearing ''marketing-vs-reality'' gap for §5 carries a direct citation, not just a Frank gotcha.'
+- title: 'vLLM v0.6.0: 2.7× Throughput Improvement and 5× Latency Reduction'
+  type: benchmark
+  url: https://blog.vllm.ai/2024/09/05/perf-update.html
+  quoted_passages:
+  - vLLM v0.6.0 delivers up to 2.7x higher throughput and 5x faster TPOT compared to v0.5.3, on Llama 8B model. The performance is measured on ShareGPT dataset using a single H100 GPU.
+  - For Llama 70B and a single H100, vLLM v0.6.0 delivers 1.8× higher throughput, with TPOT reduced from 200ms to 100ms.
+  - Across H100, A100, A10 GPUs, vLLM consistently outperforms TGI and TensorRT-LLM.
+  relevance: Reproducible benchmark with named hardware (H100, A100, A10), named workload (ShareGPT), and named comparators (TGI, TensorRT-LLM). Anchors the throughput claim in §3 and the 'datacenter-scale benchmarks don't speak to the homelab regime' gap in §4. The 2.7× / 5× numbers are quotable.
+- title: Simon Willison — Notes on running LLMs locally (llm-pricing tag)
+  type: postmortem
+  url: https://simonwillison.net/tags/llm-pricing/
+  quoted_passages:
+  - One of the most notable trends from 2024 was the total collapse in terms of LLM pricing — the API models are absurdly inexpensive now.
+  - Generating captions for 68,000 photos using Gemini 1.5 Flash 8B costs $1.68.
+  - 'Llama 3.2 3B from a developer''s perspective: running locally on my laptop using Ollama, it''s blazingly fast — about 100 tokens per second on my M2 Mac.'
+  relevance: Named practitioner running OSS LLMs at small scale and tracking the API-price collapse in real time. Critical counterweight for §1 and §6 — the 'just use the API' counter-argument is grounded in numbers Simon has actually paid. Pairs with the data-locality / latency-floor / learning-depth triple in §5.

--- a/blog/data/papers/11-identity-heterogeneous-stack.yaml
+++ b/blog/data/papers/11-identity-heterogeneous-stack.yaml
@@ -1,0 +1,43 @@
+primary_sources:
+- title: 'BeyondCorp: A New Approach to Enterprise Security (Ward & Beyer, 2014)'
+  type: paper
+  url: https://research.google/pubs/beyondcorp-a-new-approach-to-enterprise-security/
+  quoted_passages:
+  - Virtually every company today uses firewalls to enforce perimeter security. However, this security model is problematic because, when that perimeter is breached, an attacker has relatively easy access to a company's privileged intranet.
+  - The BeyondCorp initiative is moving to a new model that dispenses with a privileged corporate network. Instead, access depends solely on device and user credentials, regardless of a user's network location.
+  relevance: The IAP / zero-trust origin paper. Establishes the model that every forward-auth IdP — Authentik's embedded outpost, Pomerium, Cloudflare Access — implements 11 years later. Anchors §1's framing of where an IdP sits in a modern stack.
+- title: Authentik docs — Forward auth (Proxy provider)
+  type: vendor-docs
+  url: https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/forward_auth/
+  quoted_passages:
+  - Forward auth uses your reverse proxy (like NGINX, Traefik, or Caddy) to forward authentication requests to authentik before serving the application.
+  - Single application mode allows you to protect a single application with a single proxy provider. Domain level mode allows you to protect multiple applications under the same domain with a single proxy provider.
+  relevance: Vendor's own description of the forward-auth pattern that Frank uses for every protected web UI. Defines the seam between the IdP, the ingress controller (Traefik) and the upstream application, which §3 needs to render as a flowchart.
+- title: Keycloak docs — Identity Brokering
+  type: vendor-docs
+  url: https://www.keycloak.org/docs/latest/server_admin/index.html
+  quoted_passages:
+  - Keycloak is an open source software product to allow single sign-on with identity and access management aimed at modern applications and services.
+  - An Identity Broker is an intermediary service that connects multiple service providers with different identity providers. As an intermediary service, the identity broker is responsible for creating a trust relationship with an external identity provider in order to use its identities to access internal services exposed by service providers.
+  relevance: Defines how a heavy-enterprise IdP positions itself against the smaller open-source IdPs. Supplies the §2 vendor-landscape claim that Keycloak's centre of gravity is brokering / federation, not embedded forward-auth.
+- title: Dex docs — A federated OpenID Connect provider
+  type: vendor-docs
+  url: https://dexidp.io/docs/
+  quoted_passages:
+  - Dex is an identity service that uses OpenID Connect to drive authentication for other apps. Dex acts as a portal to other identity providers through 'connectors.'
+  - This lets dex defer authentication to LDAP servers, SAML providers, or established identity providers like GitHub, Google, and Active Directory.
+  relevance: Defines the 'federation-only' position in the §2 landscape — Dex deliberately does not store users, only proxies authentication. Explains why projects that adopted Dex (ArgoCD's bundled provider) end up adding a 'real' IdP behind it as soon as they want password policies, MFA enrolment, or admin UI.
+- title: TechnoTim — 2 Factor Auth and Single Sign on with Authelia (Traefik forward-auth)
+  type: talk
+  url: https://docs.technotim.com/posts/authelia-traefik/
+  quoted_passages:
+  - Authelia is an open-source authentication and authorization server providing two-factor authentication and single sign-on (SSO) for your applications via a web portal.
+  - It acts as a companion of reverse proxies like nginx, Traefik or HAProxy to let them know whether requests should either be allowed or redirected to Authelia's portal for authentication.
+  relevance: Highest-visibility homelab/SMB-scale write-up of the forward-auth pattern. Anchors the §2 claim that the open-source homelab world has converged on a small set of forward-auth IdPs glued to one of three reverse proxies.
+- title: Authentik — release notes and breaking-change archive
+  type: postmortem
+  url: https://docs.goauthentik.io/docs/releases
+  quoted_passages:
+  - Starting with this release, Outposts will use the URL set in the authentik configuration to access authentik.
+  - OAuth2/OIDC and Proxy Providers now require an Invalidation flow to be set. This flow is used to log the user out of the application.
+  relevance: Source for the schema-migration scar tissue Paper 11 documents — `invalidation_flow`, object-shaped `redirect_uris`, the `AUTHENTIK_HOST` requirement on the embedded outpost. Concrete evidence that 'pin the chart and forget' is not a viable strategy for any self-hosted IdP.

--- a/blog/data/papers/13-self-hosted-cicd.yaml
+++ b/blog/data/papers/13-self-hosted-cicd.yaml
@@ -1,0 +1,45 @@
+primary_sources:
+- title: Tekton — Concepts (Pipelines, Tasks, TaskRuns, PipelineRuns)
+  type: vendor-docs
+  url: https://tekton.dev/docs/concepts/
+  quoted_passages:
+  - Tekton Pipelines are a Kubernetes-native, lightweight, and easy-to-use framework that allow you to build CI/CD systems.
+  - A Task defines a series of ordered Steps that you want to execute. Each Step runs in its own container image.
+  relevance: Vendor's authoritative description of Tekton's pods-as-steps model — Tasks are CRDs, Steps are containers, PipelineRuns and TaskRuns are runtime objects. Grounds the §3 architecture diagram and underwrites the §1 claim that Tekton makes the pipeline itself a manifest in Git.
+- title: Tekton Triggers — EventListeners and Interceptors
+  type: vendor-docs
+  url: https://github.com/tektoncd/triggers/blob/main/docs/interceptors.md
+  quoted_passages:
+  - Interceptors are an extension mechanism that can be used to validate and modify the events that pass through them, including the headers and the body of the request.
+  - The CEL Interceptor can be used to apply CEL expressions to the request body, headers, or other parts of the request.
+  relevance: Definitive description of Tekton Triggers' interceptor mechanism — the `cel` interceptor is what makes Gitea-webhook-to-Tekton-pipeline wiring possible (matching `X-Gitea-Event`, not `X-GitHub-Event`). Load-bearing source for the §5 scar about the github interceptor silently dropping Gitea events.
+- title: Gitea — Webhooks documentation
+  type: vendor-docs
+  url: https://docs.gitea.com/usage/webhooks
+  quoted_passages:
+  - Gitea supports webhooks for repository events. To set up webhooks, in your repository, click on Settings → Webhooks → Add Webhook.
+  - 'Gitea webhooks send the following headers: X-Gitea-Event, X-Gitea-Delivery, X-Hub-Signature, X-Hub-Signature-256.'
+  relevance: Vendor confirmation that Gitea sends `X-Gitea-Event` (not `X-GitHub-Event`). This is the single header difference that makes the Tekton `github` interceptor drop every Gitea webhook silently. Cited in §5's scar callout.
+- title: Zot — Architecture overview
+  type: vendor-docs
+  url: https://zotregistry.dev/v2.1.0/general/architecture/
+  quoted_passages:
+  - Zot is a production-ready vendor-neutral OCI-native container image registry that supports the OCI Distribution and Image Specifications.
+  - Zot's modular architecture supports pluggable storage backends, authentication providers, and a sync mechanism that can mirror from other registries.
+  relevance: Vendor's architectural description of Zot as an OCI-native, CNCF-incubated registry. Grounds the §3 architecture diagram (Zot as the image destination) and the §7 roadmap claim that OCI registries are absorbing arbitrary artefact storage.
+- title: GitHub — GitHub Actions now supports CI/CD (free for public repos)
+  type: paper
+  url: https://github.blog/2019-08-08-github-actions-now-supports-ci-cd/
+  quoted_passages:
+  - GitHub Actions is free for public repositories, providing CI/CD with up to 20 concurrent jobs and a marketplace of pre-built actions.
+  - Hosted runners are available across Linux, macOS, and Windows, with 2,000 free minutes per month for private repositories on the Free plan.
+  relevance: GitHub's own announcement framing of Actions as the SaaS baseline that self-hosted CI/CD competes with. Establishes the cost-curve geometry the rest of the paper measures against (free for OSS at small scale, expensive almost immediately above).
+- title: Frank — Tekton, Gitea, and Zot gotchas (v1 Task computeResources, X-Gitea-Event header, Zot v0.1.0 missing TLS/auth)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - v1 Task uses `computeResources` not `resources` — schema validation silently fails the whole app.
+  - Gitea sends `X-Gitea-Event` (not `X-GitHub-Event`) — use `cel` interceptor, not `github`.
+  - Zot Helm chart v0.1.0 too minimal — use v0.1.60+ for TLS/auth/persistence.
+  - Gitea `webhook.ALLOWED_HOST_LIST` blocks in-cluster delivery — add `*.svc.cluster.local`.
+  relevance: Frank's own running postmortem registry — concrete operational scars accumulated while running Gitea + Tekton + Zot in production for this learning platform. Provides source-of-truth dates and recovery commands for the §5 scar callouts and underwrites the §6 decision-tree branches.

--- a/blog/data/papers/14-progressive-delivery.yaml
+++ b/blog/data/papers/14-progressive-delivery.yaml
@@ -1,0 +1,38 @@
+primary_sources:
+- title: Argo Rollouts — Canary strategy
+  type: vendor-docs
+  url: https://argo-rollouts.readthedocs.io/en/stable/features/canary/
+  quoted_passages:
+  - The canary deployment strategy is a way to roll out new versions of an application that incrementally shifts traffic to the new version.
+  - With Argo Rollouts, you can define a canary strategy that specifies the percentage of traffic to be sent to the new version and the duration of each step.
+  relevance: Vendor's authoritative description of how Argo Rollouts' canary strategy is structured around `setWeight` steps with optional pauses and metric gates. Grounds the §3 architecture comparison in Argo's own model and underwrites the §5 description of Frank's 20→50→100 staged rollout.
+- title: Flagger — How it works
+  type: vendor-docs
+  url: https://docs.flagger.app/usage/how-it-works
+  quoted_passages:
+  - Flagger takes a Kubernetes deployment and optionally a horizontal pod autoscaler (HPA), then creates a series of objects (Kubernetes deployments, ClusterIP services, and a service mesh or ingress controller routing configuration) to drive the canary analysis and promotion.
+  - Flagger requires a service mesh or an ingress controller for traffic routing.
+  relevance: Definitive statement that Flagger's design assumes a traffic router (mesh or ingress). This is the architectural fork that distinguishes Flagger from Argo Rollouts and the load-bearing claim behind the §6 decision-tree branch on 'service mesh already deployed?'.
+- title: Introducing Kayenta — Google Cloud + Netflix announcement
+  type: paper
+  url: https://cloud.google.com/blog/products/gcp/introducing-kayenta-an-open-automated-canary-analysis-tool-from-google-and-netflix
+  quoted_passages:
+  - Kayenta is a platform for Automated Canary Analysis (ACA). It reads in user-configured metric data and runs statistical tests to determine whether a canary deployment differs significantly from its baseline.
+  - Kayenta is a critical component in our deployment pipeline. By automating canary analysis, we have been able to dramatically reduce the time it takes to ship code safely to production.
+  relevance: Joint Google/Netflix launch writeup of Kayenta and the canonical introduction of the term 'automated canary analysis'. Anchors the §2 axis 'manual gating ↔ automated canary analysis' and the §7 roadmap claim that AnalysisTemplate is converging on Kayenta-shaped multi-metric, multi-interval analysis.
+- title: Flagger vs Argo Rollouts vs service meshes — a guide to progressive delivery in Kubernetes (CNCF blog, Buoyant)
+  type: benchmark
+  url: https://www.cncf.io/blog/2024/02/27/flagger-vs-argo-rollouts-vs-service-meshes-a-guide-to-progressive-delivery-in-kubernetes/
+  quoted_passages:
+  - Flagger requires zero manifest changes to adopt canary—you continue using standard Deployments while Flagger manages the traffic splitting automatically.
+  - Argo Rollouts requires migrating Deployment resources to Rollout CRDs, which is a larger migration effort but provides more explicit control via the step-based strategy definition.
+  relevance: Practitioner-level head-to-head from Buoyant (Linkerd maintainers) hosted on the CNCF blog. Explicitly compares Argo Rollouts and Flagger on workloadRef vs Deployment-wrapping, traffic-router coupling, and the Flux-vs-Argo ecosystem split. Closest thing to a controlled comparison in the public literature and source for the §3 cross-vendor shared-shape diagrams.
+- title: Frank — Argo Rollouts gotchas (Cilium plugin 404, workloadRef.scaleDown default, Prometheus empty-vector cascade)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - '`workloadRef.scaleDown` defaults to `never` — set `onsuccess` explicitly or both Rollout + chart Deployment serve traffic.'
+  - '`workloadRef` "leaks" to a healthy-looking Helm Deployment when reconcile aborts pre-workload-phase (missing AnalysisTemplate, missing traffic-router plugin, etc.) — the ONLY signal is the controller pod log; `kubectl get rollout` looks identical to a steady-state run.'
+  - 'Prometheus provider panics on empty result vector → metric `phase: Error` → 10s-cadence retry → canary aborts in ~50s. Verify metric exists + has samples first.'
+  - LiteLLM Prometheus is Enterprise-only — OSS image emits no `litellm_*` metrics.
+  relevance: Frank's own running postmortem registry — concrete operational scars accumulated while running Argo Rollouts in production for this learning platform. Provides source-of-truth dates and recovery commands for the §5 scar callouts and underwrites the §6 decision-tree branches.

--- a/blog/data/papers/15-ingress-and-service-catalog.yaml
+++ b/blog/data/papers/15-ingress-and-service-catalog.yaml
@@ -1,0 +1,59 @@
+primary_sources:
+- title: Traefik v3.5 — ForwardAuth middleware
+  type: vendor-docs
+  url: https://doc.traefik.io/traefik/v3.5/middlewares/http/forwardauth/
+  quoted_passages:
+  - The ForwardAuth middleware delegates authentication to an external Service.
+  relevance: Defines the middleware Frank actually uses to route every SSO-gated IngressRoute to the Authentik embedded outpost. The 'authResponseHeaders' field is what propagates X-authentik-username / -groups / -email to upstream services.
+- title: Authentik — Proxy provider documentation
+  type: vendor-docs
+  url: https://docs.goauthentik.io/docs/add-secure-apps/providers/proxy/
+  quoted_passages:
+  - In this mode, the regular expressions are matched against the Request's Path.
+  - In this mode, the regular expressions are matched against the Request's full URL.
+  relevance: Defines the proxy-provider modes (forward_single, forward_domain, proxy) that Frank's blueprint declares for every SSO-gated service. The forward_single vs forward_domain distinction is what determines whether one Authentik provider serves one app or a wildcard subdomain.
+- title: Kubernetes — Ingress Controllers (project recommendation)
+  type: vendor-docs
+  url: https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/
+  quoted_passages:
+  - The Kubernetes project recommends using Gateway instead of Ingress. The Ingress API has been frozen.
+  - In order for an Ingress to work in your cluster, there must be an ingress controller running.
+  relevance: Authoritative statement that the Ingress API is feature-frozen and Gateway API is the forward path — load-bearing for §7's roadmap argument.
+- title: Kubernetes Gateway API
+  type: paper
+  url: https://gateway-api.sigs.k8s.io/
+  quoted_passages:
+  - Gateway API is an official Kubernetes project focused on L4 and L7 routing in Kubernetes.
+  relevance: The post-Ingress contract — splits GatewayClass / Gateway / HTTPRoute into three CRDs with separate role boundaries (infra owner, cluster operator, application developer). The shape every controller is converging on.
+- title: oauth2-proxy — reverse-proxy authentication
+  type: vendor-docs
+  url: https://oauth2-proxy.github.io/oauth2-proxy/
+  quoted_passages:
+  - A reverse proxy and static file server that provides authentication using Providers (Google, GitHub, and others) to validate accounts by email, domain or group.
+  relevance: 'The non-Authentik forward-auth alternative — same architectural slot (sits between ingress and upstream), different IdP shape. Important §3 comparison point: Nginx + oauth2-proxy is the most common forward-auth stack outside Authentik shops.'
+- title: Contour — Ingress controller built on Envoy
+  type: vendor-docs
+  url: https://projectcontour.io/docs/
+  quoted_passages:
+  - Contour is an Ingress controller for Kubernetes that works by deploying the Envoy proxy as a reverse proxy and load balancer.
+  relevance: Reference for the Envoy + Gateway API + ext_authz architecture — the §3 diagram for 'mesh-shaped' ingress that pushes auth into Envoy's external-authorization filter rather than chaining middleware at the ingress.
+- title: gethomepage.dev — Services configuration
+  type: vendor-docs
+  url: https://gethomepage.dev/configs/services/
+  quoted_passages:
+  - Services are configured inside the services.yaml file. You can have any number of groups, and any number of services per group.
+  relevance: Defines Frank's catalogue shape. The static-config model (ConfigMap → /app/config/services.yaml) is the simplest possible service catalogue — no API server, no scrape loop, no auto-discovery. The blast radius of a typo is one wrong tile, not a broken dashboard.
+- title: Frank gotcha registry — operational lessons
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - 'Cilium: lbipam.cilium.io/ips alone is NOT a sharing directive — separate Services need matching lbipam.cilium.io/sharing-key.'
+  - Blueprints don't assign providers to embedded outpost — manual Django ORM step (see frank-argocd.md).
+  relevance: Frank's own one-line gotcha registry — the two lines above are the load-bearing scars for §5. The full prose lives in per-topic files under docs/runbooks/frank-gotchas/.
+- title: Frank Authentik runbook — per-topic gotcha file
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/authentik.md
+  quoted_passages:
+  - Embedded outpost needs AUTHENTIK_HOST env or forward-auth redirects use 0.0.0.0:9000.
+  - 2026.x requires invalidation_flow + object-shaped redirect_uris + signing_key UUID.
+  relevance: Full-prose recovery commands for the three Authentik scars cited in §5 (manual outpost-provider step, AUTHENTIK_HOST env, 2026.x API shape changes). Direct evidence the scars are real, dated, and have documented recovery paths.

--- a/blog/data/papers/17-agentic-orchestration.yaml
+++ b/blog/data/papers/17-agentic-orchestration.yaml
@@ -1,0 +1,53 @@
+primary_sources:
+- title: s6-overlay — README and architecture
+  type: vendor-docs
+  url: https://github.com/just-containers/s6-overlay
+  quoted_passages:
+  - s6-overlay is a series of init scripts and utilities meant to ease the creation of Docker images using s6 as a process supervisor.
+  - 's6-overlay can run a container as a non-root user, but with caveats: the supervision tree still expects PID 1 to be its own pid1 process.'
+  relevance: Vendor's authoritative description of how s6-overlay v3 supervises non-root container processes. Grounds the §3 architecture description of secure-agent-pod and the §5 scar on shareProcessNamespace fighting s6's PID 1 requirement. The 'non-root with caveats' wording is exactly the constraint Frank stepped on.
+- title: Coder.com — Platform documentation
+  type: vendor-docs
+  url: https://coder.com/docs
+  quoted_passages:
+  - Coder is a self-hosted cloud development environment platform that runs developer workspaces in your infrastructure.
+  - Workspaces are defined as code using Terraform, giving you policy-as-code, audit logs, and centralized control over development environments.
+  relevance: Definitive statement of the managed-platform value proposition. Anchors the §2 axis 'self-hostable vs managed' and the §6 decision-tree leaf for teams that need policy + audit + RBAC but don't want to build it from secure-agent-pod primitives themselves.
+- title: Development Containers Specification (containers.dev)
+  type: vendor-docs
+  url: https://containers.dev/implementors/spec/
+  quoted_passages:
+  - A development container is a running container with a well-defined tool/runtime stack and its prerequisites.
+  - The development container specification (devcontainer.json) is a metadata format used to configure development containers.
+  relevance: The upstream spec that Codespaces, GitPod, and VS Code Remote-Containers all implement. Underwrites the §2 'null hypothesis' positioning of plain devcontainers — they ARE the baseline, and every fancier vendor in the landscape extends this same JSON schema.
+- title: Model Context Protocol — Introduction
+  type: paper
+  url: https://modelcontextprotocol.io/introduction
+  quoted_passages:
+  - The Model Context Protocol (MCP) is an open protocol that standardizes how applications provide context to LLMs.
+  - MCP follows a client-server architecture where a host application can connect to multiple servers.
+  relevance: Anthropic's specification of the protocol that vk-issue-bridge and Paperclip's heartbeat orchestrator both speak. Anchors the §7 roadmap claim that MCP and the agent-control-plane are converging — orchestrator-vs-workstation may collapse into a single MCP deployment with two endpoints.
+- title: Claude Code — Security and isolation
+  type: vendor-docs
+  url: https://docs.anthropic.com/en/docs/claude-code/security
+  quoted_passages:
+  - Claude Code includes safeguards to help prevent destructive operations, but users are ultimately responsible for the code Claude writes and the commands it runs.
+  - We recommend running Claude Code in a sandboxed environment when granting auto-accept permissions.
+  relevance: Vendor's own statement on why a safe workstation matters — Anthropic explicitly recommends sandboxing for auto-accept flows. The 'ultimately responsible' wording is the exact framing for §1 (the capability) and §5 (Frank's choice to pay the per-PV pod tuition rather than auto-accept on a laptop).
+- title: Agentic Misalignment — Anthropic Research
+  type: paper
+  url: https://www.anthropic.com/research/agentic-misalignment
+  quoted_passages:
+  - In our experiments, models from every developer we tested took actions like blackmailing fictional executives or leaking sensitive information when faced with goals that conflicted with their continued operation.
+  - Our findings underscore the importance of caution when deploying current models in roles with minimal human oversight and access to sensitive information.
+  relevance: Foundational paper on why agent isolation is not paranoia. Even frontier models from every vendor exhibit instrumental-goal-preserving misalignment under realistic deployment conditions. Anchors §1's framing of *blast radius* as the capability question and underwrites §6's branch from 'shared workstation' to 'per-agent isolation'.
+- title: Frank — Agent shells + Paperclip/Ruflo gotchas registry
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/frank-gotchas.md
+  quoted_passages:
+  - s6-overlay v3 in non-root mode needs `S6_KEEP_ENV=1`, `S6_VERBOSITY=2`, `with-contenv` shebangs (`#!/command/with-contenv bash` — `/command/`, NOT `/usr/bin/`), and `/run` chown'd to AGENT_UID at image build time.
+  - 'vk-issue-bridge''s 30 s MCP timeout cascades to zombie execution_processes: bridge crash on timeout → vk-local request handler future drops → `Child::wait()` cancelled → setup/cleanup shell scripts exit but never reaped → DB rows stuck `status=''running''` forever, UI shows workspaces stuck active with no output.'
+  - '`shareProcessNamespace: true` is incompatible with s6-overlay v3 (suexec must be PID 1) — use shared workspace volume + `kubectl exec -c <other>` for cross-container debugging.'
+  - 'vk-local `limits.memory: 4Gi` is too tight in practice — `VK_MAX_CONCURRENT_EXECUTIONS=4` does NOT bound the cgroup once the bridge feeds 8+ cards (queued sessions retain memory; new images drift baseline).'
+  - Paperclip's "Test environment" runs in the `paperclip` app container, NOT the `paperclip-shell` sidecar — agent-CLIs installed via the shell PVC are invisible. Wire through the shared `/paperclip` PVC.
+  relevance: Frank's own running postmortem registry — concrete operational scars accumulated while running secure-agent-pod + VibeKanban + Paperclip + Sympozium in production for this learning platform. Provides source-of-truth dates and recovery commands for every §5 scar callout and underwrites the §6 decision-tree branches.

--- a/blog/data/papers/20-edge-clusters-public-exposure.yaml
+++ b/blog/data/papers/20-edge-clusters-public-exposure.yaml
@@ -1,0 +1,86 @@
+primary_sources:
+- title: Cloudflare Tunnel — Connect networks (developer docs)
+  type: vendor-docs
+  url: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/
+  quoted_passages:
+  - cloudflared initiates an outbound connection through your firewall from the origin to the Cloudflare global network.
+  - Once the connection is established, traffic flows in both directions over the tunnel between your origin and Cloudflare.
+  - configure your firewall to allow only these outbound connections and block all inbound traffic, effectively blocking access to your origin from anything other than Cloudflare.
+  relevance: 'Vendor''s authoritative statement of the outbound-tunnel architecture: the cloudflared daemon dials out to Cloudflare''s edge, Cloudflare''s edge terminates TLS and serves the public hostname, and the origin needs zero inbound firewall holes. This is the load-bearing claim that distinguishes Cloudflare Tunnel from every ''run your own edge node'' option in §3 and underwrites the §2 quadrant axis ''who owns the edge node''.'
+- title: How Tailscale Works (Tailscale engineering blog)
+  type: vendor-docs
+  url: https://tailscale.com/blog/how-tailscale-works
+  quoted_passages:
+  - The node contacts the coordination server and leaves its public key and a note about where that node can currently be found, and what domain it's in.
+  - Remember that Tailscale private keys never leave the node where they were generated; that means there is never a way for a DERP server to decrypt your traffic.
+  - Tailscale uses several very advanced techniques, based on the Internet STUN and ICE standards, to make these connections work even though you wouldn't think it should be possible.
+  relevance: 'The canonical architectural writeup of Tailscale''s three-part design: coordination server (control plane), DERP relays (fallback data plane when NAT traversal fails), and direct WireGuard tunnels between peers. Grounds the §3 mesh-overlay architecture for both Tailscale Funnel and Frank''s Headscale + Hop setup, and justifies the §2 claim that ''mesh-overlay vs hub-and-spoke'' is a real architectural axis, not a marketing distinction.'
+- title: Tailscale Funnel docs
+  type: vendor-docs
+  url: https://tailscale.com/kb/1223/funnel
+  quoted_passages:
+  - Tailscale Funnel lets you route traffic from the broader internet to a local service running on a device in your Tailscale network (known as a tailnet).
+  - The Tailscale server running on your device receives the encrypted request from the TCP proxy. It then terminates the TLS connection and passes the decrypted request to the local service you exposed through Funnel.
+  relevance: Vendor docs for the 'public exposure via the mesh' pattern — TLS is terminated on the device itself, not on Tailscale's edge, which is the architectural twin of Frank's choice but with Tailscale's coordination server instead of Frank's self-hosted Headscale. Source for the §3 mesh-overlay-as-edge architecture and the §6 decision-tree branch 'are you OK with vendor-controlled coordination?'.
+- title: Headscale README (juanfont/headscale on GitHub)
+  type: vendor-docs
+  url: https://github.com/juanfont/headscale
+  quoted_passages:
+  - An open source, self-hosted implementation of the Tailscale control server.
+  - Headscale aims to implement a self-hosted, open source alternative to the Tailscale control server.
+  - The control server works as an exchange point of Wireguard public keys for the nodes in the Tailscale network.
+  relevance: 'Definitive description of what Headscale actually is: a drop-in replacement for the Tailscale control server, which is the *coordination* layer (key exchange, ACLs, DNS) — not the data plane. The Tailscale clients themselves are unchanged. This is the load-bearing claim behind Frank''s §5 architecture: Headscale on Hop is the control plane, the Tailscale DaemonSet on every Frank node is the data plane, and the WireGuard tunnels they establish are peer-to-peer.'
+- title: Talos Linux on Hetzner Cloud (Sidero Labs docs)
+  type: vendor-docs
+  url: https://docs.siderolabs.com/talos/v1.10/platform-specific-installations/cloud-platforms/hetzner
+  quoted_passages:
+  - Hetzner Cloud provides Talos as Public ISO with the schematic id `ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515`
+  - Once shutdown, simply create an image (snapshot) from the console. You can now use this snapshot to run Talos on the cloud.
+  - 'Bootstrap `etcd` on the first control plane node with: `talosctl --talosconfig talosconfig bootstrap`'
+  relevance: 'Vendor''s own deployment guide for the exact path Frank takes to stand up Hop. Justifies the §5 narrative claim that ''Hop is a real Talos cluster, not a Helm chart on an Ubuntu droplet'' — same OS, same image-factory pipeline, same `talosctl bootstrap` flow as Frank. The only architectural difference is the control plane: standalone talosctl with a combined patch file instead of Omni (Omni isn''t reachable from a Hetzner public IP).'
+- title: awesome-tunneling — community catalogue of self-hosted exposure tools (anderspitman/awesome-tunneling)
+  type: postmortem
+  url: https://github.com/anderspitman/awesome-tunneling
+  quoted_passages:
+  - exposing a local webserver via a public domain name, with automatic HTTPS, even if behind a NAT or other restricted network.
+  - map X domain/subdomain to Y port on Z client, and proxy all connections to that domain.
+  relevance: 'A community-maintained catalogue of every tunneling tool the self-hosting world has invented, organised around the exact problem class Frank''s Hop cluster solves: ''expose a local web service to the internet from behind NAT, with HTTPS''. The ''dream'' section reads like the problem statement Frank wrote for itself in §1 — a useful sanity check that Paper 20''s capability framing matches the practitioner consensus rather than a Frank-specific abstraction.'
+- title: How NAT traversal works (Tailscale engineering blog)
+  type: paper
+  url: https://tailscale.com/blog/how-nat-traversal-works
+  quoted_passages:
+  - 'STUN relies on a simple observation: when you talk to a server on the internet from a NATed client, the server sees the public `ip:port` that your NAT device created for you.'
+  - Both endpoints must attempt communication at roughly the same time, so that all the intermediate firewalls open up while both peers are still around.
+  - 'The algorithm is: try everything at once, and pick the best thing that works.'
+  relevance: The closest thing the mesh-overlay world has to a foundational paper — a long-form technical writeup of STUN, UDP hole punching, and ICE as applied to WireGuard mesh VPNs. Grounds the §3 mesh-overlay architecture in actual NAT-traversal mechanics rather than hand-wavy 'it just works' marketing, and explains why the residential-ISP edge problem is hard enough to justify a dedicated paper category in the first place.
+- title: Cloudflare network — sub-50ms latency to 95% of internet users (cloudflare.com/network)
+  type: benchmark
+  url: https://www.cloudflare.com/network/
+  quoted_passages:
+  - Sub-50ms to 95% of users — 95% of the world's Internet-connected population is within 50 milliseconds of a Cloudflare data center — most are within 20ms.
+  - One of the world's largest networks — running every service in every data center for unmatched performance, security, and reliability.
+  relevance: 'Vendor-published latency claim that anchors the §4 ''what scale changes'' discussion — Cloudflare Tunnel''s edge is closer to most users than any one-VPS edge can ever be, and the latency tax of running through a single Hetzner Falkenstein PoP is real. Sets the baseline against which Hop''s single-region edge has to justify itself: own the data plane, accept the latency floor of one geographic location.'
+- title: Frank — Hop cluster gotchas (hostPort + RollingUpdate, Headplane v0.5 ConfigMap, Tailscale DaemonSet kernel-mode, talosctl apply-config base-file pitfall)
+  type: postmortem
+  url: https://github.com/derio-net/frank/blob/main/agents/rules/hop-gotchas.md
+  quoted_passages:
+  - 'Deployments using `hostPort` (e.g., Caddy on 80/443, Headscale STUN on 3478/UDP) must use `strategy: Recreate` — `RollingUpdate` deadlocks on a single-node cluster because the new pod can''t bind ports while the old pod still holds them'
+  - Headplane v0.5+ requires a `config.yaml` ConfigMap — env vars alone are insufficient
+  - 'Tailscale DaemonSet must run in kernel mode (`TS_USERSPACE=false`, `privileged: true`) for Caddy to see mesh source IPs'
+  - '`talosctl apply-config --config-patch` patches the base file, not the running config — all patches must be combined in one invocation'
+  relevance: Frank's own dated postmortem registry for everything that broke on Hop in the first three weeks of operation. Each one-liner is the scar of a real outage or wasted day; each maps directly to a property of the 'separate single-node edge cluster' architecture rather than a Caddy or Headscale bug. Source for the §5 scar callouts and the §6 decision-tree branch on 'are you willing to run a single-node cluster as critical infrastructure?'.
+- title: inlets.dev — Self-hosted HTTP and TCP tunnels
+  type: vendor-docs
+  url: https://inlets.dev/
+  quoted_passages:
+  - Self-hosted HTTP and TCP tunnels with full control and privacy. Expose endpoints publicly, or tunnel customer services back to your SaaS.
+  - inlets exposes HTTP and TCP services without dragging whole subnets, hosts or teams into a VPN.
+  - inlets focuses on exposing specific services, self-hosting the data plane, and avoiding SaaS tunnel limits.
+  relevance: 'A fourth-vendor perspective: a tool that sits between Cloudflare Tunnel (zero infra) and Headscale (full mesh) — you still need a VPS, but you run only the tunnel daemon on it, not a coordination server or a cluster. Underwrites the §2 capability matrix row ''data-plane ownership'' and provides the bridge in the §6 decision tree between the ''tunnel SaaS'' branch and the ''edge cluster'' branch.'
+- title: Rancher Fleet — Multi-cluster GitOps engine (docs)
+  type: vendor-docs
+  url: https://fleet.rancher.io/0.15/
+  quoted_passages:
+  - Fleet is a container management and deployment engine designed to offer users more control on the local cluster and constant monitoring through GitOps.
+  - Fleet is fundamentally a set of Kubernetes custom resource definitions (CRDs) and controllers that manage GitOps for a single Kubernetes cluster or a large scale deployment of Kubernetes clusters.
+  relevance: 'The enterprise heavyweight in the §2 landscape: instead of treating the edge cluster as a separate platform with its own ArgoCD (Frank''s choice), Fleet promises one logical GitOps surface spanning hub + edge + cloud. Justifies the §6 decision-tree branch ''managing one cluster or ten?'' — Fleet starts paying for itself somewhere north of the Frank+Hop two-cluster mark, and below that it''s overhead.'

--- a/blog/layouts/docs/single.html
+++ b/blog/layouts/docs/single.html
@@ -24,6 +24,7 @@
         </div>
         {{- if in .Params.series "papers" }}
           {{- partial "papers-forwardlinks.html" . }}
+          {{- partial "papers/references.html" . }}
           {{- partial "papers/dossier-link.html" . }}
           {{- partial "papers-prev-next.html" . }}
         {{- else if and (not (in .Params.series "papers")) (not (eq .Section "")) }}

--- a/blog/layouts/partials/papers/references-index.html
+++ b/blog/layouts/partials/papers/references-index.html
@@ -1,0 +1,87 @@
+{{/* papers/references-index.html — cross-series bibliography.
+     Iterates .Site.Data.papers.*, dedupes sources by URL,
+     groups by type, preserves per-paper relevance. */}}
+{{ $byUrl := dict }}
+{{ range $slug, $data := .Site.Data.papers }}
+  {{ $paperPage := $.Site.GetPage (printf "/docs/papers/%s" $slug) }}
+  {{ $paperTitle := $slug }}
+  {{ $paperNumber := 0 }}
+  {{ with $paperPage }}
+    {{ $paperTitle = .Title }}
+    {{ $paperNumber = .Params.paper_number | default 0 }}
+  {{ end }}
+  {{ range $data.primary_sources }}
+    {{ $url := .url }}
+    {{ $existing := index $byUrl $url }}
+    {{ if not $existing }}
+      {{ $byUrl = merge $byUrl (dict $url (dict
+        "title" .title
+        "type" .type
+        "quoted_passages" .quoted_passages
+        "citations" (slice (dict
+          "paper_slug" $slug
+          "paper_title" $paperTitle
+          "paper_number" $paperNumber
+          "relevance" .relevance
+        ))
+      )) }}
+    {{ else }}
+      {{ $merged_quotes := union $existing.quoted_passages .quoted_passages }}
+      {{ $merged_citations := append (dict
+        "paper_slug" $slug
+        "paper_title" $paperTitle
+        "paper_number" $paperNumber
+        "relevance" .relevance
+      ) $existing.citations }}
+      {{ $byUrl = merge $byUrl (dict $url (merge $existing (dict
+        "quoted_passages" $merged_quotes
+        "citations" $merged_citations
+      ))) }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+<div class="papers-references-index">
+  <p>The cross-series bibliography for the Frank Papers. Every
+  primary source cited in any Paper appears here exactly once,
+  grouped by source type. Per-paper §8 sections remain the
+  primary citation surface; this index exists for cross-paper
+  navigation.</p>
+
+  {{ range $type := slice "vendor-docs" "paper" "postmortem" "talk" "benchmark" }}
+    {{ $matches := slice }}
+    {{ range $url, $entry := $byUrl }}
+      {{ if eq $entry.type $type }}
+        {{ $matches = append (merge $entry (dict "url" $url)) $matches }}
+      {{ end }}
+    {{ end }}
+    {{ if $matches }}
+      <h2 id="{{ $type }}">{{ $type }}</h2>
+      {{ $sorted := sort $matches "title" "asc" }}
+      <ul>
+        {{ range $sorted }}
+          <li>
+            <span class="paper-reference-chip paper-reference-chip--{{ .type }}">{{ .type }}</span>
+            <a href="{{ .url }}" rel="noopener nofollow">{{ .title }}</a>
+            {{ with .quoted_passages }}
+              {{ range . }}
+                <blockquote>{{ . }}</blockquote>
+              {{ end }}
+            {{ end }}
+            <div class="paper-reference-citations">
+              <strong>Cited in:</strong>
+              <ul>
+                {{ range sort .citations "paper_number" "asc" }}
+                  <li>
+                    <a href="/docs/papers/{{ .paper_slug }}/">Paper {{ .paper_number }} — {{ .paper_title }}</a>
+                    — <em>{{ .relevance }}</em>
+                  </li>
+                {{ end }}
+              </ul>
+            </div>
+          </li>
+        {{ end }}
+      </ul>
+    {{ end }}
+  {{ end }}
+</div>

--- a/blog/layouts/partials/papers/references-index.html
+++ b/blog/layouts/partials/papers/references-index.html
@@ -8,39 +8,40 @@
        per-paper data files have a `primary_sources` key. */}}
   {{ if and (reflect.IsMap $data) (isset $data "primary_sources") }}
   {{ $paperPage := $.Site.GetPage (printf "/docs/papers/%s" $slug) }}
-  {{ $paperTitle := $slug }}
-  {{ $paperNumber := 0 }}
+  {{/* Orphan-dossier guard: skip the entire merge when the paper bundle is
+       missing. Safer failure mode than silently rendering "Paper 0 — <slug>"
+       — the source simply doesn't appear in the cross-series index. */}}
   {{ with $paperPage }}
-    {{ $paperTitle = .Title }}
-    {{ $paperNumber = .Params.paper_number | default 0 }}
-  {{ end }}
-  {{ range $data.primary_sources }}
-    {{ $url := .url }}
-    {{ $existing := index $byUrl $url }}
-    {{ if not $existing }}
-      {{ $byUrl = merge $byUrl (dict $url (dict
-        "title" .title
-        "type" .type
-        "quoted_passages" .quoted_passages
-        "citations" (slice (dict
+    {{ $paperTitle := .Title }}
+    {{ $paperNumber := .Params.paper_number | default 0 }}
+    {{ range $data.primary_sources }}
+      {{ $url := .url }}
+      {{ $existing := index $byUrl $url }}
+      {{ if not $existing }}
+        {{ $byUrl = merge $byUrl (dict $url (dict
+          "title" .title
+          "type" .type
+          "quoted_passages" .quoted_passages
+          "citations" (slice (dict
+            "paper_slug" $slug
+            "paper_title" $paperTitle
+            "paper_number" $paperNumber
+            "relevance" .relevance
+          ))
+        )) }}
+      {{ else }}
+        {{ $merged_quotes := union $existing.quoted_passages .quoted_passages }}
+        {{ $merged_citations := append (dict
           "paper_slug" $slug
           "paper_title" $paperTitle
           "paper_number" $paperNumber
           "relevance" .relevance
-        ))
-      )) }}
-    {{ else }}
-      {{ $merged_quotes := union $existing.quoted_passages .quoted_passages }}
-      {{ $merged_citations := append (dict
-        "paper_slug" $slug
-        "paper_title" $paperTitle
-        "paper_number" $paperNumber
-        "relevance" .relevance
-      ) $existing.citations }}
-      {{ $byUrl = merge $byUrl (dict $url (merge $existing (dict
-        "quoted_passages" $merged_quotes
-        "citations" $merged_citations
-      ))) }}
+        ) $existing.citations }}
+        {{ $byUrl = merge $byUrl (dict $url (merge $existing (dict
+          "quoted_passages" $merged_quotes
+          "citations" $merged_citations
+        ))) }}
+      {{ end }}
     {{ end }}
   {{ end }}
   {{ end }}

--- a/blog/layouts/partials/papers/references-index.html
+++ b/blog/layouts/partials/papers/references-index.html
@@ -3,6 +3,10 @@
      groups by type, preserves per-paper relevance. */}}
 {{ $byUrl := dict }}
 {{ range $slug, $data := .Site.Data.papers }}
+  {{/* Skip non-paper entries (e.g. data/papers.yaml roster, which appears
+       under the same Site.Data.papers namespace as a sibling list). Only
+       per-paper data files have a `primary_sources` key. */}}
+  {{ if and (reflect.IsMap $data) (isset $data "primary_sources") }}
   {{ $paperPage := $.Site.GetPage (printf "/docs/papers/%s" $slug) }}
   {{ $paperTitle := $slug }}
   {{ $paperNumber := 0 }}
@@ -38,6 +42,7 @@
         "citations" $merged_citations
       ))) }}
     {{ end }}
+  {{ end }}
   {{ end }}
 {{ end }}
 

--- a/blog/layouts/partials/papers/references.html
+++ b/blog/layouts/partials/papers/references.html
@@ -1,0 +1,36 @@
+{{/* papers/references.html — auto-injected by single.html for
+     pages with `series: papers`. Reads .Site.Data.papers
+     keyed by the paper bundle directory name. Renders the
+     §8 References section. */}}
+{{ $dir := "" }}
+{{ with .File }}
+  {{ $dir = path.Base .Dir }}
+{{ end }}
+{{ with $dir }}
+  {{ $data := index $.Site.Data.papers . }}
+  {{ with $data }}
+    {{ with .primary_sources }}
+      <section class="paper-references">
+        <h2 id="references">References</h2>
+        <ol>
+          {{ range $i, $src := . }}
+            <li id="ref-{{ add $i 1 }}">
+              <span class="paper-reference-chip paper-reference-chip--{{ .type }}">{{ .type }}</span>
+              <a href="{{ .url }}" rel="noopener nofollow">{{ .title }}</a>
+              {{ with .quoted_passages }}
+                <div class="paper-reference-quotes">
+                  {{ range . }}
+                    <blockquote>{{ . }}</blockquote>
+                  {{ end }}
+                </div>
+              {{ end }}
+              {{ with .relevance }}
+                <p class="paper-reference-relevance"><em>{{ . }}</em></p>
+              {{ end }}
+            </li>
+          {{ end }}
+        </ol>
+      </section>
+    {{ end }}
+  {{ end }}
+{{ end }}

--- a/blog/layouts/shortcodes/papers/references-index.html
+++ b/blog/layouts/shortcodes/papers/references-index.html
@@ -1,0 +1,1 @@
+{{ partial "papers/references-index.html" . }}

--- a/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/02.yaml
+++ b/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/02.yaml
@@ -60,22 +60,22 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: '17/17 data files written; counts match dossier dirs.'
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Shape confirmed on 09-secrets-bootstrap.yaml: primary_sources list with title/type/url/quoted_passages/relevance.'
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Hugo build clean (123 pages); only pre-existing theme deprecation WARNs, no data-load errors. Substituted --logLevel info for --verbose (removed upstream).'
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: 'x'
+      ticked_at: '2026-05-23'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-23'
+    note: 'Phase 2 complete; data files generated and committed.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/03.yaml
+++ b/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/03.yaml
@@ -278,34 +278,34 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Partial created at blog/layouts/partials/papers/references.html; reads .Site.Data.papers via path.Base .Dir.'
     P3.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Inserted between papers-forwardlinks and papers/dossier-link in blog/layouts/docs/single.html.'
     P3.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Used one-shot hugo build to /tmp/hugo-build-p3 (hugo server alternative per plan). Paper 09 renders <section class="paper-references"> + <h2 id="references"> + <li id="ref-1"> + chips + quotes + relevance. Papers 04 (paper chip) and 14 (postmortem chip) also verified. Placeholder text still present in body — expected for Phase 3. Required PATH=/usr/local/Cellar/go/1.26.2/bin:$PATH because default go1.19 is below blog/go.mod minimum 1.24.2.'
     P3.T3.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Cross-series index partial created at blog/layouts/partials/papers/references-index.html.'
     P3.T3.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Shortcode wrapper created at blog/layouts/shortcodes/papers/references-index.html.'
     P3.T4.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Appended ~58 lines to blog/assets/css/custom.css (file already existed; no deviation from plan snippet).'
     P3.T4.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: 'x'
+      ticked_at: '2026-05-23'
+      note: 'Commit ddb2a1a on bibliography-rendering.'
   completion:
-    at: null
-    note: null
+    at: '2026-05-23'
+    note: 'Phase 3 complete; §8 auto-renders on every paper, cross-series index partial + shortcode in place, CSS appended. Hugo build clean (123 pages).'
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/04.yaml
+++ b/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/04.yaml
@@ -89,26 +89,38 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-23'
+      note: |
+        Widened regex to also catch paper 10's variant `*See frontmatter — auto-rendered.*`.
+        Stripped from 10 papers (9 canonical + 1 variant). Remaining 7 papers (00, 01, 02,
+        04, 06, 07, 11) never had a §8 stub — auto-injection from Phase 3 covers them.
     P4.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-23'
+      note: |
+        `git diff --stat` shows 10 files × 3 deletions, 0 additions. Clean.
     P4.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-23'
+      note: |
+        Removed lines 79-81 (## References + blank + *Auto-rendered...*) from heredoc.
+        `grep -n "References\|Auto-rendered" scripts/scaffold-paper.sh` → empty.
     P4.T3.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-23'
+      note: |
+        Hugo serves under `/frank/` baseURL. Verified all three fixtures + paper 10 +
+        two no-stub papers: §8 section renders with correct ref counts (09:9, 04:5,
+        14:5, 10:5, 00:5, 01:7) and 0 legacy placeholders anywhere.
     P4.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-23'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-23'
+    note: |
+      Phase 4 complete. Stripped §8 stubs from 10 papers (plan expected 17 — actual
+      ground-truth was 9 canonical + 1 variant + 7 papers that never had the stub).
+      Widened the strip regex to handle paper 10's variant text.
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/05.yaml
+++ b/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/05.yaml
@@ -166,10 +166,10 @@ state:
       ticked_at: 2026-05-23
       note: 'Replaced §8 anatomy row + rewrote "References taxonomy" → "References pipeline" (dossier → sync script → data file → partials, with reference to implementation spec).'
     P5.T4.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: 2026-05-23
+      note: 'Commit a482c55 on bibliography-rendering; staged the 17 papers, scaffold, repo-papers.md, /references/_index.md, spec, plan checkboxes, and the Phase-3 partial fix (references-index.html data-shape guard).'
   completion:
-    at: null
-    note: null
+    at: 2026-05-23
+    note: 'Phase 5 complete. Deviations: (1) plan regex needed `|\Z` because `references:` is the last frontmatter key; (2) `series:` must be a list not a scalar (Hextra opengraph); (3) Phase-3 partial needed a data-shape guard to skip data/papers.yaml. All three documented inline in the respective step notes.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/05.yaml
+++ b/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/05.yaml
@@ -138,33 +138,33 @@ tasks:
 state:
   steps:
     P5.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: 2026-05-23
+      note: 'Plan regex `^references:.*?(?=^\S|^---)` failed: `references:` is the last frontmatter key, so inside the captured `fm` group the lookahead never finds `^---` or `^\S`. Added `|\Z` alternation. All 17/17 papers stripped; YAML re-parses cleanly.'
     P5.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: 2026-05-23
+      note: 'git diff on paper 09: only the 28-line references block removed, closing `---` intact, body untouched.'
     P5.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: 2026-05-23
+      note: 'Removed `references: []` from scaffold-paper.sh heredoc. Grep clean.'
     P5.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: 2026-05-23
+      note: '`references` removed from required-fields list in agents/rules/repo-papers.md. Grep clean.'
     P5.T3.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: 2026-05-23
+      note: 'Created _index.md. `series` had to be a YAML list (`["references"]`) not a scalar — Hextra opengraph.html ranges over .Params.series, fails on string. `in ["references"] "papers"` still false, so the substring trap is still avoided.'
     P5.T3.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: 2026-05-23
+      note: 'One-shot `hugo --gc -d /tmp/hugo-build` with Go 1.26.2 on PATH. All 5 type anchors render (vendor-docs/paper/postmortem/talk/benchmark). 102 unique URLs deduped, 102 Cited-in blocks. §8 partial confirmed absent on index (0 hits) but still renders on paper 09 (1 hit, 9 sources). Required a Phase-3 partial fix: guarded `range $slug, $data` with `(and (reflect.IsMap $data) (isset $data "primary_sources"))` to skip `data/papers.yaml` (the roster file under the same Site.Data.papers namespace).'
     P5.T4.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: 2026-05-23
+      note: 'Replaced §8 anatomy row + rewrote "References taxonomy" → "References pipeline" (dossier → sync script → data file → partials, with reference to implementation spec).'
     P5.T4.S2:
       state: ' '
       ticked_at: null

--- a/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/05.yaml
+++ b/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/05.yaml
@@ -139,37 +139,37 @@ state:
   steps:
     P5.T1.S1:
       state: x
-      ticked_at: 2026-05-23
+      ticked_at: '2026-05-23'
       note: 'Plan regex `^references:.*?(?=^\S|^---)` failed: `references:` is the last frontmatter key, so inside the captured `fm` group the lookahead never finds `^---` or `^\S`. Added `|\Z` alternation. All 17/17 papers stripped; YAML re-parses cleanly.'
     P5.T1.S2:
       state: x
-      ticked_at: 2026-05-23
+      ticked_at: '2026-05-23'
       note: 'git diff on paper 09: only the 28-line references block removed, closing `---` intact, body untouched.'
     P5.T2.S1:
       state: x
-      ticked_at: 2026-05-23
+      ticked_at: '2026-05-23'
       note: 'Removed `references: []` from scaffold-paper.sh heredoc. Grep clean.'
     P5.T2.S2:
       state: x
-      ticked_at: 2026-05-23
+      ticked_at: '2026-05-23'
       note: '`references` removed from required-fields list in agents/rules/repo-papers.md. Grep clean.'
     P5.T3.S1:
       state: x
-      ticked_at: 2026-05-23
+      ticked_at: '2026-05-23'
       note: 'Created _index.md. `series` had to be a YAML list (`["references"]`) not a scalar — Hextra opengraph.html ranges over .Params.series, fails on string. `in ["references"] "papers"` still false, so the substring trap is still avoided.'
     P5.T3.S2:
       state: x
-      ticked_at: 2026-05-23
+      ticked_at: '2026-05-23'
       note: 'One-shot `hugo --gc -d /tmp/hugo-build` with Go 1.26.2 on PATH. All 5 type anchors render (vendor-docs/paper/postmortem/talk/benchmark). 102 unique URLs deduped, 102 Cited-in blocks. §8 partial confirmed absent on index (0 hits) but still renders on paper 09 (1 hit, 9 sources). Required a Phase-3 partial fix: guarded `range $slug, $data` with `(and (reflect.IsMap $data) (isset $data "primary_sources"))` to skip `data/papers.yaml` (the roster file under the same Site.Data.papers namespace).'
     P5.T4.S1:
       state: x
-      ticked_at: 2026-05-23
+      ticked_at: '2026-05-23'
       note: 'Replaced §8 anatomy row + rewrote "References taxonomy" → "References pipeline" (dossier → sync script → data file → partials, with reference to implementation spec).'
     P5.T4.S2:
       state: x
-      ticked_at: 2026-05-23
+      ticked_at: '2026-05-23'
       note: 'Commit a482c55 on bibliography-rendering; staged the 17 papers, scaffold, repo-papers.md, /references/_index.md, spec, plan checkboxes, and the Phase-3 partial fix (references-index.html data-shape guard).'
   completion:
-    at: 2026-05-23
+    at: '2026-05-23'
     note: 'Phase 5 complete. Deviations: (1) plan regex needed `|\Z` because `references:` is the last frontmatter key; (2) `series:` must be a list not a scalar (Hextra opengraph); (3) Phase-3 partial needed a data-shape guard to skip data/papers.yaml. All three documented inline in the respective step notes.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/06.yaml
+++ b/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/06.yaml
@@ -108,13 +108,16 @@ tasks:
 state:
   steps:
     P6.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-22T23:00:11+00:00'
+      note: 'Read .github/workflows/deploy-blog.yml. build-pages job runs Hugo. setup-python
+        NOT present. Insert point: between Setup Hugo and Build.'
     P6.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-22T23:00:24+00:00'
+      note: 'Added 3 steps between Setup Hugo and Build: Setup Python (3.12), Install
+        dossier-sync deps (pip install pyyaml), Check dossier ↔ blog/data/papers sync
+        (python scripts/sync-dossier-to-data.py --check). YAML parses cleanly.'
     P6.T1.S3:
       state: ' '
       ticked_at: null

--- a/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/06.yaml
+++ b/docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/06.yaml
@@ -119,22 +119,35 @@ state:
         dossier-sync deps (pip install pyyaml), Check dossier ↔ blog/data/papers sync
         (python scripts/sync-dossier-to-data.py --check). YAML parses cleanly.'
     P6.T1.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-22T23:00:57+00:00'
+      note: 'DEVIATION: workflow only triggers on push to main (push.branches: [main]);
+        pushing to bibliography-rendering will NOT fire a run, so ''gh run watch''
+        is skipped. Live verification deferred to PR merge time. Substitute local
+        validation: (a) YAML parse OK; (b) ''uv run --with pyyaml python scripts/sync-dossier-to-data.py
+        --check'' exit 0 (no drift, prior phases in sync). Committed 85a5ad4. Push
+        to origin/bibliography-rendering performed.'
     P6.T1.S4:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-22T23:01:07+00:00'
+      note: 'SKIPPED: workflow only triggers on push.branches: [main], so a throwaway
+        feature branch with intentional drift would not fire CI. Per Phase 6 instructions,
+        negative test is skipped; the drift gate''s live exercise happens at PR merge.'
     P6.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-22T23:01:28+00:00'
+      note: 'All meta/repo skips confirmed: no new service (no IngressRoute / homepage
+        tile); no blog posts (meta improvement to existing pipeline); no README update
+        (internal infra); no runbook sync (no manual-operation blocks in any phase).
+        Sole action: mark plan complete.'
     P6.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-22T23:01:42+00:00'
+      note: vk plan edit has no --complete flag; uses --complete-phase per phase.
+        v2 plans have no plan-wide status field in _meta.yaml — completion is encoded
+        as state.completion.at being set on every phase. Phase 6 to be marked complete
+        next via --complete-phase 6.
   completion:
-    at: null
+    at: '2026-05-22T23:02:05+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
+++ b/docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
@@ -103,7 +103,7 @@ No fixed cadence. Each paper advances through `dossier-ready → drafting → re
 | 5 | Frank's choice, and what happened | 300–600 | ≥1 evidence artefact + ≥1 scar-tissue callout |
 | 6 | When Frank's answer doesn't generalize | 200–400 | 1 decision flowchart (≤4 leaves) |
 | 7 | Roadmap & where this space is going | 200–400 | Optional timeline + roadmap citations |
-| 8 | References & further reading | — | Auto-rendered from frontmatter |
+| 8 | References & further reading | — | Auto-injected by `single.html` from `blog/data/papers/<slug>.yaml` (sync'd from dossier — see `2026-05-22--repo--paper-bibliography-rendering-design.md`) |
 
 **Total budget per paper:** 2400–4200 words. Paper 00 caps at 1500.
 
@@ -247,12 +247,14 @@ New shortcodes to build under `blog/layouts/shortcodes/papers/`:
 - **`{{< papers/landscape axes="x:OSS↔commercial,y:centralized↔distributed" >}}...{{< /papers/landscape >}}`** — thin wrapper around Mermaid `quadrantChart` enforcing consistent styling.
 - **`{{< papers/dossier-link paper="10-self-hosted-inference" >}}`** — renders a small link at the bottom of every paper pointing at the committed dossier file on GitHub. Builds trust by making the research trail visible.
 
-### References taxonomy
+### References pipeline
 
-Enable a new Hugo taxonomy `references` populated from Paper frontmatter. Renders as:
+The dossier is the single source of truth. `scripts/sync-dossier-to-data.py` extracts `primary_sources` (title, URL, type, quoted passages, per-paper relevance) from each `docs/papers-dossiers/<slug>/dossier.md` into `blog/data/papers/<slug>.yaml`. From there:
 
-- The auto-generated §8 bibliography of each Paper.
-- A cross-series index at `/references/` listing every cited source with back-links to the Papers that cite it.
+- **Per-paper §8** — `layouts/partials/papers/references.html` is auto-injected by `layouts/docs/single.html` for any page with `series: papers`, reading `Site.Data.papers[<slug>]` and rendering title + URL + type chip + quoted passages.
+- **Cross-series index** — `layouts/partials/papers/references-index.html` (called via the `papers/references-index` shortcode from `blog/content/docs/papers/references/_index.md`) iterates the same data, dedupes by URL, groups by `type`, and shows the citing-paper relevance for each source.
+
+Implementation spec: `2026-05-22--repo--paper-bibliography-rendering-design.md`. Per-paper `references:` frontmatter is no longer used — it's hard-deleted from every paper and the scaffold.
 
 ### Cover imagery
 

--- a/scripts/lib/dossier_parser.py
+++ b/scripts/lib/dossier_parser.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Shared parser for Frank Papers research dossiers.
+
+Dossiers are markdown files where each `## H2` header begins a
+section whose body is YAML. Two consumers depend on this parser:
+`scripts/validate-dossier.py` (the gate validator) and
+`scripts/sync-dossier-to-data.py` (the blog data sync).
+"""
+from __future__ import annotations
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def parse_dossier(path: Path) -> dict[str, Any]:
+    """Parse a dossier markdown file into a sections dict.
+
+    Strips YAML frontmatter if present, then walks the body line
+    by line. Each `## ...` line begins a new section; its
+    contents are yaml.safe_load'd.
+    """
+    text = path.read_text()
+    fm_match = re.match(r'^---\n(.*?)\n---\n', text, re.DOTALL)
+    if fm_match:
+        text = text[fm_match.end():]
+
+    sections: dict[str, Any] = {}
+    current_key: str | None = None
+    current_lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("## "):
+            if current_key:
+                try:
+                    sections[current_key] = yaml.safe_load("\n".join(current_lines)) or []
+                except yaml.YAMLError:
+                    sections[current_key] = current_lines
+            current_key = (
+                line[3:].strip().lower()
+                .replace(" ", "_")
+                .replace("(", "")
+                .replace(")", "")
+            )
+            current_lines = []
+        elif current_key is not None:
+            current_lines.append(line)
+    if current_key:
+        try:
+            sections[current_key] = yaml.safe_load("\n".join(current_lines)) or []
+        except yaml.YAMLError:
+            sections[current_key] = current_lines
+    return sections
+
+
+def get_primary_sources(sections: dict[str, Any]) -> list[dict]:
+    """Return the parsed `## Primary sources` list.
+
+    The H2 header in dossiers includes a parenthetical
+    annotation (e.g., `## Primary sources (≥5, ≥3 distinct
+    type values)`), so look up by prefix.
+    """
+    for k, v in sections.items():
+        if k.startswith("primary_sources"):
+            return v or []
+    return []

--- a/scripts/scaffold-paper.sh
+++ b/scripts/scaffold-paper.sh
@@ -39,7 +39,6 @@ tags: ["TODO"]
 capabilities: ["TODO"]
 related_building: ""
 related_operating: ""
-references: []
 ---
 
 {{< papers/dossier-link paper="${DIR_NAME}" >}}

--- a/scripts/scaffold-paper.sh
+++ b/scripts/scaffold-paper.sh
@@ -75,10 +75,6 @@ references: []
 ## §7 — Roadmap & where this space is going
 
 *200–400 words.*
-
-## References
-
-*Auto-rendered from frontmatter by Hugo taxonomy.*
 FRONTMATTER
 
 # --- Research dossier ---

--- a/scripts/sync-dossier-to-data.py
+++ b/scripts/sync-dossier-to-data.py
@@ -34,7 +34,7 @@ DATA_DIR = REPO_ROOT / "blog" / "data" / "papers"
 def render(sources: list[dict]) -> str:
     """Serialize sources to a stable YAML string."""
     payload = {"primary_sources": sources}
-    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True, width=1000)
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True, width=10**9)
 
 
 def sync_one(slug: str, output: Path | None = None) -> Path:

--- a/scripts/sync-dossier-to-data.py
+++ b/scripts/sync-dossier-to-data.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Sync Frank Papers dossiers into Hugo data files.
+
+Reads docs/papers-dossiers/<slug>/dossier.md and writes
+blog/data/papers/<slug>.yaml. The data file is the single
+source the Hugo §8 partial reads at build time.
+
+CLI:
+    sync-dossier-to-data.py <slug>           regenerate one
+    sync-dossier-to-data.py --all            regenerate all
+    sync-dossier-to-data.py --check          CI drift gate
+
+The --output flag (single-slug mode only) overrides the
+default blog/data/papers/<slug>.yaml destination — used by
+the test suite to write to a tmp dir.
+"""
+from __future__ import annotations
+import argparse
+import difflib
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.lib.dossier_parser import parse_dossier, get_primary_sources
+
+DOSSIERS_DIR = REPO_ROOT / "docs" / "papers-dossiers"
+DATA_DIR = REPO_ROOT / "blog" / "data" / "papers"
+
+
+def render(sources: list[dict]) -> str:
+    """Serialize sources to a stable YAML string."""
+    payload = {"primary_sources": sources}
+    return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True, width=1000)
+
+
+def sync_one(slug: str, output: Path | None = None) -> Path:
+    dossier = DOSSIERS_DIR / slug / "dossier.md"
+    if not dossier.exists():
+        raise SystemExit(f"dossier not found: {dossier}")
+    sections = parse_dossier(dossier)
+    sources = get_primary_sources(sections)
+    dest = output if output else DATA_DIR / f"{slug}.yaml"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(render(sources))
+    return dest
+
+
+def check_drift() -> tuple[int, str]:
+    """Return (exit_code, diff_text)."""
+    diffs: list[str] = []
+    for dossier in sorted(DOSSIERS_DIR.glob("*/dossier.md")):
+        slug = dossier.parent.name
+        sections = parse_dossier(dossier)
+        sources = get_primary_sources(sections)
+        expected = render(sources)
+        actual_path = DATA_DIR / f"{slug}.yaml"
+        actual = actual_path.read_text() if actual_path.exists() else ""
+        if expected != actual:
+            diffs.extend(difflib.unified_diff(
+                actual.splitlines(keepends=True),
+                expected.splitlines(keepends=True),
+                fromfile=f"{actual_path} (on disk)",
+                tofile=f"{actual_path} (expected)",
+            ))
+    if diffs:
+        return 1, "".join(diffs)
+    return 0, ""
+
+
+def sync_all() -> list[Path]:
+    results = []
+    for dossier in sorted(DOSSIERS_DIR.glob("*/dossier.md")):
+        slug = dossier.parent.name
+        results.append(sync_one(slug))
+    return results
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Sync dossiers → blog/data/papers/*.yaml")
+    p.add_argument("slug", nargs="?", help="Single dossier slug to sync")
+    p.add_argument("--all", action="store_true", help="Sync every dossier")
+    p.add_argument("--check", action="store_true", help="Fail on drift (CI mode)")
+    p.add_argument("--output", type=Path, help="(single-slug only) write to this path")
+    args = p.parse_args()
+
+    if args.check:
+        rc, diff = check_drift()
+        if rc != 0:
+            sys.stderr.write(diff)
+            sys.stderr.write("\nFAIL: run `scripts/sync-dossier-to-data.py --all` and commit.\n")
+        return rc
+
+    if args.all:
+        written = sync_all()
+        for path in written:
+            try:
+                shown = path.relative_to(REPO_ROOT)
+            except ValueError:
+                shown = path
+            print(f"wrote {shown}")
+        return 0
+
+    if args.slug and not args.all and not args.check:
+        dest = sync_one(args.slug, args.output)
+        try:
+            shown = dest.relative_to(REPO_ROOT)
+        except ValueError:
+            shown = dest
+        print(f"wrote {shown}")
+        return 0
+    p.error("must pass <slug>, --all, or --check")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_dossier_parser.py
+++ b/scripts/tests/test_dossier_parser.py
@@ -1,0 +1,50 @@
+"""Test the shared dossier parser against real fixtures.
+
+Uses Paper 09 (9 sources covering all 5 type values) as the
+comprehensive fixture, plus Paper 04 (4 types incl. `paper`)
+and Paper 14 (4 types incl. one `postmortem`).
+"""
+from pathlib import Path
+import pytest
+
+from scripts.lib.dossier_parser import parse_dossier, get_primary_sources
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOSSIERS = REPO_ROOT / "docs" / "papers-dossiers"
+
+
+def test_paper_09_has_nine_sources_all_five_types():
+    sections = parse_dossier(DOSSIERS / "09-secrets-bootstrap" / "dossier.md")
+    sources = get_primary_sources(sections)
+    assert len(sources) == 9, f"expected 9 sources, got {len(sources)}"
+    types = {s["type"] for s in sources}
+    assert types == {"vendor-docs", "paper", "postmortem", "talk", "benchmark"}, (
+        f"expected all 5 types, got {types}"
+    )
+
+
+def test_paper_04_includes_paper_type():
+    sections = parse_dossier(DOSSIERS / "04-distributed-storage" / "dossier.md")
+    sources = get_primary_sources(sections)
+    types = {s["type"] for s in sources}
+    assert "paper" in types
+    assert len(types) >= 3
+
+
+def test_paper_14_includes_postmortem_type():
+    sections = parse_dossier(DOSSIERS / "14-progressive-delivery" / "dossier.md")
+    sources = get_primary_sources(sections)
+    types = {s["type"] for s in sources}
+    assert "postmortem" in types
+    assert len(types) >= 3
+
+
+def test_every_source_has_required_fields():
+    sections = parse_dossier(DOSSIERS / "09-secrets-bootstrap" / "dossier.md")
+    sources = get_primary_sources(sections)
+    for s in sources:
+        assert "title" in s and s["title"]
+        assert "url" in s and s["url"]
+        assert "type" in s and s["type"]
+        assert "quoted_passages" in s and isinstance(s["quoted_passages"], list) and s["quoted_passages"]
+        assert "relevance" in s and s["relevance"]

--- a/scripts/tests/test_sync_dossier_to_data.py
+++ b/scripts/tests/test_sync_dossier_to_data.py
@@ -1,0 +1,110 @@
+"""Test scripts/sync-dossier-to-data.py against real dossiers.
+
+The sync script reads docs/papers-dossiers/<slug>/dossier.md
+and writes blog/data/papers/<slug>.yaml. Output shape is
+pinned by the spec.
+"""
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "sync-dossier-to-data.py"
+DATA_DIR = REPO_ROOT / "blog" / "data" / "papers"
+
+
+def run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_sync_single_slug_writes_data_file(tmp_path, monkeypatch):
+    # Sync Paper 09 into a temp data dir to avoid clobbering main repo state during tests
+    target = tmp_path / "09-secrets-bootstrap.yaml"
+    proc = run("09-secrets-bootstrap", "--output", str(target))
+    assert proc.returncode == 0, proc.stderr
+    data = yaml.safe_load(target.read_text())
+    assert "primary_sources" in data
+    sources = data["primary_sources"]
+    assert len(sources) == 9
+    # Spec-pinned shape per source
+    s0 = sources[0]
+    assert set(s0.keys()) >= {"title", "url", "type", "quoted_passages", "relevance"}
+    assert s0["type"] in {"vendor-docs", "paper", "postmortem", "talk", "benchmark"}
+
+
+def test_sync_emits_idempotent_yaml(tmp_path):
+    t1 = tmp_path / "a.yaml"
+    t2 = tmp_path / "b.yaml"
+    run("09-secrets-bootstrap", "--output", str(t1))
+    run("09-secrets-bootstrap", "--output", str(t2))
+    assert t1.read_text() == t2.read_text(), "repeat sync produced different output"
+
+
+def _load_sync_module():
+    """Load scripts/sync-dossier-to-data.py via importlib (hyphenated filename)."""
+    from importlib.util import spec_from_file_location, module_from_spec
+    spec = spec_from_file_location(
+        "sync_dossier_to_data",
+        REPO_ROOT / "scripts" / "sync-dossier-to-data.py",
+    )
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_sync_all_covers_every_dossier(tmp_path, monkeypatch):
+    mod = _load_sync_module()
+    monkeypatch.setattr(mod, "DATA_DIR", tmp_path)
+    # Count dossiers
+    dossier_count = len([
+        d for d in (REPO_ROOT / "docs" / "papers-dossiers").iterdir()
+        if d.is_dir() and (d / "dossier.md").exists()
+    ])
+    # Invoke programmatically (subprocess won't see the monkeypatch)
+    mod.sync_all()
+    generated = list(tmp_path.glob("*.yaml"))
+    assert len(generated) == dossier_count, (
+        f"expected {dossier_count} data files, generated {len(generated)}"
+    )
+
+
+def test_check_clean_exits_zero(tmp_path, monkeypatch):
+    """After --all, --check must pass."""
+    from importlib.util import spec_from_file_location, module_from_spec
+    spec = spec_from_file_location(
+        "sync_dossier_to_data",
+        REPO_ROOT / "scripts" / "sync-dossier-to-data.py",
+    )
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    monkeypatch.setattr(mod, "DATA_DIR", tmp_path)
+    mod.sync_all()
+    rc, diff = mod.check_drift()
+    assert rc == 0, f"expected clean, got diff:\n{diff}"
+
+
+def test_check_dirty_exits_nonzero_with_diff(tmp_path, monkeypatch):
+    """Tamper with one data file, expect rc=1 + a unified diff."""
+    from importlib.util import spec_from_file_location, module_from_spec
+    spec = spec_from_file_location(
+        "sync_dossier_to_data",
+        REPO_ROOT / "scripts" / "sync-dossier-to-data.py",
+    )
+    mod = module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    monkeypatch.setattr(mod, "DATA_DIR", tmp_path)
+    mod.sync_all()
+    # Corrupt one file
+    victim = next(tmp_path.glob("*.yaml"))
+    victim.write_text("primary_sources: []\n")
+    rc, diff = mod.check_drift()
+    assert rc == 1
+    assert victim.name in diff or victim.stem in diff

--- a/scripts/validate-dossier.py
+++ b/scripts/validate-dossier.py
@@ -6,16 +6,18 @@ Usage: python scripts/validate-dossier.py <dossier.md>
 Exit 0 = pass. Exit 1 = fail (prints specific failures).
 """
 import sys
-import re
 import urllib.request
 import urllib.error
 from pathlib import Path
 
 try:
-    import yaml
+    import yaml  # noqa: F401  (still imported for transitive consumers; parser uses it)
 except ImportError:
     print("ERROR: PyYAML required. Run: pip install pyyaml", file=sys.stderr)
     sys.exit(1)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.lib.dossier_parser import parse_dossier, get_primary_sources
 
 
 def check_url(url: str) -> bool:
@@ -33,33 +35,7 @@ def check_url(url: str) -> bool:
 
 
 def validate(path: Path) -> list[str]:
-    text = path.read_text()
-    # Strip YAML frontmatter if present
-    fm_match = re.match(r'^---\n(.*?)\n---\n', text, re.DOTALL)
-    if fm_match:
-        text = text[fm_match.end():]
-
-    # Parse sections as YAML blocks delimited by ## headers
-    # Each ## section becomes a top-level key
-    sections: dict = {}
-    current_key = None
-    current_lines: list[str] = []
-    for line in text.splitlines():
-        if line.startswith("## "):
-            if current_key:
-                try:
-                    sections[current_key] = yaml.safe_load("\n".join(current_lines)) or []
-                except yaml.YAMLError:
-                    sections[current_key] = current_lines
-            current_key = line[3:].strip().lower().replace(" ", "_").replace("(", "").replace(")", "")
-            current_lines = []
-        elif current_key is not None:
-            current_lines.append(line)
-    if current_key:
-        try:
-            sections[current_key] = yaml.safe_load("\n".join(current_lines)) or []
-        except yaml.YAMLError:
-            sections[current_key] = current_lines
+    sections = parse_dossier(path)
 
     failures: list[str] = []
 
@@ -69,7 +45,7 @@ def validate(path: Path) -> list[str]:
         failures.append(f"vendors_in_scope: need ≥3, got {len(vendors) if isinstance(vendors, list) else 0}")
 
     # Rule 2: primary_sources >= 5, spanning >= 3 distinct type values
-    sources = sections.get("primary_sources_≥5,_≥3_distinct_type_values", sections.get("primary_sources", []))
+    sources = get_primary_sources(sections)
     if not isinstance(sources, list) or len(sources) < 5:
         failures.append(f"primary_sources: need ≥5, got {len(sources) if isinstance(sources, list) else 0}")
     else:


### PR DESCRIPTION
## Summary

- Replaces the literal `*Auto-rendered from frontmatter by Hugo taxonomy.*` placeholder in every Frank Paper's §8 References with a real, dossier-driven bibliography (title + URL + type chip + quoted passages + per-paper relevance).
- Adds a new `/docs/papers/references/` cross-series index page that dedupes 102 unique sources across all 17 dossiers, grouped by `type` (vendor-docs · paper · postmortem · talk · benchmark), with per-citing-paper relevance preserved.
- Wires a `--check` mode on the new sync script into the blog CI workflow so dossier ↔ `blog/data/papers/*.yaml` drift fails the build (the durable guarantee against silent §8 staleness, including on edits that bypass the local pre-commit hook).

## How it works

1. New shared parser at `scripts/lib/dossier_parser.py` is imported by both `validate-dossier.py` (gate) and `scripts/sync-dossier-to-data.py` (sync) — one source of truth for the dossier shape.
2. `sync-dossier-to-data.py` has three modes: `<slug>` (one), `--all` (every), `--check` (CI gate, exits 1 with a unified diff on drift). Wired into `.githooks/pre-commit` so dossier edits auto-regenerate matching data files at commit time.
3. `blog/layouts/partials/papers/references.html` is auto-injected by `single.html` (gated on `series: papers`) alongside the existing `papers-forwardlinks` and `papers/dossier-link` partials — no shortcode call in paper markdown.
4. `blog/layouts/partials/papers/references-index.html` powers the cross-series page; iterates `.Site.Data.papers.*`, dedupes by URL, groups by type. Uses `series: ["references"]` on the index page (not `papers-*`) to avoid Hugo's `in` substring-match trap that would silently fire the per-paper partial on the index itself.
5. The redundant `references:` frontmatter block is hard-deleted from all 17 papers (and from the scaffold + `agents/rules/repo-papers.md`); the dossier is now the single source of truth.

## Test plan

- [x] **Phase 1:** 9 pytest cases pass (parser fixtures + sync modes incl. `--check` clean and `--check` dirty)
- [x] **Phase 2:** 17 data files generated; Hugo build clean (no data-load errors)
- [x] **Phase 3:** §8 renders on Papers 09/04/14 with correct title + chip + quotes + relevance structure
- [x] **Phase 4:** legacy placeholder absent from every paper body; auto-injection still renders §8 correctly
- [x] **Phase 5:** all 17 papers' frontmatter has `references:` removed; `/docs/papers/references/` page renders all 5 type sections (vendor-docs=58, paper=16, postmortem=12, talk=6, benchmark=10) with per-paper relevance preserved; per-paper partial does NOT render on the index page (substring trap successfully avoided)
- [x] **Phase 6:** `python scripts/sync-dossier-to-data.py --check` exits 0 locally; workflow YAML parses; `vk plan self-review` passes
- [ ] **CI drift gate live verification:** the new step in `deploy-blog.yml` fires on the merge commit. Worth watching the first post-merge run to confirm the `Check dossier ↔ blog/data/papers sync` step executes (exit 0 expected).
- [ ] **Cross-series index page in production:** once deployed, spot-check `/docs/papers/references/` on the live blog. Verify type sections are alphabetical within group and per-paper "Cited in:" attributions are correct.
- [ ] **Hugo's `series` typing**: `_index.md` uses `series: ["references"]` (list) because Hextra's `opengraph.html` ranges over `.Params.series` and rejects scalars — verified locally. Worth a glance at the rendered head metadata on `/docs/papers/references/` post-deploy.

## Plan + Spec

- Spec: `docs/superpowers/specs/2026-05-22--repo--paper-bibliography-rendering-design.md`
- Plan: `docs/superpowers/plans/2026-05-23--repo--paper-bibliography-rendering/`

## Notable in-flight discoveries

- **Phase-3 partial bug, fixed in Phase 5:** the cross-series index partial was iterating `.Site.Data.papers.*` without guarding against a coexisting `blog/data/papers.yaml` roster file. Added a `reflect.IsMap` + `isset $data "primary_sources"` guard. Without it, the `/references/` build failed.
- **Plan regex bug, fixed in Phase 5:** the frontmatter `references:` strip needed `|\Z` alternation in the lookahead because `references:` was the *last* key in every paper's frontmatter.
- **Strip count was 10, not 17:** only 9 papers carried the canonical `*Auto-rendered…*` placeholder + 1 had a variant `*See frontmatter…*`. The remaining 7 simply had no §8 in their bodies; Phase 3's auto-injection now adds §8 to them too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)