### PR TITLE
docs(manifests): stop hardcoding agent-images SHA in deploy comments

### DIFF
--- a/apps/paperclip/manifests/deployment.yaml
+++ b/apps/paperclip/manifests/deployment.yaml
@@ -204,8 +204,9 @@ spec:
         # Operator's SSH+Mosh entry point. Independent home PVC keeps
         # mise/cargo/pipx state across pod restarts. The cont-init.d
         # inventory installer reconciles the operator's declared toolset
-        # against the home PVC at boot. Image SHA pinned to agent-images
-        # main HEAD (8af0d08) — see plan Deployment Notes.
+        # against the home PVC at boot. Image SHA tracks agent-images main
+        # HEAD (bumped by the agent-images-bump workflow) — the image: tag
+        # below is the live pin; see plan Deployment Notes.
         - name: paperclip-shell
           image: ghcr.io/derio-net/paperclip-shell:165f5eb45d7eae25141461e441f7c7cd56395f00
           imagePullPolicy: IfNotPresent

--- a/apps/ruflo/manifests/deployment.yaml
+++ b/apps/ruflo/manifests/deployment.yaml
@@ -3,10 +3,10 @@
 # workspace and shell-home PVCs are RWO and a rolling update would
 # deadlock waiting for the mount to release (see frank-gotchas.md).
 #
-# Image SHAs reference agent-images main commit
-# 8af32cba360d8bfa86e31fc8fc91e8fc787d55b7 (tip of derio-net/agent-images
-# main as of 2026-05-16; tail of a two-PR fix for the local-model "no
-# response" bug):
+# Image SHAs track agent-images main HEAD, bumped by the agent-images-bump
+# workflow — the `image:` tags below are the live pin. Historical context:
+# the 2026-05-16 bump to agent-images 8af32cb was the tail of a two-PR fix
+# for the local-model "no response" bug:
 #   #77 — patch upstream urlSafety.ts to allow wasm:// URLs (the browser-
 #         local "RVAgent Local (WASM)" MCP server) so autopilot-ON chat
 #         doesn't silently brick when wasm:// is the only selected MCP;


### PR DESCRIPTION
## What
Comment-only fix. The `agent-images-bump` workflow updates the `image:` tags in these deployment manifests but never the surrounding header comments, so they drift out of sync with the live pin:

- `apps/paperclip/…/deployment.yaml` — said `main HEAD (8af0d08)` (doubly stale — predates even the prior pin).
- `apps/ruflo/…/deployment.yaml` — said `Image SHAs reference agent-images main commit 8af32cb … as of 2026-05-16` while the images had since been bumped to `165f5eb`.

## Change
Both comments now say the SHA **tracks agent-images main HEAD (bumped by the `agent-images-bump` workflow)** and that the `image:` tag is the live pin — so they can't go stale again. Ruflo's #77/#78 narrative is preserved but reframed as *historical context for the 2026-05-16 bump*, since that story is specific to `8af32cb` and shouldn't masquerade as the current pin.

No manifest behavior changes (verified comment-only; both files still parse).

Surfaced while confirming the #56 rollout ([derio-net/agent-images#56](https://github.com/derio-net/agent-images/issues/56) → frank #413).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
