### PR TITLE
fix(ci): gate container build on validators + tighten mermaid regex

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -85,9 +85,14 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
-  # Build container image for Hop and update deployment manifest
+  # Build container image for Hop and update deployment manifest.
+  # Gated on build-pages so a failing validator (dossier sync, paper
+  # frontmatter, mermaid) prevents the hop image from rolling out —
+  # otherwise GitHub Pages stays on the old build but ArgoCD on hop
+  # pulls a new image whose content failed the same validators.
   build-container:
     runs-on: ubuntu-latest
+    needs: build-pages
     permissions:
       contents: write
       packages: write

--- a/scripts/validate-mermaid.mjs
+++ b/scripts/validate-mermaid.mjs
@@ -51,8 +51,13 @@ function htmlDecode(s) {
 }
 
 function extractMermaid(html) {
+  // The character classes below exclude `>` so attribute matching can't bleed
+  // past the opener and into the diagram body (which contains unescaped `>`
+  // from Mermaid arrows like `-->`). Use `[^>"']` instead of `[^"']` for
+  // attribute-internal text; non-greedy quantifiers reinforce that the
+  // opening tag should be as short as possible.
   const blocks = [];
-  const re = /<pre[^>]*class=["']?[^"']*\bmermaid\b[^"']*["']?[^>]*>([\s\S]*?)<\/pre>/gi;
+  const re = /<pre[^>]*?class=["']?[^>"']*?\bmermaid\b[^>"']*?["']?[^>]*?>([\s\S]*?)<\/pre>/gi;
   for (const m of html.matchAll(re)) {
     blocks.push(htmlDecode(m[1]).trim());
   }


### PR DESCRIPTION
## Summary

Two CI fixes triggered by the post-merge build failure on commit `faa3f99` (PR #378's merge — the bundled weight + mermaid fixes).

### 1. Mermaid validator regex was too permissive

The regex extracting `<pre class="mermaid">` blocks used `[^"']` for attribute-internal text. That class permits `>` characters, so the matcher could bleed past the opener's `>` and into the diagram body — which contains unescaped `>` from Mermaid arrows like `-->`. For `<pre class=mermaid>quadrantChart\n…x-axis "…" --> "…"`, the capture group started mid-content (`"…"` after the arrow) and `mermaid.parse()` rightly rejected the snippet.

**Why this didn't show up in local testing:** `hugo` without `--minify` produces `<pre class="mermaid hx:mt-6">` (quoted, multi-class). `hugo --minify` collapses the landscape shortcode's mermaid block to `<pre class=mermaid>` (unquoted), and the `papers/landscape` shortcode template passes `-->` through unescaped via `{{ .Inner }}`. The combination only happens under `--minify`, which CI uses but my local test didn't.

**Fix:** replace `[^"']` with `[^>"']` so attribute matching cannot cross the opener's `>`. Verified 130/130 mermaid blocks pass against the minified `blog/public` output.

### 2. build-container ran in parallel with build-pages — no gate

The `build-container` job (which builds the hop image and commits the deployment-manifest tag bump) had no `needs:` declaration, so it ran in parallel with `build-pages`. When `build-pages` failed the new mermaid validator, `deploy-pages` was correctly skipped (already gated), but `build-container` ran to completion and committed `afd587c ci(blog): update image to faa3f99`. Result: GitHub Pages stayed on the prior build, but ArgoCD on hop pulled an unvalidated new image.

**Fix:** add `needs: build-pages` to `build-container`. Single point of validation — if any validator fails (dossier sync, paper frontmatter, mermaid), neither deploy target advances. Deploy or don't deploy — never one without the other.

## Current state (pre-merge)

- `derio-net.github.io/frank` (GH Pages): stuck on the build BEFORE the bibliography PR, missing both Paper 15 fix and Paper 00 sort fix. (validator failure on faa3f99 blocked deploy)
- `blog.derio.net/frank` (hop): rolling out faa3f99 image (paper sort + Paper 15 fix landed correctly). The validator failure should have blocked this; it didn't, because of bug #2 above.

## Post-merge expectation

- New CI run on this merge commit: build-pages green (regex fix), `deploy-pages` runs → GH Pages catches up. `build-container` runs (gated on build-pages green) → publishes a fresh image bump → hop re-rolls with identical content but new SHA. No more drift between targets.

## Test plan

- [x] Local: `node scripts/validate-mermaid.mjs blog/public` exits 0 against `--minify` output (130 blocks)
- [x] Workflow YAML still parses (`yaml.safe_load`)
- [ ] CI run on merge: `build-pages` exits 0 → `deploy-pages` runs → `build-container` runs → all four checks green
- [ ] Post-deploy: GH Pages updates to reflect main HEAD; live `blog.derio.net/frank/docs/papers/` shows Paper 00 first

🤖 Generated with [Claude Code](https://claude.com/claude-code)