### PR TITLE
[derio-net/frank] 2026-05-27--orch--ruflo-upload-fix · Phase 2/4 · frank: bump deployment image + resources

### DIFF
--- a/apps/ruflo/manifests/deployment.yaml
+++ b/apps/ruflo/manifests/deployment.yaml
@@ -87,7 +87,7 @@ spec:
       containers:
         # ----- ruvocal (the multi-agent web server) ------------------
         - name: ruflo
-          image: ghcr.io/derio-net/ruflo-server:95e719b9164e3e16b6e304202ff567f22aeed39c
+          image: ghcr.io/derio-net/ruflo-server:0ff701470c7e4dc38c803134a2355b2479ff683b
           imagePullPolicy: IfNotPresent
           ports:
             - { name: http, containerPort: 3000, protocol: TCP }
@@ -126,8 +126,8 @@ spec:
             - { name: data,      mountPath: /app/db   }
           resources:
             requests:
-              cpu: 500m
-              memory: 1Gi
+              cpu: "1"
+              memory: 2Gi
             limits:
               cpu: "4"
               memory: 8Gi
@@ -151,7 +151,7 @@ spec:
 
         # ----- ruflo-shell (interactive maintainer sidecar) ----------
         - name: ruflo-shell
-          image: ghcr.io/derio-net/ruflo-shell:95e719b9164e3e16b6e304202ff567f22aeed39c
+          image: ghcr.io/derio-net/ruflo-shell:0ff701470c7e4dc38c803134a2355b2479ff683b
           imagePullPolicy: IfNotPresent
           ports:
             - { name: ssh,         containerPort: 2222,  protocol: TCP }

--- a/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/02.yaml
+++ b/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/02.yaml
@@ -45,22 +45,24 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T18:01:57+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T18:01:57+00:00'
       note: null
     P2.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-04T18:01:57+00:00'
       note: null
     P2.T1.S4:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T18:02:15+00:00'
+      note: Committed on phase branch via PR (one-phase-one-PR); ArgoCD syncs from
+        main, so live rollout watch deferred to post-merge — covered by Phase 3 live
+        verification.
   completion:
-    at: null
+    at: '2026-06-04T18:02:19+00:00'
     note: null
     observed_prs: []


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix
📐 Spec:   [docs/superpowers/specs/2026-05-27--orch--ruflo-image-upload-fix-design.md](https://github.com/derio-net/frank/blob/main/docs/superpowers/specs/2026-05-27--orch--ruflo-image-upload-fix-design.md)
🎯 Phase:  2/4 — frank: bump deployment image + resources [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/452

---

## Summary

Phase 2/4 of the ruflo file-upload fix. Bumps the ruflo deployment to the
agent-images image built in Phase 1 (PR derio-net/agent-images#96), which
carries the repaired `RvfGridFSBucket` shim so the ChatUI
upload/download/copy-on-fork paths work against the RVF backend.

## Changes (`apps/ruflo/manifests/deployment.yaml`)

- `ruflo` (ruvocal) image → `ghcr.io/derio-net/ruflo-server:0ff701470c7e4dc38c803134a2355b2479ff683b`
- `ruflo-shell` sidecar image → `ghcr.io/derio-net/ruflo-shell:0ff701470c7e4dc38c803134a2355b2479ff683b` (same agent-images SHA)
- `ruflo` container resource **requests**: `cpu 500m → 1`, `memory 1Gi → 2Gi` (limits unchanged at `cpu "4"` / `memory 8Gi`)

## Verification

- Diff is exactly the 4 intended lines (both images + 2 request lines); no other manifest churn.
- Live ArgoCD rollout watch (`kubectl -n ruflo-system rollout status deploy/ruflo`) is **deferred to post-merge** — ArgoCD syncs from `main`, not feature branches (per `frank-gotchas.md`). End-to-end upload verification against `ruflo.cluster.derio.net` is the explicit subject of **Phase 3** (live cluster verification).

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)