### PR TITLE
fix(auto): AWX managed Postgres CrashLoop — init data volume perms

### DIFF
--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -15,6 +15,7 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - RWO PVC + RollingUpdate deadlocks; use `strategy: Recreate`. Switching strategy via Helm needs a one-time `kubectl patch` to clear the orphan `rollingUpdate:` block.
 - ESO: empty `data: []` is rejected; delete the ExternalSecret if all keys are removed.
 - `envFrom.secretRef` without `optional: true` blocks rolling updates when the Secret is missing.
+- AWX operator-managed Postgres on Longhorn CrashLoops with `mkdir '/var/lib/pgsql/data/userdata': Permission denied` — the `sclorg/postgresql-15` image runs as UID 26 but the fresh PVC mounts root-owned and the operator emits an empty `securityContext`. Set `postgres_data_volume_init: true` in the AWX CR (root init container chowns the volume; storage-agnostic) rather than relying on `fsGroup`.
 - Always `ServerSideApply=true`; always `prune: false`; always `ignoreDifferences` on Secret `/data`.
 
 ### Tekton — `docs/runbooks/frank-gotchas/tekton.md`

--- a/apps/awx/manifests/awx.yaml
+++ b/apps/awx/manifests/awx.yaml
@@ -18,6 +18,14 @@ spec:
   postgres_storage_requirements:
     requests:
       storage: 8Gi
+  # DEVIATION (P1 fix): the sclorg/postgresql-15 image runs as UID 26, but a
+  # fresh Longhorn PVC mounts root-owned, so the postgres container cannot
+  # create its PGDATA subdir (`mkdir '/var/lib/pgsql/data/userdata': Permission
+  # denied` → CrashLoopBackOff, 696 restarts). The operator emits an empty
+  # securityContext unless told otherwise. postgres_data_volume_init injects a
+  # root init container that chowns the data volume to UID 26 before postgres
+  # starts — storage-agnostic (works regardless of CSI fsGroup support).
+  postgres_data_volume_init: true
   projects_persistence: false
   # Non-secret OIDC settings. SOCIAL_AUTH_OIDC_SECRET is set out-of-band
   # via the AWX Settings API (manual-op in Phase 3) so the secret value

--- a/docs/runbooks/frank-gotchas/storage-secrets-ssa.md
+++ b/docs/runbooks/frank-gotchas/storage-secrets-ssa.md
@@ -33,6 +33,46 @@ If all keys are removed, delete the ExternalSecret entirely rather than leaving 
 
 Encrypted secrets must live outside ArgoCD-managed paths (see `secrets/` dir) and be applied out-of-band.
 
+## AWX operator-managed Postgres CrashLoops on Longhorn — volume permissions
+
+**Symptom (2026-05-31, auto layer):** after deploying the `auto` layer (AWX),
+the operator-managed `awx-postgres-15-0` pod sat in CrashLoopBackOff (696
+restarts over ~2.5 days). Single log line:
+
+```
+mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission denied
+```
+
+`awx-web` CrashLooped in turn (no reachable DB) and `awx-task` was stuck at
+`Init:0/2` (waiting on DB migrations) — all three symptoms trace to the one DB
+fault.
+
+**Root cause:** the `quay.io/sclorg/postgresql-15-c9s` image has a baked-in
+`USER 26`, but a freshly provisioned Longhorn PVC mounts root-owned (`root:root`,
+mode 755). The AWX operator emits an **empty** pod `securityContext` (no
+`fsGroup`, no init container) unless the CR tells it otherwise — so UID 26 cannot
+create its `PGDATA` subdir (`/var/lib/pgsql/data/userdata`). Confirm with:
+
+```bash
+kubectl -n awx get statefulset awx-postgres-15 -o jsonpath='{.spec.template.spec.securityContext}'   # → {}
+```
+
+**Fix (declarative, in the AWX CR `apps/awx/manifests/awx.yaml`):**
+
+```yaml
+spec:
+  postgres_data_volume_init: true
+```
+
+This makes the operator inject a root init container that `chown`s the data
+volume to UID 26 before postgres starts. Chosen over
+`postgres_security_context_settings: {fsGroup: 26}` because it is
+storage-agnostic — it works regardless of whether the CSI driver honours
+`fsGroup` (Longhorn does, but the init-container route is the AWX-operator's
+purpose-built answer to this exact error and survives a storage-class swap).
+After the CR change syncs, the operator regenerates the StatefulSet with the
+init container and the postgres pod (and then web/task) reconcile to Running.
+
 ## Standing rules
 
 - Always `ServerSideApply=true` in ArgoCD sync options (avoids annotation size limits).

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/_prose.md
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/_prose.md
@@ -58,3 +58,21 @@ operator owns the runtime workload), **operator-managed Postgres** on Longhorn,
 Custom Execution Environments, receptor mesh, full device-inventory build-out,
 public exposure, a dedicated `awx-db` app, and AWX DB backups — all deferred per
 the spec.
+
+## Deployment Deviations
+
+- **P1 — managed Postgres CrashLoopBackOff (volume permissions).** After
+  Phases 1–2 the operator-managed `awx-postgres-15-0` pod entered
+  CrashLoopBackOff (696 restarts over ~2.5 days) with
+  `mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission
+  denied`. Root cause: the `sclorg/postgresql-15` image runs as UID 26, but a
+  freshly provisioned Longhorn PVC mounts root-owned, and the AWX operator emits
+  an **empty** pod `securityContext` unless told otherwise — so UID 26 cannot
+  create its PGDATA subdir. `awx-web` then CrashLooped (no DB) and `awx-task`
+  stuck at `Init:0/2` (waiting on migrations). **Fix:** added
+  `postgres_data_volume_init: true` to the AWX CR (`apps/awx/manifests/awx.yaml`),
+  which injects a root init container that `chown`s the data volume to the
+  postgres UID before the container starts. Chosen over
+  `postgres_security_context_settings: {fsGroup: 26}` because it is
+  storage-agnostic (works regardless of CSI fsGroup support). Gotcha recorded
+  under Storage / Secrets / SSA.


### PR DESCRIPTION
## Summary

The operator-managed `awx-postgres-15-0` pod entered CrashLoopBackOff (696
restarts over ~2.5 days) after the `auto` layer was deployed (P1):

```
mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission denied
```

`awx-web` CrashLooped (no reachable DB) and `awx-task` hung at `Init:0/2`
(waiting on DB migrations) as a cascade of the same fault.

## Root cause

The `quay.io/sclorg/postgresql-15-c9s` image runs as UID 26, but a freshly
provisioned Longhorn PVC mounts root-owned and the AWX operator emits an **empty**
pod `securityContext` unless told otherwise — so UID 26 cannot create its PGDATA
subdir.

```
$ kubectl -n awx get statefulset awx-postgres-15 \
    -o jsonpath='{.spec.template.spec.securityContext}'
{}
```

## Fix

Add `postgres_data_volume_init: true` to the AWX CR (`apps/awx/manifests/awx.yaml`).
The operator then injects a root init container that `chown`s the data volume to
UID 26 before postgres starts. Chosen over `postgres_security_context_settings:
{fsGroup: 26}` because it is storage-agnostic (works regardless of CSI fsGroup
support) and is the operator's purpose-built answer to this error.

## Deploy + verify

This is a **P1 deviation** — once merged, ArgoCD syncs the CR, the operator
regenerates the StatefulSet with the init container, and postgres → web → task
should reconcile to Running. Layer is not "fixed" until the postgres pod is
observed `1/1 Running` post-merge.

- Plan deviation note added to the plan prose.
- Gotcha recorded under Storage / Secrets / SSA (hot file + topic file).

Relates to #422 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
