### PR TITLE
[derio-net/frank] 2026-05-27--auto--awx-deployment · Phase 4/6 · Exposure

### DIFF
--- a/apps/homepage/manifests/files/services.yaml
+++ b/apps/homepage/manifests/files/services.yaml
@@ -91,3 +91,9 @@
         href: https://ruflo.cluster.derio.net
         description: Ruvocal multi-agent orchestrator
         siteMonitor: http://ruflo-web.ruflo-system:80
+- Automation:
+    - AWX:
+        icon: ansible
+        href: https://awx.cluster.derio.net
+        description: Ansible automation controller
+        siteMonitor: http://awx-service.awx:80

--- a/apps/traefik/manifests/ingressroutes.yaml
+++ b/apps/traefik/manifests/ingressroutes.yaml
@@ -458,3 +458,28 @@ spec:
     certResolver: cloudflare
     domains:
       - main: "*.cluster.derio.net"
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: awx
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    # No authentik-forwardauth — AWX owns its own login via native OIDC to
+    # Authentik (SOCIAL_AUTH_OIDC_*). See spec auth divergence note.
+    - match: Host(`awx.cluster.derio.net`)
+      kind: Rule
+      middlewares:
+        - name: ip-allowlist
+        - name: security-headers
+      services:
+        - name: awx-service
+          namespace: awx
+          port: 80
+  tls:
+    certResolver: cloudflare
+    domains:
+      - main: "*.cluster.derio.net"

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/04.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/04.yaml
@@ -32,14 +32,14 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T05:09:04+00:00'
       note: null
     P4.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T05:09:04+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-01T05:09:05+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--auto--awx-deployment/04.yaml
+++ b/docs/superpowers/plans/2026-05-27--auto--awx-deployment/04.yaml
@@ -37,8 +37,11 @@ state:
       note: null
     P4.T1.S2:
       state: x
-      ticked_at: '2026-06-01T05:09:04+00:00'
-      note: null
+      ticked_at: '2026-06-01T05:13:38+00:00'
+      note: Tile landed in apps/homepage/manifests/files/services.yaml — the path
+        in the plan body (apps/homepage/manifests/configmap-services.yaml) is wrong;
+        the real ConfigMap is built by Kustomize configMapGenerator from files/services.yaml
+        (see apps/homepage/manifests/kustomization.yaml).
   completion:
     at: '2026-06-01T05:09:05+00:00'
     note: null


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-27--auto--awx-deployment
📐 Spec:   docs/superpowers/specs/2026-05-26--auto--awx-deployment-design.md
🎯 Phase:  4/6 — Exposure [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/425

Closes #425

**Goal (from plan):** Make AWX reachable from the cluster's internal domain at `awx.cluster.derio.net` and surface it on the homepage dashboard — without forward-auth, because AWX owns its login via native OIDC to Authentik.

## Summary

- Added a Traefik `IngressRoute` for `awx.cluster.derio.net` → `awx-service.awx:80`, the operator-created ClusterIP service. Middlewares: `ip-allowlist` + `security-headers`. Deliberately **no** `authentik-forwardauth` — AWX handles its own OIDC via `SOCIAL_AUTH_OIDC_*` (wired in Phase 3).
- Added an `Automation` category to the homepage services config with an AWX tile (`ansible` icon, in-cluster `siteMonitor`, public `href`). The homepage uses Kustomize `configMapGenerator`, so this edit changes the ConfigMap hash and rolls the pod automatically — no manual restart needed.
- Backend service name (`awx-service`, port 80) follows the AWX operator's naming convention; Phase 5 will confirm against the live cluster and correct if the operator deviates.

## Test plan

- [ ] After ArgoCD syncs Phase 1's `awx` Application, confirm `kubectl -n awx get svc` shows `awx-service` on port 80; correct the IngressRoute if it differs.
- [ ] Browse `https://awx.cluster.derio.net` from inside the cluster's IP allowlist and see the AWX login screen (no forward-auth interception, no Authentik prompt).
- [ ] Open `https://master.cluster.derio.net` and verify the AWX tile appears under the new Automation category with the icon, description, and `siteMonitor` indicator turning green once AWX is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)