### PR TITLE
feat(repo): homelab ops skills + Hextra weight-zero guard

### DIFF
--- a/.claude/hookify.warn-hextra-weight-zero.local.md
+++ b/.claude/hookify.warn-hextra-weight-zero.local.md
@@ -1,0 +1,30 @@
+---
+name: warn-hextra-weight-zero
+enabled: true
+event: file
+action: warn
+conditions:
+  - field: file_path
+    operator: regex_match
+    pattern: blog/content/.*\.md$
+  - field: content
+    operator: regex_match
+    pattern: weight:\s*0(?!\d)
+---
+
+⚠️ **Hextra sidebar weight trap: `weight: 0`**
+
+This blog post sets `weight: 0`. Hugo treats `weight: 0` as "no weight set" and
+sorts those pages **LAST** in the Hextra sidebar — the recurring "00 is at the
+bottom" bug.
+
+**Fix — give it a non-zero weight:**
+
+- **Papers:** convention is `weight = paper_number + 1` (Paper 00 → `weight: 1`).
+  The `+1` offset exists precisely to dodge the zero-weight trap. Enforced by
+  `scripts/validate-papers.py`; see `agents/rules/repo-papers.md`.
+- **Building / operating posts:** weight matches the post number, but the **00**
+  overview post must use `weight: 1` (not `0`). Apply the same `+1` shift across
+  the series if you need to preserve strict numeric order without a collision.
+
+Canonical frontmatter rules: `agents/rules/repo-blog.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,12 @@ Repo-local skills are stored in `agents/skills/`. When a task matches a skill,
 read that skill's `SKILL.md` before acting.
 
 - `blog-post`: `agents/skills/blog-post/SKILL.md`
+- `bump-image`: `agents/skills/bump-image/SKILL.md`
 - `deploy-app`: `agents/skills/deploy-app/SKILL.md`
+- `expose-service`: `agents/skills/expose-service/SKILL.md`
+- `falco-triage`: `agents/skills/falco-triage/SKILL.md`
 - `media`: `agents/skills/media/SKILL.md`
+- `oidc-onboard`: `agents/skills/oidc-onboard/SKILL.md`
 - `papers`: `agents/skills/papers/SKILL.md`
 - `sync-runbook`: `agents/skills/sync-runbook/SKILL.md`
 - `update-readme`: `agents/skills/update-readme/SKILL.md`

--- a/agents/rules/repo-blog.md
+++ b/agents/rules/repo-blog.md
@@ -22,6 +22,12 @@ weight: <NN>    # Sort order matches post number
 ---
 ```
 
+> **Never use `weight: 0`.** Hugo treats `weight: 0` as "unset" and sorts the page
+> LAST in the Hextra sidebar (the recurring "00 is at the bottom" bug). The **00**
+> overview post must use `weight: 1`. Papers use `weight = paper_number + 1` (see
+> `repo-papers.md`). A hookify guard (`.claude/hookify.warn-hextra-weight-zero.local.md`)
+> warns on `weight: 0` in any `blog/content/**.md` write.
+
 Cover image entries go in `blog/prompt_for_images.yaml` — read the top-of-file comment block for the agent procedure. Required fields per entry: `key`, `series`, `torso_variant` (int index into `torso_variants.<series>`), `mood` (preset key), `references` (1–2 paths from `.reference-pool/<series>/subjects/` — filenames are descriptive, pick the one whose clothing+pose matches the scene intent), `output`, `description`, `prompt` (scene-only). The random pool sampler is disabled by default — explicit `references:` are the canonical path. Insert entries in their correct section (building before `# --- Operating Series Covers`, operating at end of operating section). Do NOT embed the prompt in the frontmatter `alt` field; `alt` should be a short human-readable description. Generate: `source .env_common && uv run --with pyyaml --with google-genai --with pillow scripts/generate-all-images.py --only <key>` (the script auto-picks the reference from `.reference-pool/<series>/reference-<series>.png` based on the entry's `series:` field or key prefix; pass `-r path/to/custom-ref.png` to override)
 
 ## Blog Commands

--- a/agents/rules/repo-principles.md
+++ b/agents/rules/repo-principles.md
@@ -16,6 +16,6 @@
 
 ### Skills
 
-Skills are installed at user level via the `superpowers` and `superpowers-for-vk` plugins. They are NOT vendored in this repo. Frank-specific skills remain repo-local in `agents/skills/` (gitnexus, blog-post, deploy-app, media, sync-runbook, update-readme).
+Skills are installed at user level via the `superpowers` and `superpowers-for-vk` plugins. They are NOT vendored in this repo. Frank-specific skills remain repo-local in `agents/skills/` (blog-post, bump-image, deploy-app, expose-service, falco-triage, media, oidc-onboard, papers, sync-runbook, update-readme).
 
 Plan behavior is driven by the profile at `docs/superpowers/plan-config.yaml`.

--- a/agents/skills/bump-image/SKILL.md
+++ b/agents/skills/bump-image/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: bump-image
+description: Bump a pinned/CI-built image (or *_PIN) for a Frank or Hop app, watch the ArgoCD rollout, and verify (migrations / smoke test)
+user-invocable: true
+disable-model-invocation: false
+arguments:
+  - name: app
+    description: App to bump (e.g. "paperclip", "ai-alert-helper", "blog", "vk-bridge")
+    required: true
+  - name: target
+    description: New tag / SHA / version to pin to (omit to pick the latest upstream)
+    required: false
+---
+
+# Bump-and-Roll a Pinned Image
+
+Update a SHA/version-pinned (or CI-built) image for `$ARGUMENTS.app`, drive the
+rollout through ArgoCD, and verify it actually came up. This is the recurring
+GitOps "image bump" task — distinct from `/deploy-app` (new app).
+
+> Declarative-only (`repo-principles.md`): bump the pin in git; never `kubectl
+> set image`. **Environment:** Frank apps → `source .env`; Hop apps (blog,
+> headscale, caddy) → `source .env_hop` (never `.env` first — `hop-gotchas.md`).
+
+## Steps
+
+### 1. Locate the pin
+
+Pins live in one of:
+- `apps/<app>/manifests/deployment.yaml` or `clusters/hop/apps/<app>/manifests/deployment.yaml` — `image:` with a SHA tag (e.g. `ghcr.io/derio-net/blog:<sha>`)
+- `apps/<app>/values.yaml` — `image.tag`
+- an env `*_PIN` (e.g. `VK_BRIDGE_PIN`) in a deployment/secret
+
+```bash
+grep -rn "image:\|image.tag\|_PIN" apps/$ARGUMENTS.app clusters/hop/apps/$ARGUMENTS.app 2>/dev/null
+```
+
+Note how the image is built: **CI-built** (e.g. `ai-alert-helper` via
+`gh workflow run build-ai-alert-helper.yml`; `blog` commits its own SHA tag) vs a
+straight upstream pin.
+
+### 2. Diff old → new BEFORE bumping (DB apps especially)
+
+For apps that run migrations on boot (e.g. **paperclip**), this is mandatory —
+a bad migration crashes the pod on boot:
+
+- Diff the migration files across the `<old>..<new>` SHA range on the upstream
+  **public** repo. Flag `CREATE EXTENSION` (must pre-create) and unguarded
+  `DROP CONSTRAINT` / `ALTER` (crashes if the object is absent — confirm it
+  exists in the live DB first).
+- **Snapshot the Postgres PVC first** (paperclip: `data-paperclip-db-postgresql-0`,
+  **not** `paperclip-data`). Strategy is `Recreate`, so downtime = image pull, not
+  the migration itself.
+- Full recipe: `docs/runbooks/frank-gotchas/paperclip-ruflo.md`.
+
+### 3. Bump the pin
+
+- **Upstream pin:** edit the `image:` / `image.tag` / `*_PIN` to `$ARGUMENTS.target`, commit, push. ArgoCD auto-syncs.
+- **CI-built image:** trigger the build (it commits the new tag and ArgoCD syncs):
+  ```bash
+  gh workflow run build-$ARGUMENTS.app.yml [--ref <branch>]
+  ```
+  Note: some CI workflow tags are hardcoded and must be bumped alongside the
+  version (see `obs-digest.md`).
+
+### 4. Watch the rollout
+
+```bash
+kubectl -n <ns> rollout status deploy/$ARGUMENTS.app --timeout=300s
+# or follow the ArgoCD app:
+kubectl -n argocd get application $ARGUMENTS.app -o wide -w
+kubectl -n <ns> get pods -l app=$ARGUMENTS.app -w
+```
+
+Long-running rolls are well-suited to a background `Monitor` / `Bash
+run_in_background` watch.
+
+### 5. Verify (don't trust Synced/Healthy alone)
+
+ArgoCD `Synced`/`Healthy` proves the artifact deployed, not that it works
+(`frank-gotchas.md` → Process/practice). So:
+
+- **Smoke test** the app's real entrypoint. Watch for the stderr-banner trap:
+  health checks capturing `$(... --dry-run)` must use `2>&1` (the v2 vk.bridge
+  banner goes to stderr — `agent-shells` gotcha).
+- **DB apps:** confirm the migration's *tables* exist (do **not** trust the
+  `__drizzle_migrations` row count — it doesn't map to file index).
+- Check pod logs for boot errors / crashloops.
+
+### 6. If it crashloops on boot
+
+Usually a migration hitting a missing object (step 2). Roll the pin back, restore
+the PVC snapshot if a migration partially applied, and re-diff. For paperclip
+specifics see `paperclip-ruflo.md`.
+
+## Summary
+
+Show: the pin location + old→new value, the migration diff verdict (and snapshot
+taken, if DB), rollout status, and the smoke-test / migration-table verification
+output. State plainly whether the new image is verified working — not just synced.

--- a/agents/skills/expose-service/SKILL.md
+++ b/agents/skills/expose-service/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: expose-service
+description: Expose a Frank service externally via Traefik at <name>.cluster.derio.net with TLS, optional SSO, and a homepage tile
+user-invocable: true
+disable-model-invocation: false
+arguments:
+  - name: hostname
+    description: Subdomain under cluster.derio.net (e.g. "ruflo" → ruflo.cluster.derio.net)
+    required: true
+  - name: auth
+    description: "none (app has its own login) or forwardauth (Authentik SSO in front of an app with no auth)"
+    required: false
+    default: none
+---
+
+# Expose a Service via Traefik
+
+Publish a cluster service at `$ARGUMENTS.hostname.cluster.derio.net` with a
+wildcard TLS cert, optional Authentik forward-auth, and a homepage dashboard
+tile. This is Step 1 of the Post-Deploy Checklist (`plan-post-deploy-checklist.md`).
+
+> **Domain convention:** new in-cluster services use `*.cluster.derio.net`
+> (current). `*.frank.derio.net` is legacy; `omni.frank.derio.net` is a special
+> certbot case — don't route new services through them.
+> Read first: `agents/rules/frank-gotchas.md` → **Networking** + **Other apps**
+> (homepage subPath), and `agents/rules/frank-argocd.md` → Homepage Dashboard.
+
+## Prerequisites
+
+- The backend `Service` exists (`kubectl get svc -n <ns> <name>`); note its name, namespace, port.
+- DNS is wildcard: `*.cluster.derio.net` resolves to the Traefik LB `192.168.55.220`. **No per-host DNS step** is needed — adding a subdomain is automatic.
+
+## Steps
+
+### 1. Add the IngressRoute
+
+Append a route to `apps/traefik/manifests/ingressroutes.yaml`. **Copy an existing
+route block** from that file rather than writing one — they encode the canonical
+shape (`entryPoints: [websecure]`, `certResolver: cloudflare`,
+`domains: [{main: "*.cluster.derio.net"}]`, middleware chain).
+
+- `auth=none` → copy a no-auth route (middlewares: `ip-allowlist`, `security-headers`).
+- `auth=forwardauth` → copy a route that also lists the `authentik-forwardauth`
+  middleware (namespace `authentik`).
+
+Set `match: Host(\`$ARGUMENTS.hostname.cluster.derio.net\`)` and point
+`services` at your backend (`name`, `namespace`, `port`).
+
+### 2. (forwardauth only) Wire the Authentik proxy provider
+
+Forward-auth needs a proxy provider **and a manual outpost assignment** — this is
+fully documented; follow it, don't re-derive:
+
+1. Add a `forward_single` proxy provider entry to
+   `apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml`
+   (follow the existing entries; include `invalidation_flow`).
+2. Confirm the ConfigMap is registered in `apps/authentik/values.yaml`
+   → `blueprints.configMaps`.
+3. **Manual outpost step (Django ORM):** run the exact snippet in
+   `agents/rules/frank-argocd.md` → "Manual step (outpost assignment)". Blueprints
+   cannot manage the outpost provider list. Record it as a `# manual-operation`
+   and `/sync-runbook`.
+
+### 3. Add the homepage tile
+
+Edit `apps/homepage/manifests/files/services.yaml` (kustomize
+`configMapGenerator` — the hash-suffixed name rolls the pod automatically; do
+**not** rely on a plain ConfigMap edit, subPath mounts go stale — see Other-apps
+gotcha). Add under the right category:
+
+```yaml
+    - Display Name:
+        icon: <mdi-name-or-url>          # use /homepage-icon-finder if unsure
+        href: https://$ARGUMENTS.hostname.cluster.derio.net
+        description: One-line description
+        siteMonitor: http://<backend-svc>.<backend-ns>:<port>
+```
+
+### 4. Commit & sync
+
+```bash
+git add apps/traefik/manifests/ingressroutes.yaml apps/homepage/manifests/files/services.yaml
+# + the authentik blueprint if auth=forwardauth
+git commit -m "feat(net): expose $ARGUMENTS.hostname.cluster.derio.net via Traefik"
+```
+
+ArgoCD auto-syncs `traefik`/`traefik-extras` and `homepage`.
+
+### 5. Verify
+
+- DNS: `nslookup $ARGUMENTS.hostname.cluster.derio.net` → `192.168.55.220`
+- TLS + reachable: `curl -k -sI https://$ARGUMENTS.hostname.cluster.derio.net` (no 502/503)
+- `auth=forwardauth`: `curl -k -i https://$ARGUMENTS.hostname.cluster.derio.net` → 302 to the Authentik host
+- Homepage tile appears with a green health dot at `master.cluster.derio.net`
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| 502 Bad Gateway | wrong backend name/port in the route | `kubectl get svc -n <ns>`; match `services[].port` exactly |
+| 404 from Traefik | Host rule mismatch | exact FQDN in backticks; request `https://`, full subdomain |
+| TLS bad-certificate / handshake error | ACME (Cloudflare DNS-01) hasn't issued | check Traefik logs; cert is wildcard so usually already present |
+| forward-auth redirect loop / `0.0.0.0:9000` | outpost missing `AUTHENTIK_HOST`, or step 2.3 skipped | Authentik gotcha + redo the manual outpost step |
+| Homepage tile stale / no health dot | subPath staleness, or wrong `siteMonitor` URL | kustomize rolls it; verify `siteMonitor` host:port |
+
+## Summary
+
+Show: route added, auth mode, blueprint + manual outpost step (if any), homepage
+tile, and verification output. Point the user at the rest of the Post-Deploy
+Checklist (blog post, README, runbook sync).

--- a/agents/skills/falco-triage/SKILL.md
+++ b/agents/skills/falco-triage/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 disable-model-invocation: false
 arguments:
   - name: rule
-    description: The Falco rule name from the Telegram alert (e.g. "Drop and execute new binary in container")
+    description: The Falco rule name from the Telegram alert (e.g. "Drop and execute new binary in container"). Omit to scan recent Critical events in step 1.
     required: false
 ---
 

--- a/agents/skills/falco-triage/SKILL.md
+++ b/agents/skills/falco-triage/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: falco-triage
+description: Triage a Falco security-event notification on Hop — classify false-positive vs real, then fix by image-bake or rule exception
+user-invocable: true
+disable-model-invocation: false
+arguments:
+  - name: rule
+    description: The Falco rule name from the Telegram alert (e.g. "Drop and execute new binary in container")
+    required: false
+---
+
+# Triage a Falco Security Event
+
+A Falco **Critical** event pages via Telegram (`@agent_zero_cc_bot`). This skill
+walks the alert from notification → classification → fix → verify. Falco runs on
+the **Hop** edge cluster.
+
+> **Environment (critical):** Falco is on Hop. `source .env_hop` — **never**
+> `source .env` first (it overrides KUBECONFIG to Frank). See `hop-gotchas.md`.
+> Read first: `agents/rules/hop-gotchas.md` (Falco lines) and
+> `docs/runbooks/frank-gotchas/obs-digest.md` (the Falco→VictoriaLogs field shape).
+
+## Alert pipeline (so you know where to look)
+
+Falco (eBPF, Hop) → falcosidekick → **Critical** = Telegram; **≥ notice** =
+VictoriaLogs (Frank LB `192.168.55.225:9428`) via Loki-push. Floor is `notice`.
+
+## Steps
+
+### 1. Pull the raw event from VictoriaLogs (LogsQL)
+
+Falco events carry fields `source` / `priority` / `rule` / `k8s_ns_name` — **not**
+`kubernetes.namespace_name` (that's the fluent-bit/Caddy path). Always filter
+`source:syscall`; never filter Falco by `kubernetes.namespace_name` (matches zero).
+
+```bash
+source .env          # Frank — VictoriaLogs lives on Frank
+kubectl -n monitoring port-forward svc/victoria-logs-victoria-logs-single-server 9428:9428 &
+# Recent Critical events:
+curl -s 'http://localhost:9428/select/logsql/query' \
+  --data-urlencode 'query=_time:24h source:syscall priority:critical | sort by (_time desc)' | jq .
+# Audit what a rule is firing (without paging):
+#   _time:24h source:syscall rule:"<rule>" | stats by (k8s_ns_name) count()
+```
+
+Extract: `rule`, `priority`, `k8s_ns_name`, `k8s_pod_name`, `container`,
+`syscall`, `exe_path`, `_time`.
+
+### 2. Classify: benign-true-positive vs real
+
+Falco events are usually *true* (the syscall happened); the question is whether
+it's **legitimate**. Check the known baseline first:
+
+- **"Contact K8S API Server From Container" (Notice)** — high-volume benign
+  (ArgoCD reconcile). Expected; not paged.
+- **"Drop and execute new binary in container" (Critical, `EXE_UPPER_LAYER`)** —
+  almost always a container installing a tool at runtime (`apk add` / `pip
+  install` / `npm i -g`). Benign-true-positive. First seen: headscale-backup's
+  `apk add sqlite` at 03:00.
+- **Read sensitive file / Suspicious outbound** — check `exe_path` + destination
+  against the app's normal behavior.
+
+A real positive = an executable/connection the workload has no business making.
+When unsure, treat as real and escalate to a security review.
+
+### 3. Fix — prefer image-bake over muting
+
+In priority order (narrowest, most honest first):
+
+1. **Bake the tool into a digest-pinned image** (preferred for runtime-install
+   events). The binary then lives in the read-only base layer and Falco won't
+   fire. Example: headscale-backup switched `apk add sqlite` → `alpine/sqlite`
+   pinned by digest. Edit the workload's chart/manifest, pin the digest.
+2. **Add a scoped rule/macro exception** in
+   `clusters/hop/apps/falco/values.yaml` → `customRules`. Re-declare the macro
+   with a narrowed condition, or append `and not (<benign match>)` to the rule.
+   Keep the scope as tight as possible (namespace + exe_path).
+3. **Suppress the rule** — last resort, only with strong evidence.
+
+Never mute a rule just to stop the page — that's hiding a true positive.
+
+### 4. Deploy & watch (Hop)
+
+```bash
+source .env_hop
+git add clusters/hop/apps/falco/values.yaml   # (and/or the workload image bump)
+git commit -m "falco: bake <tool> into image" # or "falco: scope exception for <rule> in <ns>"
+# ArgoCD (Hop) auto-syncs; Falco pod restarts on config change:
+kubectl -n falco-system get pods -w
+kubectl -n falco-system logs -l app.kubernetes.io/name=falco -f --tail=50
+```
+
+### 5. Verify suppression
+
+Re-trigger the activity (e.g. `kubectl -n <ns> create job --from=cronjob/<name>
+manual-test`), wait for the pod, then re-query VictoriaLogs (step 1) for the same
+`rule` over `_time:5m` — expect an empty result.
+
+### 6. Document
+
+- One-liner in `agents/rules/hop-gotchas.md` (Falco section).
+- Full prose / recovery in the matching `docs/runbooks/frank-gotchas/<topic>.md`.
+- If a new recurring benign job is found, add it to the baseline list above.
+
+## Summary
+
+Show: the event (rule, ns, pod, exe), your classification + why, the fix chosen
+(image-bake vs exception) with scope, the verify result, and the gotcha line you
+added.

--- a/agents/skills/oidc-onboard/SKILL.md
+++ b/agents/skills/oidc-onboard/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: oidc-onboard
+description: Onboard a Frank service to Authentik SSO via OIDC — blueprint, secret extraction, injection, verify
+user-invocable: true
+disable-model-invocation: false
+arguments:
+  - name: service
+    description: Service slug (kebab-case, becomes the OIDC client_id, e.g. "grafana")
+    required: true
+  - name: inject-mode
+    description: "config (app reads OIDC from its own values/env) or api (PATCH the app's settings API after boot, e.g. AWX)"
+    required: false
+    default: config
+---
+
+# Onboard a Service to Authentik SSO (OIDC)
+
+Wire a new cluster service into Authentik as an OIDC client. This is the
+**login-button** flow (the app delegates auth to Authentik). For services that
+have no auth of their own and should sit behind Traefik forward-auth instead,
+use `/expose-service` (proxy provider), not this skill.
+
+> Read first: `agents/rules/frank-gotchas.md` → **Authentik** section, and
+> `docs/runbooks/frank-gotchas/authentik.md` for the full prose + recovery.
+> The forward-auth/outpost details live in `agents/rules/frank-argocd.md`.
+
+## Steps
+
+### 1. Create the provider+application blueprint
+
+Copy the closest existing blueprint as a template — do **not** write one from
+scratch:
+
+- OIDC login app → `apps/authentik-extras/manifests/blueprints-provider-grafana.yaml`
+  (or `-argocd`, `-awx`, `-infisical` — pick the one whose redirect/scope shape
+  matches your service).
+
+Create `apps/authentik-extras/manifests/blueprints-provider-$ARGUMENTS.service.yaml`
+with the OAuth2 provider + `authentik_core.application`. Keep `client_id` equal
+to `$ARGUMENTS.service`.
+
+**2026.x schema requirements (enforced — silent failure if missing):**
+- `redirect_uris` must be the **object list** form: `[{matching_mode: strict, url: ...}]`
+- `invalidation_flow` is **required**
+- `signing_key` must reference the bundled cert via `!Find` (never hardcode a UUID)
+
+### 2. Register the blueprint ConfigMap
+
+Blueprints mount in the **worker** pod. Add the new ConfigMap name to
+`apps/authentik/values.yaml` → `blueprints.configMaps` (around line 73).
+Forgetting this means the blueprint never applies.
+
+### 3. Commit & let ArgoCD apply, then confirm the provider exists
+
+```bash
+git add apps/authentik/values.yaml apps/authentik-extras/manifests/blueprints-provider-$ARGUMENTS.service.yaml
+git commit -m "auth(blueprint): add $ARGUMENTS.service OIDC provider"
+# ArgoCD auto-syncs. Confirm the blueprint applied:
+kubectl -n authentik logs deploy/authentik-worker | grep -i "$ARGUMENTS.service"
+```
+
+### 4. Extract the auto-generated client_secret
+
+Authentik generates the secret; blueprints can't set it. Read it via the Django
+ORM in the **worker** pod:
+
+```bash
+CLIENT_SECRET=$(kubectl exec -n authentik deploy/authentik-worker -- python -c '
+import os; os.environ.setdefault("DJANGO_SETTINGS_MODULE","authentik.root.settings")
+import django; django.setup()
+from authentik.providers.oauth2.models import OAuth2Provider
+print(OAuth2Provider.objects.get(client_id="'$ARGUMENTS.service'").client_secret)' 2>/dev/null)
+echo "secret length = ${#CLIENT_SECRET}"
+```
+
+Empty/not-found ⇒ blueprint hasn't applied or its YAML is broken (re-check step 3 logs).
+
+### 5. Store the secret (SOPS, applied out-of-band)
+
+Per `repo-principles.md`, SOPS secrets are **not** ArgoCD-managed. Create
+`secrets/authentik/$ARGUMENTS.service-oidc-secret.yaml` (a `kind: Secret` in the
+target namespace), encrypt, and apply:
+
+```bash
+sops -e -i secrets/authentik/$ARGUMENTS.service-oidc-secret.yaml
+sops --decrypt secrets/authentik/$ARGUMENTS.service-oidc-secret.yaml | kubectl apply -f -
+```
+
+Document this apply as a `# manual-operation` block in the plan (see
+`repo-manual-ops.md`) and run `/sync-runbook`.
+
+### 6. Inject the secret into the service
+
+**`inject-mode=config`** (ArgoCD, Grafana, Infisical, Gitea, most apps):
+the app reads OIDC from its own `apps/$ARGUMENTS.service/values.yaml`. Add the
+issuer, client_id, scopes, and the secret reference. Copy the exact key/mechanism
+from a working peer:
+- ArgoCD: `$<secret>:<key>` injection in `configs.cm.oidc.config`
+- Grafana: `envFromSecret`; **secret key must be `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET`** (gotcha)
+- Gitea: `gitea.oauth[].existingSecret` with `GITEA_OAUTH_<PROVIDER>_CLIENT_SECRET`
+
+Confirm the discovery URL by matching a peer's values, not from memory:
+`https://<authentik-host>/application/o/$ARGUMENTS.service/.well-known/openid-configuration`
+
+**`inject-mode=api`** (AWX and other apps with no OIDC config file):
+PATCH the running app's settings API. The reference implementation is
+`scripts/tmp/awx-oidc-set-secret.sh` — read it, adapt the endpoint, re-run.
+
+### 7. Verify
+
+- Discovery endpoint resolves: `curl -sk https://<authentik-host>/application/o/$ARGUMENTS.service/.well-known/openid-configuration | jq .issuer`
+- App shows the Authentik login button / completes an OIDC round-trip
+- `inject-mode=api`: re-read the setting (expect an `$encrypted$`-prefixed value)
+
+## Common failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| No login button | blueprint applied but provider not wired into app | re-check step 6 injection; for proxy/forward-auth see `/expose-service` |
+| `client_secret` empty in step 4 | ConfigMap not registered in `values.yaml` | step 2 |
+| Provider not found / blueprint ignored | 2026.x schema (missing `invalidation_flow`, string `redirect_uris`) | step 1 schema rules |
+| Forward-auth redirects to `0.0.0.0:9000` | embedded outpost missing `AUTHENTIK_HOST` | see `authentik.md` gotcha |
+
+## Summary
+
+Show the user: blueprint file created, `values.yaml` line added, where the SOPS
+secret lives, the injection mechanism used, and the verification output. Remind
+them to `/sync-runbook` for the manual secret-apply, and to `/expose-service`
+if the app also needs an external hostname.

--- a/agents/skills/oidc-onboard/SKILL.md
+++ b/agents/skills/oidc-onboard/SKILL.md
@@ -103,8 +103,26 @@ Confirm the discovery URL by matching a peer's values, not from memory:
 `https://<authentik-host>/application/o/$ARGUMENTS.service/.well-known/openid-configuration`
 
 **`inject-mode=api`** (AWX and other apps with no OIDC config file):
-PATCH the running app's settings API. The reference implementation is
-`scripts/tmp/awx-oidc-set-secret.sh` — read it, adapt the endpoint, re-run.
+PATCH the app's settings API after the pod is up, using `$CLIENT_SECRET` from
+step 4. Worked example for AWX (confirm the deploy/container/secret names against
+the live app first):
+
+```bash
+ADMIN_PW=$(kubectl -n awx get secret awx-admin-password -o jsonpath='{.data.password}' | base64 -d)
+# PATCH the OIDC settings category (payload via stdin so the secret isn't shell-escaped):
+printf '{"SOCIAL_AUTH_OIDC_SECRET":"%s"}' "$CLIENT_SECRET" \
+  | kubectl -n awx exec -i deploy/awx-web -c awx-web -- \
+      curl -sk -u "admin:${ADMIN_PW}" -X PATCH http://localhost:8052/api/v2/settings/oidc/ \
+        -H 'Content-Type: application/json' --data-binary @-
+# verify — expect an $encrypted$-prefixed value back:
+kubectl -n awx exec deploy/awx-web -c awx-web -- \
+  curl -sk -u "admin:${ADMIN_PW}" http://localhost:8052/api/v2/settings/oidc/
+```
+
+The endpoint and setting key are app-specific — for a non-AWX app, find its OIDC
+settings endpoint and secret field name in that app's API docs. (Keep any
+throwaway helper under the gitignored `scripts/tmp/`; do not reference it from
+this skill.)
 
 ### 7. Verify
 


### PR DESCRIPTION
## Why

Analysis of Claude Code session history surfaced recurring Frank operations with **no skill coverage** (the PR/plan/blog/skill flows are already covered by `superpowers`/`vk-*`/`blog-craft`). The gaps were all homelab ops. This adds four repo-local skills plus a guard for the recurring Hextra sidebar bug.

## What

**Four skills** (`agents/skills/`, matching the existing `deploy-app` house style — thin orchestrators that reference canonical files rather than duplicating them):

| Skill | Covers | Anchors |
|---|---|---|
| `oidc-onboard` | Onboard a service to Authentik SSO (blueprint → secret extract → SOPS → inject → verify) | `blueprints-provider-*.yaml`, `awx-oidc-set-secret.sh`, `frank-gotchas#authentik` |
| `expose-service` | Publish at `<name>.cluster.derio.net` (IngressRoute + TLS + optional forward-auth + homepage tile) | `traefik/manifests/ingressroutes.yaml`, `frank-argocd.md` |
| `falco-triage` | Classify a Falco alert → fix by image-bake or scoped exception → verify | `clusters/hop/apps/falco/values.yaml`, `hop-gotchas`, `obs-digest` |
| `bump-image` | GitOps image/`*_PIN` bump → migration diff + PVC snapshot → watch rollout → smoke-verify | `paperclip-ruflo.md`, `obs-digest` |

**One hookify rule** — `.claude/hookify.warn-hextra-weight-zero.local.md`: warns on `weight: 0` in `blog/content/**.md`, the recurring "00 is at the bottom" Hextra sidebar bug. `weight: 0` sorts LAST in Hugo. Verified against the real hookify engine: fires on `weight: 0` (Write/Edit/inline), stays quiet on `weight: 10/20/1` and non-blog files.

**Wiring:** registered the skills in `AGENTS.md` + `repo-principles.md`; documented the weight trap + guard in `repo-blog.md`.

## Notes

- Skills point at *live example files* as templates, so they self-correct when the canonical pattern changes.
- Corrected two details the source material got wrong: homepage tiles live in `apps/homepage/manifests/files/services.yaml` (kustomize), and `certResolver: cloudflare` (not letsencrypt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)