### PR TITLE
vk apply: persist tracking_issue for blog-digest-rework-1

### DIFF
--- a/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/01.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/01.yaml
@@ -4,7 +4,7 @@ phase:
   title: Enrich the digest fact sheet (TDD, pure-Python, no deploy)
   tag: agentic
   depends_on: []
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/frank/issues/400
 tasks:
 - number: 1
   title: Red baseline — failing tests that pin query strings, fields, and shape

--- a/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/02.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/02.yaml
@@ -3,8 +3,9 @@ phase:
   number: 2
   title: Wire prompt + api.py, rebuild image, redeploy, verify end-to-end
   tag: agentic
-  depends_on: [1]
-  tracking_issue: null
+  depends_on:
+  - 1
+  tracking_issue: https://github.com/derio-net/frank/issues/401
 tasks:
 - number: 1
   title: Compute split windows in api.py and rewrite the digest prompt

--- a/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/03.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/03.yaml
@@ -3,8 +3,9 @@ phase:
   number: 3
   title: Docs — retro-update blog posts, add gotchas, record parent deviation
   tag: agentic
-  depends_on: [2]
-  tracking_issue: null
+  depends_on:
+  - 2
+  tracking_issue: https://github.com/derio-net/frank/issues/402
 tasks:
 - number: 1
   title: Retroactively update the obs building + operating posts


### PR DESCRIPTION
Writeback from `vk apply --yes` dispatching `2026-05-25--obs--blog-digest-rework-1`. Records the created Issue URLs into each phase YAML so the vk-issue-bridge can correlate plan phases → Issues on its next tick.

| Phase | Issue |
|-------|-------|
| 1 · Enrich the digest fact sheet (TDD) | #400 |
| 2 · Wire prompt + api.py, rebuild, redeploy, verify | #401 |
| 3 · Docs — blog retro + gotchas + parent deviation | #402 |

Mechanical change — only the `tracking_issue:` line in `01/02/03.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)