### PR TITLE
fix(obs): un-suspend surge-check on verified 0.1.5 (surge-fix P3)

### DIFF
--- a/apps/ai-alert-helper/manifests/cronjob-surge-check.yaml
+++ b/apps/ai-alert-helper/manifests/cronjob-surge-check.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: ai-alert-helper-system
 spec:
   schedule: "*/15 * * * *"
-  suspend: true            # stays suspended through the 0.1.5 deploy; un-suspended only after live verification (P3.T2.S1)
   concurrencyPolicy: Forbid
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 5


### PR DESCRIPTION
Final step of Phase 3 — resume the `surge-check` CronJob now that `0.1.5` is deployed and verified (probe exclusion confirmed live, 32 unit tests green).

Removes the temporary `suspend: true` added in #412.

**Transient behavior note:** for ~1–2h the `[HH:00,HH+1:00]` window still contains old-UA (`Blackbox Exporter/0.25.0`) probe residue that the new filter doesn't exclude, so the edge tier computes Major — but the new GoatCounter visitor gate downgrades it to a **non-urgent Notable** (no page). Once the residue ages out, `current` < floor → `triggered: false`. I'll observe the first post-merge run to confirm the gate downgrades as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)