### PR TITLE
fix(repo): correct YAML quote-escaping in falco-telegram runbook command

### DIFF
--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -1348,7 +1348,7 @@ operations:
   when: phase 4, task 1, before falcosidekick can send to Telegram
   why_manual: Falcosidekick reads TELEGRAM_TOKEN + TELEGRAM_CHATID from the falco-telegram Secret; values are replicated from Frank's grafana-alerting-secrets (no shared Infisical key path between clusters)
   commands:
-  - 'source .env ; TOKEN=$(kubectl -n monitoring get secret grafana-alerting-secrets -o jsonpath='"'"'{.data.FRANK_C2_TELEGRAM_BOT_TOKEN}'"'"') ; CHAT=$(kubectl -n monitoring get secret grafana-alerting-secrets -o jsonpath='"'"'{.data.FRANK_C2_TELEGRAM_CHAT_ID}'"'"') ; source .env_hop ; printf '"'"'apiVersion: v1\nkind: Secret\nmetadata:\n  name: falco-telegram\n  namespace: falco-system\ntype: Opaque\ndata:\n  TELEGRAM_TOKEN: %s\n  TELEGRAM_CHATID: %s\n'"'"' "$TOKEN" "$CHAT" | kubectl apply -f -'
+  - 'source .env ; TOKEN=$(kubectl -n monitoring get secret grafana-alerting-secrets -o jsonpath=''{.data.FRANK_C2_TELEGRAM_BOT_TOKEN}'') ; CHAT=$(kubectl -n monitoring get secret grafana-alerting-secrets -o jsonpath=''{.data.FRANK_C2_TELEGRAM_CHAT_ID}'') ; source .env_hop ; printf ''apiVersion: v1\nkind: Secret\nmetadata:\n  name: falco-telegram\n  namespace: falco-system\ntype: Opaque\ndata:\n  TELEGRAM_TOKEN: %s\n  TELEGRAM_CHATID: %s\n'' "$TOKEN" "$CHAT" | kubectl apply -f -'
   verify:
   - kubectl -n falco-system logs deploy/falco-falcosidekick | grep "Enabled Outputs"
   status: done


### PR DESCRIPTION
## Problem

`docs/runbooks/manual-operations.yaml` failed to parse (block-mapping error at the `obs-falco-telegram-credentials` entry). The command scalar used the **shell** single-quote escape idiom `'"'"'` inside a **YAML** single-quoted scalar. At the YAML layer the first `'` of that sequence closes the scalar early, leaving stray `"'"'"` that the parser rejects.

This was a separate, pre-existing entry (obs / hop-blog-edge-monitoring layer) from the one fixed in 7e08c4d — a strict parse stops at the first error, so it surfaced only after that one was addressed.

## Fix

In a YAML single-quoted scalar a literal apostrophe is written as a doubled quote (`''`). Each `'"'"'` → `''` (6 occurrences, all on one line).

## Verification

- Full file parses: **90 operations** loaded via `yaml.safe_load`.
- The **extracted command is unchanged** — asserted that `jsonpath='{...}'` shell quoting is intact, the `printf 'apiVersion: v1\nkind: Secret\n...'` `\n` stays a *literal* printf format (no real newline leaked in), and no spurious newline appears in the value.

```
source .env ; TOKEN=$(kubectl ... jsonpath='{.data.FRANK_C2_TELEGRAM_BOT_TOKEN}') ; CHAT=$(... jsonpath='{.data.FRANK_C2_TELEGRAM_CHAT_ID}') ; source .env_hop ; printf 'apiVersion: v1\nkind: Secret\n...\n' "$TOKEN" "$CHAT" | kubectl apply -f -
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)