### PR TITLE
docs(auto): backfill AWX plan phase tracking_issue links

### DIFF
--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/01.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/01.yaml
@@ -4,7 +4,7 @@ phase:
   title: AWX Operator + AWX CR (ArgoCD app)
   tag: agentic
   depends_on: []
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/frank/issues/422
 tasks:
 - number: 1
   title: Register the auto layer

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/02.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/02.yaml
@@ -5,7 +5,7 @@ phase:
   tag: manual
   depends_on:
   - 1
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/frank/issues/423
 tasks:
 - number: 1
   title: Generate and apply AWX bootstrap secrets

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/03.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/03.yaml
@@ -4,7 +4,7 @@ phase:
   title: Authentik OIDC provider
   tag: agentic
   depends_on: []
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/frank/issues/424
 tasks:
 - number: 1
   title: AWX OIDC provider blueprint

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/04.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/04.yaml
@@ -5,7 +5,7 @@ phase:
   tag: agentic
   depends_on:
   - 1
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/frank/issues/425
 tasks:
 - number: 1
   title: IngressRoute and homepage tile

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/05.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/05.yaml
@@ -8,7 +8,7 @@ phase:
   - 2
   - 3
   - 4
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/frank/issues/426
 tasks:
 - number: 1
   title: Sync and verify operator reconciliation

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/06.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/06.yaml
@@ -5,7 +5,7 @@ phase:
   tag: manual
   depends_on:
   - 5
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/frank/issues/427
 tasks:
 - number: 1
   title: Document, publish, and finalise the auto layer


### PR DESCRIPTION
## Summary
`vk apply --yes` dispatched the 6 phase Issues (#422–#427) for the AWX deployment plan. This records each phase's `tracking_issue` URL back into the plan YAML so the on-main plan matches the dispatched state (the established convention).

Trivial state-only change — no content edits to phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)