### PR TITLE
docs(obs): surge-detector fix Deployed — complete plan + observed end-to-end

### DIFF
--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/03.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/03.yaml
@@ -93,9 +93,9 @@ state:
         --ref obs/surge-detector-fix-p3), run 26417972070 success — the established
         pattern, not manual docker. Tag aligned 0.1.0->0.1.5.
     P3.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-25T20:37:16+00:00'
+      note: 'Un-suspended via #417; cron suspend=false confirmed.'
     P3.T2.S2:
       state: x
       ticked_at: '2026-05-25T20:31:03+00:00'
@@ -105,14 +105,18 @@ state:
       ticked_at: '2026-05-25T20:31:08+00:00'
       note: null
     P3.T3.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-25T20:37:13+00:00'
+      note: 'Observed live on 0.1.5: triggered, current=300 (residue), tier downgraded,
+        no URGENT.'
     P3.T3.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-25T20:37:15+00:00'
+      note: 'GC gate observed live: visitors=1 < SURGE_VISITOR_FLOOR(10) -> Major
+        downgraded to non-urgent Notable (not fail-open; GC reachable). No page.'
   completion:
-    at: null
-    note: null
+    at: '2026-05-25T20:37:18+00:00'
+    note: 0.1.5 built via CI + deployed; probe exclusion + visitor-gate downgrade
+      observed live end-to-end; cron resumed. Residue ages out ~22:00 UTC -> triggered=false
+      steady state.
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/04.yaml
+++ b/docs/superpowers/plans/2026-05-25--obs--surge-detector-fix/04.yaml
@@ -65,10 +65,11 @@ state:
       ticked_at: '2026-05-25T20:31:21+00:00'
       note: null
     P4.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-25T20:37:19+00:00'
+      note: 'Spec set Deployed; plan complete. sync-runbook skipped (no # manual-operation
+        blocks; image build is CI, not a manual op).'
   completion:
-    at: null
+    at: '2026-05-25T20:37:21+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
+++ b/docs/superpowers/specs/2026-05-25--obs--surge-detector-false-positive-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-05-25
 **Layer:** `obs` (fix/extension of the edge-observability layer — `ai-alert-helper`)
-**Status:** Draft
+**Status:** Deployed
 **App(s):** `apps/ai-alert-helper`, `apps/blackbox-exporter`
 
 ## Implementation Plans


### PR DESCRIPTION
Close-out of the surge-detector false-positive fix.

- Spec `**Status:** Deployed`.
- Plan `2026-05-25--obs--surge-detector-fix`: all 4 phases complete (30/30 steps).

**End-to-end observation (live, 0.1.5):** `/surge-check` returned `{"tier":"Notable","visitors":1,...}` — edge tier Major (300 = transient old-UA probe residue) was downgraded by the GoatCounter visitor gate (`visitors 1 < SURGE_VISITOR_FLOOR 10`) to a **non-urgent Notable, no page**. Confirms probe exclusion + absolute floor + visitor cross-check working together on the deployed code (and not fail-open — GC was reachable).

Residue ages out ~22:00 UTC → steady state `triggered: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)