### PR TITLE
[derio-net/frank] 2026-05-25--obs--blog-digest-rework-1 · Phase 1/3 · Enrich the digest fact sheet (TDD, pure-Python, no deploy)

### DIFF
--- a/apps/ai-alert-helper/src/ai_alert_helper/facts.py
+++ b/apps/ai-alert-helper/src/ai_alert_helper/facts.py
@@ -35,25 +35,116 @@ def _logsql_count(query: str) -> int:
         return 0
 
 
-def build_for_digest(since: datetime, until: datetime) -> dict:
-    """Daily digest fact sheet covering one ~24h window."""
-    window = f"_time:[{since.isoformat()},{until.isoformat()}]"
+def _logsql_group(query: str, label: str, top: int | None = None) -> list[dict]:
+    """Run a `... | stats by (<label>) count() as c` query.
+
+    Returns `[{label: <value>, "count": <int>}, ...]`, sorted desc.
+    Empty list on any error — fact builders must not crash callers.
+    """
+    try:
+        resp = httpx.get(
+            f"{VICTORIALOGS_URL}/select/logsql/stats_query",
+            params={"query": query},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        result = resp.json().get("data", {}).get("result", [])
+    except Exception:  # noqa: BLE001
+        return []
+    rows = [
+        {label: r["metric"].get(label, ""), "count": int(r["value"][1])}
+        for r in result
+    ]
+    rows.sort(key=lambda r: r["count"], reverse=True)
+    return rows[:top] if top else rows
+
+
+def _goatcounter(path: str, params: dict) -> dict:
+    """GET a GoatCounter /api/v0 endpoint with Bearer auth. {} on error."""
+    if not GOATCOUNTER_TOKEN:
+        return {}
+    try:
+        resp = httpx.get(
+            f"{GOATCOUNTER_URL}{path}",
+            headers={"Authorization": f"Bearer {GOATCOUNTER_TOKEN}"},
+            params=params,
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _digest_blog_facts(since: datetime, until: datetime) -> dict:
+    """Blog reader metrics from GoatCounter for the calendar day [since, until)."""
+    day = since.date().isoformat()
+    window = {"start": day, "end": day}
+    total = _goatcounter("/api/v0/stats/total", window)
+    hits = _goatcounter("/api/v0/stats/hits", {**window, "limit": 10})
+    refs = _goatcounter("/api/v0/stats/refs", {**window, "limit": 10})
     return {
-        "since": since.isoformat(),
-        "until": until.isoformat(),
-        "total_requests": _logsql_count(
-            f'{window} kubernetes.namespace_name:caddy-system AND _msg:"handled request" | stats count() as c'
-        ),
-        "crowdsec_decisions": _logsql_count(
-            f'{window} kubernetes.namespace_name:crowdsec-system AND log:Adding AND log:decisions | stats count() as c'
-        ),
-        "falco_critical": _logsql_count(
-            f'{window} source:syscall AND priority:Critical | stats count() as c'
-        ),
-        # GoatCounter pageview totals are pulled by api.py /digest using the
-        # GoatCounter API token; we keep that lookup out of facts.py to avoid
-        # making this module depend on the token at import time.
+        "blog_pageviews": int(total.get("total", 0)),
+        "blog_top_pages": [
+            {"path": h.get("path", ""), "count": int(h.get("count", 0))}
+            for h in hits.get("hits", [])
+        ],
+        "blog_top_referrers": [
+            {"name": r.get("name", ""), "count": int(r.get("count", 0))}
+            for r in refs.get("refs", [])
+        ],
     }
+
+
+def _digest_security_facts(since: datetime, security_until: datetime) -> dict:
+    """Falco (all priorities) + CrowdSec over the security window [since, security_until)."""
+    sw = f"_time:[{since.isoformat()},{security_until.isoformat()}]"
+    by_priority = _logsql_group(
+        f"{sw} source:syscall | stats by (priority) count() as c", "priority"
+    )
+    top_rules = _logsql_group(
+        f"{sw} source:syscall | stats by (rule) count() as c", "rule", top=5
+    )
+    return {
+        "falco_by_priority": [
+            {"priority": r["priority"], "count": r["count"]} for r in by_priority
+        ],
+        "falco_top_rules": [
+            {"rule": r["rule"], "count": r["count"]} for r in top_rules
+        ],
+        "crowdsec_decisions": _logsql_count(
+            f"{sw} kubernetes.namespace_name:crowdsec-system "
+            f"AND log:Adding AND log:decisions | stats count() as c"
+        ),
+    }
+
+
+def build_for_digest(since: datetime, until: datetime, security_until: datetime) -> dict:
+    """Daily digest fact sheet.
+
+    Traffic/pageviews cover the calendar day [since, until). Security
+    (Falco/CrowdSec) covers [since, security_until) so an overnight
+    Critical event surfaces same-day rather than ~24h late.
+    """
+    tw = f"_time:[{since.isoformat()},{until.isoformat()}]"
+    # All Hop-edge Caddy requests — scoped to the Hop node, grouped, no host substring filter.
+    edge = f'{tw} kubernetes.host:hop-1 AND _msg:"handled request"'
+    by_vhost = _logsql_group(f"{edge} | stats by (request.host) count() as c", "request.host", top=10)
+    by_status = _logsql_group(f"{edge} | stats by (status) count() as c", "status")
+    status_class: dict[str, int] = {}
+    for row in by_status:
+        cls = (str(row["status"])[:1] or "?") + "xx"
+        status_class[cls] = status_class.get(cls, 0) + row["count"]
+    sheet = {
+        "traffic_window": {"since": since.isoformat(), "until": until.isoformat()},
+        "security_window": {"since": since.isoformat(), "until": security_until.isoformat()},
+        "edge_requests_total": _logsql_count(f"{edge} | stats count() as c"),
+        "edge_requests_by_vhost": [{"host": r["request.host"], "count": r["count"]} for r in by_vhost],
+        "edge_requests_by_status_class": status_class,
+    }
+    sheet.update(_digest_blog_facts(since, until))      # GoatCounter
+    sheet.update(_digest_security_facts(since, security_until))  # Falco/CrowdSec
+    return sheet
 
 
 def build_for_surge(window_start: datetime, window_end: datetime) -> dict:

--- a/apps/ai-alert-helper/src/ai_alert_helper/surge.py
+++ b/apps/ai-alert-helper/src/ai_alert_helper/surge.py
@@ -17,7 +17,7 @@ def _hour_count(when: datetime) -> int:
     end = when.isoformat()
     query = (
         f'_time:[{start},{end}] AND kubernetes.namespace_name:caddy-system '
-        f'AND _msg:"handled request" AND _msg:"blog.derio.net" | stats count() as c'
+        f'AND _msg:"handled request" AND request.host:"blog.derio.net" | stats count() as c'
     )
     return facts._logsql_count(query)
 

--- a/apps/ai-alert-helper/src/tests/conftest.py
+++ b/apps/ai-alert-helper/src/tests/conftest.py
@@ -1,0 +1,11 @@
+"""Test environment setup.
+
+`facts.GOATCOUNTER_TOKEN` is captured from the environment at import time and
+the GoatCounter helper short-circuits to `{}` when it's empty. The digest
+tests assert that GoatCounter is actually queried, so a non-empty token must
+be present before `ai_alert_helper.facts` is first imported. Setting it here
+(conftest loads before any test module) guarantees that ordering.
+"""
+import os
+
+os.environ.setdefault("OBS_GOATCOUNTER_API_TOKEN", "test-token")

--- a/apps/ai-alert-helper/src/tests/test_facts.py
+++ b/apps/ai-alert-helper/src/tests/test_facts.py
@@ -4,6 +4,9 @@ Mock VictoriaLogs + GoatCounter responses; check that the right
 dict shape comes out.
 """
 from __future__ import annotations
+import re
+from datetime import datetime, timedelta, timezone
+
 import respx
 import httpx
 from ai_alert_helper import facts
@@ -41,3 +44,79 @@ def test_build_for_alert_returns_minimal_sheet_for_unknown():
     """Unknown alert name → minimal sheet (no crash)."""
     sheet = facts.build_for_alert({"alertname": "Unrecognized"})
     assert sheet["alertname"] == "Unrecognized"
+
+
+def _captured_query(route):
+    """Pull the `query` param from the last request on a respx route."""
+    req = route.calls.last.request
+    return dict(httpx.QueryParams(req.url.query.decode()))["query"]
+
+
+@respx.mock
+def test_build_for_digest_edge_requests_scoped_to_hop_and_grouped():
+    """#1: edge requests use kubernetes.host:hop-1, group by request.host + status, no _msg host filter."""
+    route = respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+        return_value=httpx.Response(200, json={"data": {"result": [
+            {"metric": {"request.host": "blog.derio.net"}, "value": [0, "120"]},
+            {"metric": {"request.host": "heads.hop.derio.net"}, "value": [0, "900"]},
+        ]}}),
+    )
+    since = datetime(2026, 5, 24, tzinfo=timezone.utc)
+    until = since + timedelta(days=1)
+    sheet = facts.build_for_digest(since, until, until)  # security_until == until for this test
+    # vhost breakdown present, sorted desc, capped
+    assert sheet["edge_requests_by_vhost"][0]["host"] == "heads.hop.derio.net"
+    # at least one query scoped to Hop and grouped by request.host
+    assert any("kubernetes.host:hop-1" in q and "by (request.host)" in q
+               for q in [c.request.url.params.get("query", "") for c in route.calls])
+    # never the broken substring filter
+    assert all('_msg:"blog.derio.net"' not in c.request.url.params.get("query", "")
+               for c in route.calls)
+
+
+@respx.mock
+def test_build_for_digest_pulls_goatcounter_pageviews_and_top_n():
+    """#2: digest queries GoatCounter for total/hits/refs with Bearer auth + day window."""
+    respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+        return_value=httpx.Response(200, json={"data": {"result": []}}))
+    total = respx.get(facts.GOATCOUNTER_URL + "/api/v0/stats/total").mock(
+        return_value=httpx.Response(200, json={"total": 42}))
+    hits = respx.get(facts.GOATCOUNTER_URL + "/api/v0/stats/hits").mock(
+        return_value=httpx.Response(200, json={"hits": [{"path": "/frank/x", "count": 30}]}))
+    refs = respx.get(facts.GOATCOUNTER_URL + "/api/v0/stats/refs").mock(
+        return_value=httpx.Response(200, json={"refs": [{"name": "news.ycombinator.com", "count": 12}]}))
+    since = datetime(2026, 5, 24, tzinfo=timezone.utc)
+    until = since + timedelta(days=1)
+    sheet = facts.build_for_digest(since, until, until)
+    assert sheet["blog_pageviews"] == 42
+    assert sheet["blog_top_pages"][0]["path"] == "/frank/x"
+    assert sheet["blog_top_referrers"][0]["name"] == "news.ycombinator.com"
+    # Bearer auth header present on GoatCounter calls
+    assert total.calls.last.request.headers["Authorization"].startswith("Bearer ")
+    # day-scoped window passed as start/end params
+    assert hits.calls.last.request.url.params["start"] == "2026-05-24"
+
+
+@respx.mock
+def test_build_for_digest_falco_all_priorities_and_split_window():
+    """#3: falco grouped by priority (not Critical-only); security window runs to security_until."""
+    captured = []
+    def _cap(request):
+        captured.append(dict(request.url.params)["query"])
+        # priority breakdown response
+        if "by (priority)" in dict(request.url.params)["query"]:
+            return httpx.Response(200, json={"data": {"result": [
+                {"metric": {"priority": "Warning"}, "value": [0, "2"]},
+                {"metric": {"priority": "Notice"}, "value": [0, "1652"]}]}})
+        return httpx.Response(200, json={"data": {"result": []}})
+    respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(side_effect=_cap)
+    respx.get(re.compile(facts.GOATCOUNTER_URL + "/api/v0/.*")).mock(
+        return_value=httpx.Response(200, json={"total": 0, "hits": [], "refs": []}))
+    since = datetime(2026, 5, 24, tzinfo=timezone.utc)
+    until = since + timedelta(days=1)
+    security_until = datetime(2026, 5, 25, 8, 0, tzinfo=timezone.utc)
+    sheet = facts.build_for_digest(since, until, security_until)
+    prios = {row["priority"]: row["count"] for row in sheet["falco_by_priority"]}
+    assert prios == {"Warning": 2, "Notice": 1652}
+    # security query window ends at security_until, NOT until
+    assert any("2026-05-25T08:00:00" in q and "source:syscall" in q for q in captured)

--- a/apps/ai-alert-helper/src/tests/test_facts.py
+++ b/apps/ai-alert-helper/src/tests/test_facts.py
@@ -46,12 +46,6 @@ def test_build_for_alert_returns_minimal_sheet_for_unknown():
     assert sheet["alertname"] == "Unrecognized"
 
 
-def _captured_query(route):
-    """Pull the `query` param from the last request on a respx route."""
-    req = route.calls.last.request
-    return dict(httpx.QueryParams(req.url.query.decode()))["query"]
-
-
 @respx.mock
 def test_build_for_digest_edge_requests_scoped_to_hop_and_grouped():
     """#1: edge requests use kubernetes.host:hop-1, group by request.host + status, no _msg host filter."""

--- a/apps/ai-alert-helper/src/tests/test_surge.py
+++ b/apps/ai-alert-helper/src/tests/test_surge.py
@@ -5,6 +5,8 @@ calls (1 for the current hour + 7 for the same hour-of-day across the past
 7 days), then compute the median in Python.
 """
 from __future__ import annotations
+from datetime import datetime, timezone
+
 import respx
 import httpx
 import pytest
@@ -96,3 +98,13 @@ def test_compute_handles_zero_current_traffic():
     assert result["current"] == 0
     assert result["ratio"] == 0.0
     assert result["tier"] is None
+
+
+@respx.mock
+def test_hour_count_filters_on_request_host_field():
+    route = respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+        return_value=httpx.Response(200, json={"data": {"result": [{"value": [0, "5"]}]}}))
+    surge._hour_count(datetime(2026, 5, 25, 12, tzinfo=timezone.utc))
+    q = route.calls.last.request.url.params["query"]
+    assert 'request.host:"blog.derio.net"' in q
+    assert '_msg:"blog.derio.net"' not in q

--- a/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/01.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/01.yaml
@@ -326,46 +326,46 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:05:54+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:05:55+00:00'
       note: null
     P1.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:05:55+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:06:54+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:06:55+00:00'
       note: null
     P1.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:06:55+00:00'
       note: null
     P1.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:06:55+00:00'
       note: null
     P1.T4.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:06:55+00:00'
       note: null
     P1.T5.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:06:55+00:00'
       note: null
     P1.T5.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T13:06:55+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-25T13:06:56+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1
📐 Spec:   docs/superpowers/specs/2026-05-23--obs--hop-blog-edge-monitoring-design.md
🎯 Phase:  1/3 — Enrich the digest fact sheet (TDD, pure-Python, no deploy) [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/400

---

## Summary

Phase 1 of `blog-digest-rework-1` — rebuilds the digest fact sheet in pure
Python (no deploy) to fix the four ways the "📊 Yesterday on the Frank blog"
Telegram digest was lying. TDD-first: new tests pin the **wire query strings
and field names**, which is the assertion gap that let the original bugs ship.

### Changes (`apps/ai-alert-helper/src/`)

- **#1 Over-broad request count** → `build_for_digest` now scopes edge
  requests to `kubernetes.host:hop-1` and breaks them down by `request.host`
  (top 10) and status class, instead of an unfiltered `caddy-system` count
  that presented every Hop vhost as blog traffic.
- **#2 Empty top page / referrer** → GoatCounter integration via
  `/api/v0/stats/{total,hits,refs}` with Bearer auth and a calendar-day window.
- **#3 Security blind spots** → Falco broken out by **all** priorities + top
  rules over a split security window `[since, security_until)` so overnight
  Criticals surface same-day.
- **#4 Dead blog surge detection** → `surge.py._hour_count` filters
  `request.host:"blog.derio.net"` (was the always-zero `_msg` substring).

`build_for_digest` gains a third `security_until` arg; `api.py` is wired to
pass it in **Phase 2** (this phase is no-deploy). The `summarize(facts)` swap
contract is unchanged — only the fact dict grows richer.

### Tests

New query-string-asserting tests in `test_facts.py` / `test_surge.py`; a
`conftest.py` seeds the GoatCounter token so the digest path is exercised.
Full suite green — **16 passed**.

Closes #400
