### PR TITLE
fix(obs): stop Sympozium gpu-1 starvation, repair ai-alert-helper fallback

### DIFF
--- a/apps/ai-alert-helper/manifests/deployment.yaml
+++ b/apps/ai-alert-helper/manifests/deployment.yaml
@@ -43,8 +43,14 @@ spec:
               value: "http://litellm.litellm.svc.cluster.local:4000"
             - name: LLM_MODEL_PRIMARY
               value: "qwen-think-14b"
+            # Fallback must NOT depend on gpu-1 — the primary's failure mode is
+            # gpu-1 saturation, so a local-model fallback would fail with it.
+            # gemma-31b is OpenRouter-backed (:free tier — can 429; tested
+            # responsive 2026-06-04, unlike qwen-next-80b/hermes-405b which
+            # were rate-limited/timing out). claude-haiku-4-5 was removed from
+            # LiteLLM entirely and 400'd on every fallback attempt.
             - name: LLM_MODEL_FALLBACK
-              value: "claude-haiku-4-5"
+              value: "gemma-31b"
             # Surge detector tuning (read in surge.compute / /surge-check).
             - name: SURGE_ABS_FLOOR        # min req/hr for any tier (kills baseline-of-1 artifacts)
               value: "50"

--- a/apps/sympozium-extras/manifests/personapack-developer-team.yaml
+++ b/apps/sympozium-extras/manifests/personapack-developer-team.yaml
@@ -10,7 +10,11 @@ metadata:
   name: developer-team
   namespace: sympozium-system
 spec:
-  enabled: true
+  # Disabled 2026-06-04: with the model alias fixed (#448) the pack's 8 personas
+  # actually ran their 30m-2h sweeps on qwen36-a3b (35B, 26GB, CPU-offloaded),
+  # pinning gpu-1 and starving every other local model (ai-alert-helper digests
+  # failed). Re-enable deliberately, with a model that fits VRAM.
+  enabled: false
   description: "A 2-pizza software development team — tech lead, backend, frontend, QA, reviewer, DevOps, and docs — collaborating on a single GitHub repository."
   category: development
   version: "1.0.0"

--- a/apps/sympozium-extras/manifests/personapack-devops-essentials.yaml
+++ b/apps/sympozium-extras/manifests/personapack-devops-essentials.yaml
@@ -4,7 +4,9 @@ metadata:
   name: devops-essentials
   namespace: sympozium-system
 spec:
-  enabled: true
+  # Disabled 2026-06-04 alongside developer-team — see that file for rationale
+  # (gpu-1 starvation via qwen36-a3b sweeps).
+  enabled: false
   description: "Development workflow agents for code review and GitOps"
   category: development
   version: "1.0.0"


### PR DESCRIPTION
## Problem

Today's 08:00 digest failed both attempts; every ai-alert-helper LLM call is dead.

**Primary (`qwen-think-14b`) starved:** the #448 model-alias fix made the `developer-team` PersonaPack's 8 personas *actually run* their 30m–2h sweeps on `qwen36-a3b` (35B, 26 GB, 41% CPU-offloaded, 3min+ per generate, keep-alive 23h). gpu-1 stays pinned, so the 14B primary never loads within the helper's 60s timeout (a 300s probe also timed out).

**Fallback (`claude-haiku-4-5`) dead:** the alias was removed from LiteLLM — 400 "Invalid model name" on every fallback attempt. The safety net for exactly this failure mode was itself broken.

## Fix

- `enabled: false` on `developer-team` + `devops-essentials` PersonaPacks (controller tears down instances + schedules; the experiment's model fix was already validated this morning)
- `LLM_MODEL_FALLBACK` → `gemma-31b` — OpenRouter-backed, outside gpu-1's failure domain. Tested responsive (1.0s); `qwen-next-80b` 429'd and `hermes-405b`/`qwen-coder-480b` timed out.

## Verification (post-merge)

- [ ] ArgoCD sync sympozium-extras + ai-alert-helper
- [ ] `ollama stop qwen3.6:35b-a3b` to free VRAM now (keep-alive would hold it 23h)
- [ ] `qwen-think-14b` responds < 60s
- [ ] Re-trigger missed digest, confirm Telegram delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)