### PR TITLE
fix(plans): correct migrated plan metadata — frank (target_repo, spec refs, vk_version)

### DIFF
--- a/docs/superpowers/archived-plans/2026-03-02--gitops--argocd-infrastructure/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-02--gitops--argocd-infrastructure/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-02--gitops--argocd-infrastructure
 spec: docs/superpowers/specs/2026-03-02--gitops--argocd-infrastructure-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-02'

--- a/docs/superpowers/archived-plans/2026-03-03--fun--openrgb-led-control/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-03--fun--openrgb-led-control/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-03--fun--openrgb-led-control
 spec: docs/superpowers/specs/2026-03-03--fun--openrgb-led-control-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-03'

--- a/docs/superpowers/archived-plans/2026-03-04--gpu--intel-igpu-stack-mini/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-04--gpu--intel-igpu-stack-mini/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-04--gpu--intel-igpu-stack-mini
 spec: none
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-04'

--- a/docs/superpowers/archived-plans/2026-03-06--repo--blog-series/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-06--repo--blog-series/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-06--repo--blog-series
 spec: docs/superpowers/specs/2026-03-06--repo--blog-series-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-06'

--- a/docs/superpowers/archived-plans/2026-03-07--obs--observability/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-07--obs--observability/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-07--obs--observability
 spec: docs/superpowers/specs/2026-03-07--obs--observability-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-07'

--- a/docs/superpowers/archived-plans/2026-03-08--backup--longhorn-r2/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-08--backup--longhorn-r2/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-08--backup--longhorn-r2
 spec: docs/superpowers/specs/2026-03-07--backup--longhorn-r2-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-08'

--- a/docs/superpowers/archived-plans/2026-03-08--repo--declarative-drift-remediation/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-08--repo--declarative-drift-remediation/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-08--repo--declarative-drift-remediation
 spec: docs/superpowers/specs/2026-03-08--repo--declarative-drift-remediation-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-08'

--- a/docs/superpowers/archived-plans/2026-03-08--secrets--infisical-eso/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-08--secrets--infisical-eso/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-08--secrets--infisical-eso
 spec: docs/superpowers/specs/2026-03-07--secrets--infisical-eso-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-08'

--- a/docs/superpowers/archived-plans/2026-03-09--agents--sympozium/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-09--agents--sympozium/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-09--agents--sympozium
 spec: docs/superpowers/specs/2026-03-09--agents--sympozium-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-09'

--- a/docs/superpowers/archived-plans/2026-03-09--fun--openrgb-server-regression-fix/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-09--fun--openrgb-server-regression-fix/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-09--fun--openrgb-server-regression-fix
 spec: docs/superpowers/specs/2026-03-09--fun--openrgb-server-regression-fix-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-09'

--- a/docs/superpowers/archived-plans/2026-03-09--gpu--pcie-link-speed-fix/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-09--gpu--pcie-link-speed-fix/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-09--gpu--pcie-link-speed-fix
 spec: docs/superpowers/specs/2026-03-09--gpu--pcie-link-speed-fix-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-09'

--- a/docs/superpowers/archived-plans/2026-03-09--infer--ollama-litellm/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-09--infer--ollama-litellm/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-09--infer--ollama-litellm
 spec: docs/superpowers/specs/2026-03-09--infer--ollama-litellm-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-09'

--- a/docs/superpowers/archived-plans/2026-03-10--gpu--operator-talos-fix/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-10--gpu--operator-talos-fix/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-10--gpu--operator-talos-fix
 spec: docs/superpowers/specs/2026-03-10--gpu--operator-talos-fix-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-10'

--- a/docs/superpowers/archived-plans/2026-03-11--auth--authentik/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-11--auth--authentik/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-11--auth--authentik
 spec: docs/superpowers/specs/2026-03-11--auth--authentik-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-11'

--- a/docs/superpowers/archived-plans/2026-03-11--tenant--vcluster/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-11--tenant--vcluster/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-11--tenant--vcluster
 spec: docs/superpowers/specs/2026-03-07--tenant--vcluster-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-11'

--- a/docs/superpowers/archived-plans/2026-03-13--repo--operating-blog-series/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-13--repo--operating-blog-series/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-13--repo--operating-blog-series
 spec: docs/superpowers/specs/2026-03-13--repo--operating-blog-series-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-13'

--- a/docs/superpowers/archived-plans/2026-03-14--media--comfyui-gpu-switcher/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-14--media--comfyui-gpu-switcher/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-14--media--comfyui-gpu-switcher
 spec: docs/superpowers/specs/2026-03-16--media--comfyui-custom-image-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-14'

--- a/docs/superpowers/archived-plans/2026-03-14--orch--paperclip/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-14--orch--paperclip/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-14--orch--paperclip
 spec: docs/superpowers/specs/2026-03-14--orch--paperclip-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-14'

--- a/docs/superpowers/archived-plans/2026-03-16--edge--hop-public/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-16--edge--hop-public/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-16--edge--hop-public
 spec: docs/superpowers/specs/2026-03-16--edge--hop-public-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-16'

--- a/docs/superpowers/archived-plans/2026-03-16--media--comfyui-custom-image/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-16--media--comfyui-custom-image/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-16--media--comfyui-custom-image
 spec: docs/superpowers/specs/2026-03-16--media--comfyui-custom-image-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-16'

--- a/docs/superpowers/archived-plans/2026-03-20--repo--multi-cluster-restructure/01.yaml
+++ b/docs/superpowers/archived-plans/2026-03-20--repo--multi-cluster-restructure/01.yaml
@@ -3,7 +3,7 @@ phase:
   number: 1
   title: ArgoCD Sync
   tag: manual
-  depends_on: []
+  depends_on: [0]
   tracking_issue:
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-03-20--repo--multi-cluster-restructure/02.yaml
+++ b/docs/superpowers/archived-plans/2026-03-20--repo--multi-cluster-restructure/02.yaml
@@ -3,7 +3,7 @@ phase:
   number: 2
   title: Update References
   tag: agentic
-  depends_on: []
+  depends_on: [1]
   tracking_issue:
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-03-20--repo--multi-cluster-restructure/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-20--repo--multi-cluster-restructure/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-20--repo--multi-cluster-restructure
 spec: docs/superpowers/specs/2026-03-20--repo--multi-cluster-restructure-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-20'

--- a/docs/superpowers/archived-plans/2026-03-21--edge--subnet-router-autoapproval/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-21--edge--subnet-router-autoapproval/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-21--edge--subnet-router-autoapproval
 spec: docs/superpowers/specs/2026-03-21--edge--subnet-router-autoapproval-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-21'

--- a/docs/superpowers/archived-plans/2026-03-21--repo--phase-to-layer-rename/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-21--repo--phase-to-layer-rename/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-21--repo--phase-to-layer-rename
 spec: none
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-21'

--- a/docs/superpowers/archived-plans/2026-03-22--auth--authentik-audit-completion/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-22--auth--authentik-audit-completion/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-22--auth--authentik-audit-completion
 spec: none
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-22'

--- a/docs/superpowers/archived-plans/2026-03-25--deploy--argo-rollouts/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-25--deploy--argo-rollouts/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-25--deploy--argo-rollouts
 spec: docs/superpowers/specs/2026-03-25--deploy--argo-rollouts-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-25'

--- a/docs/superpowers/archived-plans/2026-03-29--agents--n8n-01/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-29--agents--n8n-01/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-29--agents--n8n-01
 spec: docs/superpowers/specs/2026-03-29--agents--n8n-01-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-29'

--- a/docs/superpowers/archived-plans/2026-03-29--cicd--platform/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-29--cicd--platform/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-29--cicd--platform
 spec: docs/superpowers/specs/2026-03-29--cicd--platform-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-29'

--- a/docs/superpowers/archived-plans/2026-03-29--net--in-cluster-ingress/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-29--net--in-cluster-ingress/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-29--net--in-cluster-ingress
 spec: docs/superpowers/specs/2026-03-29--net--in-cluster-ingress-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-29'

--- a/docs/superpowers/archived-plans/2026-03-30--agents--secure-agent-pod/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-03-30--agents--secure-agent-pod/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-03-30--agents--secure-agent-pod
 spec: docs/superpowers/specs/2026-03-30--agents--secure-agent-pod-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-03-30'

--- a/docs/superpowers/archived-plans/2026-04-01--obs--work-lifecycle-health-monitoring/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-01--obs--work-lifecycle-health-monitoring/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-01--obs--work-lifecycle-health-monitoring
-spec: willikins/docs/superpowers/specs/2026-04-01-work-lifecycle-tracking-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+spec: derio-net/willikins:docs/superpowers/specs/2026-04-01-work-lifecycle-tracking-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-01'

--- a/docs/superpowers/archived-plans/2026-04-04--obs--health-bridge-service/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-04--obs--health-bridge-service/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-04--obs--health-bridge-service
-spec: willikins/docs/superpowers/specs/2026-04-01-work-lifecycle-tracking-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+spec: derio-net/willikins:docs/superpowers/specs/2026-04-01-work-lifecycle-tracking-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-04'

--- a/docs/superpowers/archived-plans/2026-04-08--obs--grafana-alerting-as-code/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-08--obs--grafana-alerting-as-code/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-08--obs--grafana-alerting-as-code
 spec: docs/superpowers/specs/2026-04-08--obs--grafana-alerting-as-code-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-08'

--- a/docs/superpowers/archived-plans/2026-04-09--repo--blog-media-infrastructure/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-09--repo--blog-media-infrastructure/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-09--repo--blog-media-infrastructure
 spec: docs/superpowers/specs/2026-04-09--repo--blog-media-infrastructure-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-09'

--- a/docs/superpowers/archived-plans/2026-04-11--repo--vk-skills-harmonization/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-11--repo--vk-skills-harmonization/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-11--repo--vk-skills-harmonization
-spec: willikins/docs/superpowers/specs/2026-04-10-vk-skills-harmonization-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+spec: derio-net/willikins:docs/superpowers/specs/2026-04-10-vk-skills-harmonization-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-11'

--- a/docs/superpowers/archived-plans/2026-04-12--agents--vk-remote-self-host/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-12--agents--vk-remote-self-host/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-12--agents--vk-remote-self-host
 spec: docs/superpowers/specs/2026-04-12--agents--vk-remote-self-host-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-12'

--- a/docs/superpowers/archived-plans/2026-04-13--agents--vk-relay-deployment/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-13--agents--vk-relay-deployment/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-13--agents--vk-relay-deployment
 spec: docs/superpowers/specs/2026-04-13--agents--vk-relay-self-host-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-13'

--- a/docs/superpowers/archived-plans/2026-04-13--repo--blog-hextra-migration/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-13--repo--blog-hextra-migration/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-13--repo--blog-hextra-migration
 spec: docs/superpowers/specs/2026-04-13--repo--blog-hextra-migration-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-13'

--- a/docs/superpowers/archived-plans/2026-04-15--agents--agent-images-and-vk-local-sidecar/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-15--agents--agent-images-and-vk-local-sidecar/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-15--agents--agent-images-and-vk-local-sidecar
 spec: docs/superpowers/specs/2026-04-15--agents--agent-images-and-vk-local-sidecar-design.md
-target_repo: '`derio-net/frank`'
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-15'

--- a/docs/superpowers/archived-plans/2026-04-15--gitops--argocd-drift-cleanup/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-15--gitops--argocd-drift-cleanup/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-15--gitops--argocd-drift-cleanup
 spec: docs/superpowers/specs/2026-04-15--gitops--argocd-drift-cleanup-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-15'

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/01.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/01.yaml
@@ -3,7 +3,7 @@ phase:
   number: 1
   title: Priority Dogfood — Layer 8 Observability
   tag: agentic
-  depends_on: []
+  depends_on: [0]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/02.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/02.yaml
@@ -3,7 +3,7 @@ phase:
   number: 2
   title: Priority — Layer 18 Persistent Agent
   tag: agentic
-  depends_on: []
+  depends_on: [0]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/03.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/03.yaml
@@ -3,7 +3,7 @@ phase:
   number: 3
   title: Foundation Layers (1–6)
   tag: agentic
-  depends_on: []
+  depends_on: [0]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/04.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/04.yaml
@@ -3,7 +3,7 @@ phase:
   number: 4
   title: Core Services (9, 10, 11, 12, 13, 14)
   tag: agentic
-  depends_on: []
+  depends_on: [0]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/05.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/05.yaml
@@ -3,7 +3,7 @@ phase:
   number: 5
   title: User-facing (15, 16, 17)
   tag: agentic
-  depends_on: []
+  depends_on: [0]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/06.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/06.yaml
@@ -3,7 +3,7 @@ phase:
   number: 6
   title: Delivery, Ingress, CI (19, 24, 25)
   tag: agentic
-  depends_on: []
+  depends_on: [0]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/07.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/07.yaml
@@ -3,7 +3,7 @@ phase:
   number: 7
   title: Alert UX + Finalization
   tag: agentic
-  depends_on: []
+  depends_on: [1, 2, 3, 4, 5, 6]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/08.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/08.yaml
@@ -3,7 +3,7 @@ phase:
   number: 8
   title: Post-Deploy Checklist
   tag: manual
-  depends_on: []
+  depends_on: [7]
   tracking_issue: null
 tasks:
 - number: 1

--- a/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-16--platform--derio-ops-pass3-grafana-wiring/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-16--platform--derio-ops-pass3-grafana-wiring
 spec: docs/superpowers/specs/2026-04-16--platform--derio-ops-layers-restoration-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-16'

--- a/docs/superpowers/archived-plans/2026-04-26--agents--secure-pod-tmux-mosh/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-26--agents--secure-pod-tmux-mosh/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-26--agents--secure-pod-tmux-mosh
 spec: docs/superpowers/specs/2026-03-30--agents--secure-agent-pod-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-26'

--- a/docs/superpowers/archived-plans/2026-04-27--agents--restart-resilience/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-27--agents--restart-resilience/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-27--agents--restart-resilience
 spec: docs/superpowers/specs/2026-04-27--agents--restart-resilience-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-27'

--- a/docs/superpowers/archived-plans/2026-04-30--agents--vk-local-oom-remediation/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-30--agents--vk-local-oom-remediation/_meta.yaml
@@ -2,5 +2,5 @@ schema_version: 2
 plan: 2026-04-30--agents--vk-local-oom-remediation
 spec: docs/superpowers/specs/2026-04-30--agents--vk-local-oom-remediation-design.md
 target_repo: derio-net/frank
-vk_version: '>=1.0.0,<3.0.0'
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-30'

--- a/docs/superpowers/archived-plans/2026-05-02--orch--paperclip-shell-sidecar/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-05-02--orch--paperclip-shell-sidecar/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-05-02--orch--paperclip-shell-sidecar
 spec: docs/superpowers/specs/2026-05-02--orch--paperclip-shell-sidecar-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-02'

--- a/docs/superpowers/archived-plans/2026-05-02--orch--ruflo-pod/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-05-02--orch--ruflo-pod/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-05-02--orch--ruflo-pod
 spec: docs/superpowers/specs/2026-05-02--orch--ruflo-pod-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-02'

--- a/docs/superpowers/archived-plans/2026-05-05--cicd--stoa-gitea-primary-rework-1/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-05-05--cicd--stoa-gitea-primary-rework-1/_meta.yaml
@@ -2,7 +2,7 @@ schema_version: 2
 plan: 2026-05-05--cicd--stoa-gitea-primary-rework-1
 spec: docs/superpowers/specs/2026-05-04--cicd--stoa-gitea-primary-design.md
 target_repo: derio-net/frank
-vk_version: '>=1.0.0,<3.0.0'
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-13'
 parent_plan: docs/superpowers/archived-plans/2026-05-05--cicd--stoa-gitea-primary/
 origin_items:

--- a/docs/superpowers/archived-plans/2026-05-05--cicd--stoa-gitea-primary/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-05-05--cicd--stoa-gitea-primary/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-05-05--cicd--stoa-gitea-primary
 spec: docs/superpowers/specs/2026-05-04--cicd--stoa-gitea-primary-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-05'

--- a/docs/superpowers/archived-plans/2026-05-05--repo--blog-craft-skill-package/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-05-05--repo--blog-craft-skill-package/_meta.yaml
@@ -2,5 +2,5 @@ schema_version: 2
 plan: 2026-05-05--repo--blog-craft-skill-package
 spec: docs/superpowers/specs/2026-05-05--repo--blog-craft-skill-design.md
 target_repo: derio-net/blog-craft
-vk_version: '>=1.0.0,<3.0.0'
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-05'

--- a/docs/superpowers/archived-plans/2026-05-11--obs--cert-expiry-alerting/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-05-11--obs--cert-expiry-alerting/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-05-11--obs--cert-expiry-alerting
 spec: docs/superpowers/specs/2026-04-20--obs--pass3-followups-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-11'

--- a/docs/superpowers/archived-plans/2026-05-16--repo--frank-papers-paper-00/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-05-16--repo--frank-papers-paper-00/_meta.yaml
@@ -2,5 +2,5 @@ schema_version: 2
 plan: 2026-05-16--repo--frank-papers-paper-00
 spec: docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
 target_repo: derio-net/frank
-vk_version: '>=1.0.0,<3.0.0'
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-16'

--- a/docs/superpowers/archived-plans/2026-05-16--repo--frank-papers-phase-0/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-05-16--repo--frank-papers-phase-0/_meta.yaml
@@ -2,5 +2,5 @@ schema_version: 2
 plan: 2026-05-16--repo--frank-papers-phase-0
 spec: docs/superpowers/specs/2026-04-15--repo--frank-papers-series-design.md
 target_repo: derio-net/frank
-vk_version: '>=1.0.0,<3.0.0'
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-16'


### PR DESCRIPTION
45 archived plans carried `target_repo: derio-net/superpowers-for-vk` — a v1→v2 migration bug (the migrator defaulted to the plugin's own repo, fixed in superpowers-for-vk#247 / `vk 2.2.12`). Every one is frank-owned (plan + spec local to frank; references to paperclip/health-bridge/frank-ops/etc. are deploy/dependency targets, not ownership), so all → **`derio-net/frank`**.

Also in this PR:
- **Backtick-malformed value** normalized (`2026-04-15--agents--agent-images-and-vk-local-sidecar`: `'`derio-net/frank`'` → `derio-net/frank`).
- **3 cross-repo spec refs** fixed: `willikins/docs/...` → `derio-net/willikins:docs/...`. The old local-form refs would be mis-resolved as same-repo by `vk apply`'s reachability gate and flagged unreachable (notation gap tracked in superpowers-for-vk#248). These plans implement frank's slice of willikins-authored designs (`vk-skills-harmonization`, `work-lifecycle-tracking`).
- Aligned all **51** loose `vk_version: >=1.0.0,<3.0.0` → `>=2.0.0,<3.0.0`.

All 51 plans pass `vk plan self-review`. Found via the post-2.2.12 cross-repo scan; sibling to #245/#246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update:** also recovered `depends_on` flattened by the migrator (#245 Bug 2) for 2 plans — `multi-cluster-restructure` (chain 1←0, 2←1) and `grafana-wiring` (1–6←0, 7←{1..6}, 8←7), reconstructed from their `.v1-archive` prose; both pass DAG validation. #245 Bug 3 (manual-operation block drops) was a scan false-positive for the 2 flagged frank plans — no real blocks dropped.