### PR TITLE
plan(obs): rework-1 — fix the lying blog digest

### DIFF
--- a/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/01.yaml
+++ b/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/01.yaml
@@ -1,0 +1,371 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Enrich the digest fact sheet (TDD, pure-Python, no deploy)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Red baseline — failing tests that pin query strings, fields, and shape
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Capture the real wire shapes as test fixtures so we never again ship a
+      query whose field names don't match the data. Two sources, two shapes:
+
+      - VictoriaLogs grouped `stats_query` returns
+        `{"data":{"result":[{"metric":{"<label>":"<v>","__name__":"c"},"value":[<ts>,"<count>"]}]}}`.
+        Confirmed live: Falco grouping by `priority` yields
+        `{"metric":{"priority":"Notice"},"value":[..,"1652"]}`.
+      - GoatCounter JSON API (same endpoints the blog-edge dashboard already
+        uses — `apps/grafana-alerting/manifests/blog-edge-dashboard-cm.yaml`):
+        - `GET /api/v0/stats/total`            → `{"total": <int>, ...}`
+        - `GET /api/v0/stats/hits?limit=10`    → `{"hits":[{"path":"/frank/...","count":<int>}, ...]}`
+        - `GET /api/v0/stats/refs?limit=10`    → `{"refs":[{"name":"<ref>","count":<int>}, ...]}`
+
+      No code yet. Just write these fixtures inline in the new tests in the
+      next steps. This step is the design note that anchors them.
+  - id: P1.T1.S2
+    text: |-
+      Add failing tests to `apps/ai-alert-helper/src/tests/test_facts.py` for the
+      new `build_for_digest` shape. These MUST assert the actual query string
+      sent (via `respx` route capture), not just the parsed count — that
+      assertion gap is why the empty-GoatCounter / wrong-host bugs shipped.
+
+      Append:
+
+      BEGIN test snippet
+      import re
+
+      def _captured_query(route):
+          """Pull the `query` param from the last request on a respx route."""
+          req = route.calls.last.request
+          return dict(httpx.QueryParams(req.url.query.decode()))["query"]
+
+
+      @respx.mock
+      def test_build_for_digest_edge_requests_scoped_to_hop_and_grouped():
+          """#1: edge requests use kubernetes.host:hop-1, group by request.host + status, no _msg host filter."""
+          route = respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+              return_value=httpx.Response(200, json={"data": {"result": [
+                  {"metric": {"request.host": "blog.derio.net"}, "value": [0, "120"]},
+                  {"metric": {"request.host": "heads.hop.derio.net"}, "value": [0, "900"]},
+              ]}}),
+          )
+          since = datetime(2026, 5, 24, tzinfo=timezone.utc)
+          until = since + timedelta(days=1)
+          sheet = facts.build_for_digest(since, until, until)  # security_until == until for this test
+          # vhost breakdown present, sorted desc, capped
+          assert sheet["edge_requests_by_vhost"][0]["host"] == "heads.hop.derio.net"
+          # at least one query scoped to Hop and grouped by request.host
+          assert any("kubernetes.host:hop-1" in q and "by (request.host)" in q
+                     for q in [c.request.url.params.get("query", "") for c in route.calls])
+          # never the broken substring filter
+          assert all('_msg:"blog.derio.net"' not in c.request.url.params.get("query", "")
+                     for c in route.calls)
+      END test snippet
+
+      Run `cd apps/ai-alert-helper/src && uv run pytest -k build_for_digest` —
+      fails (current `build_for_digest` takes 2 args, returns flat dict). Red.
+  - id: P1.T1.S3
+    text: |-
+      Add the GoatCounter + Falco-breadth failing tests to `test_facts.py`:
+
+      BEGIN test snippet
+      @respx.mock
+      def test_build_for_digest_pulls_goatcounter_pageviews_and_top_n():
+          """#2: digest queries GoatCounter for total/hits/refs with Bearer auth + day window."""
+          respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+              return_value=httpx.Response(200, json={"data": {"result": []}}))
+          total = respx.get(facts.GOATCOUNTER_URL + "/api/v0/stats/total").mock(
+              return_value=httpx.Response(200, json={"total": 42}))
+          hits = respx.get(facts.GOATCOUNTER_URL + "/api/v0/stats/hits").mock(
+              return_value=httpx.Response(200, json={"hits": [{"path": "/frank/x", "count": 30}]}))
+          refs = respx.get(facts.GOATCOUNTER_URL + "/api/v0/stats/refs").mock(
+              return_value=httpx.Response(200, json={"refs": [{"name": "news.ycombinator.com", "count": 12}]}))
+          since = datetime(2026, 5, 24, tzinfo=timezone.utc)
+          until = since + timedelta(days=1)
+          sheet = facts.build_for_digest(since, until, until)
+          assert sheet["blog_pageviews"] == 42
+          assert sheet["blog_top_pages"][0]["path"] == "/frank/x"
+          assert sheet["blog_top_referrers"][0]["name"] == "news.ycombinator.com"
+          # Bearer auth header present on GoatCounter calls
+          assert total.calls.last.request.headers["Authorization"].startswith("Bearer ")
+          # day-scoped window passed as start/end params
+          assert hits.calls.last.request.url.params["start"] == "2026-05-24"
+
+
+      @respx.mock
+      def test_build_for_digest_falco_all_priorities_and_split_window():
+          """#3: falco grouped by priority (not Critical-only); security window runs to security_until."""
+          captured = []
+          def _cap(request):
+              captured.append(dict(request.url.params)["query"])
+              # priority breakdown response
+              if "by (priority)" in dict(request.url.params)["query"]:
+                  return httpx.Response(200, json={"data": {"result": [
+                      {"metric": {"priority": "Warning"}, "value": [0, "2"]},
+                      {"metric": {"priority": "Notice"}, "value": [0, "1652"]}]}})
+              return httpx.Response(200, json={"data": {"result": []}})
+          respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(side_effect=_cap)
+          respx.get(re.compile(facts.GOATCOUNTER_URL + "/api/v0/.*")).mock(
+              return_value=httpx.Response(200, json={"total": 0, "hits": [], "refs": []}))
+          since = datetime(2026, 5, 24, tzinfo=timezone.utc)
+          until = since + timedelta(days=1)
+          security_until = datetime(2026, 5, 25, 8, 0, tzinfo=timezone.utc)
+          sheet = facts.build_for_digest(since, until, security_until)
+          prios = {row["priority"]: row["count"] for row in sheet["falco_by_priority"]}
+          assert prios == {"Warning": 2, "Notice": 1652}
+          # security query window ends at security_until, NOT until
+          assert any("2026-05-25T08:00:00" in q and "source:syscall" in q for q in captured)
+      END test snippet
+
+      Run pytest — all three new tests fail (red). Commit nothing yet.
+- number: 2
+  title: Implement the Caddy edge-request breakdown (#1)
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Add a grouped-stats helper next to `_logsql_count` in `facts.py`:
+
+      BEGIN apps/ai-alert-helper/src/ai_alert_helper/facts.py (insert after _logsql_count)
+      def _logsql_group(query: str, label: str, top: int | None = None) -> list[dict]:
+          """Run a `... | stats by (<label>) count() as c` query.
+
+          Returns `[{label: <value>, "count": <int>}, ...]`, sorted desc.
+          Empty list on any error — fact builders must not crash callers.
+          """
+          try:
+              resp = httpx.get(
+                  f"{VICTORIALOGS_URL}/select/logsql/stats_query",
+                  params={"query": query},
+                  timeout=15,
+              )
+              resp.raise_for_status()
+              result = resp.json().get("data", {}).get("result", [])
+          except Exception:  # noqa: BLE001
+              return []
+          rows = [
+              {label: r["metric"].get(label, ""), "count": int(r["value"][1])}
+              for r in result
+          ]
+          rows.sort(key=lambda r: r["count"], reverse=True)
+          return rows[:top] if top else rows
+      END snippet
+
+      Note: the group label `request.host` contains a dot. LogsQL `stats by
+      (request.host)` is fine; the response `metric` key is the literal
+      `request.host`. The helper reads it via `r["metric"].get(label)`.
+  - id: P1.T2.S2
+    text: |-
+      Rewrite `build_for_digest` signature + edge-request section. The window
+      helper now takes a third arg `security_until` (split-window fix lands in
+      T4 — wire the signature now so tests compile):
+
+      BEGIN apps/ai-alert-helper/src/ai_alert_helper/facts.py (replace build_for_digest)
+      def build_for_digest(since: datetime, until: datetime, security_until: datetime) -> dict:
+          """Daily digest fact sheet.
+
+          Traffic/pageviews cover the calendar day [since, until). Security
+          (Falco/CrowdSec) covers [since, security_until) so an overnight
+          Critical event surfaces same-day rather than ~24h late.
+          """
+          tw = f"_time:[{since.isoformat()},{until.isoformat()}]"
+          # All Hop-edge Caddy requests — scoped to the Hop node, grouped, no host substring filter.
+          edge = f'{tw} kubernetes.host:hop-1 AND _msg:"handled request"'
+          by_vhost = _logsql_group(f"{edge} | stats by (request.host) count() as c", "request.host", top=10)
+          by_status = _logsql_group(f"{edge} | stats by (status) count() as c", "status")
+          status_class: dict[str, int] = {}
+          for row in by_status:
+              cls = (str(row["status"])[:1] or "?") + "xx"
+              status_class[cls] = status_class.get(cls, 0) + row["count"]
+          sheet = {
+              "traffic_window": {"since": since.isoformat(), "until": until.isoformat()},
+              "security_window": {"since": since.isoformat(), "until": security_until.isoformat()},
+              "edge_requests_total": _logsql_count(f"{edge} | stats count() as c"),
+              "edge_requests_by_vhost": [{"host": r["request.host"], "count": r["count"]} for r in by_vhost],
+              "edge_requests_by_status_class": status_class,
+          }
+          sheet.update(_digest_blog_facts(since, until))      # T3 — GoatCounter
+          sheet.update(_digest_security_facts(since, security_until))  # T4 — Falco/CrowdSec
+          return sheet
+      END snippet
+
+      Add stub `_digest_blog_facts` / `_digest_security_facts` returning `{}`
+      for now so the module imports. Make `test_build_for_digest_edge_requests_*`
+      pass: `uv run pytest -k edge_requests`.
+- number: 3
+  title: Implement the GoatCounter integration (#2)
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      Add a GoatCounter API helper. Auth + endpoints mirror the working
+      Infinity datasource in `blog-edge-dashboard-cm.yaml`:
+
+      BEGIN apps/ai-alert-helper/src/ai_alert_helper/facts.py (add)
+      def _goatcounter(path: str, params: dict) -> dict:
+          """GET a GoatCounter /api/v0 endpoint with Bearer auth. {} on error."""
+          if not GOATCOUNTER_TOKEN:
+              return {}
+          try:
+              resp = httpx.get(
+                  f"{GOATCOUNTER_URL}{path}",
+                  headers={"Authorization": f"Bearer {GOATCOUNTER_TOKEN}"},
+                  params=params,
+                  timeout=15,
+              )
+              resp.raise_for_status()
+              return resp.json()
+          except Exception:  # noqa: BLE001
+              return {}
+      END snippet
+
+      GoatCounter `start`/`end` accept `YYYY-MM-DD` and `end` is inclusive, so a
+      single calendar day is `start == end == since.date()`.
+  - id: P1.T3.S2
+    text: |-
+      Implement `_digest_blog_facts` (replaces the T2 stub):
+
+      BEGIN apps/ai-alert-helper/src/ai_alert_helper/facts.py
+      def _digest_blog_facts(since: datetime, until: datetime) -> dict:
+          """Blog reader metrics from GoatCounter for the calendar day [since, until)."""
+          day = since.date().isoformat()
+          window = {"start": day, "end": day}
+          total = _goatcounter("/api/v0/stats/total", window)
+          hits = _goatcounter("/api/v0/stats/hits", {**window, "limit": 10})
+          refs = _goatcounter("/api/v0/stats/refs", {**window, "limit": 10})
+          return {
+              "blog_pageviews": int(total.get("total", 0)),
+              "blog_top_pages": [
+                  {"path": h.get("path", ""), "count": int(h.get("count", 0))}
+                  for h in hits.get("hits", [])
+              ],
+              "blog_top_referrers": [
+                  {"name": r.get("name", ""), "count": int(r.get("count", 0))}
+                  for r in refs.get("refs", [])
+              ],
+          }
+      END snippet
+
+      Make `test_build_for_digest_pulls_goatcounter_*` pass:
+      `uv run pytest -k goatcounter`.
+- number: 4
+  title: Implement the all-priority security section + split window (#3)
+  steps:
+  - id: P1.T4.S1
+    text: |-
+      Implement `_digest_security_facts` (replaces the T2 stub). Falco events
+      arrive via falcosidekick→Loki-push with fields `source`, `priority`,
+      `rule` (NOT `kubernetes.namespace_name` — that's the Caddy/CrowdSec
+      collector path), so the Falco queries filter on `source:syscall` only:
+
+      BEGIN apps/ai-alert-helper/src/ai_alert_helper/facts.py
+      def _digest_security_facts(since: datetime, security_until: datetime) -> dict:
+          """Falco (all priorities) + CrowdSec over the security window [since, security_until)."""
+          sw = f"_time:[{since.isoformat()},{security_until.isoformat()}]"
+          by_priority = _logsql_group(
+              f"{sw} source:syscall | stats by (priority) count() as c", "priority"
+          )
+          top_rules = _logsql_group(
+              f"{sw} source:syscall | stats by (rule) count() as c", "rule", top=5
+          )
+          return {
+              "falco_by_priority": [
+                  {"priority": r["priority"], "count": r["count"]} for r in by_priority
+              ],
+              "falco_top_rules": [
+                  {"rule": r["rule"], "count": r["count"]} for r in top_rules
+              ],
+              "crowdsec_decisions": _logsql_count(
+                  f"{sw} kubernetes.namespace_name:crowdsec-system "
+                  f"AND log:Adding AND log:decisions | stats count() as c"
+              ),
+          }
+      END snippet
+
+      Make `test_build_for_digest_falco_all_priorities_and_split_window` pass:
+      `uv run pytest -k falco`. Then run the full `test_facts.py` green.
+- number: 5
+  title: Fix surge.py host filter (#4)
+  steps:
+  - id: P1.T5.S1
+    text: |-
+      Add a failing test to `apps/ai-alert-helper/src/tests/test_surge.py` that
+      asserts the surge query filters on the `request.host` field, not the
+      `_msg` substring:
+
+      BEGIN test snippet
+      @respx.mock
+      def test_hour_count_filters_on_request_host_field():
+          route = respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+              return_value=httpx.Response(200, json={"data": {"result": [{"value": [0, "5"]}]}}))
+          surge._hour_count(datetime(2026, 5, 25, 12, tzinfo=timezone.utc))
+          q = route.calls.last.request.url.params["query"]
+          assert 'request.host:"blog.derio.net"' in q
+          assert '_msg:"blog.derio.net"' not in q
+      END snippet
+
+      Run `uv run pytest -k request_host` — fails (current filter is `_msg`). Red.
+  - id: P1.T5.S2
+    text: |-
+      Fix the filter in `surge.py:_hour_count`:
+
+      ```
+      -        f'AND _msg:"handled request" AND _msg:"blog.derio.net" | stats count() as c'
+      +        f'AND _msg:"handled request" AND request.host:"blog.derio.net" | stats count() as c'
+      ```
+
+      Make the test pass. Run the FULL suite to confirm no regression:
+
+      ```bash
+      cd apps/ai-alert-helper/src && uv run pytest
+      ```
+
+      All green. This phase touches only Python + tests — no deploy yet.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T5.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T5.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/02.yaml
+++ b/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/02.yaml
@@ -1,0 +1,172 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Wire prompt + api.py, rebuild image, redeploy, verify end-to-end
+  tag: agentic
+  depends_on: [1]
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Compute split windows in api.py and rewrite the digest prompt
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Update `apps/ai-alert-helper/src/ai_alert_helper/api.py` `/digest` to
+      compute the split window and pass `security_until=now`:
+
+      BEGIN apps/ai-alert-helper/src/ai_alert_helper/api.py (replace digest body)
+      @app.post("/digest")
+      def digest(dry_run: bool = False) -> dict:
+          now = datetime.now(timezone.utc)
+          since = (now - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+          until = since + timedelta(days=1)          # traffic = prior calendar day
+          sheet = facts.build_for_digest(since, until, now)  # security runs to now
+          if dry_run:
+              return {"facts": sheet, "narrative": None}
+          narrative = ai_adapter.summarize(sheet)
+          telegram.send(f"📊 Yesterday on the Frank blog\n\n{narrative}")
+          return {"facts": sheet, "narrative": narrative}
+      END snippet
+
+      The fact-sheet shape is the `ai_adapter` swap contract — `summarize()` is
+      unchanged (still `summarize(facts: dict) -> str`), only the dict grows
+      richer. No change to `ai_adapter.py`.
+  - id: P2.T1.S2
+    text: |-
+      Rewrite `apps/ai-alert-helper/src/ai_alert_helper/prompts/digest.txt` to
+      consume the richer fact sheet. Keep the system block ≤150 words for
+      prompt-cache friendliness; keep "never invent numbers"; explicitly
+      separate edge traffic from blog readers and require a security line that
+      reports ALL priorities (so a benign-but-Critical event is named):
+
+      BEGIN apps/ai-alert-helper/src/ai_alert_helper/prompts/digest.txt
+      You are Frank's blog observatory. Produce a short daily digest from the
+      structured facts below. Cap at 180 words. Never invent numbers — if a
+      fact is missing or zero, say so plainly.
+
+      Structure:
+      - One sentence on BLOG READERS (blog_pageviews — real humans via
+        GoatCounter), then top page (blog_top_pages) and top referrer
+        (blog_top_referrers).
+      - One sentence on EDGE TRAFFIC (edge_requests_total across all Hop
+        vhosts — mostly mesh/bots, NOT readers); name the busiest vhost from
+        edge_requests_by_vhost and call out any 4xx/5xx from
+        edge_requests_by_status_class.
+      - One SECURITY line: summarise falco_by_priority (report every priority
+        present, including a single benign Critical by rule name from
+        falco_top_rules) and crowdsec_decisions. The security window may extend
+        past midnight into today — that is intentional.
+
+      Facts:
+      {facts}
+      END digest.txt
+
+      Run `cd apps/ai-alert-helper/src && uv run pytest` once more — still green
+      (prompt is not unit-tested; this confirms no import breakage).
+- number: 2
+  title: Build, push, and redeploy the new image
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      Bump the version and image tag to `0.1.1`:
+
+      - `apps/ai-alert-helper/src/pyproject.toml`: `version = "0.1.1"`
+      - `apps/ai-alert-helper/manifests/deployment.yaml`:
+        `image: ghcr.io/derio-net/ai-alert-helper:0.1.1`
+
+      Build + push (same registry as the parent plan P5.T2.S1):
+
+      ```bash
+      docker build -t ghcr.io/derio-net/ai-alert-helper:0.1.1 apps/ai-alert-helper/src/
+      docker push ghcr.io/derio-net/ai-alert-helper:0.1.1
+      ```
+  - id: P2.T2.S2
+    text: |-
+      Commit + push; ArgoCD auto-syncs the helper Deployment:
+
+      ```bash
+      git add apps/ai-alert-helper/
+      git commit -m "fix(obs): enrich digest facts (vhost breakdown, GoatCounter, all-priority Falco, split window) + surge request.host filter"
+      git push origin HEAD
+      argocd app wait ai-alert-helper --port-forward --port-forward-namespace argocd --health --timeout 300
+      ```
+
+      Confirm the new pod is running the 0.1.1 image:
+
+      ```bash
+      kubectl -n ai-alert-helper-system get deploy ai-alert-helper \
+        -o jsonpath='{.spec.template.spec.containers[0].image}'; echo
+      # Expected: ghcr.io/derio-net/ai-alert-helper:0.1.1
+      ```
+- number: 3
+  title: Verify the digest end-to-end against live data (per "test before Deployed")
+  steps:
+  - id: P2.T3.S1
+    text: |-
+      Inspect the populated fact sheet via dry-run (no LLM, no Telegram).
+      This is the evidence that #1/#2/#3 are actually fixed against real data:
+
+      ```bash
+      kubectl exec -n ai-alert-helper-system deploy/ai-alert-helper -- \
+        python -c "import httpx,json;print(json.dumps(httpx.post('http://localhost:8080/digest?dry_run=true',timeout=30).json()['facts'],indent=2))"
+      ```
+
+      Expected, against yesterday's data:
+      - `edge_requests_total` ≈ several thousand, `edge_requests_by_vhost`
+        listing heads/headplane/blog/etc. (NOT a single 15k blob).
+      - `blog_pageviews` > 0 and `blog_top_pages` / `blog_top_referrers`
+        populated (the bug was these being absent).
+      - `falco_by_priority` showing Notice/Warning counts; if a Critical fired
+        overnight it appears here because `security_window.until` ≈ now.
+
+      NOTE: this `kubectl exec` is a one-off prod read for verification — it
+      needs operator approval (the auto-classifier blocks remote-shell reads
+      into prod). If denied, run the same query from the operator's shell.
+  - id: P2.T3.S2
+    text: |-
+      Trigger a real digest and confirm the Telegram message is correct:
+
+      ```bash
+      kubectl create job -n ai-alert-helper-system digest-verify --from=cronjob/digest
+      kubectl logs -n ai-alert-helper-system job/digest-verify -f
+      ```
+
+      Confirm the Telegram "📊 Yesterday on the Frank blog" message now contains:
+      a blog-reader line with a real top page + referrer, a separate edge-traffic
+      line, and a security line that names priorities (not silent). Clean up:
+
+      ```bash
+      kubectl delete job -n ai-alert-helper-system digest-verify
+      ```
+
+      Only after observing this message is the fix considered Deployed.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/03.yaml
+++ b/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/03.yaml
@@ -1,0 +1,134 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Docs — retro-update blog posts, add gotchas, record parent deviation
+  tag: agentic
+  depends_on: [2]
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Retroactively update the obs building + operating posts
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      Per the Layer Fix/Extension Workflow (do NOT create a new post), update
+      the existing obs building post
+      `blog/content/docs/building/31-edge-observability/index.md`:
+
+      Add a short "Deviation: the digest was lying" subsection near the AI-helper
+      section. Cover the four bugs and their one root cause — the digest read raw
+      Caddy/Falco logs as a proxy for "blog activity" without the dimensional
+      filters that data needs (vhost via `request.host`, priority breadth) while
+      the purpose-built reader source (GoatCounter) sat wired-but-unused. Note
+      that the tests only asserted the count-parser shape, never the query
+      string, which is why it shipped.
+  - id: P3.T1.S2
+    text: |-
+      Update the operating post
+      `blog/content/docs/operating/26-edge-observability/index.md`:
+
+      - Document how to read the richer digest (blog readers vs edge traffic vs
+        security; that the security window extends past midnight into "today" by
+        design, so an overnight Critical event appears the same morning).
+      - Add the dry-run inspection command
+        (`POST /digest?dry_run=true` via `kubectl exec`) as the canonical way to
+        audit the fact sheet without sending Telegram.
+
+      Rebuild check:
+
+      ```bash
+      cd blog && hugo --minify 2>&1 | tail -5
+      ```
+- number: 2
+  title: Add gotchas (one-liner in hot file + prose in per-topic file)
+  steps:
+  - id: P3.T2.S1
+    text: |-
+      Add one-liners to `agents/rules/frank-gotchas.md`. Under the
+      **Networking** section (Caddy access logs):
+
+      - Caddy JSON access logs store the vhost in field `request.host`, NOT in
+        `_msg` (which is literally `"handled request"`). `_msg:"blog.derio.net"`
+        always matches zero — filter `request.host:"blog.derio.net"`. Scope to
+        Hop with `kubernetes.host:hop-1`.
+
+      Under **Grafana** or a short new **Observability digest** note:
+
+      - Falco events reach VictoriaLogs via falcosidekick→Loki-push with fields
+        `source`/`priority`/`rule`/`k8s_ns_name` — NOT `kubernetes.namespace_name`
+        (that's the fluent-bit collector path for Caddy/CrowdSec). Query Falco
+        with `source:syscall`, never a `kubernetes.namespace_name` filter.
+      - The daily digest uses a split window: traffic = prior calendar day,
+        security = yesterday 00:00 → digest run time, so overnight Critical
+        events aren't reported ~24h late.
+  - id: P3.T2.S2
+    text: |-
+      Add the full prose / recovery detail to the matching per-topic file under
+      `docs/runbooks/frank-gotchas/` (see that dir's `README.md` for the
+      topic→file map — `networking.md` for the Caddy `request.host` item; the
+      Falco-fields + split-window items belong with the observability/grafana
+      topic file or a new `obs-digest.md` if none fits). Include the live
+      evidence: edge total 15,717/day vs `request.host:"blog.derio.net"`, and
+      the falco `priority` breakdown shape.
+- number: 3
+  title: Record the deviation against the parent plan
+  steps:
+  - id: P3.T3.S1
+    text: |-
+      Add a Deviation note to the parent plan pointing at this rework (do NOT
+      reopen the parent's closed phase Issues — that is the documented
+      `vk apply` archived-plan footgun).
+
+      - In `docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/_prose.md`,
+        append a short "## Deviations" entry: "Phase 5's `/digest` shipped with
+        the GoatCounter half unbuilt and an over-broad request count; four bugs
+        fixed in rework-1 (see `..-rework-1/`)."
+      - Optionally add a `note:` on the parent `05.yaml` completion block
+        referencing the rework slug. Do this via the Edit tool on the YAML
+        `completion.note` field — do not re-run `vk apply` on the parent.
+  - id: P3.T3.S2
+    text: |-
+      Commit the docs + deviation:
+
+      ```bash
+      git add blog/content/docs/building/31-edge-observability/ \
+              blog/content/docs/operating/26-edge-observability/ \
+              agents/rules/frank-gotchas.md docs/runbooks/frank-gotchas/ \
+              docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/
+      git commit -m "docs(obs): digest-fix retro on building/operating posts + gotchas + parent deviation"
+      git push origin HEAD
+      ```
+
+      Then set this rework plan's status: tick remaining steps and complete each
+      phase via `vk plan edit`. The plan is Complete when the digest message has
+      been observed correct (P2.T3.S2) and docs are pushed.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/_meta.yaml
+++ b/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/_meta.yaml
@@ -1,0 +1,30 @@
+schema_version: 2
+plan: 2026-05-23--obs--hop-blog-edge-monitoring-rework-1
+spec: docs/superpowers/specs/2026-05-23--obs--hop-blog-edge-monitoring-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-05-25'
+parent_plan: docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/
+origin_items:
+- id: 1
+  item: Digest total_requests counts ALL Hop-edge Caddy requests (15,717/day, all
+    vhosts) with no host filter — replace with rich per-vhost/status breakdown + separate
+    blog pageviews
+  source: telegram digest report 2026-05-25 + live VictoriaLogs query
+  track: development
+- id: 2
+  item: Top page & top referrer always empty — no GoatCounter query exists in digest
+    path despite GOATCOUNTER_URL+OBS_GOATCOUNTER_API_TOKEN wired into deployment
+  source: code review facts.py/api.py + spec line 35/291
+  track: development
+- id: 3
+  item: Security section only counts priority:Critical over prior-calendar-day window
+    — benign 03:00 UTC Critical event reported ~29h late, non-Critical events never
+    surfaced
+  source: 'live VictoriaLogs query: Drop-and-execute-new-binary 2026-05-25T03:00Z'
+  track: development
+- id: 4
+  item: surge.py _hour_count filters _msg:blog.derio.net but vhost lives in field
+    request.host — always 0, blog surge detection never fires
+  source: live VictoriaLogs field inspection (request.host vs _msg)
+  track: development

--- a/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/_prose.md
+++ b/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/_prose.md
@@ -1,0 +1,63 @@
+# Hop Blog Edge Monitoring — Rework 1: fix the lying digest
+
+Rework plan against `2026-05-23--obs--hop-blog-edge-monitoring` (phase 05, the
+`ai-alert-helper` daily digest). See `_meta.yaml` for `parent_plan` and
+`origin_items`.
+
+## Why
+
+The "📊 Yesterday on the Frank blog" Telegram digest was wrong in four ways,
+all confirmed against live VictoriaLogs/GoatCounter data on 2026-05-25:
+
+1. **Over-broad request count.** `facts.build_for_digest` counts
+   `kubernetes.namespace_name:caddy-system AND _msg:"handled request"` with no
+   host filter — 15,717/day across *every* Hop vhost (heads, headplane,
+   landing, ACME, blog, bots, probes), presented as if it were blog traffic.
+2. **Empty top page / referrer.** No GoatCounter query exists anywhere in the
+   digest path, despite `GOATCOUNTER_URL` + `OBS_GOATCOUNTER_API_TOKEN` being
+   wired into the deployment. The prompt asks the LLM for "top page, top
+   referrer" and says "if a fact is missing, say so" → permanently blank.
+   (Spec lines 35 + 291 always intended GoatCounter here; it was never built.)
+3. **Security blind spots.** The digest counts only `priority:Critical` over the
+   *prior calendar day*. A benign Critical event (headscale-backup `sqlite3
+   .backup` tripping "Drop and execute new binary in container" at 03:00 UTC)
+   is reported ~29h late, and non-Critical events (yesterday's 2 "Read
+   sensitive file untrusted" Warnings) never surface at all.
+4. **Dead blog surge detection.** `surge.py._hour_count` filters
+   `_msg:"blog.derio.net"`, but the vhost lives in field `request.host` — the
+   filter always matches zero, so `surge.compute()` never fires for the blog.
+
+**One root cause:** the digest read raw Caddy/Falco logs as a proxy for "blog
+activity" without the dimensional filters that data needs (vhost via
+`request.host`, priority breadth), while the purpose-built reader source
+(GoatCounter) sat wired-but-unused. The tests only asserted the count-*parser*
+shape, never the query string or field names — so none of it failed CI.
+
+## Approach
+
+Three phases, TDD-first:
+
+- **Phase 1** rebuilds the fact sheet in pure Python (no deploy): per-vhost +
+  per-status edge breakdown scoped to `kubernetes.host:hop-1`, GoatCounter
+  pageviews/top-pages/top-referrers, all-priority Falco breakdown + top rules
+  over a split window, and the `surge.py` `request.host` fix. New tests assert
+  the actual query strings/fields.
+- **Phase 2** computes the split window in `api.py` (traffic = calendar day,
+  security = through run time), rewrites the digest prompt, rebuilds the image
+  to `0.1.1`, redeploys via ArgoCD, and verifies end-to-end against live data
+  (dry-run fact dump + a real Telegram message).
+- **Phase 3** retro-updates the obs building/operating posts, adds gotchas
+  (`request.host` vs `_msg`; Falco Loki-push fields; split-window), and records
+  a deviation pointer on the parent plan **without** reopening its closed
+  Issues.
+
+## Decisions
+
+- **Split window** (operator choice): traffic/pageviews stay on the prior
+  calendar day (matches GoatCounter daily buckets and the "Yesterday" title);
+  the security window runs to digest-run-time so overnight Critical events
+  surface same-day.
+- **Rework plan, not parent amend** (operator choice): avoids the documented
+  `vk apply` footgun of reopening the parent's hand-closed phase Issues.
+- The `ai_adapter` swap contract is preserved: `summarize(facts: dict) -> str`
+  is unchanged; only the fact dict grows richer.

--- a/docs/superpowers/specs/2026-05-23--obs--hop-blog-edge-monitoring-design.md
+++ b/docs/superpowers/specs/2026-05-23--obs--hop-blog-edge-monitoring-design.md
@@ -566,6 +566,7 @@ Frank has multi-GB headroom across worker nodes — this is rounding error.
 | Plan | Repo | File | Depends on |
 |------|------|------|------------|
 | 2026-05-23--obs--hop-blog-edge-monitoring | `derio-net/frank` | `docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/` | — |
+| 2026-05-23--obs--hop-blog-edge-monitoring-rework-1 | `derio-net/frank` | `docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring-rework-1/` | 2026-05-23--obs--hop-blog-edge-monitoring |
 
 ## Open questions
 


### PR DESCRIPTION
## Summary

The "📊 Yesterday on the Frank blog" Telegram digest (`ai-alert-helper`, obs phase 05) is wrong in **four ways**, all confirmed against **live** VictoriaLogs/GoatCounter data on 2026-05-25. This PR adds the **fix plan only** (a rework plan — no code changes yet); dispatch/implementation follows after review.

**One root cause:** the digest reads raw Caddy/Falco logs as a proxy for "blog activity" without the dimensional filters that data needs (`request.host`, priority breadth), while the purpose-built reader source (GoatCounter) sits wired-but-unused. The tests only assert the count-*parser* shape, never the query strings — so it all passed CI.

| # | Symptom | Root cause | Live evidence |
|---|---------|-----------|---------------|
| 1 | "15k requests" | `total_requests` has no host filter → counts **all** Hop vhosts | 15,717 edge-wide; blog is a fraction |
| 2 | Top page/referrer empty | **No GoatCounter query exists** in the digest path (token wired, unused) | `facts.py`/`api.py`; spec lines 35/291 intended it |
| 3 | Benign Falco event missing | Counts only `priority:Critical` over the **prior calendar day** | Critical fired today 03:00Z (sqlite3 backup); yesterday had 2 Warning + 1652 Notice, 0 Critical |
| 4 | (bonus) blog surge dead | `surge.py` filters `_msg:"blog.derio.net"`; vhost is in field `request.host` | `_msg` → 0, `request.host` → has data |

## Plan shape

Rework plan `2026-05-23--obs--hop-blog-edge-monitoring-rework-1/` (parent linked, spec table row added, 4 `origin_items`, `vk plan self-review` green):

- **Phase 1** (TDD, no deploy): rebuild fact sheet — per-vhost + per-status edge breakdown scoped to `kubernetes.host:hop-1`, GoatCounter pageviews/top-pages/top-referrers, all-priority Falco + top rules over a split window, `surge.py` `request.host` fix. New tests assert the **query strings**.
- **Phase 2**: split-window wiring in `api.py` (traffic = calendar day, security = through run time), prompt rewrite, image `0.1.1`, ArgoCD redeploy, **end-to-end verify** (dry-run fact dump + real Telegram message).
- **Phase 3**: retro-update obs building/operating posts, gotchas (`request.host` vs `_msg`; Falco Loki-push fields; split-window), parent deviation pointer (no Issue reopening).

## Decisions baked in (operator-confirmed)

- **Split window**: traffic stays on the prior calendar day (matches GoatCounter daily buckets + the "Yesterday" title); security window runs to digest-run-time so overnight Critical events surface same-day.
- **Rework plan, not parent amend**: avoids the documented `vk apply` footgun of reopening the parent's hand-closed phase Issues.
- `ai_adapter` swap contract preserved — `summarize(facts: dict) -> str` unchanged; only the fact dict grows richer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)