### PR TITLE
chore(paperclip): bump to v2026.529.0

### DIFF
--- a/apps/paperclip/manifests/deployment.yaml
+++ b/apps/paperclip/manifests/deployment.yaml
@@ -94,21 +94,17 @@ spec:
       containers:
         - name: paperclip
           # Upstream public image. Pinned by digest-equivalent sha tag.
-          # sha-60efa38 is release v2026.525.0 (2026-05-25) — adds the
-          # first-party Modal sandbox-provider plugin (#6245), a workspace
-          # diff viewer plugin (#6071), routine-scoped secrets (#6212), and
-          # local Cloud Upstream sync (#6548). Notably fixes #6423: the
-          # company-creation retry detector now walks the Drizzle 0.45.x
-          # error cause chain for `companies_issue_prefix_idx`, so
-          # generated-prefix collisions retry instead of 500-ing (the
-          # `createCompanyWithUniquePrefix` gotcha in frank-gotchas.md).
-          # Tag scheme is upstream's: only `latest` (master HEAD),
-          # `canary`, and `sha-<short>` are published — no semver image
-          # tags. We pin to the sha for traceability: v2026.525.0 →
-          # commit 60efa38f868e838e9af2e2168daf0c70afefb9e6.
-          # Manifest digest: sha256:d9293c26de7c1cbb3e1c5026cced013063408568100684e3d26be0d033fe3997
-          # Bumped from sha-93cd933 (sha256:eb7259dfbd5c55339bd1a037f35caa28e024af493c31869d90524d292bc7ae15).
-          image: ghcr.io/paperclipai/paperclip:sha-60efa38
+          # sha-911a1e8 == git tag v2026.529.0 (released 2026-05-29).
+          # v2026.529.0 adds inline document annotations with revision-aware
+          # threads, company skills CLI + catalog management, user-scoped
+          # sidebar visibility for projects/agents, first-admin claim flow
+          # for fresh self-hosted deployments, and live Claude model discovery
+          # (auto-refreshes Anthropic catalog from the UI). Tag scheme is
+          # upstream's: only `latest` (master HEAD), `canary`, and `sha-<short>`
+          # are published — no semver image tags. We pin to the sha for
+          # traceability: v2026.529.0 → commit 911a1e8b0d24205acd5006e837a5c5e8c4bfb447.
+          # Bumped from sha-60efa38 (v2026.525.0, 2026-05-25).
+          image: ghcr.io/paperclipai/paperclip:sha-911a1e8
           ports:
             - name: http
               containerPort: 3100


### PR DESCRIPTION
Bumps `ghcr.io/paperclipai/paperclip` from `sha-60efa38` (v2026.525.0) to `sha-911a1e8` (v2026.529.0).

---

## Release notes

### v2026.529.0 (2026-05-29)

- **Inline document annotations** — revision-aware annotation threads for discussing specific document passages
- **Company skills CLI + catalog management** — first-class skill installation, auditing, and assignment from the CLI
- **Sidebar visibility controls** — users can hide projects and agents while maintaining resource accessibility
- **First-admin claim flow** — one-time browser claim for initial admin setup on fresh self-hosted deployments
- **Live Claude model discovery** — automatic Anthropic model catalog refresh within the UI
- Bug fix: duplicate subtask generation prevented when accepted plan revisions overlap

---

## Pre-deploy checklist

- [x] Snapshot `paperclip-db` PVC (`kubectl apply` a `snapshots.longhorn.io` CR with `spec.createSnapshot: true` and `spec.volume: <pvc-uuid>`)
- [x] Confirm any new env vars called out in any Upgrade Guide are added to `apps/paperclip/manifests/configmap.yaml`
- [x] Confirm new DB extensions (if any are required) are pre-created in the `paperclip` database
- [x] Confirm no breaking config changes from the Upgrade Guides
- [x] Confirm imagePullSecret is still NOT needed (upstream package is public)

---

## Pre-deploy verification (2026-06-01)

Worked through the checklist against the live cluster and the upstream `60efa38...911a1e8` diff. Single release in range: **v2026.529.0** (no intermediate releases between base and target).

**Snapshot (rollback point):** Longhorn `Snapshot/paperclip-db-pre-v529-20260601-213200` of the Postgres data volume `pvc-1929c98e-6a59-4eec-8c41-353833f43dec` (PVC `data-paperclip-db-postgresql-0`) — `readyToUse=true`, restoreSize 5Gi, created `2026-06-01T19:32:01Z`. Volume was `attached`/`healthy` at snapshot time.

**Env vars:** No new *required* server env vars. New `process.env.*` reads in range are adapter/CLI-side and optional — Claude-adapter Anthropic vars (`ANTHROPIC_API_KEY`/`ANTHROPIC_BASE_URL`/Bedrock) for the new live-model-discovery feature, and `PAPERCLIP_API_KEY`/`PAPERCLIP_API_URL`/`PAPERCLIP_COMPANY_ID` for the new skills CLI (set at CLI invocation, not server boot). Existing `paperclip-config` ConfigMap is complete for our `authenticated`/`private` deployment.

**DB extensions:** 4 new migrations (`0090`–`0093`), all additive. Only extension dependency is `pg_trgm` (used by `gin_trgm_ops` index in `0091`) — already installed in the live DB (`pg_trgm 1.6`; also `fuzzystrmatch 1.2`, `plpgsql`). `gen_random_uuid()` is PG core. No new extension to pre-create.

**Breaking config:** Migrations are additive (new `*_memberships`, `document_annotation_*`, `issue_plan_decompositions` tables — confirmed absent from the live DB, so they apply fresh). `0093` does an *unguarded* `DROP CONSTRAINT` on `execution_workspaces` / `workspace_operations` to switch their company FK to `ON DELETE cascade` — verified both constraints exist with the exact expected names, so it won't error on boot. First-admin claim flow only affects *unclaimed* deployments (ours is claimed/authenticated). Dockerfile change in range is build-only (adds the `skills-catalog` package). No breaking config.

**imagePullSecret:** Both `sha-911a1e8` and `sha-60efa38` return `HTTP 200` anonymously from GHCR; deployment has no `imagePullSecret`. Upstream package remains public.

---

Generated by the monthly upstream-watcher routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01METZaYZTvXX2h5yuSbb2jt)_
