### PR TITLE
fix(stor): raspi-1 memory-wedge incident — headroom alert, Pi replica exclusion, runbook

### DIFF
--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -18,6 +18,7 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - `envFrom.secretRef` without `optional: true` blocks rolling updates when the Secret is missing.
 - AWX operator-managed Postgres on Longhorn CrashLoops with `mkdir '/var/lib/pgsql/data/userdata': Permission denied` — the `sclorg/postgresql-15` image runs as UID 26 but the fresh PVC mounts root-owned and the operator emits an empty `securityContext`. Set `postgres_data_volume_init: true` in the AWX CR (root init container chowns the volume; storage-agnostic) rather than relying on `fsGroup`.
 - Always `ServerSideApply=true`; always `prune: false`; always `ignoreDifferences` on Secret `/data`.
+- Longhorn instance-manager working set (`usage − inactive_file`) is mostly *active page cache* from replica I/O — on a 4GB Pi it exceeds physical RAM and the kernel reclaim-thrashes instead of OOM-killing: kubelet/CRI wedge silently, node NotReady, NO process dies. Graceful `talosctl reboot` then wedges in `stopAllPods` (needs the dead CRI) — go straight to physical power-cycle (safe: immutable OS, journaled EPHEMERAL). Replica scheduling is disabled on raspi-1/raspi-2 (manual op `stor-longhorn-disable-pi-replica-scheduling`); `layer-1-node-memory-headroom` alert (<1GiB absolute, NOT a ratio) is the early warning. Full incident: `docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md`.
 
 ### Tekton — `docs/runbooks/frank-gotchas/tekton.md`
 - v1 Task uses `computeResources` not `resources` — schema validation silently fails the whole app.

--- a/apps/grafana-alerting/manifests/alert-rules-cm.yaml
+++ b/apps/grafana-alerting/manifests/alert-rules-cm.yaml
@@ -585,6 +585,53 @@ data:
               summary: "L1 Hardware: node {{ $labels.node }} NotReady"
               runbook: "kubectl describe node {{ $labels.node }}; talosctl -n {{ $labels.node }} health"
 
+      # --- Layer 1 — Node memory headroom (frank-ops#1) ---
+      # Absolute floor, NOT a ratio: 6% of 64GB (mini) is ~4GB and healthy,
+      # while 9% of 4GB (Pi) is ~355MB and one page-cache creep away from a
+      # reclaim-thrash wedge (kubelet unresponsive, no OOM kill — 2026-06-04
+      # raspi-1 incident). 1GiB catches the Pi-class wedge weeks early.
+      - orgId: 1
+        name: layer-1-node-memory-headroom
+        folder: feature-health
+        interval: 1m
+        rules:
+          - uid: layer-1-node-memory-headroom
+            title: Layer 1 Hardware Node Memory Headroom Low
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: P4169E866C3094E38
+                model:
+                  refId: A
+                  # MemAvailable in bytes, per node-exporter instance.
+                  expr: 'node_memory_MemAvailable_bytes{job="node-exporter"}'
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+              - refId: B
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model: { refId: B, type: reduce, expression: A, reducer: last, settings: { mode: dropNN } }
+              - refId: C
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: lt, params: [1073741824] }
+            noDataState: OK
+            execErrState: Error
+            for: 30m
+            labels:
+              severity: warning
+              github_issue: "frank-ops#1"
+            annotations:
+              summary: "L1 Hardware: node {{ $labels.instance }} has <1GiB memory available for 30m — reclaim-thrash wedge risk (see 2026-06-04 raspi-1 incident)"
+              runbook: "talosctl -n <node-ip> memory; check Longhorn instance-manager working set: container_memory_working_set_bytes{pod=~\"instance-manager.*\"}; docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md"
+
       # --- Layer 2 — OS & Bootstrap (frank-ops#2) ---
       # Per control-plane node only — HA lost = critical.
       - orgId: 1

--- a/docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md
+++ b/docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md
@@ -1,0 +1,102 @@
+# 2026-06-04 — raspi-1 Memory-Thrash Wedge (5-Layer Alert Storm)
+
+**Status:** Resolved (power-cycle) + durable fixes applied
+**Layers alerted:** L3 (Cilium Agent Down), L4 (Longhorn Manager NotReady), L5 (GPU Operator NotReady), L8 (Observability Degraded), L24 (Traefik Ingress Down)
+**Root cause:** Chronic memory over-commitment on raspi-1 (4 GB RPi 4) — Longhorn instance-manager working set ~4.2 GB; node ran at ~355 MB available for months, then tipped into kernel reclaim-thrash.
+
+## What happened
+
+All five alerts traced to **one node**. raspi-1 hosted the DaemonSet pods for
+each alerting layer (cilium → L3, longhorn-manager → L4, gpu-operator NFD
+worker → L5, fluent-bit + node-exporter → L8) **plus the Traefik pod itself**
+(pinned to `tier=low-power, zone=edge` with its 128Mi ACME PVC → L24). When the
+node wedged, every layer's "pod down / target down" rule fired at once.
+
+## Timeline (UTC)
+
+| Time | Event |
+|------|-------|
+| (months) | raspi-1 steady at ~355 MB MemAvailable (9.4% of 3.78 GB). node-exporter ×3179 restarts, cilium ×2052, NFD ×1893 — chronic pressure, never alerted |
+| 12:00–16:40 | Longhorn instance-manager working set flat at ~4.18 GB, creeping +3 MB/h (4176→4190 MB) |
+| 16:42–16:43 | Kubelet `/healthz` starts timing out (`context deadline exceeded`). No OOM kill — kernel reclaim-thrash instead (working set was "reclaimable" active page cache that Longhorn kept re-touching) |
+| 16:45:30 | Last node-exporter scrape: 281 MB and falling |
+| 16:46:31 | Node controller marks raspi-1 `NotReady` (NodeStatusUnknown) |
+| 16:47+ | Longhorn iSCSI sessions time out (`connection3:0 ping timeout`); `sda` (Traefik's 128Mi volume, iSCSI-attached) throws `critical medium error` — *symptom*, not cause |
+| ~17:05 | Triage: node pings, Talos API alive, CRI/kubelet wedged. `talosctl stats` returns only system containers |
+| 17:15 | `talosctl reboot` issued — sequence wedges in `cleanup/stopAllPods` (graceful teardown needs the wedged CRI; D-state I/O unbreakable from API) |
+| 17:32 | Physical power-cycle (only lever stronger than the API) |
+| 17:34:35 | Node `Ready`, all pods recover, 2.68 GB available |
+
+## Root-cause anatomy
+
+- `container_memory_working_set = usage − inactive_file`. Longhorn replica/engine
+  I/O keeps page-cache pages **active**, so the instance-manager's working set
+  (4.2 GB) exceeded physical RAM while remaining theoretically reclaimable.
+  Under pressure the kernel thrashed reclaiming pages Longhorn immediately
+  re-touched — **no OOM kill, everything stalls**. This is why the node died
+  silently instead of recovering via the OOM killer.
+- Graceful `talosctl reboot` cannot recover this state: `stopAllPods` talks to
+  the wedged CRI and D-state processes ignore SIGKILL. **Go straight to power.**
+  Power-cut is safe: Talos OS partitions are immutable, EPHEMERAL is journaled,
+  Longhorn replicas (3×) had already failed over.
+
+## Durable fixes
+
+1. **`layer-1-node-memory-headroom` alert** (`apps/grafana-alerting/manifests/alert-rules-cm.yaml`):
+   `node_memory_MemAvailable_bytes < 1 GiB` for 30m → warning. Absolute floor,
+   NOT a ratio — mini-1 sits at 6.3% of 64 GB (~4 GB, healthy) while raspi-1's
+   fatal steady state was 9.4% of 4 GB (355 MB). A ratio rule false-positives on
+   big nodes and under-warns on small ones.
+2. **Longhorn replica scheduling disabled on Pis** (manual op below). At incident
+   time the Pis held 0 of 93 replicas (raspi-1's failed over during the
+   incident); this formalizes it so replicas never return to 28 Gi SD cards.
+   Volume **attachment** (Traefik's engine on the edge zone) remains allowed —
+   a single 128Mi volume engine is a modest footprint; it's replica data
+   serving that balloons the instance-manager page cache.
+3. **Traefik PVC decision:** keep. The PVC is the ACME cert store (Cloudflare
+   DNS challenge) and is genuinely needed; with replicas banned from the Pis,
+   the remaining engine-only footprint is acceptable. Revisit only if the
+   headroom alert fires on raspi-2 (where Traefik now runs).
+
+```yaml
+# manual-operation
+id: stor-longhorn-disable-pi-replica-scheduling
+layer: stor
+app: longhorn
+plan: docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md
+when: After the 2026-06-04 raspi-1 memory-wedge incident; re-apply if a raspi node is ever re-added/replaced
+why_manual: nodes.longhorn.io CRs are created and owned by the Longhorn manager, not the Helm chart — replica scheduling intent is stored on the live CR and cannot be expressed declaratively in apps/longhorn
+commands: |
+  source .env
+  kubectl -n longhorn-system patch nodes.longhorn.io raspi-1 --type=merge -p '{"spec":{"allowScheduling":false}}'
+  kubectl -n longhorn-system patch nodes.longhorn.io raspi-2 --type=merge -p '{"spec":{"allowScheduling":false}}'
+verify: |
+  kubectl -n longhorn-system get nodes.longhorn.io
+  # raspi-1 and raspi-2 must show ALLOWSCHEDULING=false
+  kubectl -n longhorn-system get replicas.longhorn.io -o json | python3 -c "import json,sys,collections; print(collections.Counter(r['spec']['nodeID'] for r in json.load(sys.stdin)['items']))"
+  # no replicas on raspi-1/raspi-2
+status: applied 2026-06-04
+```
+
+## Recovery runbook (this incident class)
+
+```bash
+# 1. Identify: node NotReady, pings OK, Talos API OK, kubelet healthz timing out
+source .env
+kubectl describe node <node> | sed -n '/Conditions:/,/Addresses:/p'
+talosctl -n <ip> service kubelet     # HEALTH Fail, context deadline exceeded
+talosctl -n <ip> memory              # AVAILABLE near zero
+talosctl -n <ip> dmesg | tail -40    # iSCSI timeouts / medium errors = symptoms
+
+# 2. Try graceful (usually wedges in stopAllPods — give it ~5 min max)
+talosctl -n <ip> reboot
+
+# 3. Physical power-cycle. Safe: Talos immutable OS + journaled EPHEMERAL;
+#    confirm Longhorn volumes healthy first (replicas elsewhere):
+kubectl -n longhorn-system get volumes.longhorn.io | grep -v healthy
+
+# 4. Verify after rejoin
+kubectl get pods -A -o wide --field-selector spec.nodeName=<node>
+kubectl -n longhorn-system get nodes.longhorn.io <node>
+talosctl -n <ip> memory
+```

--- a/docs/runbooks/frank-gotchas/storage-secrets-ssa.md
+++ b/docs/runbooks/frank-gotchas/storage-secrets-ssa.md
@@ -73,6 +73,42 @@ purpose-built answer to this exact error and survives a storage-class swap).
 After the CR change syncs, the operator regenerates the StatefulSet with the
 init container and the postgres pod (and then web/task) reconcile to Running.
 
+## Longhorn instance-manager memory-thrash wedges low-RAM nodes (raspi-1, 2026-06-04)
+
+The instance-manager's `container_memory_working_set_bytes` is dominated by
+**active page cache** from replica/engine I/O (`working_set = usage −
+inactive_file`; Longhorn keeps re-touching the pages, so they never go
+inactive). On a 4 GB Pi the working set can exceed physical RAM while looking
+"reclaimable" — under pressure the kernel thrashes reclaiming pages Longhorn
+immediately re-touches, and **no OOM kill ever fires**. Failure signature:
+
+- Node `NotReady` (`NodeStatusUnknown`), but pings OK and Talos API responsive
+- `talosctl service kubelet` → `HEALTH Fail`, `healthz context deadline exceeded`
+- `talosctl memory` → AVAILABLE near zero; `talosctl stats` returns only
+  system-namespace containers (CRI too wedged to answer)
+- dmesg: iSCSI `ping timeout` / `critical medium error` on the Longhorn-attached
+  `sd*` device — these are *downstream symptoms*, not a failing disk
+- One wedged node fires every layer with a DaemonSet pod on it simultaneously
+  (2026-06-04: L3 cilium, L4 longhorn, L5 NFD worker, L8 fluent-bit/node-exporter,
+  L24 traefik — five layers, one root cause)
+
+**Recovery:** `talosctl reboot` wedges in `cleanup/stopAllPods` (the teardown
+needs the dead CRI; D-state I/O ignores SIGKILL). Give it ~5 min, then
+physically power-cycle — safe on Talos (immutable OS partitions, journaled
+EPHEMERAL), but confirm Longhorn volumes are healthy elsewhere first:
+`kubectl -n longhorn-system get volumes.longhorn.io | grep -v healthy`.
+
+**Prevention:** replica scheduling is disabled on raspi-1/raspi-2
+(`spec.allowScheduling=false` on `nodes.longhorn.io` — manual op
+`stor-longhorn-disable-pi-replica-scheduling`; re-apply when re-adding a Pi).
+Volume *attachment* (e.g. Traefik's ACME PVC engine on the edge zone) remains
+allowed — a single small-volume engine is fine; it's replica data serving that
+balloons the cache. The `layer-1-node-memory-headroom` Grafana alert
+(`MemAvailable < 1 GiB` for 30m) is the early warning — an **absolute** floor,
+not a ratio: 6% of 64 GB (mini) is healthy, 9% of 4 GB (Pi) is pre-wedge.
+
+Full timeline + forensics: `docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md`.
+
 ## Standing rules
 
 - Always `ServerSideApply=true` in ArgoCD sync options (avoids annotation size limits).

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -1491,3 +1491,15 @@ operations:
   - kubectl -n ai-alert-helper-system get secret ai-alert-helper-secrets
   - kubectl -n ai-alert-helper-system exec deploy/ai-alert-helper -- env | grep -c TELEGRAM
   status: done
+- id: stor-longhorn-disable-pi-replica-scheduling
+  layer: stor
+  app: longhorn
+  plan: docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md
+  when: After the 2026-06-04 raspi-1 memory-wedge incident; re-apply if a raspi node is ever re-added/replaced
+  why_manual: nodes.longhorn.io CRs are created and owned by the Longhorn manager, not the Helm chart — replica scheduling intent is stored on the live CR and cannot be expressed declaratively in apps/longhorn
+  commands:
+  - source .env ; kubectl -n longhorn-system patch nodes.longhorn.io raspi-1 --type=merge -p '{"spec":{"allowScheduling":false}}'
+  - source .env ; kubectl -n longhorn-system patch nodes.longhorn.io raspi-2 --type=merge -p '{"spec":{"allowScheduling":false}}'
+  verify:
+  - kubectl -n longhorn-system get nodes.longhorn.io   # raspi-1/raspi-2 ALLOWSCHEDULING=false
+  status: done


### PR DESCRIPTION
## Summary

2026-06-04 incident: **five layers (L3/L4/L5/L8/L24) alerted simultaneously — one root cause.** raspi-1 (4GB RPi 4) wedged at 16:42 UTC: the Longhorn instance-manager's ~4.2GB working set (active page cache from replica I/O) drove the kernel into reclaim-thrash. No OOM kill fired; kubelet/CRI stalled silently; every layer with a DaemonSet pod on the node (cilium→L3, longhorn→L4, NFD→L5, fluent-bit/node-exporter→L8) plus Traefik itself (pinned to the edge zone→L24) went dark together.

Graceful `talosctl reboot` wedged in `cleanup/stopAllPods` (teardown needs the dead CRI); recovered via physical power-cycle at 17:34 UTC. No data loss — all volumes stayed healthy on 3× replicas.

## Changes

- **`layer-1-node-memory-headroom` alert** (`apps/grafana-alerting`): `node_memory_MemAvailable_bytes < 1GiB` for 30m → warning. Absolute floor, deliberately not a ratio: mini-1 runs at 6.3% of 64GB (~4GB, healthy) while raspi-1's fatal steady state was 9.4% of 4GB (355MB). The node ran at that level for *months* unalerted.
- **Longhorn replica scheduling off on raspi-1/raspi-2** — applied live (Longhorn-owned CRs, not chart-expressible), documented as manual op `stor-longhorn-disable-pi-replica-scheduling` in `manual-operations.yaml`. Pis held 0/93 replicas at incident time; this formalizes it. Volume *attachment* (Traefik's ACME engine) stays allowed.
- **Traefik PVC decision**: keep — ACME cert store is needed; engine-only footprint is fine with replicas off the Pis.
- **Incident doc** `docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md`: full timeline, forensics, recovery runbook for this incident class.
- **Gotchas**: one-liner in `agents/rules/frank-gotchas.md`, full prose in `docs/runbooks/frank-gotchas/storage-secrets-ssa.md`.

## Post-merge

- [ ] `kubectl -n monitoring rollout restart deploy <grafana>` after ArgoCD syncs — file-provisioned alert rules are read at boot, not watched (known gotcha)
- [ ] Verify rule loaded: Grafana → Alerting → `Layer 1 Hardware Node Memory Headroom Low`

## Verification done

- Alert-rules CM validated: YAML parses, 29 groups, new group present
- `manual-operations.yaml` parses (97 operations)
- Longhorn: `ALLOWSCHEDULING=false` live on both Pis; 0 replicas on Pi nodes
- raspi-1 recovered: Ready, all DaemonSet pods Running, 2.68GB available, scrape targets `up=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)