### PR TITLE
feat(orch): deploy hermes-agent-shell pod on gpu-1

### DIFF
--- a/apps/hermes-agent-shell/client-setup/laptop/README.md
+++ b/apps/hermes-agent-shell/client-setup/laptop/README.md
@@ -1,0 +1,41 @@
+# hermes-agent-shell — laptop client setup
+
+Connect to the standalone hermes agent shell on `gpu-1`.
+
+| Transport | Endpoint | Notes |
+|-----------|----------|-------|
+| SSH  | `192.168.55.226:22` → container `2222` | `ssh-config.snippet` |
+| Mosh | `192.168.55.226` UDP `60032–60047`     | `mosh-wrapper.sh` (pins the server range) |
+
+## One-time
+
+1. Append `ssh-config.snippet` to `~/.ssh/config`, set `IdentityFile` to the
+   private key whose public half is in the `hermes-agent-shell-ssh-keys` Secret
+   (reuse the key paired with the other shells, or add a new one — see
+   `secrets/hermes-agent-shell/README.md`).
+2. For Mosh, copy `mosh-wrapper.sh` somewhere on `$PATH` (e.g.
+   `~/bin/mosh-hermes`), `chmod +x`, and fix the `IdentityFile` path inside.
+
+## Connect
+
+```bash
+ssh hermes              # SSH
+mosh-hermes             # Mosh (via the wrapper)
+```
+
+On login the MOTD prints the reconcile summary and the auth-status row
+(`~ hermes (BYOK — no login flow)`). If you see `OPENAI_BASE_URL not set`, the
+BYOK ConfigMap secret hasn't synced yet (Phase 1 bootstrap incomplete) — see
+the operating post.
+
+## Run hermes
+
+```bash
+hermes            # interactive
+hermes --version  # sanity check (needs no BYOK env)
+```
+
+> **Env caveat.** `ssh hermes -- hermes ...` (a non-interactive remote command)
+> does **not** source `/etc/profile.d`, so it won't have `OPENAI_BASE_URL` /
+> `OPENAI_API_KEY`. Run hermes from an **interactive** session, or use
+> `kubectl exec` for scripted invocations.

--- a/apps/hermes-agent-shell/client-setup/laptop/mosh-wrapper.sh
+++ b/apps/hermes-agent-shell/client-setup/laptop/mosh-wrapper.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Mosh into the hermes-agent-shell pod.
+#
+# Why a wrapper:
+#   - mosh-server picks one UDP port from a *fixed range* at session start.
+#     We pin that range to 60032–60047 to match the LoadBalancer Service
+#     (apps/hermes-agent-shell/manifests/service.yaml). The default 60000–61000
+#     would wander outside the published range and the session would never
+#     reach the client.
+#   - Single LB IP for this shell (TCP/22 + UDP 60032–60047), like ruflo /
+#     paperclip. So mosh's positional argument doubles as the SSH host:
+#     192.168.55.226.
+#
+# Substitute the IdentityFile for your private key (its public half is in the
+# hermes-agent-shell-ssh-keys Secret).
+set -euo pipefail
+exec mosh \
+    --server="mosh-server new -p 60032:60047" \
+    --ssh="ssh -i ~/.ssh/<your_private_key>" \
+    "$@" \
+    agent@192.168.55.226

--- a/apps/hermes-agent-shell/client-setup/laptop/ssh-config.snippet
+++ b/apps/hermes-agent-shell/client-setup/laptop/ssh-config.snippet
@@ -1,0 +1,17 @@
+# Append to ~/.ssh/config (or include from a modular ~/.ssh/config.d/).
+# Substitute the IdentityFile path for the private key whose public half is
+# mounted into the hermes-agent-shell container via the
+# hermes-agent-shell-ssh-keys Secret (see secrets/hermes-agent-shell/README.md
+# for rotation). Reuse the same key paired with the other shells if you keep
+# one private key for every shell.
+
+Host hermes
+    HostName 192.168.55.226
+    Port 22
+    User agent
+    IdentityFile ~/.ssh/<your_private_key>
+    # The container's SSH host keys live on the home PVC, so they're stable
+    # across restarts; on the rare PVC-rebuild event clear the old known_hosts
+    # entry.
+    UserKnownHostsFile ~/.ssh/known_hosts
+    StrictHostKeyChecking accept-new

--- a/apps/hermes-agent-shell/manifests/configmap-byok-env.yaml
+++ b/apps/hermes-agent-shell/manifests/configmap-byok-env.yaml
@@ -1,0 +1,38 @@
+# BYOK-env profile.d shim for the hermes-agent-shell pod.
+#
+# WHY THIS EXISTS (the load-bearing part of this deploy):
+# agent-shell-base's sshd runs `UsePAM no` with no `PermitUserEnvironment`
+# (agent-images/agent-shell-base/sshd_config), so the K8s-injected container
+# env — OPENAI_BASE_URL / OPENAI_API_KEY, set on PID 1 by the Deployment's
+# envFrom — is scrubbed from the interactive SSH/Mosh login shell. The
+# "sshd scrubs container env on login" gotcha
+# (docs/runbooks/frank-gotchas/agent-shells.md). Since this pod's whole job is
+# running `hermes` interactively over SSH, hermes launched from the shell would
+# silently fail to reach LiteLLM, and the image's own 50-…-motd.sh would print
+# "OPENAI_BASE_URL not set" on every login despite this manifest setting it.
+#
+# Fix without an agent-images change: mount this drop-in into /etc/profile.d via
+# subPath (same mechanism paperclip uses for its 60-…-tips.sh). It re-exports
+# the BYOK vars from /proc/1/environ — readable because the whole container runs
+# as UID 1000, so PID 1 is the same UID; this is the escape hatch the gotcha
+# names. Numbered 35- so it runs before the 50- auth-status MOTD.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agent-shell-env
+  namespace: hermes-agent-shell
+data:
+  35-hermes-agent-shell-byok-env.sh: |
+    # Re-export BYOK env scrubbed by sshd (UsePAM no, no PermitUserEnvironment).
+    # Login shells only; non-interactive `ssh host -- cmd` skips profile.d —
+    # use `kubectl exec` for that.
+    if [ -r /proc/1/environ ]; then
+        for _hv in OPENAI_BASE_URL OPENAI_API_KEY; do
+            eval "_hcur=\${$_hv:-}"
+            if [ -z "$_hcur" ]; then
+                _hval=$(tr '\0' '\n' < /proc/1/environ | sed -n "s/^${_hv}=//p" | head -n1)
+                [ -n "$_hval" ] && export "$_hv=$_hval"
+            fi
+        done
+        unset _hv _hcur _hval
+    fi

--- a/apps/hermes-agent-shell/manifests/configmap-inventory.yaml
+++ b/apps/hermes-agent-shell/manifests/configmap-inventory.yaml
@@ -1,0 +1,24 @@
+# Layer-2 inventory for the hermes-agent-shell pod.
+# `cont-init.d/40-shell-inventory` reconciles this against the home PVC at boot,
+# and again whenever the operator runs `hermes-agent-shell-reconcile`.
+#
+# Shipped sparse so the boot reconcile is a genuine no-op. All three
+# multi-harness keys are present but EMPTY.
+#
+# Do NOT seed `harnesses: { hermes: latest }` here: hermes is already on PATH
+# (baked into the image at HERMES_VERSION=0.15.2), and install-inventory.sh
+# runs `hermes update` for every populated harness entry on EVERY boot — that
+# is not a no-op, and a non-zero exit fires a Telegram alert. Leave it empty;
+# pin a PyPI version later (or float it) by adding `hermes: <ver|latest>` once
+# you actually want the reconcile to manage the harness.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hermes-agent-shell-inventory
+  namespace: hermes-agent-shell
+data:
+  inventory.yaml: |
+    # Multi-harness standard keys (empty → reconcile iterates nothing).
+    harnesses: {}
+    mcp-servers: {}
+    skills: {}

--- a/apps/hermes-agent-shell/manifests/deployment.yaml
+++ b/apps/hermes-agent-shell/manifests/deployment.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes-agent-shell
+  namespace: hermes-agent-shell
+  labels:
+    app: hermes-agent-shell
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # RWO PVC — cannot mount on two pods simultaneously
+  selector:
+    matchLabels:
+      app: hermes-agent-shell
+  template:
+    metadata:
+      labels:
+        app: hermes-agent-shell
+    spec:
+      # s6 cont-finish.d runs shutdown housekeeping (tmux state save). 45s gives
+      # it time to complete before SIGKILL. Mirrors secure-agent-pod / ruflo.
+      terminationGracePeriodSeconds: 45
+      # Pinned to gpu-1 — Frank's largest CPU/RAM box (the same reason
+      # paperclip / secure-agent-pod sit there). NO GPU is requested: hermes
+      # inference is remote via the in-cluster LiteLLM gateway. The
+      # nvidia.com/gpu:NoSchedule toleration mirrors the cluster's defensive
+      # idiom (ollama, n8n, secure-agent-pod) so the pod survives any future
+      # re-assert of the gpu-only taint.
+      nodeSelector:
+        kubernetes.io/hostname: gpu-1
+      tolerations:
+        - key: nvidia.com/gpu
+          effect: NoSchedule
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: hermes
+          image: ghcr.io/derio-net/hermes-agent-shell:95e719b9164e3e16b6e304202ff567f22aeed39c
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: ssh
+              containerPort: 2222  # Non-root sshd; Service maps 22→2222
+              protocol: TCP
+            # mosh-server picks a port from this range at session start;
+            # service.yaml exposes them on the same LB IP (UDP).
+            - { name: mosh-60032, containerPort: 60032, protocol: UDP }
+            - { name: mosh-60033, containerPort: 60033, protocol: UDP }
+            - { name: mosh-60034, containerPort: 60034, protocol: UDP }
+            - { name: mosh-60035, containerPort: 60035, protocol: UDP }
+            - { name: mosh-60036, containerPort: 60036, protocol: UDP }
+            - { name: mosh-60037, containerPort: 60037, protocol: UDP }
+            - { name: mosh-60038, containerPort: 60038, protocol: UDP }
+            - { name: mosh-60039, containerPort: 60039, protocol: UDP }
+            - { name: mosh-60040, containerPort: 60040, protocol: UDP }
+            - { name: mosh-60041, containerPort: 60041, protocol: UDP }
+            - { name: mosh-60042, containerPort: 60042, protocol: UDP }
+            - { name: mosh-60043, containerPort: 60043, protocol: UDP }
+            - { name: mosh-60044, containerPort: 60044, protocol: UDP }
+            - { name: mosh-60045, containerPort: 60045, protocol: UDP }
+            - { name: mosh-60046, containerPort: 60046, protocol: UDP }
+            - { name: mosh-60047, containerPort: 60047, protocol: UDP }
+          env:
+            # Mosh default is 168h (7d) — too long for a 16-port range.
+            # 1h reaps stuck servers fast enough to keep ports available.
+            - name: MOSH_SERVER_NETWORK_TMOUT
+              value: "3600"
+          envFrom:
+            # BYOK inference auth (OPENAI_BASE_URL + OPENAI_API_KEY). optional:
+            # true so the pod boots before the Phase 1 manual bootstrap mints
+            # HERMES_LITELLM_KEY and ESO syncs this secret. These land on PID 1's
+            # environ; the 35-…-byok-env.sh profile.d shim (hermes-agent-shell-env
+            # ConfigMap) re-exports them into the interactive login shell, which
+            # sshd would otherwise scrub.
+            - secretRef:
+                name: hermes-agent-shell-llm
+                optional: true
+            # Telegram creds for the inventory installer's notify helper.
+            # optional: true per the envFrom.secretRef gotcha — an ESO hiccup
+            # would otherwise CreateContainerConfigError instead of letting the
+            # shell boot without alerts. The helper is fail-silent if missing.
+            - secretRef:
+                name: hermes-agent-shell-alerts
+                optional: true
+          volumeMounts:
+            - name: home
+              mountPath: /home/agent
+            - name: ssh-keys
+              mountPath: /etc/ssh-keys
+              readOnly: true
+            - name: inventory
+              mountPath: /etc/hermes-agent-shell
+              readOnly: true
+            # BYOK-env profile.d shim — single-file subPath mount alongside the
+            # image-baked /etc/profile.d/{40,45,50}-hermes-agent-shell-*.sh.
+            - name: byok-env
+              mountPath: /etc/profile.d/35-hermes-agent-shell-byok-env.sh
+              subPath: 35-hermes-agent-shell-byok-env.sh
+              readOnly: true
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              # A single interactive hermes process + the s6 supervision tree.
+              # No vk-local executor fleet, so far lighter than secure-agent-pod.
+              cpu: "2"
+              memory: 4Gi
+          readinessProbe:
+            tcpSocket:
+              port: ssh
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          livenessProbe:
+            tcpSocket:
+              port: ssh
+            initialDelaySeconds: 30
+            periodSeconds: 60
+      volumes:
+        - name: home
+          persistentVolumeClaim:
+            claimName: hermes-agent-shell-home
+        - name: ssh-keys
+          # SOPS-managed bootstrap secret in secrets/hermes-agent-shell/. See the
+          # README there for rotation. optional: true (paperclip/ruflo pattern)
+          # so the pod boots before the bootstrap lands; sshd just accepts no
+          # keys until then.
+          secret:
+            secretName: hermes-agent-shell-ssh-keys
+            optional: true
+            defaultMode: 0400
+        - name: inventory
+          configMap:
+            name: hermes-agent-shell-inventory
+        - name: byok-env
+          configMap:
+            name: hermes-agent-shell-env
+            defaultMode: 0644

--- a/apps/hermes-agent-shell/manifests/externalsecret-alerts.yaml
+++ b/apps/hermes-agent-shell/manifests/externalsecret-alerts.yaml
@@ -1,0 +1,31 @@
+# Telegram bot credentials for the hermes-agent-shell inventory installer's
+# notify-telegram.sh helper (fired when the cont-init.d reconcile reports
+# failures). Same Infisical entries the rest of Frank uses for FRANK_C2_*
+# alerting (grafana-alerting, argocd-notifications, paperclip/ruflo shells).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-agent-shell-alerts
+  namespace: hermes-agent-shell
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: hermes-agent-shell-alerts
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: FRANK_C2_TELEGRAM_BOT_TOKEN
+      remoteRef:
+        key: FRANK_C2_TELEGRAM_BOT_TOKEN
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    - secretKey: FRANK_C2_TELEGRAM_CHAT_ID
+      remoteRef:
+        key: FRANK_C2_TELEGRAM_CHAT_ID
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/apps/hermes-agent-shell/manifests/externalsecret-llm.yaml
+++ b/apps/hermes-agent-shell/manifests/externalsecret-llm.yaml
@@ -1,0 +1,42 @@
+# Syncs the hermes BYOK inference auth from Infisical, exposed as the OpenAI
+# HTTP-shape env the hermes agent reads:
+#   OPENAI_BASE_URL — in-cluster LiteLLM gateway (literal; not a synced key)
+#   OPENAI_API_KEY  — HERMES_LITELLM_KEY, a LiteLLM virtual key scoped to this
+#                     agent (LiteLLM authenticates against its OWN virtual keys,
+#                     not an upstream provider key — same pattern paperclip uses
+#                     via PAPERCLIP_LITELLM_KEY and ruflo via RUFLO_LITELLM_KEY).
+#
+# One ExternalSecret carries both values (ruflo's externalsecret-llm.yaml shape)
+# so the env definition lives in one place. The Deployment consumes it via
+# `envFrom … optional: true`, so the pod boots even before the Phase 1 manual
+# bootstrap mints the key.
+#
+# NOTE the /v1 suffix on OPENAI_BASE_URL: the hermes-agent-shell image README's
+# BYOK table documents `OPENAI_BASE_URL = http://…:4000/v1` (the OpenAI-compatible
+# client appends paths to a /v1 base). ruflo omits /v1 only because its consumer
+# is opencode, not an OpenAI client.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-agent-shell-llm
+  namespace: hermes-agent-shell
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: hermes-agent-shell-llm
+    creationPolicy: Owner
+    template:
+      data:
+        OPENAI_BASE_URL: "http://litellm.litellm.svc:4000/v1"
+        OPENAI_API_KEY: "{{ .HERMES_LITELLM_KEY }}"
+    deletionPolicy: Retain
+  data:
+    - secretKey: HERMES_LITELLM_KEY
+      remoteRef:
+        key: HERMES_LITELLM_KEY
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/apps/hermes-agent-shell/manifests/pvc-home.yaml
+++ b/apps/hermes-agent-shell/manifests/pvc-home.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-agent-shell-home
+  namespace: hermes-agent-shell
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      # Holds ~/.hermes/ (config, sessions, skills, memories) plus any
+      # inventory-installed toolchain under $HOME. Matches paperclip-shell-home
+      # / ruflo-shell-home (20Gi).
+      storage: 20Gi

--- a/apps/hermes-agent-shell/manifests/service.yaml
+++ b/apps/hermes-agent-shell/manifests/service.yaml
@@ -1,0 +1,42 @@
+# SSH + Mosh LoadBalancer for the hermes-agent-shell pod.
+# Single combined LB IP (ruflo/paperclip pattern, not secure-agent-pod's
+# two-IP split): MixedProtocolLBService (TCP + UDP on one Service) works on
+# Cilium 1.17 + K8s 1.35. The mosh UDP range (60032–60047) does not overlap
+# secure-agent-pod/paperclip (60000–60015) or ruflo (60016–60031), so no
+# `lbipam.cilium.io/sharing-key` is needed.
+# 192.168.55.226 confirmed unused across `apps/` at the time of this PR.
+#
+# mosh-server picks one UDP port from this range at session start.
+#
+# Client invocation:
+#   mosh --ssh="ssh agent@192.168.55.226" \
+#        --server="mosh-server new -p 60032:60047" 192.168.55.226
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes-agent-shell
+  namespace: hermes-agent-shell
+  annotations:
+    lbipam.cilium.io/ips: "192.168.55.226"
+spec:
+  type: LoadBalancer
+  selector:
+    app: hermes-agent-shell
+  ports:
+    - { name: ssh,         port: 22,    targetPort: 2222,  protocol: TCP }
+    - { name: mosh-60032,  port: 60032, targetPort: 60032, protocol: UDP }
+    - { name: mosh-60033,  port: 60033, targetPort: 60033, protocol: UDP }
+    - { name: mosh-60034,  port: 60034, targetPort: 60034, protocol: UDP }
+    - { name: mosh-60035,  port: 60035, targetPort: 60035, protocol: UDP }
+    - { name: mosh-60036,  port: 60036, targetPort: 60036, protocol: UDP }
+    - { name: mosh-60037,  port: 60037, targetPort: 60037, protocol: UDP }
+    - { name: mosh-60038,  port: 60038, targetPort: 60038, protocol: UDP }
+    - { name: mosh-60039,  port: 60039, targetPort: 60039, protocol: UDP }
+    - { name: mosh-60040,  port: 60040, targetPort: 60040, protocol: UDP }
+    - { name: mosh-60041,  port: 60041, targetPort: 60041, protocol: UDP }
+    - { name: mosh-60042,  port: 60042, targetPort: 60042, protocol: UDP }
+    - { name: mosh-60043,  port: 60043, targetPort: 60043, protocol: UDP }
+    - { name: mosh-60044,  port: 60044, targetPort: 60044, protocol: UDP }
+    - { name: mosh-60045,  port: 60045, targetPort: 60045, protocol: UDP }
+    - { name: mosh-60046,  port: 60046, targetPort: 60046, protocol: UDP }
+    - { name: mosh-60047,  port: 60047, targetPort: 60047, protocol: UDP }

--- a/apps/root/templates/hermes-agent-shell.yaml
+++ b/apps/root/templates/hermes-agent-shell.yaml
@@ -1,0 +1,35 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: hermes-agent-shell
+  namespace: argocd
+  annotations:
+    # The named webhook in argocd-notifications-cm is `service.webhook.telegram`.
+    # notifications-engine treats the third dotted segment as the service NAME
+    # (so the registered service is `telegram`, of type webhook). Mirrors
+    # secure-agent-pod's subscription annotations.
+    notifications.argoproj.io/subscribe.on-sync-running.telegram: ""
+    notifications.argoproj.io/subscribe.on-sync-succeeded.telegram: ""
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  source:
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.targetRevision }}
+    path: apps/hermes-agent-shell/manifests
+  destination:
+    server: {{ .Values.destination.server }}
+    namespace: hermes-agent-shell
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=false
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - kind: Secret
+      jsonPointers:
+        - /data

--- a/apps/root/templates/ns-hermes-agent-shell.yaml
+++ b/apps/root/templates/ns-hermes-agent-shell.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-agent-shell
+  labels:
+    # Matches the sibling shell namespaces (ns-secure-agent-pod, paperclip,
+    # ruflo). The hermes container is runAsNonRoot + drop ALL caps, so it
+    # actually satisfies `restricted`; we enforce `baseline` to stay
+    # consistent with the family and audit/warn at `restricted`.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/01.yaml
+++ b/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/01.yaml
@@ -1,0 +1,88 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Manual bootstrap — LiteLLM virtual key + SOPS ssh-keys
+  tag: manual
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Mint LiteLLM virtual key and store it in Infisical
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Mint a dedicated LiteLLM virtual key for the hermes agent (LiteLLM
+      admin UI, or `POST /key/generate` against the gateway at
+      192.168.55.206 / `litellm.litellm.svc:4000`). Scope it to the hermes
+      agent so its budget/usage is independently observable and revocable
+      — do NOT reuse paperclip's `PAPERCLIP_LITELLM_KEY`.
+      Capture the returned `sk-...` value.
+  - id: P1.T1.S2
+    text: |-
+      Store the key in Infisical as `HERMES_LITELLM_KEY` (same
+      project/environment the other Frank keys live in — the one the
+      `infisical` ClusterSecretStore points at). This is what the Phase 2
+      `externalsecret-llm` resolves into `OPENAI_API_KEY`.
+      Verify the entry exists (Infisical UI or CLI). Cluster-side
+      verification (`externalsecret … SecretSynced`) happens in Phase 2
+      once the ExternalSecret object exists.
+- number: 2
+  title: Prepare and commit the SOPS-encrypted ssh-keys secret
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Reuse the operator SSH public key already paired with the other
+      shells (secure-agent-pod / paperclip-shell / ruflo-shell) so one
+      private key opens every shell, or generate a fresh keypair. You only
+      need the PUBLIC key for the secret.
+  - id: P1.T2.S2
+    text: |-
+      Build the Secret manifest (namespace `hermes-agent-shell`, key
+      `authorized_keys`):
+      ```bash
+      kubectl create secret generic hermes-agent-shell-ssh-keys \
+        --namespace=hermes-agent-shell \
+        --from-file=authorized_keys=<path-to-operator.pub> \
+        --dry-run=client -o yaml \
+        > secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml
+      ```
+      (The `secrets/hermes-agent-shell/` dir + its README are authored in
+      Phase 2; create the dir here if it does not exist yet.)
+  - id: P1.T2.S3
+    text: |-
+      SOPS-encrypt in place (recipients resolve from the repo-root
+      `.sops.yaml` `path_regex` — `encrypted_regex: ^(data|stringData)$`):
+      ```bash
+      sops --encrypt --in-place secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml
+      git add secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml
+      ```
+      Commit it. Do NOT apply yet — the `hermes-agent-shell` namespace does
+      not exist until ArgoCD creates it in Phase 2, so the
+      `kubectl apply` of this secret is deferred to Phase 2 / T2.
+      (SOPS secrets are applied out-of-band and are never ArgoCD-managed.)
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/01.yaml
+++ b/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/01.yaml
@@ -63,26 +63,28 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T16:07:22+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T16:07:24+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T16:07:26+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T16:07:27+00:00'
       note: null
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T16:07:29+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-06-04T16:07:45+00:00'
+    note: HERMES_LITELLM_KEY minted + stored in Infisical; operator pubkey (raspi-controller@dMac,
+      reused from ruflo-shell) SOPS-committed as hermes-agent-shell-ssh-keys; apply
+      deferred to Phase 2 (namespace not yet created)
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/02.yaml
+++ b/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/02.yaml
@@ -200,44 +200,44 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:26+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:26+00:00'
       note: null
     P2.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:26+00:00'
       note: null
     P2.T1.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:26+00:00'
       note: null
     P2.T1.S5:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:27+00:00'
       note: null
     P2.T1.S6:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:27+00:00'
       note: null
     P2.T1.S7:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:27+00:00'
       note: null
     P2.T1.S8:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:27+00:00'
       note: null
     P2.T1.S9:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:27+00:00'
       note: null
     P2.T1.S10:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T15:02:27+00:00'
       note: null
     P2.T2.S1:
       state: ' '

--- a/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/02.yaml
+++ b/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/02.yaml
@@ -1,0 +1,281 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Deploy hermes-agent-shell + verify + post-deploy
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Author the ArgoCD app manifests and supporting files
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Create `apps/root/templates/ns-hermes-agent-shell.yaml` — a
+      Namespace `hermes-agent-shell` with PSA label
+      `pod-security.kubernetes.io/enforce: baseline` (mirrors
+      `ns-secure-agent-pod.yaml` / paperclip / ruflo namespaces).
+  - id: P2.T1.S2
+    text: |-
+      Create `apps/hermes-agent-shell/manifests/pvc-home.yaml` —
+      `hermes-agent-shell-home`, `storageClassName: longhorn`, RWO, 20Gi
+      (matches `paperclip-shell-home` / `ruflo-shell-home`).
+  - id: P2.T1.S3
+    text: |-
+      Create `apps/hermes-agent-shell/manifests/configmap-inventory.yaml`
+      — ConfigMap `hermes-agent-shell-inventory` with key `inventory.yaml`
+      carrying EMPTY maps so boot reconcile is a true no-op:
+      ```yaml
+      harnesses: {}
+      mcp-servers: {}
+      skills: {}
+      ```
+      Do NOT seed `harnesses: { hermes: latest }` — hermes is on PATH
+      (baked at HERMES_VERSION 0.15.2) and install-inventory.sh runs
+      `hermes update` for each populated entry on EVERY boot, which is not
+      a no-op and fires a Telegram alert on non-zero exit.
+  - id: P2.T1.S4
+    text: |-
+      Create `apps/hermes-agent-shell/manifests/configmap-byok-env.yaml` —
+      ConfigMap `hermes-agent-shell-env` with key
+      `35-hermes-agent-shell-byok-env.sh`, a profile.d drop-in that
+      re-exports the BYOK env from `/proc/1/environ` into the interactive
+      login shell (sshd runs `UsePAM no` with no `PermitUserEnvironment`,
+      so the container env never reaches an SSH session otherwise — the
+      "sshd scrubs container env on login" gotcha). Numbered `35-` so it
+      runs before the image's `50-…-motd.sh` auth-status check. Content:
+      ```sh
+      # Re-export BYOK env scrubbed by sshd (UsePAM no, no
+      # PermitUserEnvironment). The container runs as UID 1000 so PID 1 is
+      # same-UID and /proc/1/environ is readable — the sanctioned escape
+      # hatch from frank-gotchas agent-shells.md. Login shells only.
+      [ -r /proc/1/environ ] || return 0 2>/dev/null || true
+      for _v in OPENAI_BASE_URL OPENAI_API_KEY; do
+          eval "_cur=\${$_v:-}"
+          [ -n "$_cur" ] && continue
+          _val=$(tr '\0' '\n' < /proc/1/environ | sed -n "s/^${_v}=//p" | head -n1)
+          [ -n "$_val" ] && export "$_v=$_val"
+      done
+      unset _v _cur _val
+      ```
+      Mount it in the Deployment at
+      `/etc/profile.d/35-hermes-agent-shell-byok-env.sh` via `subPath`
+      (same mechanism as paperclip's `60-…-tips.sh`).
+  - id: P2.T1.S5
+    text: |-
+      Create `apps/hermes-agent-shell/manifests/externalsecret-llm.yaml` —
+      `apiVersion: external-secrets.io/v1`, ExternalSecret
+      `hermes-agent-shell-llm`, `secretStoreRef: { name: infisical, kind:
+      ClusterSecretStore }`, `refreshInterval: 5m`, target
+      `hermes-agent-shell-llm` (`creationPolicy: Owner`,
+      `deletionPolicy: Retain`). `template.data`:
+      `OPENAI_BASE_URL: "http://litellm.litellm.svc:4000/v1"` (literal) and
+      `OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"`; `data:` maps
+      `OPENAI_API_KEY` ← remoteRef `HERMES_LITELLM_KEY`. Mirror ruflo's
+      `externalsecret-llm.yaml` shape.
+  - id: P2.T1.S6
+    text: |-
+      Create `apps/hermes-agent-shell/manifests/externalsecret-alerts.yaml`
+      — ExternalSecret `hermes-agent-shell-alerts` syncing
+      `FRANK_C2_TELEGRAM_BOT_TOKEN` + `FRANK_C2_TELEGRAM_CHAT_ID` from
+      Infisical (copy `apps/paperclip/manifests/externalsecret-shell-alerts.yaml`,
+      renaming namespace/secret).
+  - id: P2.T1.S7
+    text: |-
+      Create `apps/hermes-agent-shell/manifests/service.yaml` — a single
+      combined LoadBalancer Service on `lbipam.cilium.io/ips:
+      "192.168.55.226"`, selector `app: hermes-agent-shell`, ports
+      TCP `22 → 2222` plus UDP `60032`–`60047` (one port entry each).
+      Model on `apps/ruflo/manifests/service-shell.yaml` (single-IP
+      MixedProtocolLBService, no sharing-key).
+  - id: P2.T1.S8
+    text: |-
+      Create `apps/hermes-agent-shell/manifests/deployment.yaml` — single
+      container `hermes`, image
+      `ghcr.io/derio-net/hermes-agent-shell:95e719b9164e3e16b6e304202ff567f22aeed39c`,
+      `replicas: 1`, `strategy: Recreate`,
+      `terminationGracePeriodSeconds: 45`, `nodeSelector:
+      kubernetes.io/hostname: gpu-1`, toleration `nvidia.com/gpu:NoSchedule`,
+      pod `fsGroup: 1000`, container `runAsUser/Group: 1000`,
+      `runAsNonRoot`, drop ALL caps. Ports: ssh 2222 + mosh 60032–60047.
+      Env: `MOSH_SERVER_NETWORK_TMOUT=3600`;
+      `envFrom: [{secretRef: hermes-agent-shell-llm, optional: true},
+      {secretRef: hermes-agent-shell-alerts, optional: true}]`.
+      Volumes: home PVC → `/home/agent`; ssh-keys secret
+      `hermes-agent-shell-ssh-keys` (optional) → `/etc/ssh-keys` ro;
+      inventory CM → `/etc/hermes-agent-shell`; byok-env CM subPath →
+      `/etc/profile.d/35-hermes-agent-shell-byok-env.sh`. TCP readiness +
+      liveness probes on port 2222. Requests 500m/1Gi, limits 2/4Gi.
+  - id: P2.T1.S9
+    text: |-
+      Create `apps/root/templates/hermes-agent-shell.yaml` — Application CR
+      (`project: infrastructure`, single `source` `path:
+      apps/hermes-agent-shell/manifests`, `selfHeal: true`, explicit
+      `prune: false`, syncOptions `ServerSideApply=true` +
+      `RespectIgnoreDifferences=true` + `CreateNamespace=false`,
+      `ignoreDifferences` on Secret `/data`, resources-finalizer, Telegram
+      sync-notification annotations). Model on
+      `apps/root/templates/secure-agent-pod.yaml`.
+  - id: P2.T1.S10
+    text: |-
+      Create the client-setup helpers under
+      `apps/hermes-agent-shell/client-setup/laptop/`
+      (`ssh-config.snippet`, `mosh-wrapper.sh` pinning
+      `mosh-server new -p 60032:60047` to `192.168.55.226`, `README.md`)
+      and `secrets/hermes-agent-shell/README.md` (SOPS bootstrap runbook,
+      modeled on `secrets/paperclip/README.md`).
+- number: 2
+  title: Deploy via ArgoCD, apply the bootstrap secret, verify end-to-end
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      Open a PR with all Phase 2 manifests; on merge to `main` ArgoCD
+      auto-syncs the root App-of-Apps. Confirm the `hermes-agent-shell`
+      Application reaches Synced/Healthy:
+      `kubectl get application hermes-agent-shell -n argocd -o wide`
+      (use this, NOT port-forward — gpu-1 port-forward flakiness gotcha).
+  - id: P2.T2.S2
+    text: |-
+      With the namespace now created, apply the Phase 1 SOPS ssh-keys
+      secret out-of-band:
+      `sops --decrypt secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml | kubectl apply -f -`
+      Restart the pod (or wait for boot) so cont-init.d/30-authorized-keys
+      copies the key. Confirm both ExternalSecrets resolved:
+      `kubectl -n hermes-agent-shell get externalsecret` → both
+      `SecretSynced`.
+  - id: P2.T2.S3
+    text: |-
+      Verify end-to-end. Pod Healthy:
+      `kubectl -n hermes-agent-shell get pod`. SSH in
+      (`ssh -p 22 agent@192.168.55.226`): the MOTD prints the
+      `~ hermes (BYOK — no login flow)` row WITHOUT the
+      "OPENAI_BASE_URL not set" note — proving the 35-…-byok-env.sh shim
+      re-exported the env into the login shell. `hermes --version` runs.
+      From the interactive login shell, confirm LiteLLM reachability:
+      `curl -sf -H "Authorization: Bearer $OPENAI_API_KEY" $OPENAI_BASE_URL/models >/dev/null && echo reachable`.
+      (For any non-interactive check use `kubectl exec`, never
+      `ssh host -- cmd` — that skips profile.d.)
+- number: 3
+  title: Post-deploy checklist
+  steps:
+  - id: P2.T3.S1
+    text: |-
+      Step 1 (external web exposure): SKIP — internal SSH/Mosh-only
+      service, no web UI, no homepage tile. But DO add a service-table row
+      to `agents/rules/frank-infrastructure.md`:
+      `Hermes Agent Shell (SSH+Mosh) | 192.168.55.226 | Cilium L2
+      LoadBalancer (port 22/SSH, UDP 60032-60047/Mosh)`.
+  - id: P2.T3.S2
+    text: |-
+      Write the BUILDING blog post (`orch` layer) via the `/blog-post`
+      skill — the hermes-agent-shell deploy narrative (BYOK exception, the
+      sshd env-scrub gotcha + profile.d fix, gpu-1 placement). Update
+      `blog/content/docs/building/00-overview/index.md` (Series Index +
+      Capability Map) and `blog/layouts/shortcodes/cluster-roadmap.html`.
+  - id: P2.T3.S3
+    text: |-
+      Write the OPERATING blog post via `/blog-post` — day-to-day: SSH/Mosh
+      in, run hermes, reconcile inventory, rotate the LiteLLM key + ssh
+      keys, read the MOTD, the `ssh host -- cmd` env limitation. Update the
+      operating series index.
+  - id: P2.T3.S4
+    text: |-
+      Add a gotchas one-liner to `agents/rules/frank-gotchas.md` (Agent
+      shells section) capturing the env-scrub-needs-profile.d-shim pattern
+      for BYOK shells, with full prose in
+      `docs/runbooks/frank-gotchas/agent-shells.md`. Run `/update-readme`
+      to sync Technology Stack / Service Access / Current Status.
+  - id: P2.T3.S5
+    text: |-
+      Run `/sync-runbook` to fold the two Phase 1 `# manual-operation`
+      blocks (the LiteLLM virtual key + the SOPS ssh-keys bootstrap) from
+      the spec into `docs/runbooks/manual-operations.yaml`.
+  - id: P2.T3.S6
+    text: |-
+      Set the plan `Status` to `Deployed` ONLY after the deployment is
+      observed working end-to-end live (pod Healthy, SSH in, hermes reaches
+      LiteLLM from a login shell) — a layer is not "Deployed" until its
+      path is observed working, not merely Synced.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S5:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S6:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S7:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S8:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S9:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S10:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S5:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S6:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-03--orch--hermes-agent-shell-deploy
+spec: docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-06-04'

--- a/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/_prose.md
+++ b/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/_prose.md
@@ -6,7 +6,7 @@
 
 **Spec:** `docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md`
 **Layer:** `orch` (15 — AI Agent Orchestrator)
-**Status:** Not Started
+**Status:** In Progress
 
 **Goal:** Stand up a standalone, SSH-able shell pod on `gpu-1` running the Nous
 Research `hermes` agent, wired BYOK to Frank's in-cluster LiteLLM gateway, with

--- a/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/_prose.md
+++ b/docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/_prose.md
@@ -1,0 +1,77 @@
+# Deploy hermes-agent-shell pod on Frank (gpu-1)
+
+> **For VK agents:** use vk-execute to implement assigned phases.
+> **For local execution:** subagent-driven-development or executing-plans.
+> **For dispatch:** vk-dispatch to create Issues from this plan.
+
+**Spec:** `docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md`
+**Layer:** `orch` (15 — AI Agent Orchestrator)
+**Status:** Not Started
+
+**Goal:** Stand up a standalone, SSH-able shell pod on `gpu-1` running the Nous
+Research `hermes` agent, wired BYOK to Frank's in-cluster LiteLLM gateway, with
+PV-resident state. Consumes the `hermes-agent-shell` image just delivered by the
+`agent-images` agent-shells-batch feature (pinned at the cluster-wide
+agent-images SHA `95e719b`).
+
+**Context:** Modeled on `secure-agent-pod` (the existing standalone
+interactive-shell pod); secret/inventory/MOTD wiring borrowed from
+`paperclip-shell` / `ruflo-shell`. This is NOT the in-paperclip hermes shim — it
+is a dedicated pod whose only job is hosting `hermes` interactively.
+
+## Architecture
+
+```
+agent-base
+└── agent-shell-base
+    └── hermes-agent-shell   ← deployed here (BYOK → litellm.litellm.svc:4000/v1)
+```
+
+Single-container Deployment on `gpu-1` (no GPU requested — inference is remote
+via LiteLLM; gpu-1 chosen as Frank's largest CPU/RAM box). Combined SSH+Mosh
+LoadBalancer on `192.168.55.226` (TCP 22→2222, UDP 60032–60047). 20Gi Longhorn
+home PVC at `/home/agent` holding `~/.hermes/`.
+
+## Two-phase shape
+
+```
+Phase 1 (manual)   LiteLLM virtual key + Infisical entry; SOPS ssh-keys prep   depends_on: []
+Phase 2 (agentic)  manifests + deploy + apply secret + verify + post-deploy    depends_on: [1]
+```
+
+Phase 1 is pure prep with no cluster-ordering hazard. The `kubectl apply` of the
+SOPS ssh-keys secret deliberately lands in Phase 2/T2 because it needs the
+namespace ArgoCD creates first. The pod boots even before Phase 1 completes
+(both secret refs are `optional: true`) — it just can't reach LiteLLM and sshd
+accepts no keys until the bootstraps land. That is the declarative-only
+bootstrap exception, by design.
+
+## Critical wiring note — sshd env-scrub
+
+`agent-shell-base`'s sshd runs `UsePAM no` with no `PermitUserEnvironment`, so
+the K8s-injected BYOK env (`OPENAI_BASE_URL` / `OPENAI_API_KEY` on PID 1) does
+NOT reach an interactive SSH/Mosh login shell. Without a fix, `hermes` launched
+from the shell silently can't reach LiteLLM (and the image's own MOTD prints
+"OPENAI_BASE_URL not set" despite the manifest setting it). Phase 2 ships a
+ConfigMap-mounted profile.d shim (`35-hermes-agent-shell-byok-env.sh`) that
+re-exports the env from `/proc/1/environ` for login shells — the same `subPath`
+mechanism paperclip uses for its tips drop-in, so no `agent-images` change is
+needed. Non-interactive `ssh host -- cmd` stays env-less by design (use
+`kubectl exec`).
+
+## Manual operations
+
+Two `# manual-operation` blocks (documented in the spec, synced via
+`/sync-runbook` in Phase 2/T3.S5):
+
+- `orch-hermes-litellm-virtual-key` — mint a LiteLLM virtual key, store as
+  `HERMES_LITELLM_KEY` in Infisical.
+- `orch-hermes-shell-ssh-keys` — build + SOPS-encrypt + apply the
+  `hermes-agent-shell-ssh-keys` Secret.
+
+## Post-deploy
+
+Standard checklist minus Step 1 (the shell is SSH/Mosh-only — no web exposure,
+no homepage tile; the `frank-infrastructure.md` service-table row is still
+added). Building + operating blog posts (`orch` layer), README sync, runbook
+sync, status → Deployed after end-to-end observation.

--- a/docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md
@@ -71,7 +71,10 @@ agent-base
   `cont-init.d/30-authorized-keys` copies `/etc/ssh-keys/authorized_keys` into
   `~/.ssh/authorized_keys` on boot. Reuse the operator public key already paired
   with the other shells. SOPS-bootstrap (not ESO) mirrors `secure-agent-pod`'s
-  `agent-ssh-keys`, `paperclip-shell-ssh-keys`, and `ruflo-shell-ssh-keys`.
+  `agent-ssh-keys`, `paperclip-shell-ssh-keys`, and `ruflo-shell-ssh-keys`. The
+  `optional: true` flag follows **paperclip/ruflo** (their ssh-keys volumes are
+  optional so the pod boots before bootstrap); secure-agent-pod's is *required*,
+  so we deviate from it deliberately here.
 
 ### Services (SSH + Mosh)
 
@@ -99,14 +102,53 @@ Frank manifest and sourced via ESO from Infisical.
 
 - **Dedicated LiteLLM virtual key.** New Infisical entry `HERMES_LITELLM_KEY`,
   backed by its own LiteLLM virtual key (independently observable / revocable in
-  LiteLLM, not entangled with paperclip's `PAPERCLIP_LITELLM_KEY`). ESO
-  `ExternalSecret hermes-agent-shell-llm-key` → Secret exposing `OPENAI_API_KEY`.
-- **Container env:**
-  - `OPENAI_BASE_URL=http://litellm.litellm.svc:4000/v1` — Frank's real
-    in-cluster LiteLLM DNS (the image README's `litellm.litellm-system` is an
-    upstream-generic placeholder; Frank's namespace is `litellm`, confirmed
-    against paperclip/ruflo which both use `litellm.litellm.svc:4000`).
-  - `OPENAI_API_KEY` ← `hermes-agent-shell-llm-key` secret.
+  LiteLLM, not entangled with paperclip's `PAPERCLIP_LITELLM_KEY`).
+- **One ESO secret carries both values** (matches ruflo's
+  `externalsecret-llm.yaml`, which emits base-URL + key from a single
+  `ExternalSecret` template rather than splitting URL into deployment env). ESO
+  `ExternalSecret hermes-agent-shell-llm` → Secret `hermes-agent-shell-llm`
+  with:
+  - `OPENAI_BASE_URL: "http://litellm.litellm.svc:4000/v1"` — a literal in the
+    ESO `template.data` (not a synced key). Frank's real in-cluster LiteLLM DNS:
+    the image README's `litellm.litellm-system` is an upstream-generic
+    placeholder; Frank's namespace is `litellm`, confirmed against
+    paperclip/ruflo which both use `litellm.litellm.svc:4000`. The `/v1` suffix
+    is kept deliberately — the hermes-agent-shell image README's own BYOK table
+    documents `OPENAI_BASE_URL = http://…:4000/v1` (the OpenAI-compatible client
+    appends paths to a `/v1` base). (ruflo omits `/v1` only because its consumer
+    is opencode, not an OpenAI client.)
+  - `OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"` — synced from Infisical
+    `HERMES_LITELLM_KEY`.
+  The Deployment consumes it via `envFrom: secretRef: name: hermes-agent-shell-llm
+  optional: true` so the pod still boots before the Phase 0 bootstrap (the
+  secret won't exist until ESO syncs the minted key).
+
+- **CRITICAL — sshd scrubs the container env; a profile.d shim re-exports it.**
+  `agent-shell-base`'s sshd runs with `UsePAM no` and **no**
+  `PermitUserEnvironment` (`agent-shell-base/sshd_config`), so the K8s-injected
+  container env (`OPENAI_BASE_URL`/`OPENAI_API_KEY` on PID 1) does **not** reach
+  an interactive SSH/Mosh login shell — the `sshd scrubs container env on login`
+  gotcha (`frank-gotchas.md` → `agent-shells.md`). Because this pod's entire
+  purpose is running `hermes` interactively over SSH, the BYOK env must be
+  re-exported into the login shell or hermes silently can't reach LiteLLM. (The
+  image's own `50-hermes-agent-shell-motd.sh` would otherwise print
+  "OPENAI_BASE_URL not set" on every login despite the manifest setting it.)
+  **Fix (no image change):** mount a profile.d drop-in
+  `/etc/profile.d/35-hermes-agent-shell-byok-env.sh` from a ConfigMap
+  `hermes-agent-shell-env` via `subPath` — exactly the mechanism paperclip uses
+  for its `60-paperclip-shell-tips.sh` (`apps/paperclip/manifests/deployment.yaml:262-264`).
+  The shim sources `OPENAI_BASE_URL`/`OPENAI_API_KEY` from `/proc/1/environ`
+  (readable: the whole container runs as UID 1000, so PID 1 is same-UID — this
+  is the sanctioned escape hatch named in the gotcha) and `export`s them for the
+  login shell, only if unset. Numbered `35-` so it runs before the `50-` MOTD
+  check, suppressing the spurious "not set" note.
+  - *Limitation:* profile.d is sourced by **login** shells (`/etc/profile`), so
+    interactive `ssh agent@…` then `hermes` is covered, but non-interactive
+    `ssh agent@… -- hermes …` is not — for that, use `kubectl exec` or source
+    `/proc/1/environ` manually. The operator runbook drives interactive use, so
+    this matches the primary path; the limitation is documented in the operating
+    post.
+
 - **Telegram alerts** — ESO `ExternalSecret hermes-agent-shell-alerts` syncing
   `FRANK_C2_TELEGRAM_BOT_TOKEN` / `FRANK_C2_TELEGRAM_CHAT_ID`; consumed via
   `envFrom … secretRef … optional: true` (fail-open per the
@@ -117,16 +159,19 @@ Frank manifest and sourced via ESO from Infisical.
 
 ConfigMap `hermes-agent-shell-inventory` mounted at `/etc/hermes-agent-shell/`
 (the image's reconcile reads `/etc/hermes-agent-shell/inventory.yaml`). Ship
-**sparse** for the initial deploy so the boot reconcile is a clean no-op, with
-the multi-harness standard's three keys present:
+**sparse** for the initial deploy so the boot reconcile is a genuine no-op, with
+the multi-harness standard's three keys present but **empty**:
 
 ```yaml
-harnesses:
-  hermes: latest        # float; pin a PyPI version later if desired
-mcp-servers:
-  hermes: []
-skills:
-  hermes: []
+# All three keys empty → reconcile iterates nothing → true no-op boot.
+# NOTE: do NOT seed `harnesses: { hermes: latest }` here. hermes is on PATH
+# (baked at HERMES_VERSION=0.15.2), and install-inventory.sh runs `hermes
+# update` for every populated harness entry on EVERY boot — not a no-op, and a
+# non-zero exit fires a Telegram alert. Leave empty; the operator pins a
+# version later if they want the float behavior.
+harnesses: {}
+mcp-servers: {}
+skills: {}
 ```
 
 ### App CR conventions
@@ -135,13 +180,22 @@ Application CR at `apps/root/templates/hermes-agent-shell.yaml`, namespace via
 `apps/root/templates/ns-hermes-agent-shell.yaml`:
 
 - `project: infrastructure`, single `source` (`path: apps/hermes-agent-shell/manifests`).
-- `syncPolicy.automated.selfHeal: true`, `prune: false`.
+- `syncPolicy.automated.selfHeal: true`, explicit `prune: false`
+  (`frank-argocd.md` guidance; note secure-agent-pod's template omits `prune`
+  and relies on the ArgoCD default — we set it explicitly rather than copy that
+  template verbatim).
 - `syncOptions: ServerSideApply=true`, `RespectIgnoreDifferences=true`,
   `CreateNamespace=false` (namespace templated separately, matching secure-agent-pod).
 - `ignoreDifferences` on Secret `/data`.
 - `resources-finalizer.argocd.argoproj.io` finalizer.
 - ArgoCD Telegram sync-notification annotations (`subscribe.on-sync-running.telegram`,
   `subscribe.on-sync-succeeded.telegram`), mirroring secure-agent-pod.
+
+Namespace `ns-hermes-agent-shell.yaml` carries the Pod Security Admission label
+`pod-security.kubernetes.io/enforce: baseline`, matching the sibling shell
+namespaces (`ns-secure-agent-pod.yaml`, paperclip/ruflo). The container
+(runAsNonRoot, drop ALL caps) actually satisfies `restricted`, but `baseline`
+keeps it consistent with the family.
 
 ## Scope
 
@@ -152,7 +206,10 @@ client-setup helpers, the two manual-operation bootstraps, and the post-deploy
 documentation (blog building+operating posts, README, frank-infrastructure.md
 service-table row, runbook sync).
 
-**Out of scope:** any change to `agent-images` (the image ships as-is);
+**Out of scope:** any change to `agent-images` (the image ships as-is — note the
+BYOK-env profile.d shim is delivered as a **Frank-side ConfigMap mounted via
+`subPath`**, identical to paperclip's existing `60-…-tips.sh` mount, so it
+respects this boundary and needs no image edit);
 exposing the shell on a web domain / homepage tile (it is SSH/Mosh-only);
 cross-harness skill unification; pinning a specific hermes PyPI version or
 pre-loading MCP servers / skills (inventory ships sparse — operator fills later);
@@ -171,11 +228,14 @@ agentic build-out):
      `secrets/hermes-agent-shell/`, and apply it out-of-band.
   Both are `# manual-operation` blocks → synced to the runbook.
 - **Phase 1 — Agentic deploy + verify:** author all manifests, the Application
-  CR + Namespace, ESOs, ConfigMap, client-setup helpers; sync via ArgoCD; verify
-  end-to-end (pod Healthy, ESOs resolved, SSH in, MOTD shows the BYOK row,
-  `hermes --version` runs, `OPENAI_BASE_URL` reachable); then the post-deploy
-  checklist (building+operating blog posts, README, service-table row, runbook
-  sync, status → Deployed).
+  CR + Namespace, both ConfigMaps (inventory + BYOK-env profile.d shim), ESOs,
+  client-setup helpers; sync via ArgoCD; verify end-to-end (pod Healthy, ESOs
+  resolved, SSH in, MOTD shows the BYOK row **without** the "OPENAI_BASE_URL not
+  set" note — proving the profile.d shim re-exported the env, `hermes --version`
+  runs, and `$OPENAI_BASE_URL` is reachable **from an interactive login shell**,
+  not just from `kubectl exec`); then the post-deploy checklist
+  (building+operating blog posts, README, service-table row, runbook sync,
+  status → Deployed).
 
 Both phases depend only on Phase 0 → Phase 1 ordering. The pod boots even if
 Phase 0 is incomplete (both secret volumes/refs are `optional: true`) — it just
@@ -200,8 +260,9 @@ commands:
   - "Mint a virtual key in LiteLLM (admin UI or /key/generate) scoped to the hermes agent."
   - "Store it in Infisical as HERMES_LITELLM_KEY (same project/env the other Frank keys use)."
 verify:
-  - "kubectl -n hermes-agent-shell get externalsecret hermes-agent-shell-llm-key -o jsonpath='{.status.conditions[0].reason}' → SecretSynced"
-  - "kubectl -n hermes-agent-shell get secret hermes-agent-shell-llm-key -o jsonpath='{.data.OPENAI_API_KEY}' | base64 -d | head -c4 → non-empty"
+  - "kubectl -n hermes-agent-shell get externalsecret hermes-agent-shell-llm -o jsonpath='{.status.conditions[0].reason}' → SecretSynced"
+  - "kubectl -n hermes-agent-shell get secret hermes-agent-shell-llm -o jsonpath='{.data.OPENAI_API_KEY}' | base64 -d | head -c4 → non-empty"
+  - "kubectl -n hermes-agent-shell exec deploy/hermes-agent-shell -- sh -lc 'curl -sf -H \"Authorization: Bearer $OPENAI_API_KEY\" $OPENAI_BASE_URL/models >/dev/null && echo reachable' → reachable (exec, NOT port-forward — gpu-1 flakiness gotcha)"
 status: pending
 
 # manual-operation
@@ -221,7 +282,7 @@ commands:
   - "sops --decrypt secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml | kubectl apply -f -"
 verify:
   - "kubectl -n hermes-agent-shell get secret hermes-agent-shell-ssh-keys"
-  - "ssh -p 22 agent@192.168.55.226 'hermes --version' → prints a version"
+  - "ssh -p 22 agent@192.168.55.226 'hermes --version' → prints a version (--version needs no BYOK env; LiteLLM reachability is checked separately via kubectl exec or an interactive login shell, never `ssh host -- cmd` which skips profile.d)"
 status: pending
 ```
 
@@ -232,11 +293,12 @@ apps/hermes-agent-shell/manifests/deployment.yaml
 apps/hermes-agent-shell/manifests/service.yaml                 # combined TCP 22 + UDP 60032-60047
 apps/hermes-agent-shell/manifests/pvc-home.yaml
 apps/hermes-agent-shell/manifests/configmap-inventory.yaml
-apps/hermes-agent-shell/manifests/externalsecret-llm.yaml
+apps/hermes-agent-shell/manifests/configmap-byok-env.yaml      # 35-…-byok-env.sh profile.d shim (C1 fix)
+apps/hermes-agent-shell/manifests/externalsecret-llm.yaml      # OPENAI_BASE_URL + OPENAI_API_KEY
 apps/hermes-agent-shell/manifests/externalsecret-alerts.yaml
 apps/hermes-agent-shell/client-setup/laptop/{ssh-config.snippet,mosh-wrapper.sh,README.md}
 apps/root/templates/hermes-agent-shell.yaml                    # Application CR
-apps/root/templates/ns-hermes-agent-shell.yaml                 # Namespace
+apps/root/templates/ns-hermes-agent-shell.yaml                 # Namespace (PSA enforce: baseline)
 secrets/hermes-agent-shell/README.md                           # SOPS bootstrap runbook
 ```
 
@@ -255,6 +317,12 @@ secrets/hermes-agent-shell/README.md                           # SOPS bootstrap 
 
 ## Risks / open items
 
+- **[RESOLVED in review] sshd env-scrub breaks BYOK over SSH.** The container
+  env (`OPENAI_BASE_URL`/`OPENAI_API_KEY`) does not reach an interactive SSH
+  login shell (`UsePAM no`, no `PermitUserEnvironment`). Resolved by the
+  ConfigMap-mounted `35-…-byok-env.sh` profile.d shim that re-exports from
+  `/proc/1/environ` (see BYOK section). Non-interactive `ssh host -- cmd`
+  remains env-less by design — use `kubectl exec` for that.
 - **Two manual bootstraps gate first-green.** Acceptable: both refs are
   `optional: true`, so the pod boots regardless; hermes simply can't reach
   LiteLLM and sshd accepts no keys until they land. Standard declarative-only

--- a/docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md
@@ -1,0 +1,268 @@
+# Deploy hermes-agent-shell pod on Frank (gpu-1)
+
+**Date:** 2026-06-03
+**Status:** Draft
+**Layer:** `orch` (15 — AI Agent Orchestrator)
+**Image source:** `derio-net/agent-images` — `hermes-agent-shell` (delivered by the
+`2026-06-01-agent-shells-batch` plan, Phase 2)
+
+## Problem
+
+`agent-images` just shipped `hermes-agent-shell`: an SSH-able, single-harness
+shell image that runs the Nous Research [`hermes` agent](https://github.com/NousResearch/hermes-agent)
+wired BYOK to an OpenAI-compatible endpoint. Frank has no standalone pod
+running it. We want a dedicated, operator-accessed pod on `gpu-1` so the
+`hermes` agent can run against Frank's in-cluster LiteLLM gateway, with
+PV-resident state (config, sessions, skills, memories) that survives restarts
+and image bumps.
+
+This is **not** the in-paperclip "hermes shim" (paperclip's `paperclip` container
+already embeds a hermes binary via the shared `/paperclip` PVC). This is a
+standalone shell pod whose only job is to host `hermes` interactively.
+
+## Solution
+
+A new ArgoCD app `hermes-agent-shell` (raw-manifests, single-source App-of-Apps
+pattern) deploying a single-container Deployment on `gpu-1`, modeled on
+`secure-agent-pod` (the existing standalone interactive-shell pod) and borrowing
+the secret/inventory/MOTD wiring patterns from `paperclip-shell` / `ruflo-shell`.
+
+```
+agent-base
+└── agent-shell-base
+    └── hermes-agent-shell   ← image we deploy (BYOK → Frank LiteLLM)
+```
+
+### Container & placement
+
+- **Image:** `ghcr.io/derio-net/hermes-agent-shell:95e719b9164e3e16b6e304202ff567f22aeed39c`
+  — current `agent-images` main HEAD. That SHA includes the Phase 2
+  `hermes-agent-shell` delivery (`56bc131`) and the `#105` reconcile fix
+  (`95e719b`), and matches the agent-images SHA already pinned cluster-wide
+  (paperclip-shell, secure-agent-kali, vk-local). Bumped thereafter by the
+  existing agent-images-bump workflow.
+- **Image user:** `agent` / `/home/agent` (UID/GID 1000), inherited from
+  `agent-shell-base`. `HERMES_VERSION=0.15.2` baked (upstream tag `v2026.5.29.2`);
+  floats forward via inventory `harnesses:` or an image bump.
+- **Deployment:** `replicas: 1`, `strategy: Recreate` (RWO PVC cannot mount on
+  two pods), `terminationGracePeriodSeconds: 45` (s6 `cont-finish.d` shutdown).
+- **Placement:** `nodeSelector: kubernetes.io/hostname: gpu-1` +
+  `tolerations: nvidia.com/gpu:NoSchedule` (defensive, per the gpu-1 gotcha).
+  **No GPU requested** — inference is remote via LiteLLM; gpu-1 is chosen as
+  Frank's largest CPU/RAM box (the same reason paperclip/secure-agent-pod sit
+  there), not for the GPU.
+- **securityContext:** pod `fsGroup: 1000`; container `runAsUser/Group: 1000`,
+  `runAsNonRoot: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`.
+- **Resources:** requests `cpu: 500m` / `memory: 1Gi`; limits `cpu: "2"` /
+  `memory: 4Gi`. Lighter than secure-agent-pod (no vk-local executor fleet); a
+  single interactive `hermes` process plus the s6 supervision tree.
+- **Probes:** TCP readiness + liveness on the sshd port (`2222`), matching the
+  other shells.
+
+### Storage & SSH access
+
+- **PVC `hermes-agent-shell-home`** — `longhorn`, RWO, **20Gi** (matches
+  `paperclip-shell-home` / `ruflo-shell-home`), mounted at `/home/agent`. Holds
+  `~/.hermes/` (config, sessions, skills, memories) and any inventory-installed
+  toolchain. PV-resident per the multi-harness standard.
+- **SSH keys** — SOPS-bootstrap Secret `hermes-agent-shell-ssh-keys` in namespace
+  `hermes-agent-shell`, stored at `secrets/hermes-agent-shell/`, mounted read-only
+  at `/etc/ssh-keys`, volume `optional: true`. The image's
+  `cont-init.d/30-authorized-keys` copies `/etc/ssh-keys/authorized_keys` into
+  `~/.ssh/authorized_keys` on boot. Reuse the operator public key already paired
+  with the other shells. SOPS-bootstrap (not ESO) mirrors `secure-agent-pod`'s
+  `agent-ssh-keys`, `paperclip-shell-ssh-keys`, and `ruflo-shell-ssh-keys`.
+
+### Services (SSH + Mosh)
+
+A single combined LoadBalancer Service (the newer ruflo/paperclip single-IP
+pattern — MixedProtocolLBService works on Cilium 1.17 — not secure-agent-pod's
+two-IP split) on **`192.168.55.226`** (next free in the `192.168.55.x` pool;
+last allocated is `.225`):
+
+- TCP `22 → 2222` (non-root sshd inside the container).
+- UDP **`60032–60047`** mosh range. Distinct from the in-use ranges
+  (secure-agent-pod & paperclip-shell `60000–60015`, ruflo-shell `60016–60031`)
+  so the per-shell client wrapper is unambiguous. Container env
+  `MOSH_SERVER_NETWORK_TMOUT=3600`; client pins `mosh-server new -p 60032:60047`.
+
+Client-setup helpers under `apps/hermes-agent-shell/client-setup/laptop/`
+(`ssh-config.snippet`, `mosh-wrapper.sh`, `README.md`), mirroring the other
+shells.
+
+### BYOK auth (LiteLLM) & alerts
+
+`hermes-agent-shell` is the documented exception to the multi-harness standard's
+"no API tokens" auth contract: hermes has no subscription/OAuth login flow, so
+inference auth is BYOK via `OPENAI_BASE_URL` + `OPENAI_API_KEY`, supplied by the
+Frank manifest and sourced via ESO from Infisical.
+
+- **Dedicated LiteLLM virtual key.** New Infisical entry `HERMES_LITELLM_KEY`,
+  backed by its own LiteLLM virtual key (independently observable / revocable in
+  LiteLLM, not entangled with paperclip's `PAPERCLIP_LITELLM_KEY`). ESO
+  `ExternalSecret hermes-agent-shell-llm-key` → Secret exposing `OPENAI_API_KEY`.
+- **Container env:**
+  - `OPENAI_BASE_URL=http://litellm.litellm.svc:4000/v1` — Frank's real
+    in-cluster LiteLLM DNS (the image README's `litellm.litellm-system` is an
+    upstream-generic placeholder; Frank's namespace is `litellm`, confirmed
+    against paperclip/ruflo which both use `litellm.litellm.svc:4000`).
+  - `OPENAI_API_KEY` ← `hermes-agent-shell-llm-key` secret.
+- **Telegram alerts** — ESO `ExternalSecret hermes-agent-shell-alerts` syncing
+  `FRANK_C2_TELEGRAM_BOT_TOKEN` / `FRANK_C2_TELEGRAM_CHAT_ID`; consumed via
+  `envFrom … secretRef … optional: true` (fail-open per the
+  `envFrom.secretRef` gotcha). Powers the inventory installer's
+  `notify-telegram.sh`.
+
+### Inventory ConfigMap
+
+ConfigMap `hermes-agent-shell-inventory` mounted at `/etc/hermes-agent-shell/`
+(the image's reconcile reads `/etc/hermes-agent-shell/inventory.yaml`). Ship
+**sparse** for the initial deploy so the boot reconcile is a clean no-op, with
+the multi-harness standard's three keys present:
+
+```yaml
+harnesses:
+  hermes: latest        # float; pin a PyPI version later if desired
+mcp-servers:
+  hermes: []
+skills:
+  hermes: []
+```
+
+### App CR conventions
+
+Application CR at `apps/root/templates/hermes-agent-shell.yaml`, namespace via
+`apps/root/templates/ns-hermes-agent-shell.yaml`:
+
+- `project: infrastructure`, single `source` (`path: apps/hermes-agent-shell/manifests`).
+- `syncPolicy.automated.selfHeal: true`, `prune: false`.
+- `syncOptions: ServerSideApply=true`, `RespectIgnoreDifferences=true`,
+  `CreateNamespace=false` (namespace templated separately, matching secure-agent-pod).
+- `ignoreDifferences` on Secret `/data`.
+- `resources-finalizer.argocd.argoproj.io` finalizer.
+- ArgoCD Telegram sync-notification annotations (`subscribe.on-sync-running.telegram`,
+  `subscribe.on-sync-succeeded.telegram`), mirroring secure-agent-pod.
+
+## Scope
+
+**In scope:** the new ArgoCD app (namespace, Deployment, combined SSH+Mosh
+Service, home PVC, inventory ConfigMap, two ExternalSecrets), the Application CR
++ Namespace template, the SOPS ssh-keys bootstrap secret + its runbook,
+client-setup helpers, the two manual-operation bootstraps, and the post-deploy
+documentation (blog building+operating posts, README, frank-infrastructure.md
+service-table row, runbook sync).
+
+**Out of scope:** any change to `agent-images` (the image ships as-is);
+exposing the shell on a web domain / homepage tile (it is SSH/Mosh-only);
+cross-harness skill unification; pinning a specific hermes PyPI version or
+pre-loading MCP servers / skills (inventory ships sparse — operator fills later);
+replacing or touching the in-paperclip hermes shim.
+
+## Phases
+
+Two phases (operator chose this shape — a manual bootstrap gate, then the
+agentic build-out):
+
+- **Phase 0 — Manual bootstrap (human-only):** create the two secrets that must
+  exist before the workload is meaningful.
+  1. Mint a LiteLLM virtual key and store it as `HERMES_LITELLM_KEY` in Infisical.
+  2. Generate/collect the operator SSH public key, build the
+     `hermes-agent-shell-ssh-keys` Secret, SOPS-encrypt it into
+     `secrets/hermes-agent-shell/`, and apply it out-of-band.
+  Both are `# manual-operation` blocks → synced to the runbook.
+- **Phase 1 — Agentic deploy + verify:** author all manifests, the Application
+  CR + Namespace, ESOs, ConfigMap, client-setup helpers; sync via ArgoCD; verify
+  end-to-end (pod Healthy, ESOs resolved, SSH in, MOTD shows the BYOK row,
+  `hermes --version` runs, `OPENAI_BASE_URL` reachable); then the post-deploy
+  checklist (building+operating blog posts, README, service-table row, runbook
+  sync, status → Deployed).
+
+Both phases depend only on Phase 0 → Phase 1 ordering. The pod boots even if
+Phase 0 is incomplete (both secret volumes/refs are `optional: true`) — it just
+can't reach LiteLLM and sshd accepts no keys until the bootstraps land. That is
+the declarative-only exception for bootstrap secrets, by design.
+
+## Manual operations
+
+```yaml
+# manual-operation
+id: orch-hermes-litellm-virtual-key
+layer: orch
+app: hermes-agent-shell
+plan: 2026-06-03--orch--hermes-agent-shell-deploy
+when: Phase 0, before the pod can reach LiteLLM
+why_manual: >
+  LiteLLM virtual keys are minted via the LiteLLM admin API / UI and stored in
+  Infisical; neither is reconstructable from git. ESO then syncs the key into
+  the cluster. The key is per-agent so its budget/usage is independently
+  observable and revocable.
+commands:
+  - "Mint a virtual key in LiteLLM (admin UI or /key/generate) scoped to the hermes agent."
+  - "Store it in Infisical as HERMES_LITELLM_KEY (same project/env the other Frank keys use)."
+verify:
+  - "kubectl -n hermes-agent-shell get externalsecret hermes-agent-shell-llm-key -o jsonpath='{.status.conditions[0].reason}' → SecretSynced"
+  - "kubectl -n hermes-agent-shell get secret hermes-agent-shell-llm-key -o jsonpath='{.data.OPENAI_API_KEY}' | base64 -d | head -c4 → non-empty"
+status: pending
+
+# manual-operation
+id: orch-hermes-shell-ssh-keys
+layer: orch
+app: hermes-agent-shell
+plan: 2026-06-03--orch--hermes-agent-shell-deploy
+when: Phase 0, before SSH access works
+why_manual: >
+  SSH authorized_keys is a SOPS-bootstrap Secret applied out-of-band (matching
+  secure-agent-pod / paperclip-shell / ruflo-shell). SOPS secrets must NOT be
+  ArgoCD-managed.
+commands:
+  - "ssh-keygen or reuse the existing operator key already paired with the other shells."
+  - "kubectl create secret generic hermes-agent-shell-ssh-keys --namespace=hermes-agent-shell --from-file=authorized_keys=<pubkey> --dry-run=client -o yaml > secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml"
+  - "sops --encrypt --in-place secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml"
+  - "sops --decrypt secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml | kubectl apply -f -"
+verify:
+  - "kubectl -n hermes-agent-shell get secret hermes-agent-shell-ssh-keys"
+  - "ssh -p 22 agent@192.168.55.226 'hermes --version' → prints a version"
+status: pending
+```
+
+## Files to create
+
+```
+apps/hermes-agent-shell/manifests/deployment.yaml
+apps/hermes-agent-shell/manifests/service.yaml                 # combined TCP 22 + UDP 60032-60047
+apps/hermes-agent-shell/manifests/pvc-home.yaml
+apps/hermes-agent-shell/manifests/configmap-inventory.yaml
+apps/hermes-agent-shell/manifests/externalsecret-llm.yaml
+apps/hermes-agent-shell/manifests/externalsecret-alerts.yaml
+apps/hermes-agent-shell/client-setup/laptop/{ssh-config.snippet,mosh-wrapper.sh,README.md}
+apps/root/templates/hermes-agent-shell.yaml                    # Application CR
+apps/root/templates/ns-hermes-agent-shell.yaml                 # Namespace
+secrets/hermes-agent-shell/README.md                           # SOPS bootstrap runbook
+```
+
+## Post-deploy checklist
+
+- **Step 1 (external web exposure): SKIP** — SSH/Mosh-only operator service, no
+  web UI, no homepage tile. (The frank-infrastructure.md service-table row is
+  still added — it documents the LB IP, not a web exposure.)
+- **Step 2:** building blog post (`orch` layer) via `/blog-post`; update
+  `building/00-overview` series index + `cluster-roadmap.html`.
+- **Step 3:** operating blog post (day-to-day: SSH in, run hermes, reconcile
+  inventory, rotate keys, check MOTD).
+- **Step 4:** `/update-readme`.
+- **Step 5:** `/sync-runbook` (two manual-operation blocks above).
+- **Step 6:** plan `**Status:**` → Deployed once observed end-to-end.
+
+## Risks / open items
+
+- **Two manual bootstraps gate first-green.** Acceptable: both refs are
+  `optional: true`, so the pod boots regardless; hermes simply can't reach
+  LiteLLM and sshd accepts no keys until they land. Standard declarative-only
+  bootstrap exception.
+- **Mosh range reuse vs. distinct.** Because each Service has its own LB IP, the
+  same UDP range on a different IP would not actually collide; we allocate a
+  distinct `60032–60047` purely to keep per-shell client wrappers unambiguous
+  (matches the ruflo precedent).
+- **gpu-1 port-forward flakiness gotcha** applies to verification — use
+  `kubectl get application -n argocd -o wide` and `kubectl exec` for in-pod
+  checks rather than `kubectl port-forward`.

--- a/docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md
+++ b/docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md
@@ -6,6 +6,12 @@
 **Image source:** `derio-net/agent-images` — `hermes-agent-shell` (delivered by the
 `2026-06-01-agent-shells-batch` plan, Phase 2)
 
+## Implementation Plans
+
+| Plan | Repo | Path | Status |
+|------|------|------|--------|
+| 2026-06-03--orch--hermes-agent-shell-deploy | `derio-net/frank` | `docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/` | — |
+
 ## Problem
 
 `agent-images` just shipped `hermes-agent-shell`: an SSH-able, single-harness

--- a/secrets/hermes-agent-shell/README.md
+++ b/secrets/hermes-agent-shell/README.md
@@ -1,0 +1,57 @@
+# SOPS-encrypted bootstrap secrets for hermes-agent-shell
+
+Apply with: `sops --decrypt <file> | kubectl apply -f -`
+
+This directory holds:
+
+- `hermes-agent-shell-ssh-keys.yaml` *(created during the Phase 1 bootstrap —
+  see below)* — Secret in `hermes-agent-shell` mounted read-only into the
+  `hermes` container at `/etc/ssh-keys`. Same shape as
+  `secrets/secure-agent-pod/`'s `agent-ssh-keys`,
+  `secrets/paperclip/`'s `paperclip-shell-ssh-keys`, and
+  `secrets/ruflo/`'s `ruflo-shell-ssh-keys`.
+
+## Why SOPS not ESO
+
+Frank's pattern for SSH user keys is SOPS-bootstrap applied out-of-band —
+`secure-agent-pod`'s `agent-ssh-keys`, plus the `paperclip` / `ruflo` shells all
+follow it. SOPS-encrypted secrets must NOT be ArgoCD-managed; the Deployment
+references a stable Secret name and marks the volume `optional: true` so the pod
+still boots if the Secret is missing — sshd just won't accept any keys until the
+bootstrap runs.
+
+## On first deploy (Phase 1)
+
+```bash
+# 1. Reuse the operator key already paired with the other shells (so one private
+#    key opens every shell sidecar), or generate a fresh keypair. You only need
+#    the PUBLIC key here.
+#    ssh-keygen -t ed25519 -f ~/.ssh/hermes -C "operator@hermes"
+
+# 2. Build a Secret manifest (namespace hermes-agent-shell, key authorized_keys).
+kubectl create secret generic hermes-agent-shell-ssh-keys \
+  --namespace=hermes-agent-shell \
+  --from-file=authorized_keys=<path-to-operator.pub> \
+  --dry-run=client -o yaml \
+  > secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml
+
+# 3. SOPS-encrypt in place + commit. Recipients resolve from the repo-root
+#    .sops.yaml path_regex (encrypted_regex ^(data|stringData)$).
+sops --encrypt --in-place secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml
+git add secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml
+
+# 4. Apply ONCE — but only after the namespace exists. The hermes-agent-shell
+#    namespace is created by ArgoCD when the app first syncs (Phase 2), so apply
+#    this secret after that sync (Phase 2 / T2). Subsequent rotations: re-encrypt
+#    + re-apply, then restart the pod (cont-init.d/30-authorized-keys copies the
+#    key only at boot).
+sops --decrypt secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml | kubectl apply -f -
+```
+
+## LiteLLM virtual key (the other Phase 1 bootstrap)
+
+`OPENAI_API_KEY` is sourced via ESO from Infisical entry `HERMES_LITELLM_KEY`
+(see `apps/hermes-agent-shell/manifests/externalsecret-llm.yaml`). Mint a
+dedicated LiteLLM virtual key for the hermes agent and store it in Infisical as
+`HERMES_LITELLM_KEY` — that is a separate `# manual-operation` (see the plan and
+`docs/runbooks/manual-operations.yaml`), not a SOPS secret in this directory.

--- a/secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml
+++ b/secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    authorized_keys: ENC[AES256_GCM,data:7vKCLPFOFTwX/c59Khc7u/01CP9CmyUclnxdbED+DfUE2tg7SGy0IQV/FEEWeuUUwR50ROoMoh+0Q4Ks2eyFXcQI7lzqZQ1OGn/3LFT3xNaiDR87u2daLrA++x/9bOJYBrTO4eeWyHpDhWnt2oqITNNRSE5iXb3J7d8fn11toQeDQX12naduH7wtLGCwFoDeSyGUfi5CnSPZ1xKm5AmBEMiMbVlOOTMwu2BaQsZMH7eKGG5c7KloCFhbr9iGlVpKflgmNdty+8q8H4gU1SMqY7s6BAQhnItEpMoYtpwwTXFyo2WjLN+ez9BHAE1stmjC9zK+OEJDXJiJHVvC9s1+LAG0FhRhq6lsw2TLenQozy7HGfQMyV2trs/SMIXwks7oeByQP7UJ4wFeXM1DJxi4Ll1YS9UahGCO8uRUPXy1WowUTmrjI+bJ6HIo+sm8uIzcRM6d1SjCNAal+Jofg7wrkef9A2fhCGeKkc+yIHVdb6QvWE0XgpH+HIhMrejzb4ksPJpfH7h98Bq/pmA/InISHVo2uaYOzvKGMC3PfcI/ooHDqkeB6ivf5O4o3vVLbW0Ahhko9Nv2U6o6m4ZJuVlHfoq+59X9A5tenzlwGCgOlBDeAFynXBw8fzyZC2fYNy4yHrcJQTnYbRC7np5c5vHsR32F1/3WhpukPUfnka+37WIkpJQzHmvjJyb314cLJAbHfOmmwHvAE2L7WIT23m6FNivVtkKziULgtgdDMIsvM9kOQV27ckmI2gFRG3oJJFz0ce61Ip1SQRheIQQCDWdJ44LbP2YLE+ekYR/JzjJbLSrLC8TBJy3HTU0G9FTq97Sjmc4JyHf50TVwr+lsz3AKmzWuN0g/zglHuGUfXPdTdbJ5iHqztMB4OOk82C3Zyqei/GEIQtZx5GKu4WjEPjBSI7EvjtIjzLVNqTz1UtS9U6Ll5sKlckncyJSn0RyrngqCORJJTF7e6OS0glTYl51RonG01pJyBJ4kps3VVEID0zsdg8FcuxOjOsBw3VeUINDMuikEy7777Gy+/z32Y6eexfbxlGvlzzBZgfZpIaI3ADoLff4/3D10gxw3OLdF8D+50KjGRy8ZrdubOW890B1fvmCVpKqkkdgsCqpIe488pNtlNlov+/Z44uYT7ejrJ0Sl4uW/SEGN9DVU3hL/YnH2nMZLKn+fCMOKNvZp69vHJrb9BUnsanrw/tXeOsrdikOAdmDJX9sKBJu1CxCG6eKD9CcMTECmnoF5WNCJTVSJsX8KVTalMYSeuc7+9PSONepDJ2CUbTxfHLf1Hs1yU/jww/TSxkZzPzm/8+LlVcdpTaf0A4Ck,iv:fJi0JDdlxO53RgOymUXPS1ovqweiymKHiJ1bGCFEhl0=,tag:S29MNjnDsNS3tFT6ZmhNMQ==,type:str]
+kind: Secret
+metadata:
+    name: hermes-agent-shell-ssh-keys
+    namespace: hermes-agent-shell
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBucjNQWVIxeDJQMEtaSmZP
+            UXBjMXRyOVNnbFhQMWRQQkZpaUJ4SUZjNjI0ClUxdm11UVVDc05DQ3doZXkyRDVy
+            dXRrRWRCSndIRFJ1MUloVEZGOHdycjgKLS0tIGRWQjd3SERuenpIVFc1OXFxUWkw
+            ajA3L0wvQ2R2c2VhUGJMV3ZabHFwNGcKmF0WRxItqUSDP7wei+6tGfMHqx0ecTpB
+            iRaGtdDZ4C8QDgsrRYjBmVhWTHTWIG+uvtinTo8WoxmuoC4ho0mT9A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ufxvcn4us3cue5dglwn4uk8ctjfpuaw6dqlwu4hjzszf2g4htpcqkszjne
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-06-04T16:06:50Z"
+    mac: ENC[AES256_GCM,data:B14MHAVb3Z60eTmJJY0wl4dB0ssbK2MQxKVImM6l0cxK6I1PUBgTmQCI17fCQ/PMSoRQZD8OpGcP7uWSyq8pWSZ9VyI2sgiOH+JYuRYQb4sBQpqA2a39MMaYbyLBIU3jRrijI4kgCOoIJlzU8R60uQYaheo3D0RrkSZxbH5DWgQ=,iv:DjWCrYfv1KQasfzEgT8VIuWyaHUEq7gDLEyM8VndWLI=,tag:js5dK/IoaAUqxMpVmZ7MbA==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## What

Stands up a standalone, SSH-able **hermes-agent-shell** pod on `gpu-1` — the Nous Research `hermes` agent wired BYOK to Frank's in-cluster LiteLLM gateway, with PV-resident state. Consumes the `hermes-agent-shell` image just delivered by the `agent-images` agent-shells-batch feature (pinned at the cluster-wide agent-images SHA `95e719b`).

This is **not** the in-paperclip hermes shim — it's a dedicated pod whose only job is hosting `hermes` interactively.

## Process (superpowers flow)

`/brainstorming` → spec → `/requesting-code-review` (found + fixed 1 Critical) → `/vk-plan` (two-phase plan, `vk plan self-review` passed) → Phase 2/T1 authoring (this PR).

- **Spec:** `docs/superpowers/specs/2026-06-03--orch--hermes-agent-shell-deploy-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-03--orch--hermes-agent-shell-deploy/`

## What's in this PR (Phase 2, Task 1 — authoring)

New ArgoCD app `hermes-agent-shell` (raw-manifests, single-source), modeled on `secure-agent-pod`; secret/inventory/MOTD patterns from `paperclip-shell`/`ruflo-shell`:

| File | Purpose |
|------|---------|
| `apps/root/templates/ns-hermes-agent-shell.yaml` | Namespace (PSA `enforce: baseline`) |
| `apps/root/templates/hermes-agent-shell.yaml` | Application CR (infrastructure project, selfHeal, SSA, ignoreDifferences Secret `/data`, Telegram sync notifications) |
| `apps/hermes-agent-shell/manifests/deployment.yaml` | Single `hermes` container, gpu-1 (no GPU requested), Recreate, runAsNonRoot/drop-ALL, 20Gi home PVC |
| `…/service.yaml` | Combined SSH+Mosh LB on `192.168.55.226` (TCP 22→2222, UDP 60032–60047) |
| `…/pvc-home.yaml` | 20Gi Longhorn home PVC |
| `…/externalsecret-llm.yaml` | `OPENAI_BASE_URL` + `OPENAI_API_KEY` (`HERMES_LITELLM_KEY`) in one ESO template |
| `…/externalsecret-alerts.yaml` | `FRANK_C2_TELEGRAM_*` for the inventory notifier |
| `…/configmap-inventory.yaml` | Empty multi-harness maps → true no-op boot |
| `…/configmap-byok-env.yaml` | **Load-bearing fix** — profile.d shim (see below) |
| `…/client-setup/laptop/*` | ssh-config snippet, mosh wrapper, README |
| `secrets/hermes-agent-shell/README.md` | SOPS ssh-keys bootstrap runbook |

### The load-bearing fix (caught in code review)

`agent-shell-base`'s sshd runs `UsePAM no` with no `PermitUserEnvironment`, so the K8s-injected BYOK env (`OPENAI_BASE_URL`/`OPENAI_API_KEY`) is **scrubbed from the interactive login shell** — a pod whose whole purpose is interactive `hermes` over SSH would silently fail to reach LiteLLM (and the image's own MOTD would print "OPENAI_BASE_URL not set" despite the manifest setting it). Fix: a `subPath`-mounted `/etc/profile.d/35-…-byok-env.sh` ConfigMap that re-exports the env from `/proc/1/environ` — same mechanism paperclip uses for its tips drop-in, so **no `agent-images` change** is needed. The re-export loop is functionally verified (extracts both vars from a NUL-separated environ stream; `sh -n` passes).

## ⚠️ Operator steps remaining (not in this PR — need Infisical + cluster access)

**Phase 1 (manual bootstrap):**
1. Mint a dedicated LiteLLM virtual key → store in Infisical as `HERMES_LITELLM_KEY`.
2. Build + SOPS-encrypt + commit `secrets/hermes-agent-shell/hermes-agent-shell-ssh-keys.yaml` (runbook in that dir).

**Phase 2 (T2–T3, post-merge):** ArgoCD syncs → apply the SOPS ssh-keys secret (namespace now exists) → verify end-to-end (pod Healthy, ESOs `SecretSynced`, SSH in, MOTD has the BYOK row **without** the "not set" note, `hermes` reaches LiteLLM from a login shell) → post-deploy checklist (service-table row, building+operating blog posts, README, `/sync-runbook`, status → Deployed).

## Verification done here

- All 8 manifests parse (PyYAML); embedded inventory → `{harnesses:{}, mcp-servers:{}, skills:{}}`; profile.d shim `sh -n` clean + re-export logic smoke-tested.
- No out-of-bounds symlinks (ArgoCD ComparisonError gotcha).
- `vk plan self-review` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)