### PR TITLE
docs(auto): AWX deployment implementation plan (6 phases)

### DIFF
--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/01.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/01.yaml
@@ -1,0 +1,210 @@
+schema_version: 2
+phase:
+  number: 1
+  title: AWX Operator + AWX CR (ArgoCD app)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Register the auto layer
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Register the `auto` layer (#20) in docs/layers.yaml
+
+      Append a new entry after the `cicd` layer (number 19) in `docs/layers.yaml`:
+
+      ```yaml
+        - code: auto
+          number: 20
+          name: Infrastructure Automation
+          description: AWX Ansible controller for non-Talos / external devices
+      ```
+
+      Verify: `grep -A3 "code: auto" docs/layers.yaml` shows the new entry, and `scripts/validate-plans.sh` still recognises the `auto` code (no "unknown layer" error when this plan is validated).
+  - id: P1.T1.S2
+    text: |-
+      Add the auto layer to the roadmap shortcode
+
+      Add a roadmap entry for the `auto` layer to `blog/layouts/shortcodes/cluster-roadmap.html`, following the existing per-layer pattern (copy the most recent layer block, bump to layer 20 "Infrastructure Automation / AWX", keep status markup consistent with neighbours).
+
+      Verify: `grep -i "automation\|awx" blog/layouts/shortcodes/cluster-roadmap.html` shows the new roadmap line.
+- number: 2
+  title: AWX Operator chart values
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Confirm the awx-operator chart version to pin
+
+      ```bash
+      helm repo add awx-operator https://ansible-community.github.io/awx-operator-helm/ 2>/dev/null
+      helm repo update awx-operator
+      helm search repo awx-operator/awx-operator --versions | head -3
+      ```
+
+      Expected: chart `3.2.1` (appVersion `2.19.1`) is the current stable. Pin `targetRevision: 3.2.1` in the Application (Task 4). If a newer stable exists at implementation time, pin that instead and note it in the prose.
+  - id: P1.T2.S2
+    text: |-
+      Create apps/awx/values.yaml
+
+      The operator chart itself needs almost no overrides (it deploys the operator Deployment; the AWX workload is driven by the separate CR). Create `apps/awx/values.yaml`:
+
+      BEGIN apps/awx/values.yaml
+      # awx-operator Helm chart values.
+      # The operator only runs the controller; the AWX workload is declared
+      # by apps/awx/manifests/awx.yaml (the AWX custom resource).
+      AWX:
+        enabled: false   # we manage the AWX CR ourselves as a raw manifest
+      END apps/awx/values.yaml
+
+      Verify: `test -f apps/awx/values.yaml`. (Setting `AWX.enabled: false` ensures the chart does NOT also template its own AWX CR — we own that manifest.)
+- number: 3
+  title: AWX custom resource
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      Create apps/awx/manifests/awx.yaml (the AWX CR)
+
+      Operator-managed Postgres on Longhorn, ClusterIP, no operator ingress
+      (Traefik handles ingress in Phase 4), OIDC non-secret settings inline.
+      The CR carries SkipDryRunOnMissingResource via the Application (Task 4),
+      not here.
+
+      BEGIN apps/awx/manifests/awx.yaml
+      apiVersion: awx.ansible.com/v1beta1
+      kind: AWX
+      metadata:
+        name: awx
+        namespace: awx
+      spec:
+        service_type: ClusterIP
+        ingress_type: none
+        replicas: 1
+        admin_user: admin
+        admin_password_secret: awx-admin-password
+        secret_key_secret: awx-secret-key
+        # Operator-managed Postgres (no postgres_configuration_secret given):
+        postgres_storage_class: longhorn
+        postgres_storage_requirements:
+          requests:
+            storage: 8Gi
+        projects_persistence: false
+        # Non-secret OIDC settings. SOCIAL_AUTH_OIDC_SECRET is set out-of-band
+        # via the AWX Settings API (manual-op in Phase 3) so the secret value
+        # never lands in git.
+        extra_settings:
+          - setting: SOCIAL_AUTH_OIDC_OIDC_ENDPOINT
+            value: "https://auth.cluster.derio.net/application/o/awx/"
+          - setting: SOCIAL_AUTH_OIDC_KEY
+            value: "awx"
+      END apps/awx/manifests/awx.yaml
+
+      Verify: `kubeconform -ignore-missing-schemas apps/awx/manifests/awx.yaml` (or a plain `yq .` parse) succeeds. The CRD is not installed locally, so a schema-less YAML parse is sufficient at author time.
+- number: 4
+  title: ArgoCD Application
+  steps:
+  - id: P1.T4.S1
+    text: |-
+      Create apps/root/templates/awx.yaml (multi-source Application)
+
+      Copy an existing multi-source template (e.g. apps/root/templates with an
+      upstream chart + $values ref) and adapt. Critical pieces: sync waves so
+      the operator chart (CRD) applies BEFORE the AWX CR, SkipDryRunOnMissingResource
+      on the CR source, ignoreDifferences on operator-generated Secrets, and the
+      standard ServerSideApply / prune:false / selfHeal:true.
+
+      BEGIN apps/root/templates/awx.yaml
+      apiVersion: argoproj.io/v1alpha1
+      kind: Application
+      metadata:
+        name: awx
+        namespace: argocd
+        annotations:
+          argocd.argoproj.io/sync-wave: "0"
+      spec:
+        project: default
+        destination:
+          server: https://kubernetes.default.svc
+          namespace: awx
+        sources:
+          # Wave 0: operator chart (installs the AWX CRD + operator Deployment)
+          - repoURL: https://ansible-community.github.io/awx-operator-helm/
+            chart: awx-operator
+            targetRevision: 3.2.1
+            helm:
+              valueFiles:
+                - $values/apps/awx/values.yaml
+          - repoURL: https://github.com/derio-net/frank.git
+            targetRevision: main
+            ref: values
+          # Wave 1: the AWX CR (needs the CRD from wave 0 to exist first)
+          - repoURL: https://github.com/derio-net/frank.git
+            targetRevision: main
+            path: apps/awx/manifests
+            directory:
+              include: 'awx.yaml'
+        syncPolicy:
+          automated:
+            prune: false
+            selfHeal: true
+          syncOptions:
+            - ServerSideApply=true
+            - SkipDryRunOnMissingResource=true
+            - CreateNamespace=true
+        ignoreDifferences:
+          - group: ""
+            kind: Secret
+            jsonPointers:
+              - /data
+      END apps/root/templates/awx.yaml
+
+      Note on sync waves with multi-source: ArgoCD sync waves order resources within one Application by the `argocd.argoproj.io/sync-wave` annotation on each *resource*. The operator chart's CRD/Deployment carry wave 0 (chart default); annotate the AWX CR manifest body with `argocd.argoproj.io/sync-wave: "1"` if a clean first-sync needs it. SkipDryRunOnMissingResource is the primary guard against the "CRD not yet present" dry-run failure.
+
+      Verify: `yq '.spec.sources | length' apps/root/templates/awx.yaml` returns 3; `grep -c SkipDryRunOnMissingResource apps/root/templates/awx.yaml` returns 1.
+  - id: P1.T4.S2
+    text: |-
+      Add the sync-wave annotation to the AWX CR and commit Phase 1
+
+      Add `argocd.argoproj.io/sync-wave: "1"` under `metadata.annotations` in `apps/awx/manifests/awx.yaml` so the CR applies after the operator CRD.
+
+      ```bash
+      git add docs/layers.yaml blog/layouts/shortcodes/cluster-roadmap.html apps/awx/ apps/root/templates/awx.yaml
+      git commit -m "feat(auto): AWX operator + CR ArgoCD app (P1)"
+      ```
+
+      Verify: `git show --stat HEAD` lists the layers.yaml, roadmap, values.yaml, awx.yaml CR, and Application template.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/02.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/02.yaml
@@ -1,0 +1,59 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Bootstrap secrets (SOPS, out-of-band)
+  tag: manual
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Generate and apply AWX bootstrap secrets
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Generate, SOPS-encrypt, and apply the AWX bootstrap secrets
+
+      These names MUST match the CR refs from Phase 1 (`awx-admin-password`, `awx-secret-key`). Per repo principle, SOPS secrets are applied out-of-band and are NOT ArgoCD-managed.
+
+      ```yaml
+      # manual-operation
+      id: auto-awx-bootstrap-secrets
+      layer: auto
+      app: awx
+      plan: 2026-05-27--auto--awx-deployment
+      when: Before/at first ArgoCD sync of the awx Application (Phase 5)
+      why_manual: >-
+        AWX admin password and Django secret key are sensitive and must exist
+        before the operator reconciles the AWX pods. SOPS-encrypted secrets are
+        applied out-of-band, never ArgoCD-managed (repo declarative-only exception).
+      commands: |
+        kubectl create namespace awx --dry-run=client -o yaml | kubectl apply -f -
+        # admin password (key MUST be 'password' per awx-operator)
+        kubectl -n awx create secret generic awx-admin-password \
+          --from-literal=password="$(openssl rand -base64 24)" \
+          --dry-run=client -o yaml > secrets/awx/awx-admin-password.yaml
+        # Django secret key (key MUST be 'secret_key')
+        kubectl -n awx create secret generic awx-secret-key \
+          --from-literal=secret_key="$(openssl rand -base64 48)" \
+          --dry-run=client -o yaml > secrets/awx/awx-secret-key.yaml
+        sops --encrypt --in-place secrets/awx/awx-admin-password.yaml
+        sops --encrypt --in-place secrets/awx/awx-secret-key.yaml
+        sops --decrypt secrets/awx/awx-admin-password.yaml | kubectl apply -f -
+        sops --decrypt secrets/awx/awx-secret-key.yaml | kubectl apply -f -
+      verify: |
+        kubectl -n awx get secret awx-admin-password awx-secret-key
+      status: pending
+      ```
+
+      Verify: both secrets exist in the `awx` namespace; the encrypted files are committed under `secrets/awx/`. Record the generated admin password in the operator's password manager (it is the break-glass login).
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/03.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/03.yaml
@@ -1,0 +1,133 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Authentik OIDC provider
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: AWX OIDC provider blueprint
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      Create apps/authentik-extras/manifests/blueprints-provider-awx.yaml
+
+      Model on `blueprints-provider-infisical.yaml`. Confidential client, AWX
+      OIDC callback host = awx.cluster.derio.net (the routable domain; do NOT use
+      frank.derio.net). The client_secret is intentionally absent — set later
+      (manual-op).
+
+      BEGIN apps/authentik-extras/manifests/blueprints-provider-awx.yaml
+      # Authentik Blueprint: AWX OIDC Provider
+      # Creates an OAuth2 provider + application for AWX SSO.
+      # client_secret is set via Authentik Admin UI / API (manual operation).
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: authentik-blueprints-provider-awx
+        namespace: authentik
+        labels:
+          app.kubernetes.io/component: blueprint
+      data:
+        provider-awx.yaml: |
+          # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+          version: 1
+          metadata:
+            name: AWX OIDC Provider
+            labels:
+              blueprints.goauthentik.io/instantiate: "true"
+          entries:
+            - model: authentik_providers_oauth2.oauth2provider
+              state: present
+              identifiers:
+                name: AWX
+              id: provider-awx
+              attrs:
+                authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+                authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+                client_type: confidential
+                client_id: awx
+                # client_secret is set via Authentik Admin UI (from SOPS secret)
+                redirect_uris: |
+                  https://awx.cluster.derio.net/sso/complete/oidc/
+                signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+                property_mappings:
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+                  - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+                sub_mode: hashed_user_id
+                include_claims_in_id_token: true
+            - model: authentik_core.application
+              state: present
+              identifiers:
+                slug: awx
+              attrs:
+                name: AWX
+                provider: !KeyOf provider-awx
+                meta_launch_url: https://awx.cluster.derio.net
+      END apps/authentik-extras/manifests/blueprints-provider-awx.yaml
+
+      Verify: `yq '.data | keys' apps/authentik-extras/manifests/blueprints-provider-awx.yaml` shows `provider-awx.yaml`. Confirm the AWX OIDC callback path against the pinned AWX version's docs — `/sso/complete/oidc/` is the social-auth default; adjust if the version differs.
+  - id: P3.T1.S2
+    text: |-
+      Register the blueprint ConfigMap and commit
+
+      Add `authentik-blueprints-provider-awx` to `blueprints.configMaps` in `apps/authentik/values.yaml` (the WORKER pod mounts blueprints from there — see Authentik gotchas).
+
+      ```bash
+      git add apps/authentik-extras/manifests/blueprints-provider-awx.yaml apps/authentik/values.yaml
+      git commit -m "feat(auto): Authentik OIDC provider blueprint for AWX (P3)"
+      ```
+
+      Verify: `grep awx apps/authentik/values.yaml` shows the ConfigMap registered under blueprints.configMaps.
+  - id: P3.T1.S3
+    text: |-
+      Set the OIDC client_secret (Authentik side + AWX side)
+
+      ```yaml
+      # manual-operation
+      id: auto-awx-oidc-client-secret
+      layer: auto
+      app: awx
+      plan: 2026-05-27--auto--awx-deployment
+      when: After the AWX blueprint applies (Authentik worker reconciles it) and AWX is up (Phase 5)
+      why_manual: >-
+        Authentik blueprints do not carry the OAuth2 client_secret, and AWX's
+        SOCIAL_AUTH_OIDC_SECRET is a sensitive value that must not live in git.
+        Both sides are set out-of-band from the same SOPS-stored secret.
+      commands: |
+        # 1. Generate the shared client secret and store in SOPS:
+        CLIENT_SECRET="$(openssl rand -base64 32)"
+        # 2. Authentik: set it on the AWX provider (Admin UI > Providers > AWX,
+        #    or the API). Must equal CLIENT_SECRET.
+        # 3. AWX: set SOCIAL_AUTH_OIDC_SECRET via the Settings API (DB-backed):
+        #    curl -sk -u admin:<admin-pw> -X PATCH \
+        #      https://awx.cluster.derio.net/api/v2/settings/authentication/ \
+        #      -H 'Content-Type: application/json' \
+        #      -d "{\"SOCIAL_AUTH_OIDC_SECRET\": \"$CLIENT_SECRET\"}"
+      verify: |
+        # OIDC login button appears at https://awx.cluster.derio.net and a
+        # round-trip login through Authentik succeeds (validated in Phase 5).
+      status: pending
+      ```
+
+      Verify: the client_secret matches on both sides; deferred end-to-end confirmation happens in Phase 5.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/04.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/04.yaml
@@ -1,0 +1,45 @@
+schema_version: 2
+phase:
+  number: 4
+  title: Exposure
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: IngressRoute and homepage tile
+  steps:
+  - id: P4.T1.S1
+    text: |-
+      Add the Traefik IngressRoute for awx.cluster.derio.net
+
+      Add an IngressRoute entry to `apps/traefik/manifests/ingressroutes.yaml` matching `Host(\`awx.cluster.derio.net\`)` → the `awx-service` ClusterIP Service on its HTTP port (the operator names the Service `awx-service`, port 80). Follow the existing entries' structure. Do NOT attach the `authentik-forwardauth` middleware — AWX does its own OIDC (see spec Auth divergence note).
+
+      Verify: `grep -A6 "awx.cluster.derio.net" apps/traefik/manifests/ingressroutes.yaml` shows the route with no forward-auth middleware; confirm the backend service name against `kubectl -n awx get svc` once AWX is up (Phase 5) and correct if the operator names it differently.
+  - id: P4.T1.S2
+    text: |-
+      Add the homepage tile and commit
+
+      Add an AWX tile to `apps/homepage/manifests/configmap-services.yaml` under an Automation category (icon e.g. `ansible.png`/`awx`, description "Ansible automation controller", href `https://awx.cluster.derio.net`).
+
+      ```bash
+      git add apps/traefik/manifests/ingressroutes.yaml apps/homepage/manifests/configmap-services.yaml
+      git commit -m "feat(auto): expose AWX via Traefik + homepage tile (P4)"
+      ```
+
+      Verify: `grep -i awx apps/homepage/manifests/configmap-services.yaml` shows the tile.
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/05.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/05.yaml
@@ -1,0 +1,83 @@
+schema_version: 2
+phase:
+  number: 5
+  title: Deploy and verify end-to-end (Deployed gate)
+  tag: manual
+  depends_on:
+  - 1
+  - 2
+  - 3
+  - 4
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Sync and verify operator reconciliation
+  steps:
+  - id: P5.T1.S1
+    text: |-
+      Merge to main, sync, and confirm AWX reconciles to Running
+
+      After the Phase 1/3/4 PRs merge to main (ArgoCD pulls main, not feature branches), sync the awx Application and watch the operator do the real work.
+
+      ```bash
+      argocd app sync awx --port-forward --port-forward-namespace argocd
+      kubectl -n awx get awx awx -o jsonpath='{.status.conditions}' ; echo
+      kubectl -n awx get pods
+      ```
+
+      Expected: the `awx` CR reaches a Successful/Running reconcile; `awx-task` and `awx-web` pods are Running; the operator-managed `awx-postgres-*` StatefulSet pod is Running; migrations complete (check `awx-task` logs for "Migrations complete"). Remember: ArgoCD Synced/Healthy alone does NOT prove this — verify the pods directly.
+  - id: P5.T1.S2
+    text: |-
+      Confirm the UI is reachable
+
+      ```bash
+      curl -skI https://awx.cluster.derio.net/ | head -1
+      ```
+
+      Expected: HTTP 200/302 from the AWX web UI via Traefik. If the backend service name in the IngressRoute was a guess, correct it now against `kubectl -n awx get svc` and re-sync traefik.
+- number: 2
+  title: Verify OIDC and run the smoke playbook
+  steps:
+  - id: P5.T2.S1
+    text: |-
+      Verify Authentik OIDC login end-to-end
+
+      In a browser, open https://awx.cluster.derio.net, click the OIDC/SSO login, authenticate through Authentik, and confirm you land in AWX as an SSO user. Verify an Authentik group maps to the expected AWX team/role (configure the group→team mapping in AWX Settings → Authentication if not already driven by claims).
+
+      Expected: SSO round-trip succeeds; the test user's Authentik group grants the intended AWX team membership. The local `admin` remains available as break-glass.
+  - id: P5.T2.S2
+    text: |-
+      Run the smoke playbook against a real non-Talos host (the gate)
+
+      In AWX: create a Machine Credential (SSH key/become) for one real non-Talos
+      home-lab host, an Inventory containing that host, a Project pointing at the
+      Gitea playbooks repo (or an inline ping), and a Job Template running an
+      Ansible `ping`. Launch it.
+
+      Expected: the Job completes with status `successful` and the `ping` task
+      returns `pong` for the target host. THIS is the Deployed gate — until a
+      playbook actually runs green against a host, the layer is not Deployed.
+
+      Verify: AWX Job output shows `ok=1` / `pong`; capture the job URL/screenshot for the operating blog post.
+state:
+  steps:
+    P5.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/06.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/06.yaml
@@ -1,0 +1,72 @@
+schema_version: 2
+phase:
+  number: 6
+  title: Post-Deploy Checklist
+  tag: manual
+  depends_on:
+  - 5
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Document, publish, and finalise the auto layer
+  steps:
+  - id: P6.T1.S1
+    text: |-
+      Confirm external exposure is documented
+
+      The IngressRoute + homepage tile were added in Phase 4. Confirm both are live (`awx.cluster.derio.net` reachable, tile visible on master.cluster.derio.net) and that the spec/blog record the domain + native-OIDC auth mode (no forward-auth).
+  - id: P6.T1.S2
+    text: |-
+      Write the building blog post
+
+      Use the `/blog-post` skill to write the "Building Frank" post for the `auto` layer (AWX as the imperative counterweight; the declarative-vs-imperative tension; operator + CR; OIDC). Update the series index in `blog/content/docs/building/00-overview/index.md` and confirm the roadmap shortcode entry from Phase 1.
+  - id: P6.T1.S3
+    text: |-
+      Write the operating blog post
+
+      Use the `/blog-post` skill for the companion operating guide: day-2 commands (sync/verify operator, run a Job Template, OIDC troubleshooting, rotate the OIDC secret, restore from the bootstrap secrets). Update the operating series index.
+  - id: P6.T1.S4
+    text: |-
+      Update the README
+
+      Run `/update-readme` to sync Technology Stack (add AWX/Ansible), Repository Structure (apps/awx), Service Access (awx.cluster.derio.net), and Current Status with the new `auto` layer.
+  - id: P6.T1.S5
+    text: |-
+      Sync the runbook
+
+      Run `/sync-runbook` to pull the two `# manual-operation` blocks (auto-awx-bootstrap-secrets, auto-awx-oidc-client-secret) into `docs/runbooks/manual-operations.yaml`.
+  - id: P6.T1.S6
+    text: |-
+      Set plan + spec status to Deployed
+
+      Set the plan `_prose.md` Status and the spec `**Status:**` to `Deployed`. Add any deployment deviations encountered (e.g. corrected backend Service name, OIDC callback path) to the spec.
+state:
+  steps:
+    P6.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S5:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S6:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/_meta.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-05-27--auto--awx-deployment
+spec: docs/superpowers/specs/2026-05-26--auto--awx-deployment-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-05-27'

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/_prose.md
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/_prose.md
@@ -1,0 +1,60 @@
+# AWX Deployment Implementation Plan
+
+**Spec:** `docs/superpowers/specs/2026-05-26--auto--awx-deployment-design.md`
+**Status:** Not Started
+
+## Overview
+
+Deploy AWX (the upstream Ansible automation controller) as Frank's new `auto`
+layer (#20) — the imperative counterweight to a declarative cluster, reaching
+the non-Talos / external home-lab devices that Talos and ArgoCD cannot manage.
+
+The deployment follows the locked spec decisions: **AWX Operator via ArgoCD**
+(two-layer reconciliation — ArgoCD owns the operator chart + the `AWX` CR, the
+operator owns the runtime workload), **operator-managed Postgres** on Longhorn,
+**native OIDC to Authentik** (not forward-auth), and **internal exposure** at
+`awx.cluster.derio.net` via the shared Traefik LB (no dedicated LB IP).
+
+## Phase shape and dependencies
+
+- **Phase 1** (agentic, root) — register the `auto` layer, then author the
+  ArgoCD app: operator chart values, the `AWX` CR, and a multi-source
+  Application with sync waves + `SkipDryRunOnMissingResource` to handle the
+  CRD-before-CR first-sync race, plus `ignoreDifferences` on operator-generated
+  Secrets.
+- **Phase 2** (manual, depends on 1) — generate/SOPS-encrypt/apply the AWX
+  bootstrap secrets (`awx-admin-password`, `awx-secret-key`) out-of-band. Names
+  match the CR refs from Phase 1. Per repo principle SOPS secrets are never
+  ArgoCD-managed.
+- **Phase 3** (agentic + manual, independent root) — Authentik OIDC provider
+  blueprint modelled on the Infisical one, registered in the worker's
+  `blueprints.configMaps`. A manual op sets the shared `client_secret` on both
+  the Authentik provider and AWX's `SOCIAL_AUTH_OIDC_SECRET` (neither belongs in
+  git).
+- **Phase 4** (agentic, depends on 1) — Traefik IngressRoute (no forward-auth
+  middleware — AWX owns its login) + homepage tile.
+- **Phase 5** (manual, fan-in on 1–4) — the Deployed gate: sync, confirm the
+  operator reconciles AWX + Postgres to Running, UI reachable, OIDC login
+  round-trips through Authentik, and a smoke `ping` playbook runs green against
+  one real non-Talos host. The layer is not Deployed until that playbook
+  succeeds.
+
+## Key risks and mitigations
+
+- **CRD-before-CR race:** the operator chart installs the `AWX` CRD; the CR
+  can't apply until it exists. Mitigated by sync waves (operator wave 0, CR
+  wave 1) and `SkipDryRunOnMissingResource=true`.
+- **OIDC secret in git:** avoided — only non-secret OIDC settings live in the CR
+  `extra_settings`; the secret is set via the AWX Settings API out-of-band.
+- **`Synced/Healthy` ≠ running:** the two-layer reconciliation means ArgoCD
+  reports healthy before the operator finishes. Phase 5 verifies pods + workflow
+  directly.
+- **OIDC settings vehicle:** `SOCIAL_AUTH_OIDC_*` via `extra_settings` is correct
+  for the pinned AWX 2.19.x; re-confirm at implementation since recent AWX has
+  been migrating auth config toward the DB-backed Settings flow.
+
+## Out of scope
+
+Custom Execution Environments, receptor mesh, full device-inventory build-out,
+public exposure, a dedicated `awx-db` app, and AWX DB backups — all deferred per
+the spec.

--- a/docs/superpowers/specs/2026-05-26--auto--awx-deployment-design.md
+++ b/docs/superpowers/specs/2026-05-26--auto--awx-deployment-design.md
@@ -210,3 +210,9 @@ expose externally (IngressRoute + homepage tile — already in the design),
 building blog post, operating blog post, README update, runbook sync (the SOPS
 bootstrap is a manual-operation), register the `auto` layer in
 `docs/layers.yaml` and the roadmap shortcode, and set Status to Deployed.
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-05-27--auto--awx-deployment | `derio-net/frank` | `docs/superpowers/plans/2026-05-27--auto--awx-deployment/` | — |


### PR DESCRIPTION
## Summary
Phase-structured v2 implementation plan for the new **`auto`** layer (#20) — deploying **AWX** as Frank's imperative automation controller for non-Talos / external devices. Builds on the merged design spec (#420).

**Plan only — no implementation, no GitHub Issues yet.** After this merges, the 6 phase Issues get dispatched via `vk apply --yes` (dry-run already verified clean).

### Phases
1. **AWX Operator + AWX CR** (ArgoCD app) — register `auto` layer, operator chart values, `AWX` CR, multi-source Application with sync waves + `SkipDryRunOnMissingResource`, `ignoreDifferences` on Secrets
2. **Bootstrap secrets** (SOPS, out-of-band) — admin pw + Django secret key
3. **Authentik OIDC provider** — blueprint modeled on Infisical; client_secret injected out-of-band
4. **Exposure** — Traefik IngressRoute `awx.cluster.derio.net` (no forward-auth) + homepage tile
5. **Deploy + verify** (Deployed gate) — operator reconciles → UI → OIDC round-trip → smoke `ping` playbook against a real host
6. **Post-Deploy Checklist** — blog posts, README, runbook sync, status

### Also in this PR
- Adds the spec's `## Implementation Plans` table (one row → this plan)

## Test plan
- [ ] Review the 6 phase YAMLs for accuracy (chart version 3.2.1 / AWX 2.19.1, CR fields, OIDC settings, manual-op blocks)
- [ ] Confirm the phasing + deploy gate before dispatch
- [ ] `vk plan self-review` passes (already green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)