### PR TITLE
[derio-net/frank] 2026-05-27--orch--ruflo-upload-fix · Phase 1/4 · agent-images: RvfGridFSBucket parity fix + upstream bump

### DIFF
--- a/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/01.yaml
+++ b/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/01.yaml
@@ -139,38 +139,43 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T14:58:43+00:00'
+      note: Contract test merged in agent-images PR#96 (ruflo-server/test/rvf-gridfs-contract.test.mjs);
+        passes 3/3 via node --test
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T14:58:44+00:00'
+      note: Patched rvf.ts authored (objectMode Writable + Readable.from + sync find
+        cursor)
     P1.T1.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T14:58:44+00:00'
+      note: patches/rvf-gridfs-parity.patch — git apply --check exit 0 vs pinned ref
+        a6dd4ab
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T14:58:44+00:00'
+      note: Dockerfile RUFLO_GIT_REF bumped ca0a6fa→a6dd4ab
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T14:58:44+00:00'
+      note: COPY+git apply+grep guards wired (Dockerfile:85-89)
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T14:58:44+00:00'
+      note: wasm:// sed guard intact (Dockerfile:62-65)
     P1.T3.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T14:58:44+00:00'
+      note: agent-images PR#96 (commit 0ff7014) merged; CI built ruflo-server + ruflo-shell
     P1.T3.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T14:58:44+00:00'
+      note: 'Images: ghcr.io/derio-net/{ruflo-server,ruflo-shell}:0ff701470c7e4dc38c803134a2355b2479ff683b'
   completion:
-    at: null
-    note: null
+    at: '2026-06-04T14:58:50+00:00'
+    note: 'Executed inline by operator; merged in agent-images PR#96 (commit 0ff7014).
+      Verified: contract test 3/3, patch applies clean vs ref a6dd4ab, both images
+      published at ghcr.io/derio-net/{ruflo-server,ruflo-shell}:0ff701470c7e4dc38c803134a2355b2479ff683b'
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix
📐 Spec:   [docs/superpowers/specs/2026-05-27--orch--ruflo-image-upload-fix-design.md](https://github.com/derio-net/frank/blob/main/docs/superpowers/specs/2026-05-27--orch--ruflo-image-upload-fix-design.md)
🎯 Phase:  1/4 — agent-images: RvfGridFSBucket parity fix + upstream bump [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/451

**Goal (from plan):** Make `RvfGridFSBucket` faithfully implement the GridFS
contract (real `Writable`, real `Readable`, sync cursor) so file
upload/download/copy-on-share work against the RVF backend; carry the fix
forward on a bump `ca0a6fa → a6dd4ab`, and produce the new image via
agent-images CI.

---

## Summary

Phase 1 lands entirely in the **agent-images** repo (per `_prose.md`,
"Executed inline / subagent-driven by the operator"). The code work was
already implemented and **merged in agent-images PR #96** (commit `0ff7014`).
This frank-side PR **reconciles the plan tracking** that was never updated.

I verified the merged work satisfies every step before ticking:

| Step | Evidence |
|---|---|
| P1.T1.S1 | `ruflo-server/test/rvf-gridfs-contract.test.mjs` passes **3/3** (`node --test`) |
| P1.T1.S2 | patched `rvf.ts` authored — objectMode `Writable` + `Readable.from` + sync `find` cursor |
| P1.T1.S3 | `patches/rvf-gridfs-parity.patch` — `git apply --check` **exit 0** against pinned ref `a6dd4ab` |
| P1.T2.S1 | `Dockerfile`: `RUFLO_GIT_REF` bumped `ca0a6fa → a6dd4ab` |
| P1.T2.S2 | patch `COPY` + `git apply` + `grep` guards wired (Dockerfile:85-89) |
| P1.T2.S3 | `wasm://` sed guard intact (Dockerfile:62-65) |
| P1.T3.S1 | agent-images PR #96 merged; CI built both images |
| P1.T3.S2 | **Images:** `ghcr.io/derio-net/ruflo-server:0ff701470c7e4dc38c803134a2355b2479ff683b` and `ghcr.io/derio-net/ruflo-shell:0ff701470c7e4dc38c803134a2355b2479ff683b` |

## Changes in this PR

- Ticks all 8 Phase 1 steps and marks the phase complete in
  `docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/01.yaml`, recording
  the image SHA in the completion note.

**Image SHA for Phase 2:** `0ff701470c7e4dc38c803134a2355b2479ff683b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
Closes #451
