### PR TITLE
feat(ingress): enable Traefik dashboard on the internal entrypoint

### DIFF
--- a/apps/traefik/values.yaml
+++ b/apps/traefik/values.yaml
@@ -69,7 +69,12 @@ env:
         name: traefik-cloudflare-credentials
         key: api-token
 
-# Disable Traefik dashboard (accessed via ArgoCD, not needed)
+# Traefik dashboard — internal entrypoint only (port 8080, `traefik`).
+# Not exposed on the LB or any public domain; reach it via
+#   kubectl port-forward -n traefik-system deploy/traefik 9000:8080
+# then http://localhost:9000/dashboard/ . Enabled for operational
+# visibility of routers/middlewares (and the building/24 blog shots).
 ingressRoute:
   dashboard:
-    enabled: false
+    enabled: true
+    entryPoints: ["traefik"]


### PR DESCRIPTION
## Summary
- Flips `ingressRoute.dashboard.enabled` to `true`, pinned to the internal `traefik` entrypoint (8080). The dashboard becomes reachable **only** via `kubectl port-forward -n traefik-system deploy/traefik 9000:8080` → `http://localhost:9000/dashboard/`. No LB, no public domain, no auth surface added.
- Motivation: the `building/24-in-cluster-ingress` post documents the routers overview, and right now `api@internal` is registered but unrouted (probed: `/dashboard/`, `/api/*` all 404 on every entrypoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)