### PR TITLE
fix(blog): capability-matrix actually scrolls on mobile + zoomed browser

### DIFF
--- a/blog/assets/css/custom.css
+++ b/blog/assets/css/custom.css
@@ -168,30 +168,32 @@
 }
 
 .paper-post .paper-capability-matrix {
-  /* Wrapper handles horizontal scroll on narrow viewports (phones in
-     portrait) — wider-than-viewport tables scroll left/right with the
-     finger instead of squeezing every column down to ~30 px. Tables that
-     fit naturally don't show a scrollbar (overflow-x: auto only renders
-     one when needed). The 1.25rem auto margin lives here rather than on
-     the table so the vertical rhythm survives the overflow context. */
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
+  /* Visual frame lives on the WRAPPER, not the table itself. Hextra's
+     default rule for `.content table` sets `display: block; width: 100%;
+     overflow-x: auto` — the same pattern that makes mermaid blocks
+     scrollable on mobile. The previous attempt (wrapper overflow-x +
+     `overflow: hidden` on the table) accidentally clipped that scrollbar
+     away on Android / zoomed browsers because `overflow: hidden` on the
+     table cancels Hextra's `overflow-x: auto`. Now we leave the table
+     alone (Hextra's scroll works) and put the frame on the wrapper, with
+     `overflow: hidden` here to clip the table's square corners against
+     the wrapper's border-radius. Scrollbar lives INSIDE the table block,
+     INSIDE the wrapper — visible and finger-swipeable. */
   margin: 1.25rem auto;
-}
-
-.paper-post .paper-capability-matrix table {
-  /* Size to content. NO max-width: 100% — that constraint would prevent
-     the wrapper's overflow-x: auto from doing anything, since the table
-     would re-squeeze to the wrapper's width. Without it, the table sizes
-     to its intrinsic content; the wrapper governs horizontal extent. */
-  width: auto;
-  margin: 0 auto;
-  border-collapse: collapse;
-  font-size: 0.875rem;
-  background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(148, 180, 255, 0.25);
   border-radius: 6px;
   overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.paper-post .paper-capability-matrix table {
+  /* DO NOT set width / display / overflow / margin / border / background
+     here. Those belong on the wrapper or come from Hextra's `.content
+     table` defaults. `overflow: hidden` here kills mobile scroll.
+     `width: auto` cancels Hextra's `width: 100%` and produces inconsistent
+     layout under browser zoom. */
+  border-collapse: collapse;
+  font-size: 0.875rem;
 }
 
 .paper-post .paper-capability-matrix thead {


### PR DESCRIPTION
## What this fixes

The PR #380 piggyback (\`a0a6960 style(blog): make Papers feature tables horizontally scrollable on mobile\`) didn't actually work. User reported the feature tables still squeeze cells on Android and in a Cmd-+-zoomed browser.

## Root cause

Hextra's \`.content table\` rule already applies \`display: block; width: 100%; overflow-x: auto\` to every table inside \`.content\` — the SAME scroll pattern that makes mermaid blocks finger-swipeable on mobile.

My PR #380 fix put \`overflow: hidden\` on the table itself (paired with border-radius to clip the rounded corners). That \`overflow: hidden\` CANCELLED Hextra's \`overflow-x: auto\`. The scroll mechanism was already there; my override clipped its scrollbar away.

## Fix

Move the visual frame (border + border-radius + \`overflow: hidden\` for corner-clipping + background) to the **wrapper div**. Strip the table rule down to cell-level concerns only (border-collapse, font-size). Let Hextra's table defaults apply.

Resulting cascade:
- **Wrapper** (\`.paper-capability-matrix\`): margin, border, border-radius, overflow:hidden, background. The \`overflow:hidden\` here clips the inner table's square corners against the wrapper's rounded border. Nothing else.
- **Table** (\`.paper-capability-matrix table\`): only \`border-collapse\` + \`font-size\`. Hextra's defaults (\`display: block; width: 100%; overflow-x: auto\`) supply the actual scroll behaviour.
- Scrollbar lives **inside the table block, inside the wrapper** — visible, finger-swipeable.

## Verified locally

```
.paper-capability-matrix{margin:1.25rem auto;border:1px solid rgba(148,180,255,.25);border-radius:6px;overflow:hidden;background:rgba(255,255,255,3%)}
.paper-capability-matrix table{border-collapse:collapse;font-size:.875rem}
```

Mermaid validator: 130/130 still passes. Other capability-matrix rules (thead, th, td, hover, light-mode) untouched.

## Test plan

- [x] Hugo build clean
- [x] Mermaid validator green (no regression)
- [ ] **Post-deploy on mobile (Android Chrome)**: open a Paper with a wide capability matrix (e.g. Paper 04 distributed-storage), verify horizontal scroll works
- [ ] **Post-deploy in zoomed desktop browser**: Cmd-+ to ~150% zoom, verify scroll appears + works
- [ ] Visual frame (rounded corners + border) still renders cleanly on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)