### PR TITLE
[derio-net/frank] 2026-05-27--auto--awx-deployment · Phase 2/6 · Bootstrap secrets (SOPS, out-of-band)

### DIFF
--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/02.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/02.yaml
@@ -50,10 +50,12 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-05-31T18:24:47+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-05-31T18:24:52+00:00'
+    note: 'Secrets awx-admin-password + awx-secret-key generated, SOPS-encrypted (committed
+      under secrets/awx/), and applied out-of-band to ns awx. Verified live: both
+      secrets present with correct keys (password / secret_key). Runbook id: auto-awx-bootstrap-secrets.'
     observed_prs: []

--- a/secrets/awx/awx-admin-password.yaml
+++ b/secrets/awx/awx-admin-password.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:SP8E6hUeQ0wAaXmN4a78T4QgrosaHIdGrRSVKdOlb5RMxedVD7kApkKnWKE=,iv:SlWJLJmsYnrj3fPQHs+sqDznlBB/okjtOk8OnGGAFe8=,tag:qQ6/Cflf3lwNDQdmYBlOHQ==,type:str]
+kind: Secret
+metadata:
+    name: awx-admin-password
+    namespace: awx
+sops:
+    age:
+        - recipient: age1ufxvcn4us3cue5dglwn4uk8ctjfpuaw6dqlwu4hjzszf2g4htpcqkszjne
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBKOTFlSFJaZ0dIeVdrd1Q1
+            K2dPenhrQ0VpNU5QVzkrUDRCSWxzU0o4M0QwCnBLZW1rVmE2Y1ZqdEs4V2o0NXhu
+            L09LbVBvZzhTc3lTT1ZSMDIxMnpaUW8KLS0tIDdEWUJZUVJkZ0NXeCszOXVPbGhV
+            NXh1a2ZTRU1HNThVd2R2SEwyRlBabFkKqgQQAwdBb1a26rSv1oUK65Yq6rhI3ITZ
+            bNodVSh0LhY8XTJ0kpfL81YZ4W0Gj0Peo2x4VfwfqwvpPzO4GsjX0Q==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-31T18:16:23Z"
+    mac: ENC[AES256_GCM,data:6Hph11V19uNDSsqGR2XW1Rum8iY8HkdU4/E7EsVJ/F5PC1Q2eYkbbfM+DKkhcCaew+TcAx0g3lTOxLAgzPClK+Iv8yKE7+HF866URS+8pXjOFQO87gge6Ua4jCid9X24jM4IfX+wPUsf+A32TgDaLZogqoD1z/zaIEh6Bv+dThQ=,iv:vCNuu1bF1l1ALRFLw3+Uyqho83BaoiCIzlsIdWgJCxI=,tag:sfdOujrymwgkCLjuMVFJAw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2

--- a/secrets/awx/awx-secret-key.yaml
+++ b/secrets/awx/awx-secret-key.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    secret_key: ENC[AES256_GCM,data:ZudnkXRMDIrp0tAoRIMVJCQC4JQlE7UgOcOy5gOmjrUWovYGooW1nmiohH6qXjxlvtIpqvTffQuOZC2JyY3DxPGxZLD9P+kwtdV1yjo3RGd+CvHN4pIRwQ==,iv:c9494d36RiuJmi/UelamFr4mAB+P1NHOdAGHtnTn7hU=,tag:QtHYzj3+jW3W7W2kxW+anw==,type:str]
+kind: Secret
+metadata:
+    name: awx-secret-key
+    namespace: awx
+sops:
+    age:
+        - recipient: age1ufxvcn4us3cue5dglwn4uk8ctjfpuaw6dqlwu4hjzszf2g4htpcqkszjne
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBnM1BiWVIvdFAxRDR5Rm9J
+            SzVFdGxVcklJZmVUWllnanNOZTVSTFZkdnhFClRtRVc0L3RXRWFsN2ZvRml3V2xW
+            Lzh3T1Vwa3ZXU041UDlObWl6cmdncFkKLS0tIHhjS1BMNjUxM24wVklacSsrT0tD
+            OVRrOHdSbzNUbTZMQk04OUpocTRIVTAKcxPL2t5BetGhxmOlimgEbp9JMvDMwaY2
+            AZoJ/sr0ln7XQ2nwGQjuGm5igzK2rAvX7DN47kUBXSIfKhTVFLzOug==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-31T18:16:34Z"
+    mac: ENC[AES256_GCM,data:hnXJMXucFWwd6ZrjyVXmF0bPB9hXH/KKy2wYyg1Xg1MATizQBUm3pBE3FGEqGe/u0hZTymSUIcBHgoi269oiJxpCiuKJ2MDuqHluFUU5p9HEknDWInI45sTH1Ldw/sAbhtM3cgViRXRdhDSsYUl9USJKnahLF+rnWxozmFRJozc=,iv:cFAq/IZ+xa6HcjPGfdIn1wH8TWKgG6mwzJEZaefynIA=,tag:WDnjPlj4cBBZ2p3kDIgEgA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.12.2


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-27--auto--awx-deployment
📐 Spec:   docs/superpowers/specs/2026-05-26--auto--awx-deployment-design.md
🎯 Phase:  2/6 — Bootstrap secrets (SOPS, out-of-band) [manual]
🔗 Issue:  https://github.com/derio-net/frank/issues/423

---

## Summary

Phase 2 (manual): the AWX bootstrap secrets were generated, SOPS-encrypted, and
applied out-of-band by the operator. This PR records that completion:

- Commit the two SOPS-encrypted files under `secrets/awx/` (`awx-admin-password`,
  `awx-secret-key`) — they existed on disk but were untracked.
- Tick `P2.T1.S1` and `--complete-phase 2` in the plan.

## Verification

- Both secrets present in ns `awx` with the operator-required keys (`password`,
  `secret_key`) — verified live.
- Files are age-encrypted (cluster recipient), safe to commit; applied
  out-of-band, **not** ArgoCD-managed (declarative-only exception).
- Manual-op id: `auto-awx-bootstrap-secrets`.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)
