### PR TITLE
build(obs): surge-detector P3 — deploy 0.1.5 (cron stays suspended until verified)

### DIFF
--- a/.github/workflows/build-ai-alert-helper.yml
+++ b/.github/workflows/build-ai-alert-helper.yml
@@ -30,5 +30,5 @@ jobs:
           context: apps/ai-alert-helper/src
           push: true
           tags: |
-            ghcr.io/derio-net/ai-alert-helper:0.1.0
+            ghcr.io/derio-net/ai-alert-helper:0.1.5
             ghcr.io/derio-net/ai-alert-helper:latest

--- a/apps/ai-alert-helper/manifests/cronjob-surge-check.yaml
+++ b/apps/ai-alert-helper/manifests/cronjob-surge-check.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: ai-alert-helper-system
 spec:
   schedule: "*/15 * * * *"
-  suspend: true            # TEMPORARY — reverted in surge-detector-fix P3.T2.S1 once the fix is verified live
+  suspend: true            # stays suspended through the 0.1.5 deploy; un-suspended only after live verification (P3.T2.S1)
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5

--- a/apps/ai-alert-helper/manifests/deployment.yaml
+++ b/apps/ai-alert-helper/manifests/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: ai-alert-helper
-          image: ghcr.io/derio-net/ai-alert-helper:0.1.4
+          image: ghcr.io/derio-net/ai-alert-helper:0.1.5
           imagePullPolicy: Always
           ports:
             - name: http

--- a/apps/ai-alert-helper/src/ai_alert_helper/api.py
+++ b/apps/ai-alert-helper/src/ai_alert_helper/api.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI, Request
 
 from . import ai_adapter, facts, surge, telegram
 
-app = FastAPI(title="ai-alert-helper", version="0.1.4")
+app = FastAPI(title="ai-alert-helper", version="0.1.5")
 
 
 @app.get("/healthz")

--- a/apps/ai-alert-helper/src/pyproject.toml
+++ b/apps/ai-alert-helper/src/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-alert-helper"
-version = "0.1.4"
+version = "0.1.5"
 description = "AI-enriched alert helper for Frank's blog edge observability"
 requires-python = ">=3.12"
 dependencies = [

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/03.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/03.yaml
@@ -83,13 +83,15 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-25T20:13:22+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-25T20:13:28+00:00'
+      note: Built via CI workflow_dispatch on the branch (gh workflow run build-ai-alert-helper.yml
+        --ref obs/surge-detector-fix-p3), run 26417972070 success — the established
+        pattern, not manual docker. Tag aligned 0.1.0->0.1.5.
     P3.T2.S1:
       state: ' '
       ticked_at: null


### PR DESCRIPTION
Phase 3 (deploy) of the **surge-detector false-positive fix**. The `0.1.5` image is **already built and pushed** via CI (`workflow_dispatch` on this branch, run `26417972070` ✓) — so merging this just advances ArgoCD to an image that already exists.

## Changes
- Version `0.1.4` → `0.1.5` (`api.py`, `pyproject.toml`, deployment image pin).
- `build-ai-alert-helper.yml`: align the hardcoded tag `0.1.0` → `0.1.5` (matches the caddy/openrgb version-pinned-tag convention; image is now built via CI, not manual docker).
- **Cron stays `suspend: true`.** It is *not* un-suspended here — deliberately. Un-suspending alongside the rollout would risk one stale-pod false page in the ~25s rollout window. Instead I'll verify the `0.1.5` code via a manual job trigger (works while suspended), then un-suspend in a final one-line PR.

## After merge I'll verify (P3.T3)
1. `kubectl -n ai-alert-helper-system get deploy ai-alert-helper -o jsonpath='{..image}'` → `0.1.5` (proves the image pulled).
2. Live LogsQL exclusion query returns 200 + probe-excluded count.
3. `kubectl create job --from=cronjob/surge-check` → confirm `{"triggered": false, ...}` (probe-free `current` < floor) on the new code.

Then the final un-suspend PR resumes the detector with verified code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)