### PR TITLE
[derio-net/frank] 2026-05-25--obs--blog-digest-rework-1 · Phase 3/3 · Docs — retro-update blog posts, add gotchas, record parent deviation

### DIFF
--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -57,11 +57,16 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - VictoriaMetrics chart `genCA` regenerates webhook caBundle — `ignoreDifferences` on the validating webhook caBundle.
 - `ALERTS{}` does NOT exist in VM for Grafana-managed alerts — use `alertlist` panel type.
 
+### Observability digest — `docs/runbooks/frank-gotchas/obs-digest.md`
+- Falco events reach VictoriaLogs via falcosidekick→Loki-push with fields `source`/`priority`/`rule`/`k8s_ns_name` — NOT `kubernetes.namespace_name` (that's the fluent-bit collector path for Caddy/CrowdSec). Query Falco with `source:syscall`, never a `kubernetes.namespace_name` filter.
+- The daily digest uses a split window: traffic = prior calendar day, security = yesterday 00:00 → digest run time, so overnight Critical events aren't reported ~24h late.
+
 ### Networking — `docs/runbooks/frank-gotchas/networking.md`
 - Cilium: `lbipam.cilium.io/ips` alone is NOT a sharing directive — separate Services need matching `lbipam.cilium.io/sharing-key`. Always check `kubectl get svc -A | grep pending` after deploying a chart that splits one service into multiple Services on a shared LB IP.
 - Cilium 1.17 FQDN policies need DNS-proxy initialization on the node first; restart the agent if the LRU isn't ready (stale BPF rules also persist after CNP deletion — agent restart clears them).
 - MixedProtocolLBService (TCP + UDP on one Service) works on Cilium 1.17 + K8s 1.35 — no feature gate needed.
 - mosh: flags only in `--ssh="ssh ..."`; `user@host` positional; pin `--server="mosh-server new -p 60000:60015"` to match the Service's port range. Use the per-shell wrappers in `apps/*/client-setup/laptop/`.
+- Caddy JSON access logs store the vhost in field `request.host`, NOT in `_msg` (which is literally `"handled request"`). `_msg:"blog.derio.net"` always matches zero — filter `request.host:"blog.derio.net"`. Scope edge queries to Hop with `kubernetes.host:hop-1`.
 
 ### gpu-1 specifics — `docs/runbooks/frank-gotchas/gpu-1.md`
 - `kubectl port-forward` flakes regularly with CNI-netns errors on gpu-1 pods only — use `kubectl get application -n argocd -o wide` for argocd-cli replacements; use `kubectl exec ... wget -qO-` for in-pod metrics.

--- a/blog/content/docs/building/31-edge-observability/index.md
+++ b/blog/content/docs/building/31-edge-observability/index.md
@@ -349,6 +349,19 @@ echo '{"alerts":[{"labels":{"alertname":"CrowdSecDecisionBurst","severity":"warn
 
 Both produced Telegram messages with LLM narratives generated against real fact sheets. The local qwen model on gpu-1 handled both, well under one second of inference. The fallback path is untested in production because LiteLLM hasn't failed yet — but the unit test is enough confidence to leave the path quiet.
 
+### Deviation: the digest was lying
+
+That smoke-test line — *"Yesterday: 1,593 requests, 0 security events"* — read like success. It wasn't. Two days of digests later, on a careful look against live data, the "📊 Yesterday on the Frank blog" message turned out to be wrong in four ways at once:
+
+- **The request count wasn't blog traffic.** `facts.build_for_digest` counted every Caddy `"handled request"` log line with no host filter — 15,717/day across *every* Hop vhost (Headscale, Headplane, the landing page, ACME probes, bots, the blog). Presented as if it were the blog's day.
+- **Top page and top referrer were always blank.** No GoatCounter query existed anywhere in the digest path, even though `GOATCOUNTER_URL` and the API token were wired into the deployment. The prompt asked the LLM for "top page, top referrer" and told it to say so if a fact was missing — so it dutifully said so, every single morning.
+- **Security was nearly blind.** The digest counted only `priority:Critical` over the prior calendar day. A benign overnight Critical (the headscale-backup `sqlite3 .backup` tripping "Drop and execute new binary in container" at 03:00 UTC) showed up ~29h late, and every non-Critical Warning never surfaced at all.
+- **Surge detection was dead for the blog.** `surge.py._hour_count` filtered `_msg:"blog.derio.net"` — but the vhost lives in the `request.host` field; `_msg` is literally the string `"handled request"`. The filter matched zero rows forever, so `surge.compute()` could never fire.
+
+One root cause under all four: the digest read raw Caddy and Falco logs as a *proxy* for "blog activity" without the dimensional filters that data needs — vhost via `request.host`, the full priority breadth — while the purpose-built reader source, GoatCounter, sat wired but unqueried. And it shipped because the tests only asserted the shape of the count *parser*; not one of them checked the query string or the field names the parser was fed. The parser was correct. It was correctly parsing the wrong question.
+
+The fix is its own rework plan (`2026-05-25--obs--blog-digest-rework-1`): a richer per-vhost/per-status edge breakdown scoped to `kubernetes.host:hop-1`, real GoatCounter pageviews/top-pages/top-referrers, an all-priority Falco breakdown over a split window (traffic on the prior calendar day, security running through the digest's run time so overnight Criticals land same-morning), the `request.host` surge fix — and tests that now assert the actual query strings. The lesson rhymes with the chart-key one: a green test that asserts the wrong thing is more dangerous than no test, because it buys false confidence. Assert the question, not just the answer.
+
 ## The DatasourceError storm
 
 The day after deployment, Telegram lit up. Every minute, an URGENT `DatasourceError` alert. The new `blog-edge` rule group was failing on every evaluation cycle:

--- a/blog/content/docs/operating/26-edge-observability/index.md
+++ b/blog/content/docs/operating/26-edge-observability/index.md
@@ -314,7 +314,31 @@ curl -sf -X POST -H 'Content-Type: application/json' -d @/tmp/p.json http://ai-a
 kubectl delete pod -n ai-alert-helper-system alert-test --force --grace-period=0
 ```
 
-The helper's `/digest?dry_run=true` returns the fact sheet without invoking the LLM — useful when you suspect the prompt is producing bad output and want to see the underlying facts first.
+### Reading the digest
+
+The morning digest is three distinct things stacked into one message, and they answer three different questions:
+
+- **Blog readers** — `blog_pageviews`, `blog_top_pages`, `blog_top_referrers`, sourced from GoatCounter. This is "who actually read the blog yesterday." A direct (no-referrer) hit shows up labelled `direct`, not blank.
+- **Edge traffic** — `edge_requests_total` plus the per-vhost and per-status-class breakdown, sourced from Caddy access logs scoped to `kubernetes.host:hop-1`. This is "everything Hop's reverse proxy handled" — Headscale, Headplane, ACME, bots, probes, *and* the blog. Edge total dwarfs blog pageviews (15k+/day vs. low hundreds); the per-vhost line is what tells you how much of that was actually `blog.derio.net`.
+- **Security** — `falco_by_priority` (all priorities, not just Critical), `falco_top_rules`, `falco_critical_rules` (rule names for the Criticals specifically), and `crowdsec_decisions`.
+
+The one window asymmetry worth internalising: **traffic and pageviews cover the prior calendar day, but the security window runs from yesterday 00:00 through the moment the digest runs.** That's deliberate — a benign Critical that fires at 03:00 UTC (e.g. the headscale-backup `sqlite3 .backup`) would otherwise wait ~29h to appear. With the split window it lands in *this* morning's digest, the same day you'd want to glance at it. So an "overnight" Critical event appearing in today's message is by design, not a clock bug.
+
+### Auditing the fact sheet without sending Telegram
+
+`POST /digest?dry_run=true` builds the exact fact sheet the digest would summarise and returns it as JSON **without** calling the LLM or posting to Telegram. This is the canonical way to check what the digest is actually seeing — if a number looks wrong in the morning message, dump the facts first and decide whether the bug is in the data or the prompt:
+
+```
+# Exec into the running helper and hit its own port — no extra pod needed
+kubectl exec -n ai-alert-helper-system deploy/ai-alert-helper -- \
+  curl -sf -X POST "http://localhost:8080/digest?dry_run=true" | jq .
+# → {"facts": {"edge_requests_total": ..., "edge_requests_by_vhost": [...],
+#               "blog_pageviews": ..., "blog_top_pages": [...],
+#               "falco_by_priority": [...], "falco_critical_rules": [...], ...},
+#     "narrative": null}
+```
+
+The `"narrative": null` confirms the LLM was skipped. Cross-check `edge_requests_by_vhost` against `blog_pageviews` here — if edge traffic is high but blog pageviews are zero, the problem is GoatCounter (token permissions, range, SSO redirect), not the prompt.
 
 ### Rotating LLM models
 

--- a/docs/runbooks/frank-gotchas/README.md
+++ b/docs/runbooks/frank-gotchas/README.md
@@ -12,6 +12,7 @@ Long-form companion to `agents/rules/frank-gotchas.md`. That hot file is auto-lo
 | [argo-rollouts.md](argo-rollouts.md) | Canary mechanics, AnalysisTemplate, workloadRef, Prometheus provider |
 | [authentik.md](authentik.md) | Blueprints, outpost assignment, API shape (Bearer + 2026.x) |
 | [grafana.md](grafana.md) | Provisioning, alert SSE format, dashboards, false-positive queries |
+| [obs-digest.md](obs-digest.md) | AI digest: Falco Loki-push field names, traffic/security split window, dry-run audit |
 | [networking.md](networking.md) | Cilium L2 IPAM, FQDN policies, MixedProtocolLBService, mosh |
 | [gpu-1.md](gpu-1.md) | Node-pinning idiom, port-forward CNI flake, Ollama cgroup memory |
 | [agent-shells.md](agent-shells.md) | s6-overlay v3, sshd env, `cont-init.d`, tmux-continuum |

--- a/docs/runbooks/frank-gotchas/networking.md
+++ b/docs/runbooks/frank-gotchas/networking.md
@@ -38,3 +38,23 @@ Order of preference for "two ports, one IP":
 - (a) one Service with both ports if the chart allows it (MixedProtocolLBService gotcha above)
 - (b) two Services with matching `sharing-key`
 - (c) accept two distinct LB IPs
+
+## Caddy JSON access logs put the vhost in `request.host`, not `_msg`
+
+Hop's Caddy ships JSON access logs to Frank's VictoriaLogs. Every access-log line shares the same `_msg` value — literally `"handled request"`. The requested host lives in a structured field, `request.host`. This trips anyone who reaches for the obvious substring filter:
+
+```logsql
+# WRONG — matches zero rows, always. _msg is the constant "handled request".
+_time:1d kubernetes.host:hop-1 AND _msg:"blog.derio.net"
+
+# RIGHT — filter the structured field.
+_time:1d kubernetes.host:hop-1 AND request.host:"blog.derio.net"
+```
+
+The failure is silent: a zero-match filter returns `0`, which reads like "no traffic" rather than "wrong field." It bit the AI digest twice — `surge.py._hour_count` filtered `_msg:"blog.derio.net"` and so could never detect a blog surge, and `facts.build_for_digest` omitted any host filter at all, counting *every* Hop vhost.
+
+Live evidence (2026-05-25): the unfiltered edge total was **15,717 requests/day** across all Hop vhosts (Headscale, Headplane, landing, ACME, bots, probes, blog), while `request.host:"blog.derio.net"` was a small fraction of that. Always scope edge queries to the node with `kubernetes.host:hop-1`, then group or filter on `request.host` for a specific vhost:
+
+```logsql
+_time:1d kubernetes.host:hop-1 AND _msg:"handled request" | stats by (request.host) count()
+```

--- a/docs/runbooks/frank-gotchas/obs-digest.md
+++ b/docs/runbooks/frank-gotchas/obs-digest.md
@@ -1,0 +1,90 @@
+# Frank Gotchas — Observability Digest
+
+Long-form companion to the **Observability digest** section in
+`agents/rules/frank-gotchas.md`. Covers the `ai-alert-helper` daily digest's
+log-field and time-window traps. The hot file has the one-liners; this file has
+the prose, the field maps, and the live evidence.
+
+## Falco events use Loki-push field names, not the fluent-bit ones
+
+There are two log-shipping paths into Frank's VictoriaLogs, and they label
+their fields differently:
+
+| Path | Source | Namespace field | Notable fields |
+|---|---|---|---|
+| fluent-bit collector | Caddy, CrowdSec | `kubernetes.namespace_name` | `kubernetes.host`, `request.host` |
+| falcosidekick → Loki-push | Falco | `k8s_ns_name` | `source`, `priority`, `rule` |
+
+Falco events arrive via falcosidekick's Loki output, which emits the Falco-native
+labels `source` / `priority` / `rule` / `k8s_ns_name` — **not**
+`kubernetes.namespace_name`. A Falco query written with the fluent-bit field
+name matches nothing.
+
+```logsql
+# WRONG — Falco events don't carry kubernetes.namespace_name.
+_time:1d kubernetes.namespace_name:falco
+
+# RIGHT — Falco syscall events, all priorities.
+_time:1d source:syscall | stats by (priority) count()
+```
+
+Query Falco with `source:syscall` and break down by `priority` / `rule`. The
+digest's `_digest_security_facts` builds three facts off this path:
+`falco_by_priority` (all priorities), `falco_top_rules`, and
+`falco_critical_rules` (rule names filtered to `priority:Critical`, so the LLM
+can name *which* rule was the benign Critical rather than guessing).
+
+Live evidence (2026-05-25), the `priority` breakdown shape over a day:
+
+```
+priority   count
+Critical   1     # headscale-backup sqlite3 .backup → "Drop and execute new binary in container" @ 03:00 UTC
+Warning    2     # "Read sensitive file untrusted"
+```
+
+The original digest counted only `priority:Critical`, so the two Warnings never
+surfaced and the single Critical was reported ~29h late (see split window
+below).
+
+## The digest's split window: traffic vs. security
+
+The daily "📊 Yesterday on the Frank blog" digest runs at 08:00 UTC and uses
+**two different time windows**, by design:
+
+- **Traffic + pageviews** = the prior calendar day `[since, until)`. This
+  matches GoatCounter's daily buckets and the literal "Yesterday" in the title.
+- **Security (Falco / CrowdSec)** = `[since, security_until)` where
+  `security_until` is the digest's *run time* (≈08:00 today), not midnight.
+
+The asymmetry exists so an overnight Critical surfaces same-morning. A benign
+Critical that fires at 03:00 UTC (the headscale-backup CronJob's `sqlite3
+.backup` tripping "Drop and execute new binary in container") would, under a
+strict prior-calendar-day window, wait until the *next* morning's digest — ~29h
+late. With the security window extended through run time, it lands in today's
+message. So an "overnight" Critical appearing in a morning digest is expected
+behaviour, not a clock bug.
+
+In `api.py` the windows are:
+
+```python
+since = (now - timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
+until = since + timedelta(days=1)                 # traffic = prior calendar day
+sheet = facts.build_for_digest(since, until, now) # security runs to now
+```
+
+## Auditing the fact sheet
+
+`POST /digest?dry_run=true` returns the full fact sheet as JSON without invoking
+the LLM or posting to Telegram — the canonical way to confirm what the digest
+actually sees before blaming the prompt:
+
+```bash
+kubectl exec -n ai-alert-helper-system deploy/ai-alert-helper -- \
+  curl -sf -X POST "http://localhost:8080/digest?dry_run=true" | jq .
+# "narrative": null confirms the LLM was skipped.
+```
+
+If `edge_requests_by_vhost` shows traffic but `blog_pageviews` is `0`, the
+problem is the GoatCounter reader (token `stats` permission, exclusive-`end`
+date range, or SSO redirect on the public URL — see the rework plan's
+deployment deviations), not the prompt.

--- a/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/05.yaml
+++ b/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/05.yaml
@@ -489,5 +489,7 @@ state:
         Telegram'
   completion:
     at: '2026-05-24T08:33:16+00:00'
-    note: null
+    note: 'Digest shipped wrong in four ways (over-broad edge count, GoatCounter
+      readers unbuilt, security blind spots, dead surge filter); fixed in rework
+      plan 2026-05-25--obs--blog-digest-rework-1.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/_prose.md
+++ b/docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/_prose.md
@@ -122,6 +122,15 @@ Success criteria:
   ships.
 - Hop's memory limits stay below 90% allocatable across all phases.
 
+## Deviations
+
+Phase 5's `/digest` shipped with the GoatCounter half unbuilt and an over-broad
+edge request count (every Hop vhost, not just the blog). Four bugs were fixed in
+rework-1 — see `docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/`.
+The fix was done as a dedicated rework plan, not an amend here, to avoid
+reopening this plan's hand-closed phase Issues (the documented `vk apply`
+archived-plan footgun).
+
 Resource budget on Hop:
 
 | Component | Memory limit | Phase |

--- a/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/03.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1/03.yaml
@@ -106,30 +106,30 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T16:44:54+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T16:44:54+00:00'
       note: null
     P3.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T16:45:57+00:00'
       note: null
     P3.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T16:45:57+00:00'
       note: null
     P3.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T16:46:32+00:00'
       note: null
     P3.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T16:46:46+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-25T16:46:49+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-25--obs--blog-digest-rework-1
📐 Spec:   docs/superpowers/specs/2026-05-23--obs--hop-blog-edge-monitoring-design.md
🎯 Phase:  3/3 — Docs — retro-update blog posts, add gotchas, record parent deviation [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/402

---

Phase 3/3 of the blog-digest-rework. Pure docs/runbook work — no cluster changes.

## What changed

**Blog posts** (Layer Fix/Extension Workflow — retro-updated existing posts, no new post):
- **Building** `31-edge-observability`: added a *"Deviation: the digest was lying"* subsection under Phase 5. Covers the four bugs and their one root cause — the digest read raw Caddy/Falco logs as a proxy for "blog activity" without the dimensional filters that data needs (`request.host`, priority breadth) while GoatCounter sat wired-but-unused — and notes the tests only asserted the count-parser shape, never the query string, so it shipped green.
- **Operating** `26-edge-observability`: documents reading the richer digest (blog readers vs. edge traffic vs. security; the security window extends past midnight into "today" by design) and the `POST /digest?dry_run=true` fact-sheet audit command.

**Gotchas**:
- `frank-gotchas.md` Networking: Caddy stores the vhost in `request.host`, not `_msg` (`"handled request"`).
- New **Observability digest** section + `docs/runbooks/frank-gotchas/obs-digest.md`: Falco Loki-push field names (`source`/`priority`/`rule`/`k8s_ns_name`, not `kubernetes.namespace_name`), the traffic/security split window, and the dry-run audit. Includes the live evidence (edge total 15,717/day, Falco priority breakdown shape).

**Parent deviation** (no Issue reopen — avoids the `vk apply` archived-plan footgun):
- `_prose.md` Deviations entry on `2026-05-23--obs--hop-blog-edge-monitoring`.
- `completion.note` on the parent `05.yaml` pointing at the rework slug.

## Verification

- `hugo --minify` builds clean.
- Phase 3 marked complete; all steps ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #402
