### PR TITLE
fix(obs): surge-detector false-positive — P1 silence + probe identity

### DIFF
--- a/apps/ai-alert-helper/manifests/cronjob-surge-check.yaml
+++ b/apps/ai-alert-helper/manifests/cronjob-surge-check.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: ai-alert-helper-system
 spec:
   schedule: "*/15 * * * *"
+  suspend: true            # TEMPORARY — reverted in surge-detector-fix P3.T2.S1 once the fix is verified live
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5

--- a/apps/blackbox-exporter/manifests/configmap.yaml
+++ b/apps/blackbox-exporter/manifests/configmap.yaml
@@ -10,6 +10,11 @@ data:
         prober: http
         timeout: 10s
         http:
+          # User-Agent identifies Frank's own uptime probes so the edge-traffic
+          # definition can exclude them. KEEP IN SYNC with facts.PROBE_UA_TOKEN
+          # in apps/ai-alert-helper/src/ai_alert_helper/facts.py.
+          headers:
+            User-Agent: "Frank-Blackbox-Probe/1.0 (+https://blog.derio.net)"
           valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
           valid_status_codes: [200, 301, 302]
           follow_redirects: true
@@ -18,6 +23,9 @@ data:
         prober: http
         timeout: 10s
         http:
+          # See note above — keep in sync with facts.PROBE_UA_TOKEN.
+          headers:
+            User-Agent: "Frank-Blackbox-Probe/1.0 (+https://blog.derio.net)"
           valid_status_codes: [200]
           follow_redirects: false
           preferred_ip_protocol: ip4

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/01.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/01.yaml
@@ -95,16 +95,16 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:22:53+00:00'
       note: null
     P1.T1.S2:
       state: ' '
       ticked_at: null
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:22:55+00:00'
       note: null
     P1.T2.S2:
       state: ' '

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/01.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/01.yaml
@@ -1,0 +1,120 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Cluster prep — silence the storm + probe identity (deploy on main)
+  tag: manual
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Silence the surge-check alert declaratively
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Stop the every-15-min false page while we implement the fix. Edit
+      `apps/ai-alert-helper/manifests/cronjob-surge-check.yaml` — add
+      `suspend: true` as a sibling of `schedule:` under `spec:`:
+
+      BEGIN edit (spec block head)
+      spec:
+        schedule: "*/15 * * * *"
+        suspend: true            # TEMPORARY — reverted in P3.T2.S1 after the fix is verified live
+        concurrencyPolicy: Forbid
+      END edit
+
+      This is the declarative "stop the bleeding" — ArgoCD will stop
+      spawning surge-check Jobs. The digest CronJob is untouched.
+  - id: P1.T1.S2
+    text: |-
+      Commit, open a PR, and merge to `main` (ArgoCD only watches main).
+      After merge, wait for the ai-alert-helper app to sync, then verify
+      the CronJob is suspended and no new Jobs spawn:
+
+      source .env
+      kubectl -n ai-alert-helper-system get cronjob surge-check \
+        -o jsonpath='{.spec.suspend}{"\n"}'        # expect: true
+      # Confirm no new surge-check Jobs over ~16 min (count must not grow):
+      kubectl -n ai-alert-helper-system get jobs | grep -c surge-check
+- number: 2
+  title: Tag Frank's uptime probes with a self-controlled identity
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Give Frank's blackbox probes an owned User-Agent so the edge
+      definition can exclude *Frank's probe*, not the vendor default UA.
+      Edit `apps/blackbox-exporter/manifests/configmap.yaml` — add a
+      `headers:` map to the `http:` block of BOTH `http_2xx` and
+      `http_2xx_no_redirect`:
+
+      BEGIN edit (http_2xx)
+            http_2xx:
+              prober: http
+              timeout: 10s
+              http:
+                # User-Agent identifies Frank's own uptime probes so the
+                # edge-traffic definition can exclude them. KEEP IN SYNC
+                # with facts.PROBE_UA_TOKEN in apps/ai-alert-helper.
+                headers:
+                  User-Agent: "Frank-Blackbox-Probe/1.0 (+https://blog.derio.net)"
+                valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+                valid_status_codes: [200, 301, 302]
+                follow_redirects: true
+                preferred_ip_protocol: ip4
+      END edit
+
+      Add the same `headers:` block to `http_2xx_no_redirect`. Verified
+      supported: blackbox_exporter's http module accepts `headers:` and
+      User-Agent is overridable (upstream CONFIGURATION.md).
+  - id: P1.T2.S2
+    text: |-
+      Commit + merge to `main`. blackbox-exporter does NOT hot-reload its
+      config file, so after ArgoCD syncs the ConfigMap, restart the pod to
+      pick up the new module config:
+
+      source .env
+      kubectl -n monitoring rollout restart deploy/blackbox-exporter
+      kubectl -n monitoring rollout status  deploy/blackbox-exporter --timeout=120s
+  - id: P1.T2.S3
+    text: |-
+      LOAD-BEARING live verification (the exclusion filter in Phase 2 is
+      only trustworthy once this passes). Wait one probe cycle, then query
+      VictoriaLogs and confirm probe requests to blog.derio.net now carry
+      the new UA and the OLD stock UA is gone:
+
+      source .env
+      VL=http://192.168.55.225:9428
+      curl -s "$VL/select/logsql/stats_query" --data-urlencode \
+        'query=_time:15m kubernetes.host:hop-1 AND _msg:"handled request" AND request.host:"blog.derio.net" | stats by (request.headers.User-Agent) count() as c'
+      # Expect the dominant UA to be ["Frank-Blackbox-Probe/1.0 (+https://blog.derio.net)"]
+      # and ["Blackbox Exporter/0.25.0"] absent.
+
+      # Confirm the exclusion query (Phase 2's filter) now bites:
+      curl -s "$VL/select/logsql/stats_query" --data-urlencode \
+        'query=_time:15m kubernetes.host:hop-1 AND _msg:"handled request" AND request.host:"blog.derio.net" AND -`request.headers.User-Agent`:"Frank-Blackbox-Probe" | stats count() as c'
+      # Expect a small count (scanners/humans only), NOT ~the probe volume.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/02.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/02.yaml
@@ -1,0 +1,327 @@
+schema_version: 2
+phase:
+  number: 2
+  title: ai-alert-helper logic — edge_filter, floor, GoatCounter gate (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Centralized probe-aware edge filter + migrate all three callers
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      RED. Add failing tests to `apps/ai-alert-helper/src/tests/test_facts.py`
+      pinning the generated query strings (string-shape guard — a mocked
+      test cannot validate the live query; that is the Phase-3 gate):
+
+      BEGIN test snippet
+      from ai_alert_helper import facts
+
+      def test_edge_filter_excludes_probe_by_default():
+          f = facts.edge_filter(host="blog.derio.net")
+          assert "kubernetes.host:hop-1" in f
+          assert '`request.host`:"blog.derio.net"' in f
+          assert '-`request.headers.User-Agent`:"Frank-Blackbox-Probe"' in f
+
+      def test_edge_filter_no_host_no_probe_optout():
+          f = facts.edge_filter()
+          assert "request.host" not in f          # all vhosts
+          assert "Frank-Blackbox-Probe" in f       # still probe-excluded
+
+      def test_edge_filter_can_include_probes():
+          assert "Frank-Blackbox-Probe" not in facts.edge_filter(exclude_probes=False)
+
+      def test_probe_ua_token_is_pinned():
+          # Drift guard vs apps/blackbox-exporter/manifests/configmap.yaml
+          assert facts.PROBE_UA_TOKEN == "Frank-Blackbox-Probe"
+      END test snippet
+  - id: P2.T1.S2
+    text: |-
+      GREEN. Add to `facts.py` (near the top, after the URL constants):
+
+      BEGIN code
+      PROBE_UA_TOKEN = "Frank-Blackbox-Probe"   # MUST match the User-Agent in
+                                                # apps/blackbox-exporter/manifests/configmap.yaml
+
+
+      def edge_filter(host: str | None = None, *, exclude_probes: bool = True) -> str:
+          """Canonical Hop-edge Caddy filter. Backtick-quote dotted/hyphenated
+          field names (verified live against VictoriaLogs)."""
+          f = 'kubernetes.host:hop-1 AND _msg:"handled request"'
+          if host:
+              f += f' AND `request.host`:"{host}"'
+          if exclude_probes:
+              f += f' AND -`request.headers.User-Agent`:"{PROBE_UA_TOKEN}"'
+          return f
+      END code
+  - id: P2.T1.S3
+    text: |-
+      GREEN. Migrate all three callers to `edge_filter`:
+
+      - `surge.py` `_hour_count`: replace the hand-built query prefix with
+        `facts.edge_filter(host="blog.derio.net")`, keeping the
+        `_time:[...]` prefix and `| stats count() as c` suffix.
+      - `facts.build_for_surge`: `total_requests` query becomes
+        `f'_time:[...] {edge_filter(host="blog.derio.net")} | stats count() as c'`
+        (drops the old `kubernetes.namespace_name:caddy-system`, no-host,
+        probe-polluted form).
+      - `facts.build_for_digest`: the `edge` variable becomes
+        `f'{tw} {edge_filter()}'` (all vhosts, probe-excluded, hop-1 scoped).
+      Update any existing test_facts tests that asserted the old
+      `caddy-system` / no-exclusion query strings.
+  - id: P2.T1.S4
+    text: |-
+      Run the suite, expect green:
+      cd apps/ai-alert-helper/src && uv run pytest -q
+- number: 2
+  title: Absolute floor in surge.compute()
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      RED. In `test_surge.py`, add floor-boundary tests and SPLIT the
+      existing `test_compute_handles_empty_baseline_without_divide_by_zero`
+      into a crash-safety test and a boundary test:
+
+      BEGIN test snippet
+      def _counts(current, base=1):  # base list of 7 historical samples
+          return [current] + [base]*7
+
+      @respx.mock
+      def test_floor_suppresses_tier_below_abs_floor():
+          # current 49 with baseline 1 → ratio 49 but below floor 50 → None
+          counts = [49, 1, 0, 0, 0, 0, 0, 0]
+          respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+              side_effect=[httpx.Response(200, json=_stats_response(c)) for c in counts])
+          assert surge.compute()["tier"] is None
+
+      @respx.mock
+      def test_floor_boundary_fires_at_abs_floor():
+          counts = [50, 1, 0, 0, 0, 0, 0, 0]   # exactly 50 → fires (>=)
+          respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+              side_effect=[httpx.Response(200, json=_stats_response(c)) for c in counts])
+          assert surge.compute()["tier"] == "Major"
+      END test snippet
+
+      Rewrite the empty-baseline test to assert only no-crash (tier may now
+      be None if current < floor) — keep a separate test that current >=
+      floor with empty baseline still classifies.
+  - id: P2.T2.S2
+    text: |-
+      GREEN. In `surge.py`: add `import os` and the floor, gating tier:
+
+      BEGIN code
+      ABS_FLOOR = int(os.environ.get("SURGE_ABS_FLOOR", "50"))
+      ...
+          tier: str | None = None
+          if current < ABS_FLOOR:
+              tier = None
+          elif ratio >= 10:
+              tier = "Major"
+          elif ratio >= 3:
+              tier = "Notable"
+      END code
+  - id: P2.T2.S3
+    text: |-
+      cd apps/ai-alert-helper/src && uv run pytest -q   # green
+- number: 3
+  title: GoatCounter reachability + visitor-pageviews helper
+  steps:
+  - id: P2.T3.S1
+    text: |-
+      RED. Tests in `test_facts.py`: `_goatcounter_raw` returns None on
+      error / dict on success; `surge_visitor_pageviews` returns None when
+      unreachable, an int otherwise, and passes hour-rounded RFC3339
+      start/end to `/api/v0/stats/total`; and the C1 regression —
+      `build_for_digest` survives an unreachable GoatCounter without
+      raising:
+
+      BEGIN test snippet
+      @respx.mock
+      def test_visitor_pageviews_none_when_unreachable():
+          respx.get(re.compile(facts.GOATCOUNTER_URL + "/api/v0/stats/total.*")).mock(
+              side_effect=httpx.ConnectError("down"))
+          s = datetime(2026,5,25,16,tzinfo=timezone.utc); e = s + timedelta(hours=1)
+          assert facts.surge_visitor_pageviews(s, e) is None
+
+      @respx.mock
+      def test_visitor_pageviews_counts_and_uses_hour_window(monkeypatch):
+          monkeypatch.setattr(facts, "GOATCOUNTER_TOKEN", "t")
+          route = respx.get(re.compile(facts.GOATCOUNTER_URL + "/api/v0/stats/total.*")).mock(
+              return_value=httpx.Response(200, json={"total": 7}))
+          s = datetime(2026,5,25,16,tzinfo=timezone.utc); e = s + timedelta(hours=1)
+          assert facts.surge_visitor_pageviews(s, e) == 7
+          q = dict(httpx.QueryParams(route.calls.last.request.url.query.decode()))
+          assert q["start"].startswith("2026-05-25T16:00") and q["end"].startswith("2026-05-25T17:00")
+
+      @respx.mock
+      def test_build_for_digest_survives_unreachable_goatcounter(monkeypatch):
+          monkeypatch.setattr(facts, "GOATCOUNTER_TOKEN", "t")
+          respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+              return_value=httpx.Response(200, json={"data": {"result": []}}))
+          respx.get(re.compile(facts.GOATCOUNTER_URL + ".*")).mock(side_effect=httpx.ConnectError("down"))
+          since = datetime(2026,5,24,tzinfo=timezone.utc); until = since + timedelta(days=1)
+          sheet = facts.build_for_digest(since, until, until)   # must NOT raise
+          assert sheet["blog_pageviews"] == 0
+      END test snippet
+  - id: P2.T3.S2
+    text: |-
+      GREEN. Refactor `facts.py` so the contract change is additive (does
+      NOT break `_digest_blog_facts`, which `.get()`s the result):
+
+      BEGIN code
+      def _goatcounter_raw(path: str, params: dict) -> dict | None:
+          """GET a GoatCounter /api/v0 endpoint. None on error, dict on success."""
+          if not GOATCOUNTER_TOKEN:
+              return None
+          try:
+              resp = httpx.get(f"{GOATCOUNTER_URL}{path}",
+                               headers={"Authorization": f"Bearer {GOATCOUNTER_TOKEN}"},
+                               params=params, timeout=15)
+              resp.raise_for_status()
+              return resp.json()
+          except Exception:  # noqa: BLE001
+              return None
+
+
+      def _goatcounter(path: str, params: dict) -> dict:
+          return _goatcounter_raw(path, params) or {}
+
+
+      def surge_visitor_pageviews(window_start: datetime, window_end: datetime) -> int | None:
+          """Human pageviews in the surge window; None when GoatCounter is unreachable.
+          GoatCounter start/end are date-time, 'rounded to the hour' (per /api.json)."""
+          data = _goatcounter_raw("/api/v0/stats/total", {
+              "start": window_start.replace(minute=0, second=0, microsecond=0).isoformat(),
+              "end":   window_end.replace(minute=0, second=0, microsecond=0).isoformat(),
+          })
+          return None if data is None else int(data.get("total", 0))
+      END code
+  - id: P2.T3.S3
+    text: |-
+      cd apps/ai-alert-helper/src && uv run pytest -q   # green
+- number: 4
+  title: /surge-check decision matrix + env wiring
+  steps:
+  - id: P2.T4.S1
+    text: |-
+      RED. Tests for the `/surge-check` decision matrix (FastAPI
+      TestClient; mock `surge.compute`, `facts.surge_visitor_pageviews`,
+      `telegram.send`, `ai_adapter.investigate`). Assert the `urgent` flag
+      passed to telegram.send for each row:
+
+      BEGIN test snippet
+      # Major + humans>=floor      -> telegram.send(..., urgent=True)
+      # Major + visitors None      -> urgent=True AND "visitor data unavailable" in message
+      # Major + humans<floor       -> urgent=False (downgraded to Notable)
+      # Notable                    -> urgent=False
+      END test snippet
+  - id: P2.T4.S2
+    text: |-
+      GREEN. Rewrite `/surge-check` in `api.py` to run the visitor gate:
+
+      BEGIN code
+      @app.post("/surge-check")
+      def surge_check() -> dict:
+          s = surge.compute()
+          if s["tier"] is None:
+              return {"triggered": False, **s}
+          now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
+          start = now - timedelta(hours=1)
+          visitors = facts.surge_visitor_pageviews(start, now)
+          visitor_floor = int(os.environ.get("SURGE_VISITOR_FLOOR", "10"))
+          if s["tier"] == "Major" and visitors is not None and visitors < visitor_floor:
+              s["tier"] = "Notable"      # edge surge, no human confirmation
+          urgent = s["tier"] == "Major"
+          surge_facts = facts.build_for_surge(start, now)
+          surge_facts.update(s)
+          surge_facts["visitor_pageviews"] = visitors
+          surge_facts["visitor_data_available"] = visitors is not None
+          narrative = ai_adapter.investigate({"alertname": f"BlogTrafficSurge{s['tier']}"}, surge_facts)
+          note = "" if visitors is not None else "  (visitor data unavailable)"
+          telegram.send(
+              f"📈 Blog traffic surge — {s['ratio']:.1f}× baseline ({s['tier']}){note}\n\n{narrative}",
+              urgent=urgent,
+          )
+          return {"triggered": True, **s, "visitors": visitors, "narrative": narrative}
+      END code
+
+      Add `import os` to api.py if not present.
+  - id: P2.T4.S3
+    text: |-
+      Wire the env knobs into the DEPLOYMENT (not the CronJobs — they are
+      curl triggers). Add to `apps/ai-alert-helper/manifests/deployment.yaml`
+      container `env:`:
+
+      BEGIN edit
+          - name: SURGE_ABS_FLOOR
+            value: "50"
+          - name: SURGE_VISITOR_FLOOR
+            value: "10"
+      END edit
+  - id: P2.T4.S4
+    text: |-
+      Full suite green; this is the last code task before deploy:
+      cd apps/ai-alert-helper/src && uv run pytest -q
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T4.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T4.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T4.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/03.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/03.yaml
@@ -1,0 +1,116 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Build, deploy & end-to-end verify + restore detector (deploy on main)
+  tag: manual
+  depends_on:
+  - 1
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Version bump + build/push image
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      Bump the version to 0.1.5 in three places and align the stale CI tag:
+      - `apps/ai-alert-helper/src/ai_alert_helper/api.py`: `version="0.1.5"`
+      - `apps/ai-alert-helper/src/pyproject.toml`: `version = "0.1.5"`
+      - `apps/ai-alert-helper/manifests/deployment.yaml`:
+        `image: ghcr.io/derio-net/ai-alert-helper:0.1.5`
+      - `.github/workflows/build-ai-alert-helper.yml`: bump the two
+        hardcoded `0.1.0` tags to `0.1.5` (so the auto-fire on src/** isn't
+        actively mis-tagged; proper version-parametrization is a deferred
+        follow-up, noted in gotchas).
+  - id: P3.T1.S2
+    text: |-
+      manual-operation — build + push the image (needs local docker +
+      GHCR push creds; the CI workflow tag is unreliable):
+
+      docker build -t ghcr.io/derio-net/ai-alert-helper:0.1.5 apps/ai-alert-helper/src/
+      docker push  ghcr.io/derio-net/ai-alert-helper:0.1.5
+- number: 2
+  title: Restore the detector + deploy to main
+  steps:
+  - id: P3.T2.S1
+    text: |-
+      Revert Phase 1's silence — set `suspend: false` (or remove the line)
+      in `apps/ai-alert-helper/manifests/cronjob-surge-check.yaml`. The
+      fixed detector is about to go live, so it should run again.
+  - id: P3.T2.S2
+    text: |-
+      Commit + merge ALL Phase 2 + Phase 3 changes to `main`. ArgoCD syncs
+      the new image and un-suspends the CronJob. Verify:
+
+      source .env
+      argocd app wait ai-alert-helper --port-forward --port-forward-namespace argocd --health --timeout 300
+      kubectl -n ai-alert-helper-system get deploy ai-alert-helper -o jsonpath='{..image}{"\n"}'   # expect 0.1.5
+      kubectl -n ai-alert-helper-system get cronjob surge-check -o jsonpath='{.spec.suspend}{"\n"}' # expect false/empty
+- number: 3
+  title: End-to-end verification (not Deployed until observed)
+  steps:
+  - id: P3.T3.S1
+    text: |-
+      Live exclusion gate — run the exact edge_filter negation query and
+      assert HTTP 200 + probe excluded:
+
+      source .env
+      VL=http://192.168.55.225:9428
+      curl -s -o /dev/null -w "%{http_code}\n" "$VL/select/logsql/stats_query" --data-urlencode \
+        'query=_time:1h kubernetes.host:hop-1 AND _msg:"handled request" AND request.host:"blog.derio.net" AND -`request.headers.User-Agent`:"Frank-Blackbox-Probe" | stats count() as c'
+      # expect 200, and the count is the small non-probe remainder
+  - id: P3.T3.S2
+    text: |-
+      Trigger the detector once and confirm the probe no longer fires an
+      URGENT (probe-free current < ABS_FLOOR → tier None):
+
+      source .env
+      kubectl -n ai-alert-helper-system delete job surge-verify --ignore-not-found
+      kubectl -n ai-alert-helper-system create job surge-verify --from=cronjob/surge-check
+      kubectl -n ai-alert-helper-system wait --for=condition=complete job/surge-verify --timeout=60s
+      kubectl -n ai-alert-helper-system logs job/surge-verify
+      # expect curl to print {"triggered": false, ... "current": <small>, "tier": null}
+  - id: P3.T3.S3
+    text: |-
+      OPTIONAL live GC-gate test (the unit matrix already covers the logic;
+      this exercises it against the live service). Use the documented
+      suspend-selfHeal → patch → observe → restore pattern (frank-argocd.md)
+      to temporarily set SURGE_ABS_FLOOR=1 on the live Deployment, trigger
+      one surge-check, and confirm a Major-with-no-humans is DOWNGRADED to a
+      non-urgent Notable (urgent flag false). Restore selfHeal + sync to
+      git HEAD afterwards. Skip if not exercising live; note it will be
+      observed on the next genuine surge.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/04.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/04.yaml
@@ -1,0 +1,74 @@
+schema_version: 2
+phase:
+  number: 4
+  title: Docs & close-out
+  tag: agentic
+  depends_on:
+  - 3
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Deviation note + gotchas
+  steps:
+  - id: P4.T1.S1
+    text: |-
+      Add a Deviation entry to the parent plan
+      `docs/superpowers/plans/2026-05-23--obs--hop-blog-edge-monitoring/_prose.md`
+      (Deployment Deviations section): root cause (probe-as-traffic +
+      baseline-of-1 + missing GC gate) and the fix summary, linking this
+      plan.
+  - id: P4.T1.S2
+    text: |-
+      Gotcha one-liners in `agents/rules/frank-gotchas.md` under the
+      Observability digest section, full prose in
+      `docs/runbooks/frank-gotchas/obs-digest.md`:
+      - Surge baseline is hour-of-day median forced to 1 on quiet hours →
+        ratio is an artifact unless gated by an absolute floor.
+      - Frank's own blackbox probe hits the public blog edge (~360/hr via
+        the home egress IP) and counted as blog traffic until tagged
+        `Frank-Blackbox-Probe` and excluded; GoatCounter (JS beacon) never
+        saw it — that divergence is the bot-vs-human signal.
+      - surge URGENT now requires a GoatCounter visitor cross-check
+        (fail-open); the cross-check token needs the GoatCounter `stats`
+        permission (manual-op obs-goatcounter-token-stats-permission).
+      - build-ai-alert-helper.yml hardcodes the image tag (stale vs the
+        deployed version) and auto-fires on src/** — builds are manual
+        docker build+push; parametrizing the tag is a deferred follow-up.
+- number: 2
+  title: Operating post + status + runbook
+  steps:
+  - id: P4.T2.S1
+    text: |-
+      Add a "Tuning the surge detector" subsection to the obs/edge
+      operating post (locate under `blog/content/docs/operating/` for the
+      hop-blog-edge-monitoring layer): document SURGE_ABS_FLOOR (default 50,
+      >= fires) and SURGE_VISITOR_FLOOR (default 10), how to read a surge
+      alert (Major = humans confirmed/urgent; Notable = edge surge without
+      visitor confirmation), and this incident as a worked example.
+  - id: P4.T2.S2
+    text: |-
+      Run /sync-runbook (the P3.T1.S2 docker build is a manual-operation).
+      Set the spec `Status:` to Deployed and this plan's status. Run
+      scripts/validate-plans.sh.
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/_meta.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-05-25--obs--surge-detector-fix
+spec: docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-05-25'

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/_prose.md
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/_prose.md
@@ -1,0 +1,85 @@
+# Plan: Blog Traffic Surge Detector — False-Positive Fix
+
+**Spec:** `docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md`
+**Layer:** `obs` (fix/extension of `2026-05-23--obs--hop-blog-edge-monitoring`)
+
+## Why
+
+The `ai-alert-helper` `surge-check` CronJob fired an **URGENT** "Blog traffic
+surge" alert while GoatCounter showed no human activity. Both signals were
+correct — they measure different things. The 370 edge requests were 97% Frank's
+*own* blackbox uptime probe (`Blackbox Exporter/0.25.0`, ~360/hr to
+`https://blog.derio.net`), plus a couple of internet scanners. GoatCounter
+counts only JS-beacon pageviews from real browsers, so it correctly showed
+nothing. The URGENT was a false positive from three compounding issues:
+
+1. **Baseline forced to `1`** (`surge.py:35` `... or 1`) — the 7-day hour-of-day
+   median was 0, so `ratio = 370/1 = 370×`.
+2. **Frank's own probe counted as blog traffic** — no exclusion in
+   `surge._hour_count` / `build_for_digest` / `build_for_surge`.
+3. **The documented GoatCounter visitor-side cross-check was never implemented**
+   — `/surge-check` sends `urgent=(tier=="Major")` with no human confirmation.
+
+The CronJob re-fires every 15 min, so it is a sustained false-page storm until
+the trailing baseline absorbs the probe (~3 days).
+
+## What this plan does
+
+- **Tags Frank's probes** with a self-controlled User-Agent
+  (`Frank-Blackbox-Probe/...`) and excludes *that identity* (not the vendor's
+  default UA) from the edge definition — see spec for why identity-based beats
+  signature-based.
+- **Centralizes** the edge query in one `facts.edge_filter()` so the surge
+  alert, the surge narrative, and the daily digest can never disagree about
+  what "blog traffic" is, canonicalized on `kubernetes.host:hop-1`.
+- **Adds an absolute floor** (`SURGE_ABS_FLOOR`, default 50) so a baseline of 1
+  cannot manufacture a high ratio from a trickle.
+- **Implements the missing GoatCounter cross-check** in `/surge-check`:
+  URGENT requires real visitors (`SURGE_VISITOR_FLOOR`, default 10), fails
+  **open** (still pages, annotated) when GoatCounter is unreachable, and
+  **downgrades** a Major to non-urgent Notable when GoatCounter confirms no
+  humans.
+
+## Execution constraints (important)
+
+- **ArgoCD only watches `main`.** Every cluster-affecting change (cron suspend,
+  blackbox UA, image deploy, un-suspend) takes effect *only after merge to
+  `main`*. Phases 1 and 3 are therefore operator/manual: they include the
+  `commit → PR → merge to main → ArgoCD sync → live verify` loop and require
+  GHCR push creds for the manual `docker build`. Phase 2 is pure
+  code/tests (CI-verifiable, no cluster effect).
+- **Deploy ordering is structural.** Phase 3 `depends_on: [1]` so the exclusion
+  filter never ships before the probe's new UA is live and verified — flipping
+  it early would silently re-introduce the false page (the `Frank-Blackbox-Probe`
+  token excludes 0 rows while the probe still sends the stock UA).
+- **Silence during the work window.** Phase 1 sets the surge-check CronJob
+  `suspend: true` (declarative); Phase 3 reverts it to `false` after the fix is
+  verified live.
+
+## Build / deploy recipe (proven, from the parent plan + digest-rework)
+
+The image is built **manually** (the CI workflow's hardcoded `0.1.0` tag is
+stale — aligned in Phase 3, proper parametrization deferred):
+
+```bash
+docker build -t ghcr.io/derio-net/ai-alert-helper:0.1.5 apps/ai-alert-helper/src/
+docker push  ghcr.io/derio-net/ai-alert-helper:0.1.5
+# bump api.py + pyproject.toml + deployment.yaml to 0.1.5; merge to main; ArgoCD syncs
+```
+
+The GoatCounter API token already carries the `stats` permission (manual-op
+`obs-goatcounter-token-stats-permission`, done), so `/api/v0/stats/total`
+returns 200 for the cross-check — no new secret needed.
+
+## Phases
+
+1. **Cluster prep — silence + probe identity** (manual): suspend surge-check;
+   tag probes with `Frank-Blackbox-Probe`; merge; verify live UA.
+2. **ai-alert-helper logic** (agentic, TDD): `edge_filter` + migrate 3 callers;
+   absolute floor; GoatCounter reachability + visitor helper; `/surge-check`
+   decision matrix + env wiring.
+3. **Build, deploy & end-to-end verify + restore detector** (manual): bump +
+   build/push 0.1.5; un-suspend; merge; live exclusion-query gate; confirm the
+   probe no longer triggers; exercise the GC gate.
+4. **Docs & close-out** (agentic): deviation note, gotchas, operating-post
+   tuning section, runbook sync, status.

--- a/docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
+++ b/docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
@@ -1,0 +1,254 @@
+# Design: Blog Traffic Surge Detector — False-Positive Fix
+
+**Date:** 2026-05-25
+**Layer:** `obs` (fix/extension of the edge-observability layer — `ai-alert-helper`)
+**Status:** Draft
+**App(s):** `apps/ai-alert-helper`, `apps/blackbox-exporter`
+
+## Problem
+
+On 2026-05-25 the `ai-alert-helper` `surge-check` CronJob fired an **URGENT**
+"Blog traffic surge" Telegram alert. GoatCounter (`counter.cluster.derio.net`)
+showed no human activity. Investigation (read-only) established that *both
+signals were correct* — they measure different things — and that the URGENT
+was a false positive produced by two compounding bugs plus a missing safeguard.
+
+### Evidence
+
+The firing `surge-check` pod computed `current: 370, baseline: 1,
+ratio: 370.0, tier: Major`. Breaking the 16:00–17:00 UTC edge window down by
+source (VictoriaLogs, Caddy access logs, `request.host:"blog.derio.net"`):
+
+| Requests | Source | Notes |
+|---|---|---|
+| 360 | `77.12.102.149` · `Blackbox Exporter/0.25.0` | Frank's **own** uptime probe (`GET /` → 301 → `/frank/`, ~every 10s) |
+| 8 | `CensysInspect/1.1` | Internet-wide scanner (background noise) |
+| 2 | `TelegramBot` | Link-preview fetch |
+
+All requests were `GET`; there was no human browser traffic. GoatCounter only
+counts JS-beacon pageviews from real browsers, so it correctly showed nothing.
+
+The hour-of-day baseline samples for 16:00–17:00 over the prior 7 days were
+`[373, 0, 0, 0, 0, 0, 0]` (the probe only began reaching the blog edge ~05-24).
+
+### Root causes
+
+1. **Baseline forced to `1`.** `surge.py:35` does
+   `baseline = int(median(historical)) or 1`. The median of the samples above
+   is `0`, forced to `1` to avoid divide-by-zero, so `ratio = 370 / 1 = 370×`.
+   On a low-traffic blog whose hour-of-day median is 0, the "10× baseline" rule
+   degenerates into "≥10 absolute requests in an hour".
+
+2. **Frank's own uptime probe counts as blog traffic.** Neither
+   `surge._hour_count` nor `facts.build_for_digest` excludes the Blackbox probe,
+   so a `360 req/hour` internal monitoring probe (`apps/blackbox-exporter`,
+   target `https://blog.derio.net`) reads as external blog traffic.
+
+3. **The documented GoatCounter cross-check was never implemented.**
+   `surge.py`'s docstring and `test_compute_returns_major_when_10x_baseline`
+   ("*caller will then validate visitor side*") both state that a Major tier
+   must be confirmed against GoatCounter before sending an URGENT message.
+   `api.py:/surge-check` sends `urgent=(s["tier"] == "Major")` and never calls
+   GoatCounter; `facts.build_for_surge` does not query it. The gate that was
+   meant to suppress exactly this "bots spiked the edge, no humans came" case
+   does not exist in the code path.
+
+Because the CronJob runs every 15 minutes against the same baseline, the URGENT
+re-fires ~4×/hour until the trailing-7-day hour-of-day median absorbs the probe
+(~3 days) — i.e. a sustained false-page storm.
+
+## Goals
+
+- Frank must not page on its own uptime probe.
+- An URGENT page must require visitor-side confirmation (real humans), with a
+  safe behaviour when GoatCounter is unreachable.
+- A baseline forced to `1` must not be able to manufacture a high ratio from a
+  trickle of requests.
+- "Blog traffic" must mean the same thing in the surge alert and the daily
+  digest.
+
+## Non-goals (YAGNI)
+
+- **No alert de-duplication / cooldown layer.** The 15-min repeat storm is
+  eliminated at the source (probe excluded → `current` near 0 → no tier), so a
+  cooldown is unnecessary now. Noted as a possible future enhancement only.
+- **No new app and no metrics-based rearchitecture.** The fix stays in the
+  existing `obs` apps and the working LogsQL path. (Rejected alternatives:
+  dropping probe logs at ingestion — destroys logs we want and mutates a shared
+  pipeline; re-basing surge detection on VictoriaMetrics — a rearchitecture when
+  the real human signal is GoatCounter anyway.)
+- **No spoof-resistant/secret probe identity.** The custom UA is for
+  disambiguation, not as a security control.
+
+## Design
+
+### Component 1 — Probe identity (`apps/blackbox-exporter`)
+
+Tag Frank's own uptime probes with a self-controlled User-Agent so the edge
+definition can exclude *Frank's probe identity* rather than the vendor's
+default UA (which would wrongly whitelist any third-party blackbox_exporter or
+spoofer). Confirmed supported: blackbox_exporter's `http` module accepts a
+`headers:` map and `User-Agent` is overridable (verified against upstream
+`CONFIGURATION.md`; 0.25.0 supports it).
+
+Add to the **shared** `http_2xx` (and `http_2xx_no_redirect`) module in
+`apps/blackbox-exporter/manifests/configmap.yaml`:
+
+```yaml
+http:
+  headers:
+    User-Agent: "Frank-Blackbox-Probe/1.0 (+https://blog.derio.net)"
+```
+
+All Frank uptime probes (blog, paperclip, grafana, n8n, health-bridge) then
+carry one consistent Frank identity. They are all internal/own services, so
+nothing downstream depends on the previous UA. A dedicated blog-only module was
+considered and rejected (more config, no benefit).
+
+### Component 2 — Centralized probe-aware edge filter (`facts.py`)
+
+The edge query string is currently built in two places with no probe
+exclusion. Introduce one helper as the single source of truth so the surge
+alert and the digest can never silently disagree about what "blog traffic" is:
+
+```python
+# facts.py
+PROBE_UA_TOKEN = "Frank-Blackbox-Probe"   # MUST match the UA in
+                                          # apps/blackbox-exporter/manifests/configmap.yaml
+
+def edge_filter(host: str | None = None, *, exclude_probes: bool = True) -> str:
+    f = 'kubernetes.host:hop-1 AND _msg:"handled request"'
+    if host:
+        f += f' AND request.host:"{host}"'
+    if exclude_probes:
+        f += f' AND -request.headers.User-Agent:"{PROBE_UA_TOKEN}"'
+    return f
+```
+
+`surge._hour_count` and `facts.build_for_digest` both call `edge_filter(...)`.
+The exact LogsQL negation syntax for the hyphenated field name
+(`-request.headers.User-Agent:"..."` vs. backtick-quoting) is **pinned by a
+test** before we rely on it — that field returned a 422 during investigation
+when mis-quoted.
+
+### Component 3 — Absolute floor (`surge.py`)
+
+Add a floor so a baseline of `1` cannot produce a high ratio from a trickle.
+Applies to all tiers (a sub-floor "5× of 5 requests" Notable is also noise):
+
+```python
+ABS_FLOOR = int(os.environ.get("SURGE_ABS_FLOOR", "50"))
+...
+if current < ABS_FLOOR:
+    tier = None
+elif ratio >= 10:
+    tier = "Major"
+elif ratio >= 3:
+    tier = "Notable"
+```
+
+Default **50 req/hour**: organic surges (HN/Reddit) run into the hundreds/hour,
+so 50 sits well below a real event while killing the trickle-ratio artifact.
+The floor is computed on probe-free traffic (Component 2), so Frank's ~360/hr
+probe no longer contributes to it.
+
+### Component 4 — GoatCounter cross-check (`api.py` `/surge-check`, `facts.py`)
+
+Implement the missing visitor-side gate.
+
+**4a. Distinguish unreachable from genuinely-zero.** `_goatcounter` currently
+returns `{}` on both error and empty result. Add a reachability signal (return
+`None` on transport/HTTP error; a dict — possibly empty — on success) so
+fail-open can be implemented correctly. Add a `facts.surge_visitor_pageviews(
+window_start, window_end) -> int | None` helper returning human pageviews for
+the surge window (`None` = GoatCounter unreachable).
+
+**4b. Final-severity decision in `/surge-check`** after `surge.compute()`
+returns a non-`None` tier:
+
+| Edge tier | GoatCounter result | Action |
+|---|---|---|
+| Major | pageviews ≥ `VISITOR_FLOOR` (dflt 10) | **URGENT** — confirmed real surge |
+| Major | unreachable (`None`) | **URGENT**, narrative annotated *"visitor data unavailable"* (fail-open) |
+| Major | pageviews < `VISITOR_FLOOR` | **downgrade → Notable** (non-urgent): "edge surge, no visitor confirmation — likely automated" |
+| Notable | (any) | non-urgent message as today |
+
+`VISITOR_FLOOR` default 10, env `SURGE_VISITOR_FLOOR`. The surge fact sheet
+(`build_for_surge`) is extended to include the visitor pageview count (and its
+reachability state) so the AI narrative reflects the real situation instead of
+guessing. Today's incident outcome under this design: probe excluded →
+`current` near 0 → below `ABS_FLOOR` → **no message at all**.
+
+**Open item to verify in implementation:** whether GoatCounter's
+`/api/v0/stats/total` accepts hour-granularity timestamps (the existing digest
+code uses day granularity only). If hour granularity is unsupported, fall back
+to "today's running pageviews" as the human signal (coarser but functional);
+the plan records which path was taken.
+
+### Digest consistency
+
+`facts.build_for_digest` switches its edge queries to `edge_filter(...)` so the
+digest's `edge_requests_total` and per-vhost breakdown exclude Frank's probe,
+matching the surge definition. (The probe is ~8.6k req/day, so the digest's
+edge totals currently overcount substantially.)
+
+## Configuration (env, with defaults)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `SURGE_ABS_FLOOR` | `50` | Minimum `current` req/hour for any tier |
+| `SURGE_VISITOR_FLOOR` | `10` | Minimum GoatCounter pageviews in window to confirm a Major as a real (URGENT) surge |
+
+Both set on the `surge-check` CronJob (and where relevant the deployment) in
+`apps/ai-alert-helper/manifests/`.
+
+## Testing
+
+- `edge_filter`: probe exclusion present/absent, host scoping, and the exact
+  LogsQL negation string (regression guard for the 422).
+- `PROBE_UA_TOKEN`: a test pinning the exact token string the filter expects
+  (drift between the two systems fails CI).
+- `surge.compute`: floor suppresses tier when `current < ABS_FLOOR`; existing
+  ratio/tier tests updated for the floor.
+- `/surge-check` decision matrix: each row of the Component-4b table
+  (mock GoatCounter ≥floor, <floor, and unreachable/`None`).
+- `_goatcounter` / `surge_visitor_pageviews`: error → `None`, success-empty →
+  `0`, success → integer.
+
+## Deployment & verification (ordering matters)
+
+1. Deploy the blackbox UA change (`apps/blackbox-exporter`). ArgoCD sync +
+   blackbox config reload.
+2. **Verify in live Caddy logs** that probe requests to `blog.derio.net` now
+   carry `Frank-Blackbox-Probe` (VictoriaLogs query). The exact-match exclusion
+   filter is only trustworthy once this is confirmed — flipping the filter
+   before the probe's live UA changes would silently re-introduce the false
+   page.
+3. Deploy the `ai-alert-helper` image + manifest changes.
+4. **End-to-end verification:** trigger `/surge-check` (or wait for the
+   CronJob) and confirm `current` for the blog window is now probe-free and
+   below `ABS_FLOOR` → no URGENT. Confirm a forced Major path (e.g. temporary
+   low `SURGE_ABS_FLOOR` or synthetic load) exercises the GoatCounter gate.
+   A layer is not "Deployed" until the workflow is observed end-to-end.
+
+## Layer-fix follow-ups (per repo workflow)
+
+- **Plan deviation note** in the obs edge-observability plan (locate exact file
+  during planning) — root cause + fix summary.
+- **Operating post** (`obs` / inference-adjacent operating series): add a
+  "tuning the surge detector" section (env knobs, how to read a surge alert,
+  this incident as a worked example). Retroactive update, not a new post.
+- **Gotchas:** one-liners in `agents/rules/frank-gotchas.md` (the
+  baseline-of-1 ratio artifact; Frank's own probe counting as blog traffic;
+  surge URGENT requires the GoatCounter gate) + full prose in
+  `docs/runbooks/frank-gotchas/obs-digest.md`.
+
+## Risks
+
+- **Cross-system UA coupling** (blackbox config ↔ `PROBE_UA_TOKEN`): guarded by
+  a pinning test, cross-referencing comments in both files, and the live-log
+  verification step.
+- **Floor too high** masks a genuinely small surge: mitigated by env-tunability
+  and the GoatCounter gate (a real surge with humans still pages once it clears
+  the floor).
+- **GoatCounter API granularity** (open item above): fallback defined.

--- a/docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
+++ b/docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
@@ -69,9 +69,14 @@ re-fires ~4×/hour until the trailing-7-day hour-of-day median absorbs the probe
 
 ## Non-goals (YAGNI)
 
-- **No alert de-duplication / cooldown layer.** The 15-min repeat storm is
-  eliminated at the source (probe excluded → `current` near 0 → no tier), so a
-  cooldown is unnecessary now. Noted as a possible future enhancement only.
+- **No alert de-duplication / cooldown layer.** The `surge-check` endpoint is
+  stateless and re-evaluates every 15 minutes, so *any* sustained condition
+  re-notifies while it persists — a confirmed human surge (URGENT) and a
+  downgraded no-visitor bot surge (Notable) alike. This fix eliminates the
+  **specific** storm that was reported (Frank's own probe → `current` near 0 →
+  no tier), but it does not add general repeat-suppression. Genuine sustained
+  surges re-notifying every 15 min is accepted for now; a cooldown/state layer
+  is deferred and tracked as a follow-up (see Risks).
 - **No new app and no metrics-based rearchitecture.** The fix stays in the
   existing `obs` apps and the working LogsQL path. (Rejected alternatives:
   dropping probe logs at ingestion — destroys logs we want and mutates a shared
@@ -107,29 +112,50 @@ considered and rejected (more config, no benefit).
 
 ### Component 2 — Centralized probe-aware edge filter (`facts.py`)
 
-The edge query string is currently built in two places with no probe
-exclusion. Introduce one helper as the single source of truth so the surge
-alert and the digest can never silently disagree about what "blog traffic" is:
+The edge query is currently built in **three** places with no probe exclusion
+and *two different node/namespace selectors* — `surge._hour_count`
+(`surge.py:18-21`, scoped `kubernetes.namespace_name:caddy-system`),
+`facts.build_for_digest` (`facts.py:155`, scoped `kubernetes.host:hop-1`), and
+`facts.build_for_surge` (`facts.py:180-181`, scoped
+`kubernetes.namespace_name:caddy-system`, **no host filter at all**).
+Introduce one helper as the single source of truth so the surge alert, the
+surge narrative, and the digest can never silently disagree about what "blog
+traffic" is, and canonicalize on **one** selector: `kubernetes.host:hop-1`
+(the documented convention in `docs/runbooks/frank-gotchas/networking.md`).
 
 ```python
 # facts.py
-PROBE_UA_TOKEN = "Frank-Blackbox-Probe"   # MUST match the UA in
+PROBE_UA_TOKEN = "Frank-Blackbox-Probe"   # MUST match the User-Agent set in
                                           # apps/blackbox-exporter/manifests/configmap.yaml
+                                          # (cross-system coupling — see Risks)
 
 def edge_filter(host: str | None = None, *, exclude_probes: bool = True) -> str:
+    # Backtick-quote the dotted/hyphenated field names (verified live against
+    # VictoriaLogs; phrase-matches the array-valued UA field correctly).
     f = 'kubernetes.host:hop-1 AND _msg:"handled request"'
     if host:
-        f += f' AND request.host:"{host}"'
+        f += f' AND `request.host`:"{host}"'
     if exclude_probes:
-        f += f' AND -request.headers.User-Agent:"{PROBE_UA_TOKEN}"'
+        f += f' AND -`request.headers.User-Agent`:"{PROBE_UA_TOKEN}"'
     return f
 ```
 
-`surge._hour_count` and `facts.build_for_digest` both call `edge_filter(...)`.
-The exact LogsQL negation syntax for the hyphenated field name
-(`-request.headers.User-Agent:"..."` vs. backtick-quoting) is **pinned by a
-test** before we rely on it — that field returned a 422 during investigation
-when mis-quoted.
+**All three** call sites are migrated to `edge_filter(...)`:
+`surge._hour_count(host="blog.derio.net")`,
+`build_for_surge` (`total_requests` → `edge_filter(host="blog.derio.net")`),
+and `build_for_digest` (grouped/total edge queries → `edge_filter()` with no
+host, i.e. all vhosts, probe-excluded). This also fixes `build_for_surge`
+currently feeding the AI narrative an unfiltered, probe-polluted count.
+
+**LogsQL syntax — verified live, not hand-waved.** Against VictoriaLogs for the
+incident window (total 370, probe 360): every negation form
+(`-request.headers.User-Agent:"..."`, backtick-quoted, and `NOT`) correctly
+returned 10. The 422 seen during investigation was a missing `| stats` pipe,
+not the field name. The future token `Frank-Blackbox-Probe` correctly excludes
+nothing until the probe's live UA changes (confirming the deployment ordering
+below). A `respx`-mocked unit test can only pin the *generated string*, so the
+real query is also exercised by a **live** LogsQL check in the deployment
+verification (not a substitute — an addition).
 
 ### Component 3 — Absolute floor (`surge.py`)
 
@@ -150,18 +176,28 @@ elif ratio >= 3:
 Default **50 req/hour**: organic surges (HN/Reddit) run into the hundreds/hour,
 so 50 sits well below a real event while killing the trickle-ratio artifact.
 The floor is computed on probe-free traffic (Component 2), so Frank's ~360/hr
-probe no longer contributes to it.
+probe no longer contributes to it. **Boundary:** the comparison is
+`current < ABS_FLOOR → tier None`, i.e. exactly `ABS_FLOOR` requests *does*
+qualify (≥50 fires). The operating-post tuning section documents this.
 
 ### Component 4 — GoatCounter cross-check (`api.py` `/surge-check`, `facts.py`)
 
 Implement the missing visitor-side gate.
 
-**4a. Distinguish unreachable from genuinely-zero.** `_goatcounter` currently
-returns `{}` on both error and empty result. Add a reachability signal (return
-`None` on transport/HTTP error; a dict — possibly empty — on success) so
-fail-open can be implemented correctly. Add a `facts.surge_visitor_pageviews(
-window_start, window_end) -> int | None` helper returning human pageviews for
-the surge window (`None` = GoatCounter unreachable).
+**4a. Distinguish unreachable from genuinely-zero — WITHOUT breaking the
+digest.** `_goatcounter` currently returns `{}` on both error and empty result,
+and its only callers (`_digest_blog_facts`, `facts.py:91-96`) immediately
+`.get(...)` the result. Changing `_goatcounter` to return `None` on error would
+throw `AttributeError` and **crash the daily `/digest`** (unwrapped at
+`api.py:29`). So the contract change is additive, not in-place:
+
+- Introduce `_goatcounter_raw(path, params) -> dict | None` — `None` on
+  transport/HTTP error, dict (possibly empty) on success.
+- `_goatcounter` becomes `return _goatcounter_raw(...) or {}` — **digest
+  behaviour and all existing call sites are unchanged.**
+- New `facts.surge_visitor_pageviews(window_start, window_end) -> int | None`
+  uses `_goatcounter_raw` against `/api/v0/stats/total`; returns the human
+  pageview count, or `None` when GoatCounter is unreachable.
 
 **4b. Final-severity decision in `/surge-check`** after `surge.compute()`
 returns a non-`None` tier:
@@ -179,11 +215,13 @@ reachability state) so the AI narrative reflects the real situation instead of
 guessing. Today's incident outcome under this design: probe excluded →
 `current` near 0 → below `ABS_FLOOR` → **no message at all**.
 
-**Open item to verify in implementation:** whether GoatCounter's
-`/api/v0/stats/total` accepts hour-granularity timestamps (the existing digest
-code uses day granularity only). If hour granularity is unsupported, fall back
-to "today's running pageviews" as the human signal (coarser but functional);
-the plan records which path was taken.
+**GoatCounter window granularity — resolved.** GoatCounter's OpenAPI spec
+(`/api.json`) defines `start`/`end` on the stats endpoints as `format:
+date-time` ("*should be rounded to the hour*"), so the cross-check passes the
+**exact 1-hour surge window** as RFC3339 timestamps — no day-granularity
+fallback is needed (the earlier concern about midnight under-count / late-day
+over-confirm does not arise). `_digest_blog_facts` keeps its existing whole-day
+range for the daily digest; only the surge path uses the hour window.
 
 ### Digest consistency
 
@@ -199,31 +237,53 @@ edge totals currently overcount substantially.)
 | `SURGE_ABS_FLOOR` | `50` | Minimum `current` req/hour for any tier |
 | `SURGE_VISITOR_FLOOR` | `10` | Minimum GoatCounter pageviews in window to confirm a Major as a real (URGENT) surge |
 
-Both set on the `surge-check` CronJob (and where relevant the deployment) in
-`apps/ai-alert-helper/manifests/`.
+Both set in the **Deployment**'s `env:` block
+(`apps/ai-alert-helper/manifests/deployment.yaml`) — **not** the CronJobs. The
+`surge-check` and `digest` CronJobs are pure `curlimages/curl` triggers that
+`POST` to the Service; the Python (`surge.compute()`, `/surge-check`) runs only
+in the Deployment pod, so that is the only place `os.environ.get(...)` reads.
+Env on the CronJob would be silently ignored. Both have safe code defaults
+(50 / 10) so unset is non-breaking.
 
 ## Testing
 
 - `edge_filter`: probe exclusion present/absent, host scoping, and the exact
-  LogsQL negation string (regression guard for the 422).
-- `PROBE_UA_TOKEN`: a test pinning the exact token string the filter expects
-  (drift between the two systems fails CI).
+  backtick-quoted negation string the helper generates (string-shape guard).
+  Note: this is a *generated-string* assertion only — it cannot validate the
+  query against VictoriaLogs; that is covered by the live check in Deployment.
+- `PROBE_UA_TOKEN`: a test pinning the exact token string the filter expects.
+  This pins only the **Python side**; the blackbox configmap must carry an
+  inline comment cross-referencing `facts.PROBE_UA_TOKEN` (a configmap edit
+  can still silently desync — the only runtime signal would be a re-fired false
+  page, so the cross-ref comment is the guard).
 - `surge.compute`: floor suppresses tier when `current < ABS_FLOOR`; existing
-  ratio/tier tests updated for the floor.
+  ratio/tier tests updated for the floor. **Split** the current
+  `test_compute_handles_empty_baseline_without_divide_by_zero`
+  (`test_surge.py:74-85`) into two tests — one for crash-safety on an empty
+  baseline, one for the floor boundary (49 → None, 50 → fires) — so the two
+  concerns aren't entangled at the boundary.
 - `/surge-check` decision matrix: each row of the Component-4b table
   (mock GoatCounter ≥floor, <floor, and unreachable/`None`).
-- `_goatcounter` / `surge_visitor_pageviews`: error → `None`, success-empty →
-  `0`, success → integer.
+- `_goatcounter_raw` / `surge_visitor_pageviews`: error → `None`,
+  success-empty → `0`, success → integer.
+- **Digest regression (ties to C1):** `build_for_digest` must survive an
+  unreachable GoatCounter — assert it returns a sheet (probe-excluded edge
+  facts + zeroed blog facts) and does **not** raise, with `_goatcounter_raw`
+  mocked to `None`.
 
 ## Deployment & verification (ordering matters)
 
 1. Deploy the blackbox UA change (`apps/blackbox-exporter`). ArgoCD sync +
    blackbox config reload.
-2. **Verify in live Caddy logs** that probe requests to `blog.derio.net` now
-   carry `Frank-Blackbox-Probe` (VictoriaLogs query). The exact-match exclusion
-   filter is only trustworthy once this is confirmed — flipping the filter
+2. **Verify in live Caddy logs** (VictoriaLogs) that probe requests to
+   `blog.derio.net` now carry `Frank-Blackbox-Probe`, then run the **exact
+   `edge_filter` negation query live** and assert it (a) returns HTTP 200 (not
+   422) and (b) excludes the probe count (blog total drops by ~probe volume).
+   This is the integration check the mocked unit test cannot perform. The
+   exclusion filter is only trustworthy once both pass — flipping the filter
    before the probe's live UA changes would silently re-introduce the false
-   page.
+   page (empirically confirmed: the `Frank-Blackbox-Probe` token excludes 0
+   rows while the probe still sends the stock `Blackbox Exporter` UA).
 3. Deploy the `ai-alert-helper` image + manifest changes.
 4. **End-to-end verification:** trigger `/surge-check` (or wait for the
    CronJob) and confirm `current` for the blog window is now probe-free and
@@ -246,9 +306,16 @@ Both set on the `surge-check` CronJob (and where relevant the deployment) in
 ## Risks
 
 - **Cross-system UA coupling** (blackbox config ↔ `PROBE_UA_TOKEN`): guarded by
-  a pinning test, cross-referencing comments in both files, and the live-log
-  verification step.
+  a Python-side pinning test, a cross-referencing comment in the blackbox
+  configmap, and the live-log + live-query verification step. The remaining
+  exposure is a configmap edit that desyncs without touching `facts.py` — its
+  only runtime signal is a re-fired false page.
 - **Floor too high** masks a genuinely small surge: mitigated by env-tunability
   and the GoatCounter gate (a real surge with humans still pages once it clears
   the floor).
-- **GoatCounter API granularity** (open item above): fallback defined.
+- **Repeat notifications for sustained surges** (deferred follow-up): the
+  stateless 15-min cadence re-notifies for any persistent surge — confirmed
+  human (URGENT) or downgraded bot (Notable). This fix removes the *probe*
+  storm but not this general property; a cooldown/state layer is out of scope
+  (see Non-goals) and should be tracked as a future enhancement if sustained
+  non-probe surges prove noisy in practice.

--- a/docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
+++ b/docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
@@ -5,6 +5,12 @@
 **Status:** Draft
 **App(s):** `apps/ai-alert-helper`, `apps/blackbox-exporter`
 
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-05-25--obs--surge-detector-fix | `derio-net/frank` | `docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/` | — |
+
 ## Problem
 
 On 2026-05-25 the `ai-alert-helper` `surge-check` CronJob fired an **URGENT**


### PR DESCRIPTION
Phase 1 of the **surge-detector false-positive fix** (plan: `docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/`, spec linked there).

## Why
The `surge-check` CronJob fired URGENT "Blog traffic surge" every 15 min while GoatCounter showed nothing. 97% of the "surge" was **Frank's own blackbox uptime probe** (~360/hr to `blog.derio.net`); GoatCounter correctly ignores it (no JS beacon). Full root cause + design in the spec.

## What this PR does (Phase 1 — cluster prep)
- **`surge-check` CronJob `suspend: true`** — stops the false-page storm while the real fix lands. Reverted to `false` in Phase 3 after live verification.
- **blackbox-exporter probes get a self-controlled `User-Agent`** (`Frank-Blackbox-Probe/1.0`) on the shared `http_2xx`/`http_2xx_no_redirect` modules, so the edge-traffic definition (Phase 2) can exclude Frank's *own* probe by identity rather than the vendor's default UA.

Also bundles the design spec + the 4-phase implementation plan (docs only).

## Post-merge verification (I'll run these once merged to main)
1. `kubectl -n ai-alert-helper-system get cronjob surge-check -o jsonpath='{.spec.suspend}'` -> `true`
2. `kubectl -n monitoring rollout restart deploy/blackbox-exporter` (config isn't hot-reloaded)
3. VictoriaLogs: confirm probe requests to `blog.derio.net` now carry `Frank-Blackbox-Probe` and the exclusion filter drops them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)