### PR TITLE
docs(gotchas): screenshot-session learnings — sympozium, argocd, env

### DIFF
--- a/agents/rules/frank-commands.md
+++ b/agents/rules/frank-commands.md
@@ -2,6 +2,10 @@
 
 ```bash
 # Environment — Frank cluster
+# CAUTION: .env sets KUBECONFIG to a RELATIVE path (.talos/Frank_Kubeconfig.yaml).
+# Always `cd` to the repo root BEFORE sourcing — a shell sourced elsewhere (or a
+# backgrounded job with a different cwd) silently falls back to ~/.kube/config,
+# whose endpoint is dead (192.168.64.2 i/o timeout).
 source .env          # Frank (KUBECONFIG, TALOSCONFIG, OMNICONFIG)
 source .env_devops   # DevOps (OMNI_ENDPOINT, service account key)
 

--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -9,6 +9,7 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - Manual `kubectl patch application … --type=merge -p '{"operation":{"sync":...}}'` does NOT inherit `spec.syncPolicy.syncOptions` — pass `["ServerSideApply=true","RespectIgnoreDifferences=true"]` explicitly or large CMs blow the 256KB last-applied-config annotation.
 - Out-of-bounds symlinks anywhere in the repo lock the entire GitOps loop into `ComparisonError` — check after symlink commits: `find . -type l -lname '*../../..*'`.
 - Root App-of-Apps re-templates leaf Application specs on every sync; live spec patches (selfHeal off, branch override) are reverted within the sync window.
+- The UI LoadBalancer (192.168.55.200) is plain HTTP — the Service maps 443→8080 *plaintext*, so `https://` gets a TLS reset. Use `http://192.168.55.200`.
 
 ### Storage / Secrets / SSA — `docs/runbooks/frank-gotchas/storage-secrets-ssa.md`
 - SOPS-encrypted secrets must NOT be ArgoCD-managed; apply out-of-band from `secrets/`.
@@ -117,6 +118,8 @@ One-line reminders only. Each section header points at a per-topic file under `d
 
 ### Other in-cluster apps — `docs/runbooks/frank-gotchas/other-apps.md`
 - Sympozium chart is Git-sourced (no OCI), service template doesn't take type/annotations (use extras LB), `image.tag` must be overridden.
+- Sympozium PersonaPack per-persona `model` applies only at SympoziumInstance CREATION — PersonaPack edits never propagate to existing instances; merge to git first (ArgoCD heals live PersonaPack edits back), then delete the SympoziumInstances to recreate. A removed LiteLLM alias fails every run (350 failed AgentRuns over 2 weeks on `qwen3.5`; fixed #448).
+- Sympozium AgentRun: `spec.sessionKey` is required (use `""`); terminal success phase is `Succeeded`, NOT `Completed` — poll loops checking `Completed` never exit.
 - Zot Helm chart v0.1.0 too minimal — use v0.1.60+ for TLS/auth/persistence. htpasswd hash regenerates if `ZOT_PUSH_PASSWORD` rotates.
 - Gitea `webhook.ALLOWED_HOST_LIST` blocks in-cluster delivery — add `*.svc.cluster.local`.
 - n8n CE has no `user:create` CLI (browser wizard only), no SSO (use Authentik forward-auth), needs `N8N_SECURE_COOKIE=false` over plain HTTP.

--- a/docs/runbooks/frank-gotchas/argocd.md
+++ b/docs/runbooks/frank-gotchas/argocd.md
@@ -60,3 +60,9 @@ Workarounds:
 - if you need a longer window — patch `apps/root/templates/<app>.yaml` itself on the feature branch so root re-templates with the values you want
 
 Same constraint applies to every leaf under `apps/root/`.
+
+## The UI LoadBalancer is plain HTTP (443→8080 plaintext)
+
+The `argocd-server` LB Service at 192.168.55.200 maps port 443 to the server's plaintext 8080 — ArgoCD runs in `--insecure` mode behind the LB, so there is no TLS listener at all. `https://192.168.55.200` fails with a connection reset that looks like a network problem; the fix is just `http://192.168.55.200`.
+
+Bites automation hardest: blog screenshot placeholders and runbooks that reflexively write `https://` URLs get a reset, and `curl -k` doesn't help (it's not a cert problem — there's no TLS handshake to complete). Also note for captures: the UI ignores `prefers-color-scheme` (own theme system), so dark-mode emulation has no effect.

--- a/docs/runbooks/frank-gotchas/other-apps.md
+++ b/docs/runbooks/frank-gotchas/other-apps.md
@@ -10,6 +10,28 @@ Apps with only one or two gotchas live here together (Sympozium, Zot, Gitea, n8n
 - Service template doesn't support type/annotations — use a separate LB Service in `extras`.
 - `image.tag` must be overridden (chart appVersion lags behind latest fix releases).
 
+### PersonaPack `model` only applies at SympoziumInstance creation
+
+The PersonaPack controller stamps each persona's `model` into its SympoziumInstance **when the instance is created** — editing the PersonaPack afterwards does NOT reconcile existing instances. Two traps stack on top of each other:
+
+1. **Live edits get healed away.** Patching the PersonaPack on the cluster looks like it worked, but ArgoCD self-heal reverts it to git within the sync window. Merge the manifest change to `main` first.
+2. **Even a synced PersonaPack changes nothing.** After the merge, existing SympoziumInstances still carry the old model. Delete them and let the controller recreate:
+
+```bash
+kubectl delete sympoziuminstances -n sympozium-system --all
+# controller recreates from PersonaPacks within ~30s; verify:
+kubectl get sympoziuminstances -n sympozium-system -o custom-columns=NAME:.metadata.name,MODEL:.spec.model
+```
+
+**Incident (2026-06-04, PR #448):** the LiteLLM alias `qwen3.5` was removed from `apps/litellm/values.yaml`; every scheduled AgentRun failed for ~2 weeks (350 failures) because all SympoziumInstances were created with the dead alias. Fix: `sed` the three PersonaPack manifests to `qwen36-a3b-nothin` (the no-think variant — right choice for agent orchestration), merge, sync, then delete all 8 instances. Validated with a manual AgentRun (`Succeeded` in 273s) and the next hourly scheduled run.
+
+### AgentRun quirks
+
+- `spec.sessionKey` is **required** by schema validation even when unused — set `sessionKey: ""` or creation is rejected.
+- Terminal success phase is **`Succeeded`**, not `Completed` — a poll loop matching `Completed` never exits.
+- The web UI's Runs page defaults to the `default` namespace (empty) — real runs live in `sympozium-system`; the namespace switcher is a custom dropdown, not a `<select>`.
+- UI login is token-only (`#token` input); token lives in the `sympozium-ui-token` secret in `sympozium-system`.
+
 ## Zot
 
 - Helm chart v0.1.0 is too minimal — no support for `mountConfig`, `mountSecret`, `persistence`, or `externalSecrets`. Use v0.1.60+ for TLS, htpasswd auth, and persistent storage.

--- a/docs/superpowers/archived-plans/2026-03-09--agents--sympozium/_prose.md
+++ b/docs/superpowers/archived-plans/2026-03-09--agents--sympozium/_prose.md
@@ -119,3 +119,16 @@
 - P1.T13.S1: Push all commits
 
 - P1.T13.S2: Full health check
+
+## Deviations
+
+**2026-06-04 — dead LiteLLM model alias broke every AgentRun for ~2 weeks (PR #448).**
+The PersonaPacks pinned `model: qwen3.5`, an alias later removed from
+`apps/litellm/values.yaml`; all 350 scheduled AgentRuns since the removal failed.
+Fix: point all 10 persona `model` fields at `qwen36-a3b-nothin` across the three
+PersonaPack manifests in `apps/sympozium-extras/manifests/`, merge, then **delete
+all SympoziumInstances** — the controller applies a persona's `model` only at
+instance creation, so the merged PersonaPack alone changes nothing (gotcha
+documented in `docs/runbooks/frank-gotchas/other-apps.md#sympozium`). Verified
+with a manual AgentRun (`Succeeded`, 273s; note `spec.sessionKey: ""` is required
+and the terminal phase is `Succeeded`, not `Completed`) and the next hourly run.


### PR DESCRIPTION
Folds back the durable learnings from the 2026-06-04 blog-screenshot session (PRs #446/#447/#448/#449/#450).

## What's in here

**Sympozium** (one-liners in `frank-gotchas.md`, prose in `other-apps.md`, deviation in the archived sympozium plan):
- PersonaPack per-persona `model` applies only at SympoziumInstance **creation** — merge the manifest change first (ArgoCD heals live edits), then delete the instances to recreate. Incident: removed `qwen3.5` alias → 350 failed AgentRuns over ~2 weeks, fixed in #448.
- AgentRun: `spec.sessionKey` required (use `""`); terminal success phase is `Succeeded`, not `Completed`.
- UI quirks: Runs page defaults to empty `default` ns; token-only login (`sympozium-ui-token`).

**ArgoCD** (`argocd.md` + one-liner):
- The UI LB (192.168.55.200) is plain HTTP — 443→8080 plaintext, `https://` gets a TLS reset. Also: UI ignores `prefers-color-scheme`.

**Env** (`frank-commands.md`):
- `.env` KUBECONFIG is a **relative** path — `cd` to repo root before sourcing, or kubectl silently falls back to the dead `~/.kube/config` endpoint.

Companion (not in this PR): media-screenshots + browser-screenshot skill updates land in their own repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)