### PR TITLE
chore(litellm): drop free-tier OpenRouter models — local inference only

### DIFF
--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -85,6 +85,7 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - s6-overlay v3 in non-root mode needs `S6_KEEP_ENV=1`, `S6_VERBOSITY=2`, `with-contenv` shebangs (`#!/command/with-contenv bash` — `/command/`, NOT `/usr/bin/`), and `/run` chown'd to AGENT_UID at image build time.
 - `cont-init.d/30-authorized-keys` only fires at pod boot and COPIES (not symlinks) `/etc/ssh-keys/authorized_keys` — re-run by hand or restart pod after adding/rotating SOPS-managed keys.
 - sshd scrubs container env on login — env-dependent commands launched via `ssh agent@host -- cmd` see no `FRANK_C2_*`/`INFISICAL_*`. Use `kubectl exec` or source from `/proc/1/environ`.
+- BYOK shells (env-keyed CLIs like hermes) need a numbered `/etc/profile.d/` shim (ConfigMap + `subPath` mount) re-exporting the keys from `/proc/1/environ` into login shells — number it BELOW the image's `50-…-motd.sh` so the auth-status check sees the env. Verify with `ssh host 'bash -lc …'`, never `ssh host -- cmd` (skips profile.d).
 - `shareProcessNamespace: true` is incompatible with s6-overlay v3 (suexec must be PID 1) — use shared workspace volume + `kubectl exec -c <other>` for cross-container debugging.
 - s6 crashloop bail (5 deaths in 60s) leaves service down silently — `s6-svc -u /run/service/<name>` after fixing the root cause.
 - tmux-continuum auto-restore only fires when the tmux server starts fresh, not on `tmux source-file ~/.tmux.conf`.

--- a/agents/rules/frank-infrastructure.md
+++ b/agents/rules/frank-infrastructure.md
@@ -39,4 +39,5 @@
 | GitHub webhook receiver (Tekton github-listener) | 192.168.55.223 | Cilium L2 LoadBalancer (port 8080) |
 | GoatCounter | 192.168.55.224 | Cilium L2 LoadBalancer (port 8080, public ingest via Hop) |
 | VictoriaLogs (LB) | 192.168.55.225 | Cilium L2 LoadBalancer (port 9428, cross-cluster ingest from Hop) |
+| Hermes Agent Shell (SSH+Mosh) | 192.168.55.226 | Cilium L2 LoadBalancer (port 22/SSH, UDP 60032-60047/Mosh) |
 | Homepage | (via Traefik) | IngressRoute (master.cluster.derio.net) |

--- a/apps/ai-alert-helper/manifests/deployment.yaml
+++ b/apps/ai-alert-helper/manifests/deployment.yaml
@@ -43,14 +43,15 @@ spec:
               value: "http://litellm.litellm.svc.cluster.local:4000"
             - name: LLM_MODEL_PRIMARY
               value: "qwen-think-14b"
-            # Fallback must NOT depend on gpu-1 — the primary's failure mode is
-            # gpu-1 saturation, so a local-model fallback would fail with it.
-            # gemma-31b is OpenRouter-backed (:free tier — can 429; tested
-            # responsive 2026-06-04, unlike qwen-next-80b/hermes-405b which
-            # were rate-limited/timing out). claude-haiku-4-5 was removed from
-            # LiteLLM entirely and 400'd on every fallback attempt.
+            # No-fallback policy (operator decision 2026-06-04): free cloud
+            # models were purged from LiteLLM as unreliable, and no paid
+            # frontier key is wired — local inference only. Pointing fallback
+            # at the primary gives one retry then a loud failure; do NOT
+            # delete this env var: ai_adapter.py's built-in default is the
+            # dead claude-haiku-4-5 alias. Make the fallback optional in code
+            # on the next helper image bump.
             - name: LLM_MODEL_FALLBACK
-              value: "gemma-31b"
+              value: "qwen-think-14b"
             # Surge detector tuning (read in surge.compute / /surge-check).
             - name: SURGE_ABS_FLOOR        # min req/hr for any tier (kills baseline-of-1 artifacts)
               value: "50"

--- a/apps/litellm/manifests/external-secret.yaml
+++ b/apps/litellm/manifests/external-secret.yaml
@@ -13,12 +13,8 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   data:
-    - secretKey: OPENROUTER_API_KEY
-      remoteRef:
-        key: OPENROUTER_API_KEY
-        conversionStrategy: Default
-        decodingStrategy: None
-        metadataPolicy: None
+    # OPENROUTER_API_KEY entry removed 2026-06-04 with the free-tier cloud
+    # model section (the Infisical secret itself is kept for posterity).
     - secretKey: LITELLM_MASTER_KEY
       remoteRef:
         key: LITELLM_MASTER_KEY

--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -68,14 +68,17 @@ envVars:
 
 # LiteLLM proxy configuration (rendered as config.yaml)
 #
-# Lineup refresh — 2026-05-03 (qwen3.6:35b-a3b added 2026-05-06)
+# Lineup refresh — 2026-05-03 (qwen3.6:35b-a3b added 2026-05-06; OpenRouter
+# free-tier cloud section removed 2026-06-04 — rate limits made every cloud
+# alias unreliable (429s/timeouts), and an unreliable model is worse than a
+# missing one for anything automated. Local inference only; if frontier-scale
+# is ever needed, add a PAID provider entry + key, never a :free one.)
 # Sized for gpu-1's RTX 5070 Ti (16GB GDDR7). With OLLAMA_MAX_LOADED_MODELS=1,
 # only one model loads at a time. Most entries are dense and fully resident
 # in VRAM (≤14GB after KV cache + multimodal overhead); qwen36-a3b is the
 # exception — MoE 35B-A3B that relies on partial CPU offload of inactive
 # experts to gpu-1's 128GB host RAM. Local covers default + multimodal +
-# coding + reasoning + MoE-flagship; cloud covers frontier-scale, video,
-# and 200B+-class reasoning.
+# coding + reasoning + MoE-flagship.
 proxy_config:
   model_list:
     # ──────────────────────────────────────────────
@@ -164,63 +167,6 @@ proxy_config:
         api_base: http://ollama.ollama.svc.cluster.local:11434
         extra_body:
           think: false
-
-    # ──────────────────────────────────────────────
-    # CLOUD MODELS — Free tier via OpenRouter
-    # Rate limit: 20 req/min, 200 req/day per model
-    # Slugs verified live against /api/v1/models on 2026-05-03 — refresh
-    # via /update-openrouter-models when entries start 404'ing.
-    # ──────────────────────────────────────────────
-
-    # Gemma 4 31B Instruct — flagship free multimodal, 256K context
-    # Text + image + video input, function calling, 140+ languages.
-    # ✅ Data: Open-weight, served by third-party
-    - model_name: gemma-31b
-      litellm_params:
-        model: openrouter/google/gemma-4-31b-it:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
-    # NVIDIA Nemotron Nano 2 VL — 12B multimodal, 128K context
-    # Video understanding + document intelligence; the smaller, faster
-    # video-capable companion to Gemma 4 31B.
-    # ✅ Data: Open-weight, served by third-party
-    - model_name: nemotron-vl-12b
-      litellm_params:
-        model: openrouter/nvidia/nemotron-nano-12b-v2-vl:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
-    # NVIDIA Nemotron 3 Nano Omni 30B — multimodal + reasoning, 256K context
-    # Accepts text/image/video/audio; reasoning mode. Largest free omni model.
-    # ✅ Data: Open-weight, served by third-party
-    - model_name: nemotron-omni-30b
-      litellm_params:
-        model: openrouter/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
-    # Qwen3 Next 80B A3B Instruct — top free general/reasoning, 262K context
-    # MoE (3B active), strong on coding + math + general knowledge.
-    # Replaces step-flash slot.
-    # ⚠ Data: Alibaba Cloud; prompts may be retained
-    - model_name: qwen-next-80b
-      litellm_params:
-        model: openrouter/qwen/qwen3-next-80b-a3b-instruct:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
-    # Qwen3 Coder — 480B MoE (35B active), 262K context
-    # Frontier free coding model — for cases the local 14B coder isn't enough.
-    # ⚠ Data: Alibaba Cloud; prompts may be retained
-    - model_name: qwen-coder-480b
-      litellm_params:
-        model: openrouter/qwen/qwen3-coder:free
-        api_key: os.environ/OPENROUTER_API_KEY
-
-    # Hermes 3 405B — NousResearch fine-tune of Llama 3.1 405B, 131K context
-    # Largest free open-weight model; backstop for general-purpose at scale.
-    # ✅ Data: Open-weight, served by third-party
-    - model_name: hermes-405b
-      litellm_params:
-        model: openrouter/nousresearch/hermes-3-llama-3.1-405b:free
-        api_key: os.environ/OPENROUTER_API_KEY
 
   litellm_settings:
     default_model: mistral-small-24b


### PR DESCRIPTION
Operator decision: the :free cloud aliases are unreliable (qwen-next-80b
429'd, hermes-405b/qwen-coder-480b timed out on 2026-06-04) and an
unreliable model is worse than a missing one for automated callers.
Remove all six OpenRouter entries and the now-unused OPENROUTER_API_KEY
ExternalSecret sync (Infisical secret retained).

ai-alert-helper fallback becomes same-as-primary (one retry, fail loud):
the env var can't be deleted because ai_adapter.py's built-in default is
the dead claude-haiku-4-5 alias. Follow-up for next image bump: make the
fallback optional in code.

If frontier-scale is ever needed again, wire a PAID provider entry +
key — never a :free one.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
