### PR TITLE
chore(repo): dispatch safe-update-automation + pin ARC runner to gpu-1 (scale-to-zero)

### DIFF
--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/00.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/00.yaml
@@ -4,7 +4,7 @@ phase:
   title: GitHub App Prerequisites
   tag: manual
   depends_on: []
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/frank/issues/387
 tasks:
 - number: 1
   title: Install ARC GitHub App

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/01.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/01.yaml
@@ -3,8 +3,9 @@ phase:
   number: 1
   title: ARC Self-Hosted Runner
   tag: agentic
-  depends_on: [0]
-  tracking_issue: null
+  depends_on:
+  - 0
+  tracking_issue: https://github.com/derio-net/frank/issues/388
 tasks:
 - number: 1
   title: ARC Controller ArgoCD App

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/01.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/01.yaml
@@ -112,13 +112,21 @@ tasks:
       # gha-runner-scale-set
       # Chart: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set
       #
-      # Registers a runner pool labelled "frank-cluster" pinned to pc-1.
+      # Registers a runner pool labelled "frank-cluster", pinned to gpu-1.
+      # Pinned OFF pc-1 (which already runs zot/gitea/Tekton on only 4 cores)
+      # to leave headroom for a future AWX. gpu-1 is a 32-core/128GB worker
+      # with spare RAM/CPU — its real constraint is VRAM. In-cluster kubectl
+      # works from any node via the pod ServiceAccount, so co-locating with
+      # Tekton on pc-1 was never required.
       # The GitHub App credentials are in the arc-github-app-secret Secret (applied out-of-band).
 
       githubConfigUrl: "https://github.com/<YOUR_GITHUB_ORG_OR_USER>/<YOUR_REPO>"
       githubConfigSecret: arc-github-app-secret
 
-      minRunners: 1
+      # Scale-to-zero: no idle runner pod. A runner is spawned only when a
+      # Renovate-PR smoke-test job arrives, then torn down. Renovate runs
+      # weekly, so steady-state footprint on gpu-1 is zero.
+      minRunners: 0
       maxRunners: 3
 
       runnerGroup: "Default"
@@ -126,7 +134,14 @@ tasks:
       template:
         spec:
           nodeSelector:
-            kubernetes.io/hostname: pc-1
+            kubernetes.io/hostname: gpu-1
+          tolerations:
+            # Defensive: gpu-1 has no taint today, but GPU-operator driver
+            # re-validation can re-assert nvidia.com/gpu:NoSchedule (see
+            # frank-gotchas → gpu-1). Tolerate it so the runner isn't evicted.
+            - key: nvidia.com/gpu
+              operator: Exists
+              effect: NoSchedule
           containers:
             - name: runner
               image: ghcr.io/actions/actions-runner:latest

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/02.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/02.yaml
@@ -3,8 +3,9 @@ phase:
   number: 2
   title: ARC Bootstrap Secret
   tag: manual
-  depends_on: [1]
-  tracking_issue: null
+  depends_on:
+  - 1
+  tracking_issue: https://github.com/derio-net/frank/issues/389
 tasks:
 - number: 3
   title: Bootstrap Secret (Manual Operation)

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/02.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/02.yaml
@@ -79,10 +79,13 @@ tasks:
       # Expected: runner shows as registered
       ```
 
-      Also verify the runner is pinned to pc-1:
+      Verify runner placement on gpu-1. With `minRunners: 0` (scale-to-zero)
+      there is no idle runner pod, so observe one while a job runs — trigger a
+      smoke-test (or temporarily set `minRunners: 1`) and watch:
       ```bash
-      kubectl get pod -n arc-system -o wide | grep runner
-      # EXPECTED: node column shows "pc-1"
+      kubectl get pod -n arc-system -o wide -w | grep runner
+      # EXPECTED: an ephemeral runner pod appears on node "gpu-1" for the
+      # duration of the job, then terminates.
       ```
 
       ---

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/03.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/03.yaml
@@ -3,8 +3,9 @@ phase:
   number: 3
   title: Version Tracking
   tag: agentic
-  depends_on: [2]
-  tracking_issue: null
+  depends_on:
+  - 2
+  tracking_issue: https://github.com/derio-net/frank/issues/390
 tasks:
 - number: 4
   title: Create versions.yaml

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/04.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/04.yaml
@@ -3,8 +3,10 @@ phase:
   number: 4
   title: Renovate & Smoke Testing
   tag: agentic
-  depends_on: [0, 3]
-  tracking_issue: null
+  depends_on:
+  - 0
+  - 3
+  tracking_issue: https://github.com/derio-net/frank/issues/391
 tasks:
 - number: 6
   title: Renovate Configuration

--- a/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/05.yaml
+++ b/docs/superpowers/plans/2026-03-25--repo--safe-update-automation/05.yaml
@@ -3,8 +3,9 @@ phase:
   number: 5
   title: Branch Protection & End-to-End Verification
   tag: manual
-  depends_on: [4]
-  tracking_issue: null
+  depends_on:
+  - 4
+  tracking_issue: https://github.com/derio-net/frank/issues/392
 tasks:
 - number: 8
   title: GitHub Branch Protection (Manual Operation)

--- a/docs/superpowers/specs/2026-03-25--repo--safe-update-automation-design.md
+++ b/docs/superpowers/specs/2026-03-25--repo--safe-update-automation-design.md
@@ -32,7 +32,7 @@ Three pipelines, scoped to their update frequency and risk level:
 ```text
 ArgoCD layer (weekly+)
   Renovate ──► PR (targetRevision bump)
-            ──► GitHub Actions: namespace smoke test (self-hosted runner, pc-1)
+            ──► GitHub Actions: namespace smoke test (self-hosted runner, gpu-1, scale-to-zero)
             ──► auto-merge on green (stateless only) or manual review (stateful/core)
 
 Omni/Talos layer (monthly)
@@ -47,10 +47,13 @@ Omni/Talos layer (monthly)
 
 ### 1. Self-Hosted GitHub Actions Runner (ARC)
 
-A lightweight `actions-runner-controller` (ARC) Deployment pinned to `pc-1` via `nodeSelector: kubernetes.io/hostname: pc-1`. This gives GitHub Actions direct in-cluster `kubectl` access without any network tunneling. Headscale and the subnet router are not in the CI critical path.
+A lightweight `actions-runner-controller` (ARC) runner pinned to `gpu-1` via `nodeSelector: kubernetes.io/hostname: gpu-1`, configured **scale-to-zero** (`minRunners: 0`). In-cluster `kubectl` access comes from the runner pod's ServiceAccount token, which works from any node — no network tunneling, and no need to co-locate with Tekton.
+
+> **Node-placement rationale (revised 2026-05-25):** The original spec pinned the runner to `pc-1` because that's where Tekton lived and it was the path of least resistance when no in-cluster CI yet existed. By the time this layer is built, `pc-1` (a 4-core/32GB edge node on a 2013 BIOS) already runs zot, gitea, and both Tekton EventListeners + PipelineRuns, with AWX likely to land there next. The runner is therefore pinned to `gpu-1` (32-core/128GB worker; its real constraint is VRAM, not RAM/CPU) and scaled to zero so the steady-state footprint is nil — a runner pod exists only while a Renovate-PR smoke-test job runs. A defensive `nvidia.com/gpu:NoSchedule` toleration guards against the GPU operator re-asserting the taint (see `frank-gotchas → gpu-1`).
 
 - **Location:** `apps/arc-controller/` + `apps/arc-runners/` — two ArgoCD apps. Uses the current ARC v2 architecture: two charts installed in sequence — `gha-runner-scale-set-controller` (controller, sync-wave `-1`) and `gha-runner-scale-set` (runner set). Do NOT use the legacy `actions-runner-controller` chart (v1, unmaintained).
-- **Node binding:** `nodeSelector: kubernetes.io/hostname: pc-1` (label is automatically set by Kubernetes; no Talos patch required)
+- **Node binding:** `nodeSelector: kubernetes.io/hostname: gpu-1` + a defensive `nvidia.com/gpu:NoSchedule` toleration (label is automatically set by Kubernetes; no Talos patch required)
+- **Scaling:** `minRunners: 0`, `maxRunners: 3` — scale-to-zero; runner pods are ephemeral, spawned per job
 - **Runner group:** `self-hosted`, labelled `frank-cluster`
 
 **ServiceAccount RBAC** — the runner's ServiceAccount grants:
@@ -191,7 +194,7 @@ Scheduled weekly cron (`0 9 * * 1` — Monday 09:00 UTC). Runs on the self-hoste
 apps/arc-controller/
   values.yaml                    # gha-runner-scale-set-controller Helm values
 apps/arc-runners/
-  values.yaml                    # gha-runner-scale-set Helm values (pc-1 pin)
+  values.yaml                    # gha-runner-scale-set Helm values (gpu-1 pin, scale-to-zero)
   manifests/
     rbac.yaml                    # ClusterRole + ClusterRoleBinding for smoke tests
 apps/root/templates/


### PR DESCRIPTION
## Summary

Two things, both finalizing the `safe-update-automation` dispatch:

1. **Dispatch writeback** — `vk apply --yes` created 6 phase Issues (#387–#392) and stamped `tracking_issue:` into each phase YAML so the bridge can correlate Issues↔phases.
2. **Node-placement re-think** — moved the ARC runner off pc-1.

## Why move the runner (decided 2026-05-25)

The spec is dated 2026-03-25 — **4 days before** the in-cluster Tekton platform landed — so it pinned the runner to `pc-1` simply because that was the path of least resistance when no in-cluster CI existed. Revisiting now:

- **pc-1 is the wrong home:** a 4-core/32GB 2013-BIOS edge node already running zot + gitea + both Tekton EventListeners + PipelineRuns, with **AWX likely to land there next**.
- **The pc-1 pin was never load-bearing:** in-cluster `kubectl` comes from the runner pod's ServiceAccount token, which works from any node. Co-location with Tekton was convenience.
- **Decision:** keep ARC (the GitHub-Actions/Tekton heterogeneity is deliberate and on-brand) but pin it to **gpu-1** (32-core/128GB worker; real constraint is VRAM) with **`minRunners: 0`** so the steady-state footprint is **zero** — a runner pod exists only while a weekly Renovate-PR smoke-test runs.

Tekton was considered as the executor (it already does GitHub-PR CI with commit-status reporting via the `github-status` task), but the operator wants a local GH runner, and gpu-1 + scale-to-zero satisfies that without taxing pc-1.

## Changes
- `01.yaml`: runner `nodeSelector` pc-1 → **gpu-1**; `minRunners` 1 → **0**; defensive `nvidia.com/gpu:NoSchedule` toleration (per `frank-gotchas → gpu-1`)
- `02.yaml`: placement-verify step rewritten for scale-to-zero (observe the ephemeral runner during a job)
- spec: node-placement rationale + scaling fields; diagram/File-Layout updated
- `00.yaml`–`05.yaml`: `tracking_issue:` writeback

## Issue reconciliation
`vk apply --yes` re-rendered all 6 Issue bodies against the updated plan. Gating unchanged: Phase 0 `manual`, Phases 1–5 `vk-blocked` by dependency — nothing is `vk-ready` until Phase 0 completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)