### PR TITLE
fix(agents): replace removed LiteLLM alias qwen3.5 in Sympozium PersonaPacks

### DIFF
--- a/apps/sympozium-extras/manifests/personapack-developer-team.yaml
+++ b/apps/sympozium-extras/manifests/personapack-developer-team.yaml
@@ -24,7 +24,7 @@ spec:
   personas:
     - name: tech-lead
       displayName: "Tech Lead"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are the tech lead of a software development team. You coordinate
         work across the team by triaging issues, reviewing architecture
@@ -67,7 +67,7 @@ spec:
 
     - name: backend-dev
       displayName: "Backend Developer"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are a backend software developer. You implement server-side
         features, APIs, data models, and business logic. You write clean,
@@ -108,7 +108,7 @@ spec:
 
     - name: frontend-dev
       displayName: "Frontend Developer"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are a frontend software developer. You implement user interfaces,
         components, styling, and client-side logic. You focus on usability,
@@ -148,7 +148,7 @@ spec:
 
     - name: qa-engineer
       displayName: "QA Engineer"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are a QA engineer. You ensure software quality through testing,
         bug discovery, and coverage analysis. You think adversarially — your
@@ -194,7 +194,7 @@ spec:
 
     - name: code-reviewer
       displayName: "Code Reviewer"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are a senior code reviewer. You review every PR opened by team
         members for correctness, security, performance, and maintainability.
@@ -242,7 +242,7 @@ spec:
 
     - name: devops-engineer
       displayName: "DevOps Engineer"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are a DevOps engineer. You maintain the project's build pipeline,
         deployment configuration, containerisation, and infrastructure-as-code.
@@ -283,7 +283,7 @@ spec:
 
     - name: docs-writer
       displayName: "Documentation Writer"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are a technical documentation writer. You keep the project's
         documentation accurate, comprehensive, and up-to-date. You write

--- a/apps/sympozium-extras/manifests/personapack-devops-essentials.yaml
+++ b/apps/sympozium-extras/manifests/personapack-devops-essentials.yaml
@@ -18,7 +18,7 @@ spec:
   personas:
     - name: code-reviewer
       displayName: "Code Reviewer"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are a code review agent. You review pull requests and provide
         constructive feedback on code quality, security, and best practices.

--- a/apps/sympozium-extras/manifests/personapack-platform-team.yaml
+++ b/apps/sympozium-extras/manifests/personapack-platform-team.yaml
@@ -18,7 +18,7 @@ spec:
   personas:
     - name: sre-agent
       displayName: "SRE Agent"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are an SRE agent for the Frank Kubernetes cluster (Talos Linux).
         Your job is to monitor cluster health, diagnose failures, and recommend
@@ -51,7 +51,7 @@ spec:
 
     - name: incident-responder
       displayName: "Incident Responder"
-      model: qwen3.5
+      model: qwen36-a3b-nothin
       systemPrompt: |
         You are an incident response agent for the Frank Kubernetes cluster.
         You triage alerts, investigate failures, and coordinate remediation.


### PR DESCRIPTION
## Summary
- All 350 AgentRuns since the LiteLLM Qwen3.6 lineup change have failed: personas pin `model: qwen3.5`, an alias that no longer exists in `apps/litellm/values.yaml`.
- Replaces it with **`qwen36-a3b-nothin`** (10 occurrences across the 3 PersonaPack manifests) — the no-think Qwen3.6 35B-A3B variant whose values.yaml comment explicitly recommends it for agent orchestration.

## Verification plan (post-merge)
1. ArgoCD auto-syncs `sympozium-extras`.
2. Delete the `SympoziumInstance` CRs — the controller only applies per-persona `model` at instance creation; "pack-level settings" updates don't propagate it. Owner PersonaPacks recreate them with the new model.
3. Trigger an AgentRun and confirm `Completed` (also yields the `building/11` blog screenshot).

## Notes
- Live-patch validation was attempted under the suspend-selfHeal pattern but the root App-of-Apps re-template race (documented gotcha) reverted it within seconds — hence verify-after-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)