### PR TITLE
plan(repo): safe-update-automation — finalize v2 plan + code-review fixes

### DIFF
--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -1206,7 +1206,7 @@ operations:
 - id: arc-github-app-secret
   layer: repo
   app: arc-runners
-  plan: docs/superpowers/plans/2026-03-25--repo--safe-update-automation.md
+  plan: docs/superpowers/plans/2026-03-25--repo--safe-update-automation/
   when: After arc-controller and arc-runners apps are synced by ArgoCD, before runner pod reaches Running state
   why_manual: GitHub App credentials are a bootstrap secret. The runner cannot register without it, and SOPS+ArgoCD don't mix per repo convention.
   commands:
@@ -1219,7 +1219,7 @@ operations:
 - id: github-branch-protection-smoke-test
   layer: repo
   app: renovate
-  plan: docs/superpowers/plans/2026-03-25--repo--safe-update-automation.md
+  plan: docs/superpowers/plans/2026-03-25--repo--safe-update-automation/
   when: After smoke-test.yaml workflow exists on main branch and has run at least once successfully
   why_manual: Branch protection rules must be configured via GitHub UI or API. The smoke-test/readiness check must be a required status check so Renovate's automerge only fires after tests pass.
   commands:

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -1360,7 +1360,7 @@ operations:
   why_manual: Token replication across Frank secrets (LITELLM_MASTER_KEY from .env, FRANK_C2_TELEGRAM_* from grafana-alerting-secrets, OBS_GOATCOUNTER_API_TOKEN from grafana-goatcounter-token) — Infisical seed deferred
   commands:
   - source .env ; kubectl create ns ai-alert-helper-system ; kubectl label ns ai-alert-helper-system pod-security.kubernetes.io/enforce=restricted --overwrite
-  - 'See commands inline in P5.T2.S2 — apply ai-alert-helper-secrets Secret with FRANK_C2_TELEGRAM_BOT_TOKEN, FRANK_C2_TELEGRAM_CHAT_ID, OBS_GOATCOUNTER_API_TOKEN, LITELLM_API_KEY'
+  - See commands inline in P5.T2.S2 — apply ai-alert-helper-secrets Secret with FRANK_C2_TELEGRAM_BOT_TOKEN, FRANK_C2_TELEGRAM_CHAT_ID, OBS_GOATCOUNTER_API_TOKEN, LITELLM_API_KEY
   verify:
   - kubectl -n ai-alert-helper-system get secret ai-alert-helper-secrets
   - kubectl -n ai-alert-helper-system exec deploy/ai-alert-helper -- env | grep -c TELEGRAM

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/01.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/01.yaml
@@ -79,7 +79,8 @@ tasks:
           namespace: arc-system
         syncPolicy:
           automated:
-            prune: false
+            # prune omitted intentionally — apps/root/values.yaml documents that
+            # ArgoCD normalizes explicit `prune: false` to absent, causing drift.
             selfHeal: true
           syncOptions:
             - CreateNamespace=true
@@ -136,24 +137,14 @@ tasks:
                   cpu: 2000m
                   memory: 2Gi
               env:
-                - name: ACTIONS_RUNNER_CONTAINER_HOOKS
-                  value: /home/runner/k8s/index.js
-                - name: ACTIONS_RUNNER_POD_NAME
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.name
+                # Smoke-test jobs run directly on the runner pod (no per-job
+                # `container:`), so they use the pod's ServiceAccount
+                # (frank-cluster-gha-rs-no-permission) + the smoke-test RBAC.
+                # We deliberately do NOT set containerMode.type=kubernetes (which
+                # would bind a different SA, <release>-gha-rs-kube-mode) nor the
+                # DinD sidecar — neither is needed for direct kubectl/helm steps.
                 - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
                   value: "false"
-          initContainers:
-            - name: init-dind-externals
-              image: ghcr.io/actions/actions-runner:latest
-              command: ["cp", "-r", "-v", "/home/runner/externals/.", "/home/runner/tmpDir/"]
-              volumeMounts:
-                - name: dind-externals
-                  mountPath: /home/runner/tmpDir
-          volumes:
-            - name: dind-externals
-              emptyDir: {}
       ```
 
       Replace `<YOUR_GITHUB_ORG_OR_USER>/<YOUR_REPO>` with the actual repo path (e.g. `derio-net/frank-cluster`).
@@ -251,7 +242,8 @@ tasks:
           namespace: arc-system
         syncPolicy:
           automated:
-            prune: false
+            # prune omitted intentionally — apps/root/values.yaml documents that
+            # ArgoCD normalizes explicit `prune: false` to absent, causing drift.
             selfHeal: true
           syncOptions:
             - CreateNamespace=true

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/01.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/01.yaml
@@ -3,7 +3,7 @@ phase:
   number: 1
   title: ARC Self-Hosted Runner
   tag: agentic
-  depends_on: []
+  depends_on: [0]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/02.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/02.yaml
@@ -3,7 +3,7 @@ phase:
   number: 2
   title: ARC Bootstrap Secret
   tag: manual
-  depends_on: []
+  depends_on: [1]
   tracking_issue: null
 tasks:
 - number: 3
@@ -21,6 +21,37 @@ tasks:
     text: |-
       Apply and encrypt the secret
 
+
+      The GitHub App credentials must exist as a Kubernetes Secret before the runner pod can register. This is a SOPS-encrypted bootstrap secret applied out-of-band.
+
+      ```yaml
+      # manual-operation
+      id: arc-github-app-secret
+      layer: repo
+      app: arc-runners
+      plan: docs/superpowers/plans/2026-03-25--repo--safe-update-automation/
+      when: "After arc-controller and arc-runners apps are synced by ArgoCD, before runner pod reaches Running state"
+      why_manual: "GitHub App credentials are a bootstrap secret. The runner cannot register without it, and SOPS+ArgoCD don't mix per repo convention."
+      commands:
+        - |
+          # Create the Secret manifest
+          kubectl create secret generic arc-github-app-secret \
+            --namespace arc-system \
+            --from-literal=github_app_id=<APP_ID> \
+            --from-literal=github_app_installation_id=<INSTALLATION_ID> \
+            --from-literal=github_app_private_key="$(cat path/to/private-key.pem)" \
+            --dry-run=client -o yaml > /tmp/arc-secret.yaml
+          # Encrypt with SOPS (use the same age key as other secrets/)
+          sops --encrypt /tmp/arc-secret.yaml > secrets/arc/github-app-secret.yaml
+          rm /tmp/arc-secret.yaml
+          # Apply to cluster
+          sops --decrypt secrets/arc/github-app-secret.yaml | kubectl apply -f -
+      verify:
+        - kubectl get secret arc-github-app-secret -n arc-system
+        - kubectl get pods -n arc-system   # runner pod should reach Running within ~60s
+        - kubectl get runners -n arc-system  # should show registered runner
+      status: pending
+      ```
 
       Follow the commands in the manual-operation block above. Replace `<APP_ID>`, `<INSTALLATION_ID>`, and `path/to/private-key.pem` with your actual GitHub App values.
   - id: P2.T3.S3

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/03.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/03.yaml
@@ -105,9 +105,13 @@ tasks:
                 # Extract current minor from current talos version (e.g. v1.9.3 -> 1.9)
                 CURRENT_TALOS="${{ steps.current.outputs.talos }}"
                 CURRENT_MINOR=$(echo "$CURRENT_TALOS" | grep -oP 'v\d+\.\d+')
-                # Find latest patch within same minor
-                LATEST=$(gh api repos/siderolabs/talos/releases \
-                  --jq "[.[] | select(.prerelease == false) | select(.tag_name | startswith(\"$CURRENT_MINOR.\")) | .tag_name] | first")
+                # Find latest patch within same minor. The releases API is sorted
+                # by publish date (newest first) and paginated, so `| first` can
+                # miss a patch or pick an out-of-order backport. Page through all
+                # releases, emit matching stable tags, and take the highest semver.
+                LATEST=$(gh api --paginate repos/siderolabs/talos/releases \
+                  --jq ".[] | select(.prerelease == false) | select(.tag_name | startswith(\"$CURRENT_MINOR.\")) | .tag_name" \
+                  | sort -V | tail -1)
                 echo "version=$LATEST" >> $GITHUB_OUTPUT
                 echo "release_url=https://github.com/siderolabs/talos/releases/tag/$LATEST" >> $GITHUB_OUTPUT
 
@@ -117,8 +121,13 @@ tasks:
                 GH_TOKEN: ${{ github.token }}
               run: |
                 MINOR="v${{ steps.current.outputs.k8s_minor }}"
-                LATEST=$(gh api repos/kubernetes/kubernetes/releases \
-                  --jq "[.[] | select(.prerelease == false) | select(.tag_name | startswith(\"$MINOR.\")) | .tag_name] | first")
+                # See the Talos step: page through all releases and pick the
+                # highest semver patch, not the most-recently-published one.
+                # kubernetes/kubernetes interleaves many minors, so the target
+                # patch is rarely on the first page.
+                LATEST=$(gh api --paginate repos/kubernetes/kubernetes/releases \
+                  --jq ".[] | select(.prerelease == false) | select(.tag_name | startswith(\"$MINOR.\")) | .tag_name" \
+                  | sort -V | tail -1)
                 echo "version=$LATEST" >> $GITHUB_OUTPUT
                 echo "release_url=https://github.com/kubernetes/kubernetes/releases/tag/$LATEST" >> $GITHUB_OUTPUT
 

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/03.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/03.yaml
@@ -3,7 +3,7 @@ phase:
   number: 3
   title: Version Tracking
   tag: agentic
-  depends_on: []
+  depends_on: [2]
   tracking_issue: null
 tasks:
 - number: 4

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/04.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/04.yaml
@@ -19,7 +19,7 @@ tasks:
       ```json
       {
         "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-        "extends": ["config:base"],
+        "extends": ["config:recommended"],
         "schedule": ["every weekend"],
         "labels": ["renovate"],
         "prCreation": "not-pending",
@@ -27,7 +27,7 @@ tasks:
           {
             "customType": "regex",
             "description": "ArgoCD Application CR Helm chart versions",
-            "fileMatch": ["apps/root/templates/.+\\.yaml"],
+            "managerFilePatterns": ["/apps/root/templates/.+\\.yaml/"],
             "matchStrings": [
               "repoURL: (?<registryUrl>https://[^\\n]+)\\n      chart: (?<depName>[^\\n]+)\\n      targetRevision: \"(?<currentValue>[^\"]+)\""
             ],

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/04.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/04.yaml
@@ -3,7 +3,7 @@ phase:
   number: 4
   title: Renovate & Smoke Testing
   tag: agentic
-  depends_on: []
+  depends_on: [0, 3]
   tracking_issue: null
 tasks:
 - number: 6

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/05.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/05.yaml
@@ -3,7 +3,7 @@ phase:
   number: 5
   title: Branch Protection & End-to-End Verification
   tag: manual
-  depends_on: []
+  depends_on: [4]
   tracking_issue: null
 tasks:
 - number: 8
@@ -13,6 +13,31 @@ tasks:
     text: |-
       Apply branch protection after smoke-test workflow is live
 
+
+      The `smoke-test/readiness` status check must be a required status check on `main` so Renovate's auto-merge only fires after the smoke test passes.
+
+      ```yaml
+      # manual-operation
+      id: github-branch-protection-smoke-test
+      layer: repo
+      app: renovate
+      plan: docs/superpowers/plans/2026-03-25--repo--safe-update-automation/
+      when: "After smoke-test.yaml workflow exists on main branch and has run at least once successfully"
+      why_manual: "Branch protection rules must be configured via GitHub UI or API. The smoke-test/readiness check must be a required status check so Renovate's automerge only fires after tests pass."
+      commands:
+        - |
+          # Via GitHub CLI — sets branch protection on main requiring smoke-test/readiness
+          gh api repos/:owner/:repo/branches/main/protection \
+            --method PUT \
+            --field required_status_checks='{"strict":false,"checks":[{"context":"smoke-test/readiness"}]}' \
+            --field enforce_admins=false \
+            --field required_pull_request_reviews=null \
+            --field restrictions=null
+      verify:
+        - gh api repos/:owner/:repo/branches/main/protection --jq '.required_status_checks.checks'
+        # Expected: [{"context":"smoke-test/readiness","app_id":null}]
+      status: pending
+      ```
 
       Run the `gh api` command above (after Task 7 is complete and the workflow has run). Replace `:owner/:repo` with your actual values.
 - number: 9

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/_meta.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-25--repo--safe-update-automation
 spec: docs/superpowers/specs/2026-03-25--repo--safe-update-automation-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-25'

--- a/docs/superpowers/specs/2026-03-25--repo--safe-update-automation-design.md
+++ b/docs/superpowers/specs/2026-03-25--repo--safe-update-automation-design.md
@@ -49,7 +49,7 @@ Omni/Talos layer (monthly)
 
 A lightweight `actions-runner-controller` (ARC) Deployment pinned to `pc-1` via `nodeSelector: kubernetes.io/hostname: pc-1`. This gives GitHub Actions direct in-cluster `kubectl` access without any network tunneling. Headscale and the subnet router are not in the CI critical path.
 
-- **Location:** `apps/arc/` — new ArgoCD app. Uses the current ARC v2 architecture: two charts installed in sequence — `gha-runner-scale-set-controller` (controller) and `gha-runner-scale-set` (runner set). Do NOT use the legacy `actions-runner-controller` chart (v1, unmaintained).
+- **Location:** `apps/arc-controller/` + `apps/arc-runners/` — two ArgoCD apps. Uses the current ARC v2 architecture: two charts installed in sequence — `gha-runner-scale-set-controller` (controller, sync-wave `-1`) and `gha-runner-scale-set` (runner set). Do NOT use the legacy `actions-runner-controller` chart (v1, unmaintained).
 - **Node binding:** `nodeSelector: kubernetes.io/hostname: pc-1` (label is automatically set by Kubernetes; no Talos patch required)
 - **Runner group:** `self-hosted`, labelled `frank-cluster`
 
@@ -70,8 +70,8 @@ Cluster-scoped resources outside namespace management (ClusterRoles, ClusterRole
 # manual-operation
 id: arc-github-app-secret
 layer: repo
-app: arc
-plan: docs/superpowers/plans/2026-03-25--repo--safe-update-automation.md
+app: arc-runners
+plan: docs/superpowers/plans/2026-03-25--repo--safe-update-automation/
 when: "After ARC app is synced by ArgoCD, before runner pod starts"
 why_manual: "GitHub App credentials are a bootstrap secret — ARC must exist to manage itself, and the secret must exist before the runner can register. SOPS-encrypted per repo convention."
 commands:
@@ -132,18 +132,18 @@ Core infra apps are excluded from the smoke test because they install CRDs and r
 
 Triggered on every Renovate PR via `pull_request` event (filter: `paths: ["apps/root/templates/*.yaml"]`). Runs on the self-hosted runner (`runs-on: [self-hosted, frank-cluster]`). Skips if the PR has the `no-smoke-test` label.
 
-**Mechanism:** Direct Helm install into an ephemeral namespace `smoke-test-<pr-number>`. No vCluster — namespace isolation is sufficient for pod readiness checks, and vCluster overhead is unnecessary for this use case.
+**Mechanism:** Direct Helm install into an ephemeral namespace `smoke-test-<pr-number>-<app>`. No vCluster — namespace isolation is sufficient for pod readiness checks, and vCluster overhead is unnecessary for this use case.
 
 **Workflow steps:**
 
 1. Checkout the PR branch
 2. Skip if `no-smoke-test` label is present (exit 0, report skipped status)
 3. Extract app name, chart repo URL, and new `targetRevision` from the changed template file using `yq`. The chart source entry in Application CR templates is a static YAML block (Go template variables only appear in the `ref: values` source, not the helm source) — `yq` can parse it directly: `yq '.spec.sources[] | select(.chart != null) | {name: .chart, repo: .repoURL, version: .targetRevision}' <file>`. If multiple template files changed in one PR (Renovate batch), the workflow runs a smoke test for each changed file sequentially.
-4. Create namespace: `kubectl create namespace smoke-test-<pr-number>`
-5. `helm install <app> <chart-repo>/<chart-name> --version <new-version> -n smoke-test-<pr-number> -f apps/<app>/values.yaml`. If `apps/<app>/smoke-test-values.yaml` exists, append it as an additional `-f` override (used to stub cluster-internal endpoints such as OIDC issuer URLs or LoadBalancer IPs that prevent pod startup in an isolated namespace).
-6. `kubectl wait --for=condition=Ready pod -l <app-label-selector> -n smoke-test-<pr-number> --timeout=120s`
+4. Create namespace: `kubectl create namespace smoke-test-<pr-number>-<app>`
+5. `helm install <app> <chart-repo>/<chart-name> --version <new-version> -n smoke-test-<pr-number>-<app> -f apps/<app>/values.yaml`. If `apps/<app>/smoke-test-values.yaml` exists, append it as an additional `-f` override (used to stub cluster-internal endpoints such as OIDC issuer URLs or LoadBalancer IPs that prevent pod startup in an isolated namespace).
+6. `kubectl wait --for=condition=Ready pod -l <app-label-selector> -n smoke-test-<pr-number>-<app> --timeout=120s`
 7. On timeout/failure: capture `kubectl describe pod` and `kubectl events` output; post as PR comment
-8. `kubectl delete namespace smoke-test-<pr-number>` (always runs — in `finally` block)
+8. `kubectl delete namespace smoke-test-<pr-number>-<app>` (always runs — in `finally` block)
 9. Report pass/fail as GitHub status check `smoke-test/readiness`
 
 **Per-app label selectors** are defined in a lookup table in the workflow YAML (e.g., `grafana: "app.kubernetes.io/name=grafana"`). Apps not in the table use `app=<app-name>` as a fallback.
@@ -188,10 +188,15 @@ Scheduled weekly cron (`0 9 * * 1` — Monday 09:00 UTC). Runs on the self-hoste
 ## File Layout
 
 ```text
-apps/arc/
-  values.yaml                    # ARC Helm values (nodeSelector, RBAC, runner config)
+apps/arc-controller/
+  values.yaml                    # gha-runner-scale-set-controller Helm values
+apps/arc-runners/
+  values.yaml                    # gha-runner-scale-set Helm values (pc-1 pin)
+  manifests/
+    rbac.yaml                    # ClusterRole + ClusterRoleBinding for smoke tests
 apps/root/templates/
-  arc.yaml                       # ArgoCD Application CR for ARC
+  arc-controller.yaml            # Application CR, sync-wave: "-1"
+  arc-runners.yaml               # Application CR, ignoreDifferences on Secrets
 secrets/arc/
   github-app-secret.yaml         # SOPS-encrypted GitHub App credentials (applied out-of-band)
 renovate.json                    # Renovate config (regex manager, packageRules, schedule)

--- a/docs/superpowers/specs/2026-03-25--repo--safe-update-automation-design.md
+++ b/docs/superpowers/specs/2026-03-25--repo--safe-update-automation-design.md
@@ -233,4 +233,4 @@ versions.yaml                    # Declarative Talos + K8s version targets
 
 | Plan | Repo | File | Depends on |
 |------|------|------|------------|
-| Safe Update Automation Implementation Plan |  | `docs/superpowers/plans/2026-03-25--repo--safe-update-automation/` | — |
+| Safe Update Automation Implementation Plan | derio-net/frank | `docs/superpowers/plans/2026-03-25--repo--safe-update-automation/` | — |


### PR DESCRIPTION
## Summary

Finalizes the implementation plan for the **safe-update-automation** spec (`docs/superpowers/specs/2026-03-25--repo--safe-update-automation-design.md`) as a v2 plan-as-folder, and fixes defects in the mechanically-migrated plan that a code-review pass surfaced.

The plan automates version updates across three planes for the Frank cluster:
1. **ArgoCD Helm charts** — Renovate opens `targetRevision` bump PRs; a self-hosted ARC runner (pinned to pc-1) runs a Helm smoke test in an ephemeral namespace; stateless apps auto-merge on green.
2. **Talos / Kubernetes** — a weekly cron workflow detects new stable patches and opens a `versions.yaml` PR (Omni applies the upgrade; human-gated).
3. **ARC v2 runner** — `gha-runner-scale-set-controller` + `gha-runner-scale-set` as two ArgoCD apps.

## Commit 1 — correct migration defects (`2f2ded3`)

The v1→v2 migration (#252) introduced three defects:
- `target_repo` pointed at `derio-net/superpowers-for-vk` → corrected to `derio-net/frank`
- all phases had `depends_on: []` → restored the chain `1←0, 2←1, 3←2, 4←{0,3}, 5←4`
- both `# manual-operation` blocks (ARC GitHub App secret; branch protection) were dropped, leaving steps that referenced a block no longer present → restored
- bumped `vk_version` to `>=2.0.0,<3.0.0`; filled the spec table Repo column

## Commit 2 — code-review fixes (`22a1d9f`)

A reviewer audited the full plan against the spec and the live repo and surfaced latent errors (verified before applying):
- **Renovate** `config:base` → `config:recommended`, `fileMatch` → `managerFilePatterns` (both deprecated; current Renovate auto-migrates, but the plan should ship current)
- **ArgoCD `prune: false` dropped** from both ARC app CRs — `apps/root/values.yaml` documents that ArgoCD normalizes explicit `prune: false` to *absent* and causes permanent drift (only 1/71 templates set it). This is a case where live repo convention overrides the CLAUDE.md "always prune: false" gotcha.
- **ARC runner values** — removed a contradictory DinD init container + kubernetes container-hooks env; smoke-test jobs run directly on the runner pod, so the `-no-permission` ServiceAccount the RBAC binds is correct without `containerMode`
- **version-check** picks the latest patch via `gh api --paginate ... | sort -V | tail -1` instead of `| first` (the releases API sorts by publish date and paginates, so a backport could yield a downgrade or miss a patch)
- **spec brought into line with the plan** — `apps/arc-controller` + `apps/arc-runners` split, `smoke-test-<pr>-<app>` namespace naming, folder-form manual-op `plan:` path; runbook entries updated to the v2 folder path

## Validation
- `vk plan self-review` passes
- all phase YAMLs parse; embedded `renovate.json` parses; the custom-manager regex still matches `apps/root/templates/cert-manager.yaml`
- multi-source ArgoCD pattern (chart + `path:` + `ref: values`) confirmed already in use via `apps/root/templates/victoria-metrics.yaml`

## Scope
This PR delivers the **plan only** — no cluster resources are created. Execution (ARC deploy, Renovate install, workflows) is gated behind the plan's manual Phase 0 / Phase 2 / Phase 5 steps.

~Note: `docs/runbooks/manual-operations.yaml` has a pre-existing YAML parse issue near line 1344 (present on `main`, unrelated to this change) — left untouched.~ Fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)