### PR TITLE
[derio-net/frank] 2026-05-27--auto--awx-deployment · Phase 1/6 · AWX Operator + AWX CR (ArgoCD app)

### DIFF
--- a/apps/awx/manifests/awx.yaml
+++ b/apps/awx/manifests/awx.yaml
@@ -1,0 +1,29 @@
+apiVersion: awx.ansible.com/v1beta1
+kind: AWX
+metadata:
+  name: awx
+  namespace: awx
+  annotations:
+    # Apply the CR after the operator chart (CRD + Deployment, wave 0).
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  service_type: ClusterIP
+  ingress_type: none
+  replicas: 1
+  admin_user: admin
+  admin_password_secret: awx-admin-password
+  secret_key_secret: awx-secret-key
+  # Operator-managed Postgres (no postgres_configuration_secret given):
+  postgres_storage_class: longhorn
+  postgres_storage_requirements:
+    requests:
+      storage: 8Gi
+  projects_persistence: false
+  # Non-secret OIDC settings. SOCIAL_AUTH_OIDC_SECRET is set out-of-band
+  # via the AWX Settings API (manual-op in Phase 3) so the secret value
+  # never lands in git.
+  extra_settings:
+    - setting: SOCIAL_AUTH_OIDC_OIDC_ENDPOINT
+      value: "https://auth.cluster.derio.net/application/o/awx/"
+    - setting: SOCIAL_AUTH_OIDC_KEY
+      value: "awx"

--- a/apps/awx/values.yaml
+++ b/apps/awx/values.yaml
@@ -1,0 +1,5 @@
+# awx-operator Helm chart values.
+# The operator only runs the controller; the AWX workload is declared
+# by apps/awx/manifests/awx.yaml (the AWX custom resource).
+AWX:
+  enabled: false   # we manage the AWX CR ourselves as a raw manifest

--- a/apps/root/templates/awx.yaml
+++ b/apps/root/templates/awx.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: awx
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  sources:
+    # Wave 0: operator chart (installs the AWX CRD + operator Deployment)
+    - repoURL: https://ansible-community.github.io/awx-operator-helm/
+      chart: awx-operator
+      targetRevision: "3.2.1"
+      helm:
+        releaseName: awx-operator
+        valueFiles:
+          - $values/apps/awx/values.yaml
+    - repoURL: {{ .Values.repoURL }}
+      targetRevision: {{ .Values.targetRevision }}
+      ref: values
+    # Wave 1: the AWX CR (needs the CRD from wave 0 to exist first)
+    - repoURL: {{ .Values.repoURL }}
+      targetRevision: {{ .Values.targetRevision }}
+      path: apps/awx/manifests
+      directory:
+        include: 'awx.yaml'
+  destination:
+    server: {{ .Values.destination.server }}
+    namespace: awx
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+      - SkipDryRunOnMissingResource=true
+      - CreateNamespace=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - kind: Secret
+      jsonPointers:
+        - /data

--- a/blog/layouts/shortcodes/cluster-roadmap.html
+++ b/blog/layouts/shortcodes/cluster-roadmap.html
@@ -646,6 +646,23 @@
   </div>
 
   <div class="roadmap-layer">
+    <div class="roadmap-card layer-cicd">
+      <div class="layer-title"><span class="layer-num">31</span> Infrastructure Automation</div>
+      <div class="sub-items">
+        <span class="sub-item">AWX Ansible controller (operator + CR)</span>
+        <span class="sub-item">Reaches non-Talos / external home-lab devices</span>
+        <span class="sub-item">Native OIDC login via Authentik</span>
+        <span class="sub-item">awx.cluster.derio.net (Traefik)</span>
+      </div>
+      <div class="tags">
+        <span class="tag">awx</span>
+        <span class="tag">ansible</span>
+        <span class="tag">automation</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="roadmap-layer">
     <div class="roadmap-card layer-upcoming">
       <div class="layer-title"><span class="layer-num">—</span> Virtual Machines — upcoming</div>
       <div class="sub-items">

--- a/docs/layers.yaml
+++ b/docs/layers.yaml
@@ -105,6 +105,11 @@ layers:
     name: CI/CD Platform
     description: Gitea, Tekton, Zot registry, supply chain security
 
+  - code: auto
+    number: 20
+    name: Infrastructure Automation
+    description: AWX Ansible controller for non-Talos / external devices
+
   - code: repo
     name: Repository & Tooling
     description: Blog infrastructure, CI, repo restructuring, meta-tasks

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/01.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/01.yaml
@@ -108,11 +108,23 @@ tasks:
     text: |-
       Create apps/root/templates/awx.yaml (multi-source Application)
 
-      Copy an existing multi-source template (e.g. apps/root/templates with an
-      upstream chart + $values ref) and adapt. Critical pieces: sync waves so
-      the operator chart (CRD) applies BEFORE the AWX CR, SkipDryRunOnMissingResource
-      on the CR source, ignoreDifferences on operator-generated Secrets, and the
-      standard ServerSideApply / prune:false / selfHeal:true.
+      Copy an existing multi-source template (e.g. apps/root/templates/gitea.yaml
+      or infisical.yaml — upstream chart + $values ref) and adapt. Critical pieces:
+      sync waves so the operator chart (CRD) applies BEFORE the AWX CR,
+      SkipDryRunOnMissingResource on the CR source, ignoreDifferences on
+      operator-generated Secrets, and the standard ServerSideApply / selfHeal:true.
+
+      DEVIATION (implemented): the snippet below was reconciled to repo conventions
+      during implementation, replacing the original draft. Changes vs. the first
+      draft: project is `infrastructure` (all sibling templates use it, never
+      `default`); repoURL/targetRevision/destination are Helm-templated via
+      `{{ .Values.* }}` (App-of-Apps norm) rather than hardcoded; `finalizers`
+      added; `RespectIgnoreDifferences=true` added so the Secret /data ignore holds
+      during sync; `releaseName: awx-operator` set on the chart source; the explicit
+      `prune: false` was DROPPED (apps/root/values.yaml documents it normalizes to
+      absent and causes permanent drift — the schema default already gives
+      manual-only pruning); the Application-level `sync-wave: "0"` annotation was
+      dropped (the within-Application resource waves are what order the CRD vs CR).
 
       BEGIN apps/root/templates/awx.yaml
       apiVersion: argoproj.io/v1alpha1
@@ -120,41 +132,41 @@ tasks:
       metadata:
         name: awx
         namespace: argocd
-        annotations:
-          argocd.argoproj.io/sync-wave: "0"
+        finalizers:
+          - resources-finalizer.argocd.argoproj.io
       spec:
-        project: default
-        destination:
-          server: https://kubernetes.default.svc
-          namespace: awx
+        project: infrastructure
         sources:
           # Wave 0: operator chart (installs the AWX CRD + operator Deployment)
           - repoURL: https://ansible-community.github.io/awx-operator-helm/
             chart: awx-operator
-            targetRevision: 3.2.1
+            targetRevision: "3.2.1"
             helm:
+              releaseName: awx-operator
               valueFiles:
                 - $values/apps/awx/values.yaml
-          - repoURL: https://github.com/derio-net/frank.git
-            targetRevision: main
+          - repoURL: {{ .Values.repoURL }}
+            targetRevision: {{ .Values.targetRevision }}
             ref: values
           # Wave 1: the AWX CR (needs the CRD from wave 0 to exist first)
-          - repoURL: https://github.com/derio-net/frank.git
-            targetRevision: main
+          - repoURL: {{ .Values.repoURL }}
+            targetRevision: {{ .Values.targetRevision }}
             path: apps/awx/manifests
             directory:
               include: 'awx.yaml'
+        destination:
+          server: {{ .Values.destination.server }}
+          namespace: awx
         syncPolicy:
           automated:
-            prune: false
             selfHeal: true
           syncOptions:
             - ServerSideApply=true
             - SkipDryRunOnMissingResource=true
             - CreateNamespace=true
+            - RespectIgnoreDifferences=true
         ignoreDifferences:
-          - group: ""
-            kind: Secret
+          - kind: Secret
             jsonPointers:
               - /data
       END apps/root/templates/awx.yaml

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/01.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/01.yaml
@@ -177,34 +177,34 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:09:30+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:09:30+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:09:30+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:09:30+00:00'
       note: null
     P1.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:09:30+00:00'
       note: null
     P1.T4.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:09:31+00:00'
       note: null
     P1.T4.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-27T21:09:31+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-05-27T21:09:34+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-27--auto--awx-deployment
📐 Spec:   docs/superpowers/specs/2026-05-26--auto--awx-deployment-design.md
🎯 Phase:  1/6 — AWX Operator + AWX CR (ArgoCD app) [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/422

Closes #422

## Summary

Phase 1 registers the new `auto` layer (#20) and authors the ArgoCD app for AWX — the imperative counterweight that reaches non-Talos / external home-lab devices.

- **`docs/layers.yaml`** — new `auto` layer (#20, Infrastructure Automation).
- **`blog/layouts/shortcodes/cluster-roadmap.html`** — roadmap card for the AWX layer.
- **`apps/awx/values.yaml`** — operator chart values (`AWX.enabled: false`; we own the CR).
- **`apps/awx/manifests/awx.yaml`** — the `AWX` CR: operator-managed Postgres on Longhorn, `ClusterIP`, no operator ingress (Traefik in Phase 4), non-secret OIDC settings inline, `sync-wave: "1"`.
- **`apps/root/templates/awx.yaml`** — multi-source Application: operator chart (wave 0) → AWX CR (wave 1), `SkipDryRunOnMissingResource=true` for the CRD-before-CR race, `ignoreDifferences` on operator-generated Secrets.

## Deviations from the plan template (matched to repo conventions)

- `project: infrastructure` (all 56 existing templates use it; the plan's `default` was an oversight).
- Helm-templated `repoURL` / `targetRevision` / `destination.server` refs (repo norm) instead of hardcoded literals.
- Dropped the explicit `prune: false` — it normalizes to absent and causes permanent drift (see `apps/root/values.yaml` comment); the schema default already gives us manual-only pruning.
- Added `RespectIgnoreDifferences=true` so the Secret `/data` ignore actually holds during sync.
- Roadmap card numbered **31** (next blog-narrative slot) rather than the plan's `20`: roadmap numbers have diverged from `layers.yaml` numbers (`cicd` is layers.yaml #19 but roadmap #25).

## Verification

- `grep -A3 "code: auto" docs/layers.yaml` → new entry present.
- `scripts/validate-plans.sh <plan>` → exit 0 (auto layer recognised).
- Chart version confirmed: `awx-operator 3.2.1` / appVersion `2.19.1` is current stable (fetched from the helm index).
- `yq '.spec.sources | length'` → 3; `grep -c SkipDryRunOnMissingResource` → 1; CR `sync-wave` → "1".

Not verified in-cluster (deferred to Phase 5 per plan): actual ArgoCD sync / operator reconcile. `helm`/`kubeconform` are not installed in this environment, so the chart render was validated structurally against existing multi-source templates rather than by `helm template`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)