### PR TITLE
fix(obs): surge-detector P2 — edge_filter, abs floor, GoatCounter gate

### DIFF
--- a/apps/ai-alert-helper/manifests/deployment.yaml
+++ b/apps/ai-alert-helper/manifests/deployment.yaml
@@ -45,6 +45,11 @@ spec:
               value: "qwen-think-14b"
             - name: LLM_MODEL_FALLBACK
               value: "claude-haiku-4-5"
+            # Surge detector tuning (read in surge.compute / /surge-check).
+            - name: SURGE_ABS_FLOOR        # min req/hr for any tier (kills baseline-of-1 artifacts)
+              value: "50"
+            - name: SURGE_VISITOR_FLOOR    # min GoatCounter pageviews to confirm a Major as URGENT
+              value: "10"
           envFrom:
             - secretRef:
                 name: ai-alert-helper-secrets

--- a/apps/ai-alert-helper/src/ai_alert_helper/api.py
+++ b/apps/ai-alert-helper/src/ai_alert_helper/api.py
@@ -6,6 +6,7 @@
 - POST /surge-check   — 15-min CronJob computes baseline + maybe sends
 """
 from __future__ import annotations
+import os
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -54,16 +55,28 @@ def surge_check() -> dict:
     s = surge.compute()
     if s["tier"] is None:
         return {"triggered": False, **s}
-    # Build the surge fact sheet and call investigate
+    # Visitor-side cross-check: an URGENT (Major) page requires real human
+    # pageviews (GoatCounter). Fail OPEN — if GoatCounter is unreachable we
+    # still page, annotated, rather than suppress a possibly-real surge.
     now = datetime.now(timezone.utc).replace(minute=0, second=0, microsecond=0)
-    surge_facts = facts.build_for_surge(now - timedelta(hours=1), now)
+    start = now - timedelta(hours=1)
+    visitors = facts.surge_visitor_pageviews(start, now)
+    visitor_floor = int(os.environ.get("SURGE_VISITOR_FLOOR", "10"))
+    if s["tier"] == "Major" and visitors is not None and visitors < visitor_floor:
+        s["tier"] = "Notable"  # edge surge with no visitor confirmation — likely automated
+    urgent = s["tier"] == "Major"
+
+    surge_facts = facts.build_for_surge(start, now)
     surge_facts.update(s)
+    surge_facts["visitor_pageviews"] = visitors
+    surge_facts["visitor_data_available"] = visitors is not None
     narrative = ai_adapter.investigate(
         {"alertname": f"BlogTrafficSurge{s['tier']}"},
         surge_facts,
     )
+    note = "" if visitors is not None else "  (visitor data unavailable)"
     telegram.send(
-        f"📈 Blog traffic surge — {s['ratio']:.1f}× baseline ({s['tier']})\n\n{narrative}",
-        urgent=(s["tier"] == "Major"),
+        f"📈 Blog traffic surge — {s['ratio']:.1f}× baseline ({s['tier']}){note}\n\n{narrative}",
+        urgent=urgent,
     )
-    return {"triggered": True, **s, "narrative": narrative}
+    return {"triggered": True, **s, "visitors": visitors, "narrative": narrative}

--- a/apps/ai-alert-helper/src/ai_alert_helper/facts.py
+++ b/apps/ai-alert-helper/src/ai_alert_helper/facts.py
@@ -22,6 +22,25 @@ GOATCOUNTER_URL = os.environ.get(
 )
 GOATCOUNTER_TOKEN = os.environ.get("OBS_GOATCOUNTER_API_TOKEN", "")
 
+# Self-controlled User-Agent that Frank's blackbox uptime probes carry. The edge
+# definition excludes Frank's *own probe identity* (not the vendor default UA).
+# MUST match the User-Agent set in
+# apps/blackbox-exporter/manifests/configmap.yaml.
+PROBE_UA_TOKEN = "Frank-Blackbox-Probe"
+
+
+def edge_filter(host: str | None = None, *, exclude_probes: bool = True) -> str:
+    """Canonical Hop-edge Caddy access-log filter — single source of truth so the
+    surge alert, the surge narrative, and the digest agree on what "blog traffic"
+    is. Backtick-quote the dotted/hyphenated field names (verified live against
+    VictoriaLogs; phrase-matches the array-valued User-Agent field)."""
+    f = 'kubernetes.host:hop-1 AND _msg:"handled request"'
+    if host:
+        f += f' AND `request.host`:"{host}"'
+    if exclude_probes:
+        f += f' AND -`request.headers.User-Agent`:"{PROBE_UA_TOKEN}"'
+    return f
+
 
 def _logsql_count(query: str) -> int:
     """Issue a `... | stats count() as c` query and return the integer count."""
@@ -64,10 +83,16 @@ def _logsql_group(query: str, label: str, top: int | None = None) -> list[dict]:
     return rows[:top] if top else rows
 
 
-def _goatcounter(path: str, params: dict) -> dict:
-    """GET a GoatCounter /api/v0 endpoint with Bearer auth. {} on error."""
+def _goatcounter_raw(path: str, params: dict) -> dict | None:
+    """GET a GoatCounter /api/v0 endpoint with Bearer auth.
+
+    Returns the parsed dict on success, or `None` when GoatCounter is
+    unreachable / errors — so callers that must distinguish "down" from
+    "genuinely zero" (the surge cross-check) can. Callers that only need a
+    dict use `_goatcounter`, which coerces `None` to `{}`.
+    """
     if not GOATCOUNTER_TOKEN:
-        return {}
+        return None
     try:
         resp = httpx.get(
             f"{GOATCOUNTER_URL}{path}",
@@ -78,7 +103,31 @@ def _goatcounter(path: str, params: dict) -> dict:
         resp.raise_for_status()
         return resp.json()
     except Exception:  # noqa: BLE001
-        return {}
+        return None
+
+
+def _goatcounter(path: str, params: dict) -> dict:
+    """GET a GoatCounter /api/v0 endpoint with Bearer auth. {} on error/empty.
+
+    Back-compat wrapper for the digest builders, which `.get()` the result.
+    """
+    return _goatcounter_raw(path, params) or {}
+
+
+def surge_visitor_pageviews(window_start: datetime, window_end: datetime) -> int | None:
+    """Human pageviews (GoatCounter, JS-beacon) in the surge window.
+
+    `None` when GoatCounter is unreachable (so /surge-check can fail open).
+    GoatCounter start/end are date-time, "rounded to the hour" (per /api.json).
+    """
+    data = _goatcounter_raw(
+        "/api/v0/stats/total",
+        {
+            "start": window_start.replace(minute=0, second=0, microsecond=0).isoformat(),
+            "end": window_end.replace(minute=0, second=0, microsecond=0).isoformat(),
+        },
+    )
+    return None if data is None else int(data.get("total", 0))
 
 
 def _digest_blog_facts(since: datetime, until: datetime) -> dict:
@@ -151,8 +200,8 @@ def build_for_digest(since: datetime, until: datetime, security_until: datetime)
     Critical event surfaces same-day rather than ~24h late.
     """
     tw = f"_time:[{since.isoformat()},{until.isoformat()}]"
-    # All Hop-edge Caddy requests — scoped to the Hop node, grouped, no host substring filter.
-    edge = f'{tw} kubernetes.host:hop-1 AND _msg:"handled request"'
+    # All Hop-edge Caddy requests — canonical filter, probe-excluded, grouped.
+    edge = f'{tw} {edge_filter()}'
     by_vhost = _logsql_group(f"{edge} | stats by (request.host) count() as c", "request.host", top=10)
     by_status = _logsql_group(f"{edge} | stats by (status) count() as c", "status")
     status_class: dict[str, int] = {}
@@ -178,7 +227,7 @@ def build_for_surge(window_start: datetime, window_end: datetime) -> dict:
         "window_start": window_start.isoformat(),
         "window_end": window_end.isoformat(),
         "total_requests": _logsql_count(
-            f'{window} kubernetes.namespace_name:caddy-system AND _msg:"handled request" | stats count() as c'
+            f'{window} {edge_filter(host="blog.derio.net")} | stats count() as c'
         ),
         # The richer top-N breakdowns (top_referrers, top_pages, geo) would be
         # built here in production; first ship lands with the essential

--- a/apps/ai-alert-helper/src/ai_alert_helper/surge.py
+++ b/apps/ai-alert-helper/src/ai_alert_helper/surge.py
@@ -5,6 +5,7 @@ LogsQL has no `quantile_over_time`, so we issue 8 queries (current hour +
 volume (~8 queries, total ~50ms).
 """
 from __future__ import annotations
+import os
 from datetime import datetime, timedelta, timezone
 from statistics import median
 
@@ -12,13 +13,10 @@ from . import facts
 
 
 def _hour_count(when: datetime) -> int:
-    """Caddy-namespace request count in the 1h window ending at `when`."""
+    """Probe-free blog edge request count in the 1h window ending at `when`."""
     start = (when - timedelta(hours=1)).isoformat()
     end = when.isoformat()
-    query = (
-        f'_time:[{start},{end}] AND kubernetes.namespace_name:caddy-system '
-        f'AND _msg:"handled request" AND request.host:"blog.derio.net" | stats count() as c'
-    )
+    query = f'_time:[{start},{end}] {facts.edge_filter(host="blog.derio.net")} | stats count() as c'
     return facts._logsql_count(query)
 
 
@@ -34,8 +32,13 @@ def compute() -> dict:
     historical = [_hour_count(now - timedelta(days=d)) for d in range(1, 8)]
     baseline = int(median(historical)) or 1  # avoid divide-by-zero on dead-blog days
     ratio = current / baseline if current else 0.0
+    # Absolute floor: a baseline forced to 1 on a quiet hour must not manufacture
+    # a high ratio from a trickle of requests. No tier below the floor.
+    abs_floor = int(os.environ.get("SURGE_ABS_FLOOR", "50"))
     tier: str | None = None
-    if ratio >= 10:
+    if current < abs_floor:
+        tier = None
+    elif ratio >= 10:
         tier = "Major"
     elif ratio >= 3:
         tier = "Notable"

--- a/apps/ai-alert-helper/src/tests/test_api.py
+++ b/apps/ai-alert-helper/src/tests/test_api.py
@@ -1,0 +1,60 @@
+"""Tests for /surge-check's visitor-side decision matrix.
+
+The GoatCounter cross-check is the safeguard that was specified but never
+implemented (the bug that fired URGENT on Frank's own probe). Each row of the
+matrix asserts the `urgent` flag actually passed to telegram.send.
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from ai_alert_helper import api, surge, facts, ai_adapter, telegram
+
+
+def _setup(monkeypatch, tier, visitors):
+    """Stub compute() to return `tier`, GoatCounter to return `visitors`, and
+    capture what telegram.send was called with."""
+    monkeypatch.setattr(surge, "compute", lambda: {
+        "tier": tier, "ratio": 12.0, "current": 600, "baseline": 50,
+        "window_end": "2026-05-25T17:00:00+00:00",
+    })
+    monkeypatch.setattr(facts, "surge_visitor_pageviews", lambda a, b: visitors)
+    monkeypatch.setattr(facts, "build_for_surge", lambda a, b: {})
+    monkeypatch.setattr(ai_adapter, "investigate", lambda labels, sheet: "narrative")
+    sent: dict = {}
+    monkeypatch.setattr(telegram, "send",
+                        lambda msg, urgent=False: sent.update(msg=msg, urgent=urgent))
+    return sent
+
+
+def test_major_with_humans_pages_urgent(monkeypatch):
+    sent = _setup(monkeypatch, "Major", visitors=50)   # >= SURGE_VISITOR_FLOOR (10)
+    r = TestClient(api.app).post("/surge-check").json()
+    assert r["triggered"] is True
+    assert sent["urgent"] is True
+
+
+def test_major_no_humans_downgrades_to_notable(monkeypatch):
+    sent = _setup(monkeypatch, "Major", visitors=0)    # < floor → not a human surge
+    r = TestClient(api.app).post("/surge-check").json()
+    assert r["tier"] == "Notable"
+    assert sent["urgent"] is False
+
+
+def test_major_goatcounter_unreachable_fails_open(monkeypatch):
+    sent = _setup(monkeypatch, "Major", visitors=None)  # unreachable
+    TestClient(api.app).post("/surge-check")
+    assert sent["urgent"] is True
+    assert "visitor data unavailable" in sent["msg"]
+
+
+def test_notable_is_not_urgent(monkeypatch):
+    sent = _setup(monkeypatch, "Notable", visitors=0)
+    TestClient(api.app).post("/surge-check")
+    assert sent["urgent"] is False
+
+
+def test_no_tier_does_not_send(monkeypatch):
+    sent = _setup(monkeypatch, None, visitors=0)
+    r = TestClient(api.app).post("/surge-check").json()
+    assert r["triggered"] is False
+    assert sent == {}   # nothing sent

--- a/apps/ai-alert-helper/src/tests/test_facts.py
+++ b/apps/ai-alert-helper/src/tests/test_facts.py
@@ -135,3 +135,66 @@ def test_build_for_digest_falco_all_priorities_and_split_window():
     assert any("priority:Critical" in q and "by (rule)" in q for q in captured)
     # security query window ends at security_until, NOT until
     assert any("2026-05-25T08:00:00" in q and "source:syscall" in q for q in captured)
+
+
+# --- edge_filter (Phase 2: centralized probe-aware edge definition) ---
+
+def test_edge_filter_excludes_probe_by_default():
+    f = facts.edge_filter(host="blog.derio.net")
+    assert "kubernetes.host:hop-1" in f
+    assert '`request.host`:"blog.derio.net"' in f
+    assert '-`request.headers.User-Agent`:"Frank-Blackbox-Probe"' in f
+
+
+def test_edge_filter_no_host_still_excludes_probe():
+    f = facts.edge_filter()
+    assert "request.host" not in f          # all vhosts
+    assert "Frank-Blackbox-Probe" in f       # still probe-excluded
+
+
+def test_edge_filter_can_include_probes():
+    assert "Frank-Blackbox-Probe" not in facts.edge_filter(exclude_probes=False)
+
+
+def test_probe_ua_token_is_pinned():
+    # Drift guard vs apps/blackbox-exporter/manifests/configmap.yaml
+    assert facts.PROBE_UA_TOKEN == "Frank-Blackbox-Probe"
+
+
+# --- GoatCounter reachability + visitor cross-check ---
+
+@respx.mock
+def test_goatcounter_raw_none_on_error():
+    respx.get(re.compile(facts.GOATCOUNTER_URL + "/api/v0/.*")).mock(
+        side_effect=httpx.ConnectError("down"))
+    assert facts._goatcounter_raw("/api/v0/stats/total", {}) is None
+
+
+@respx.mock
+def test_visitor_pageviews_none_when_unreachable():
+    respx.get(re.compile(facts.GOATCOUNTER_URL + "/api/v0/stats/total.*")).mock(
+        side_effect=httpx.ConnectError("down"))
+    s = datetime(2026, 5, 25, 16, tzinfo=timezone.utc); e = s + timedelta(hours=1)
+    assert facts.surge_visitor_pageviews(s, e) is None
+
+
+@respx.mock
+def test_visitor_pageviews_counts_and_uses_hour_window():
+    route = respx.get(re.compile(facts.GOATCOUNTER_URL + "/api/v0/stats/total.*")).mock(
+        return_value=httpx.Response(200, json={"total": 7}))
+    s = datetime(2026, 5, 25, 16, 37, tzinfo=timezone.utc); e = s + timedelta(hours=1)
+    assert facts.surge_visitor_pageviews(s, e) == 7
+    q = dict(httpx.QueryParams(route.calls.last.request.url.query.decode()))
+    assert q["start"].startswith("2026-05-25T16:00")   # rounded to the hour
+    assert q["end"].startswith("2026-05-25T17:00")
+
+
+@respx.mock
+def test_build_for_digest_survives_unreachable_goatcounter():
+    """C1 regression: an unreachable GoatCounter must not crash the daily digest."""
+    respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+        return_value=httpx.Response(200, json={"data": {"result": []}}))
+    respx.get(re.compile(facts.GOATCOUNTER_URL + ".*")).mock(side_effect=httpx.ConnectError("down"))
+    since = datetime(2026, 5, 24, tzinfo=timezone.utc); until = since + timedelta(days=1)
+    sheet = facts.build_for_digest(since, until, until)   # must NOT raise
+    assert sheet["blog_pageviews"] == 0

--- a/apps/ai-alert-helper/src/tests/test_surge.py
+++ b/apps/ai-alert-helper/src/tests/test_surge.py
@@ -101,10 +101,39 @@ def test_compute_handles_zero_current_traffic():
 
 
 @respx.mock
-def test_hour_count_filters_on_request_host_field():
+def test_hour_count_filters_on_request_host_field_and_excludes_probe():
     route = respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
         return_value=httpx.Response(200, json={"data": {"result": [{"value": [0, "5"]}]}}))
     surge._hour_count(datetime(2026, 5, 25, 12, tzinfo=timezone.utc))
     q = route.calls.last.request.url.params["query"]
-    assert 'request.host:"blog.derio.net"' in q
-    assert '_msg:"blog.derio.net"' not in q
+    assert '`request.host`:"blog.derio.net"' in q          # backtick-quoted field
+    assert '_msg:"blog.derio.net"' not in q                 # never the broken substring filter
+    assert '-`request.headers.User-Agent`:"Frank-Blackbox-Probe"' in q  # probe excluded
+
+
+@respx.mock
+def test_floor_suppresses_tier_below_abs_floor():
+    """current below SURGE_ABS_FLOOR (default 50) → no tier even at a huge ratio."""
+    counts = [49, 1, 0, 0, 0, 0, 0, 0]    # ratio 49 but below the floor
+    respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+        side_effect=[httpx.Response(200, json=_stats_response(c)) for c in counts])
+    assert surge.compute()["tier"] is None
+
+
+@respx.mock
+def test_floor_boundary_fires_at_abs_floor():
+    """exactly SURGE_ABS_FLOOR requests qualifies (>=)."""
+    counts = [50, 1, 0, 0, 0, 0, 0, 0]
+    respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+        side_effect=[httpx.Response(200, json=_stats_response(c)) for c in counts])
+    assert surge.compute()["tier"] == "Major"
+
+
+@respx.mock
+def test_empty_baseline_no_crash_below_floor():
+    """Crash-safety on an empty baseline, decoupled from the floor boundary."""
+    counts = [10, 0, 0, 0, 0, 0, 0, 0]
+    respx.get(facts.VICTORIALOGS_URL + "/select/logsql/stats_query").mock(
+        side_effect=[httpx.Response(200, json=_stats_response(c)) for c in counts])
+    r = surge.compute()
+    assert r["baseline"] == 1 and r["tier"] is None

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/01.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/01.yaml
@@ -99,22 +99,23 @@ state:
       ticked_at: '2026-05-25T19:22:53+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:52:37+00:00'
       note: null
     P1.T2.S1:
       state: x
       ticked_at: '2026-05-25T19:22:55+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:52:42+00:00'
       note: null
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:52:48+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-25T19:53:10+00:00'
+    note: 'Merged #412; verified live: surge-check suspend=true (jobs stopped), blackbox
+      probes now emit Frank-Blackbox-Probe (old UA gone), exclusion filter confirmed.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/02.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/02.yaml
@@ -266,62 +266,62 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:57:52+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:57:57+00:00'
       note: null
     P2.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:04+00:00'
       note: null
     P2.T1.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:11+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:17+00:00'
       note: null
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:24+00:00'
       note: null
     P2.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:31+00:00'
       note: null
     P2.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:38+00:00'
       note: null
     P2.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:44+00:00'
       note: null
     P2.T3.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:51+00:00'
       note: null
     P2.T4.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:58:58+00:00'
       note: null
     P2.T4.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:59:04+00:00'
       note: null
     P2.T4.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:59:09+00:00'
       note: null
     P2.T4.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T19:59:16+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-25T19:59:22+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
Phase 2 of the **surge-detector false-positive fix** (plan: `docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/`). Pure code + tests — **no cluster effect** (image stays `0.1.4`, detector stays suspended from P1). The actual build/deploy/un-suspend is Phase 3.

## Changes
- **`facts.edge_filter()`** — single source of truth for the Hop-edge Caddy filter, probe-excluded by default, backtick-quoted fields. `surge._hour_count`, `build_for_surge`, and `build_for_digest` all migrate onto it (canonical `kubernetes.host:hop-1`). Fixes `build_for_surge` previously feeding the AI narrative an unfiltered, probe-polluted count.
- **Absolute floor** (`SURGE_ABS_FLOOR`, default 50) in `surge.compute()` — no tier below the floor, so a baseline forced to `1` can't manufacture a high ratio from a trickle.
- **GoatCounter cross-check** — `_goatcounter_raw()` distinguishes unreachable (`None`) from zero; `_goatcounter` kept as a `{}`-coercing wrapper so the daily digest can't crash (C1). `/surge-check` now requires real pageviews (`SURGE_VISITOR_FLOOR`, default 10) for URGENT, **fails open** when GoatCounter is down, and **downgrades** a Major to non-urgent Notable when no humans are confirmed.
- Deployment env: `SURGE_ABS_FLOOR`, `SURGE_VISITOR_FLOOR`.

## Tests — 32 pass
Decision matrix (4 rows + no-tier), floor boundary (49→none, 50→fires), C1 digest-survives-unreachable, `edge_filter` shape + `PROBE_UA_TOKEN` pin, updated `_hour_count` backtick assertion.

> Note: merging this fires the `build-ai-alert-helper.yml` workflow (auto-builds the stale `0.1.0`/`latest` tags from the new code) — harmless, nothing references those; Phase 3 aligns the tag to `0.1.5` and builds the real image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)