### PR TITLE
[derio-net/frank] 2026-05-27--auto--awx-deployment · Phase 3/6 · Authentik OIDC provider

### DIFF
--- a/apps/authentik-extras/manifests/blueprints-provider-awx.yaml
+++ b/apps/authentik-extras/manifests/blueprints-provider-awx.yaml
@@ -1,0 +1,47 @@
+# Authentik Blueprint: AWX OIDC Provider
+# Creates an OAuth2 provider + application for AWX SSO.
+# client_secret is set via Authentik Admin UI / API (manual operation).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authentik-blueprints-provider-awx
+  namespace: authentik
+  labels:
+    app.kubernetes.io/component: blueprint
+data:
+  provider-awx.yaml: |
+    # yaml-language-server: $schema=https://goauthentik.io/blueprints/schema.json
+    version: 1
+    metadata:
+      name: AWX OIDC Provider
+      labels:
+        blueprints.goauthentik.io/instantiate: "true"
+    entries:
+      - model: authentik_providers_oauth2.oauth2provider
+        state: present
+        identifiers:
+          name: AWX
+        id: provider-awx
+        attrs:
+          authorization_flow: !Find [authentik_flows.flow, [slug, default-provider-authorization-implicit-consent]]
+          authentication_flow: !Find [authentik_flows.flow, [slug, default-authentication-flow]]
+          client_type: confidential
+          client_id: awx
+          # client_secret is set via Authentik Admin UI (from SOPS secret)
+          redirect_uris: |
+            https://awx.cluster.derio.net/sso/complete/oidc/
+          signing_key: !Find [authentik_crypto.certificatekeypair, [name, authentik Self-signed Certificate]]
+          property_mappings:
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, openid]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, email]]
+            - !Find [authentik_providers_oauth2.scopemapping, [scope_name, profile]]
+          sub_mode: hashed_user_id
+          include_claims_in_id_token: true
+      - model: authentik_core.application
+        state: present
+        identifiers:
+          slug: awx
+        attrs:
+          name: AWX
+          provider: !KeyOf provider-awx
+          meta_launch_url: https://awx.cluster.derio.net

--- a/apps/authentik/values.yaml
+++ b/apps/authentik/values.yaml
@@ -75,6 +75,7 @@ blueprints:
     - authentik-blueprints-provider-argocd
     - authentik-blueprints-provider-grafana
     - authentik-blueprints-provider-infisical
+    - authentik-blueprints-provider-awx
     - authentik-blueprints-proxy-providers
     - authentik-blueprints-cluster-proxy-providers
     - authentik-blueprints-agent-auth

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -303,6 +303,29 @@ operations:
   - After login, Longhorn UI loads normally
   - Repeat for https://hubble.frank.derio.net and https://sympozium.frank.derio.net
   status: done
+- id: auto-awx-oidc-client-secret
+  layer: auto
+  app: awx
+  plan: docs/superpowers/plans/2026-05-27--auto--awx-deployment
+  when: After the AWX blueprint applies (Authentik worker reconciles it) and AWX is up (Phase 5)
+  why_manual: >-
+    Authentik blueprints do not carry the OAuth2 client_secret, and AWX's
+    SOCIAL_AUTH_OIDC_SECRET is a sensitive value that must not live in git.
+    Both sides are set out-of-band from the same SOPS-stored secret.
+  commands: |
+    # 1. Generate the shared client secret and store in SOPS:
+    CLIENT_SECRET="$(openssl rand -base64 32)"
+    # 2. Authentik: set it on the AWX provider (Admin UI > Providers > AWX,
+    #    or the API). Must equal CLIENT_SECRET.
+    # 3. AWX: set SOCIAL_AUTH_OIDC_SECRET via the Settings API (DB-backed):
+    #    curl -sk -u admin:<admin-pw> -X PATCH \
+    #      https://awx.cluster.derio.net/api/v2/settings/authentication/ \
+    #      -H 'Content-Type: application/json' \
+    #      -d "{\"SOCIAL_AUTH_OIDC_SECRET\": \"$CLIENT_SECRET\"}"
+  verify: |
+    # OIDC login button appears at https://awx.cluster.derio.net and a
+    # round-trip login through Authentik succeeds (validated in Phase 5).
+  status: pending
 - id: backup-r2-sops-secret
   layer: backup
   app: longhorn

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/03.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/03.yaml
@@ -129,6 +129,7 @@ state:
       note: 'Executed in Phase 5 — requires AWX running; manual-op registered in runbook
         (status: pending)'
   completion:
-    at: null
-    note: null
+    at: '2026-05-27T21:08:36+00:00'
+    note: Blueprint authored + registered; client_secret manual-op (auto-awx-oidc-client-secret)
+      registered in runbook, executes in Phase 5
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/03.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/03.yaml
@@ -116,17 +116,18 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:07:42+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:07:42+00:00'
       note: null
     P3.T1.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-05-27T21:07:43+00:00'
+      note: 'Executed in Phase 5 — requires AWX running; manual-op registered in runbook
+        (status: pending)'
   completion:
     at: null
     note: null


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-27--auto--awx-deployment
📐 Spec:   docs/superpowers/specs/2026-05-26--auto--awx-deployment-design.md
🎯 Phase:  3/6 — Authentik OIDC provider [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/424

**Goal (from plan):** Authentik OIDC provider blueprint modelled on the
Infisical one, registered in the worker's `blueprints.configMaps`. A manual op
sets the shared `client_secret` on both the Authentik provider and AWX's
`SOCIAL_AUTH_OIDC_SECRET` (neither belongs in git).

## Summary

Adds native OIDC SSO wiring for AWX into Authentik (the `auto` layer's auth path).

- **New blueprint** `apps/authentik-extras/manifests/blueprints-provider-awx.yaml` —
  a confidential OAuth2 provider (`client_id: awx`) + application, modelled on the
  Infisical provider. Redirect URI is the routable `https://awx.cluster.derio.net/sso/complete/oidc/`
  (the social-auth-core OIDC default callback). `client_secret` is intentionally
  absent — set out-of-band per the manual op.
- **Registered** `authentik-blueprints-provider-awx` under `blueprints.configMaps`
  in `apps/authentik/values.yaml` so the worker pod mounts and reconciles it.
- **Manual op** `auto-awx-oidc-client-secret` synced into
  `docs/runbooks/manual-operations.yaml` (status: pending). It executes in Phase 5
  once AWX is up — sets the shared secret on both the Authentik provider and AWX's
  `SOCIAL_AUTH_OIDC_SECRET`.

Phase 3 steps ticked (S1/S2 done, S3 deferred to Phase 5) and the phase marked complete.

## Verification

- `yq '.data | keys'` on the blueprint → `provider-awx.yaml` ✅
- `grep awx apps/authentik/values.yaml` → ConfigMap registered ✅
- runbook parses; `auto` layer entry present ✅

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
