### PR TITLE
[derio-net/frank] 2026-05-27--orch--ruflo-upload-fix · Phase 3/4 · Verify end-to-end (cluster + browser)

### DIFF
--- a/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/03.yaml
+++ b/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/03.yaml
@@ -43,30 +43,67 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T18:39:24+00:00'
+      note: 'Upload+read-back verified against the LIVE deployed image (0ff70147,
+        matches Phase-2 pin). Real HTTP route POST /conversation/<id> with a multipart
+        image part -> 200, file persisted (msg.files hash 587188c0...); read back
+        byte-exact via the app''s real downloadFile() (find({filename}).next()+openDownloadStream).
+        Also openUploadStream(Writable,''finish'',ArrayBuffer)+openDownloadStream(Readable)
+        byte-exact via in-pod harness against the live RVF DB. Browser UI not used:
+        edge ip-allowlist is RFC1918-only so the remote Browser-Use cloud browser
+        (public egress IP) is rejected before Authentik SSO, and all deployed models
+        report multimodal:false (UI attach gated off). Logs clean: no upload.once/ERR_INVALID_ARG_TYPE/500.'
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T18:39:54+00:00'
+      note: 'File-storing path verified. It is the same openUploadStream path: a file
+        uploaded through the real HTTP route landed in GridFS (filename <convId>-<sha256>)
+        and is usable (read back byte-exact). The literal ''tool fetches a URL then
+        stores'' trigger could not be exercised because no deployed model reports
+        supportsTools:true ([mcp] ''tools disabled for model; skipping MCP flow''),
+        so the tool loop never runs — but the storage primitive it would call (openUploadStream
+        + scheduleSave) is the exact code proven here and in S1. No 500, no upload.once
+        errors.'
     P3.T1.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T18:39:54+00:00'
+      note: 'Copy-on-fork .pipe() verified by exercising createConversationFromShare''s
+        exact deployed copy block (BBA_Z3mf:64-77) against the live shim: bucket.find({filename:{$regex:''^<id>-''}}).toArray()
+        matched, then downloadStream.on(''error'',reject).pipe(uploadStream).on(''error'',reject).on(''finish'',resolve)
+        completed and the copy was byte-exact. Confirms openDownloadStream returns
+        a real Readable (.on works -> no ''downloadStream.on is not a function''),
+        .pipe works, and openUploadStream emits ''finish''. Full share->fork HTTP
+        dance not run (requires auth + the Elysia share API); the copy code it invokes
+        is unchanged and was exercised directly.'
     P3.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T18:39:54+00:00'
+      note: 'Plain chat against local model gemma-12b via real HTTP route (anonymous
+        in-pod session, no MCP): POST /conversation/<id> -> HTTP 200, stream completed
+        (title auto-generated, status ''finished''). No 500.'
     P3.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T18:40:06+00:00'
+      note: 'MCP/wasm regression: wasm:// urlSafety allow-line present in deployed
+        bundle (urlSafety-CMNAzyRy.js:31 ''if (url.protocol==="wasm:") return true'').
+        Direct test of the deployed isValidUrl: wasm://* -> true while unsafe URLs
+        still rejected (link-local 169.254/private 10.0/ftp -> false) — fix applied
+        without over-permissive regression. HTTP request carrying a wasm:// MCP server
+        -> 200 with NO ''rejected ... by URL safety'' / ''all selected MCP servers
+        rejected'' warning (note: MCP flow itself skips because no deployed model
+        has supportsTools, so the url-safety filter was proven directly rather than
+        through the request).'
     P3.T2.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-04T18:40:06+00:00'
+      note: 'Broad smoke (154-commit bump): /api/v2/models -> 200 (7 models listed),
+        /api/v2/feature-flags -> 200, clean boot window (no errors before ''Listening
+        on http://0.0.0.0:3000''), and RVF backend intact (''[RuVocal] Database: /app/db/ruvocal.rvf.json''
+        + ''[RVF] Loaded 10 collections''). Full pod-log scan over all verification
+        activity: no upload.once/ERR_INVALID_ARG_TYPE/downloadStream.on/is-not-a-function/fatal/uncaught
+        signatures.'
   completion:
-    at: null
+    at: '2026-06-04T18:40:11+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/03.yaml
+++ b/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/03.yaml
@@ -56,15 +56,16 @@ state:
         report multimodal:false (UI attach gated off). Logs clean: no upload.once/ERR_INVALID_ARG_TYPE/500.'
     P3.T1.S2:
       state: x
-      ticked_at: '2026-06-04T18:39:54+00:00'
-      note: 'File-storing path verified. It is the same openUploadStream path: a file
-        uploaded through the real HTTP route landed in GridFS (filename <convId>-<sha256>)
-        and is usable (read back byte-exact). The literal ''tool fetches a URL then
-        stores'' trigger could not be exercised because no deployed model reports
-        supportsTools:true ([mcp] ''tools disabled for model; skipping MCP flow''),
-        so the tool loop never runs — but the storage primitive it would call (openUploadStream
-        + scheduleSave) is the exact code proven here and in S1. No 500, no upload.once
-        errors.'
+      ticked_at: '2026-06-04T20:07:42+00:00'
+      note: 'SCOPE: the literal trigger (a tool fetching a file by URL) was NOT exercised
+        — no deployed model reports supportsTools:true ([mcp] ''tools disabled for
+        model; skipping MCP flow''), a deployment-config limitation unrelated to the
+        fix. PROVEN: the file-storing PRIMITIVE this path calls — openUploadStream
+        + scheduleSave — is exercised end-to-end in P3.T1.S1 (real HTTP multipart
+        upload -> 200, persisted, read back byte-exact) and at the module level (evidence
+        file §2.1, §3.C). The fix lives entirely in that primitive; the tool-fetch
+        caller is an unchanged thin wrapper over it. No 500 / upload.once errors.
+        See phase3-evidence.md.'
     P3.T1.S3:
       state: x
       ticked_at: '2026-06-04T18:39:54+00:00'
@@ -84,16 +85,17 @@ state:
         (title auto-generated, status ''finished''). No 500.'
     P3.T2.S2:
       state: x
-      ticked_at: '2026-06-04T18:40:06+00:00'
-      note: 'MCP/wasm regression: wasm:// urlSafety allow-line present in deployed
-        bundle (urlSafety-CMNAzyRy.js:31 ''if (url.protocol==="wasm:") return true'').
-        Direct test of the deployed isValidUrl: wasm://* -> true while unsafe URLs
-        still rejected (link-local 169.254/private 10.0/ftp -> false) — fix applied
-        without over-permissive regression. HTTP request carrying a wasm:// MCP server
-        -> 200 with NO ''rejected ... by URL safety'' / ''all selected MCP servers
-        rejected'' warning (note: MCP flow itself skips because no deployed model
-        has supportsTools, so the url-safety filter was proven directly rather than
-        through the request).'
+      ticked_at: '2026-06-04T20:07:42+00:00'
+      note: 'SCOPE: the prescribed log-grep-on-MCP-request-flow could NOT fire — the
+        MCP flow skips before url-safety because no deployed model has supportsTools
+        ([mcp] ''tools disabled for model''), so a clean grep there is vacuous, not
+        a pass. PROVEN (the actual regression target): the wasm:// urlSafety allow-line
+        survived the 154-commit bump — deployed isValidUrl(''wasm://...'') returns
+        true while unsafe URLs are still rejected (169.254/10.0/ftp -> false: negative
+        controls confirm no over-permissive regression), bundle line urlSafety-CMNAzyRy.js:31.
+        An HTTP request carrying a wasm:// MCP server returns 200 with no rejection
+        warning. Direct-function proof, not request-flow proof. See phase3-evidence.md
+        §2.5/§3.D.'
     P3.T2.S3:
       state: x
       ticked_at: '2026-06-04T18:40:06+00:00'

--- a/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/phase3-evidence.md
+++ b/docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix/phase3-evidence.md
@@ -1,0 +1,186 @@
+# Phase 3 Verification Evidence
+
+End-to-end verification of the ruflo RVF GridFS shim fix (Phase 2 / PR #464)
+against the **live cluster**. Captured 2026-06-04.
+
+Deployed artifact under test:
+`ghcr.io/derio-net/ruflo-server:0ff701470c7e4dc38c803134a2355b2479ff683b`
+— matches the Phase-2 pin in `apps/ruflo/manifests/deployment.yaml`.
+
+## Why not the browser
+
+The prescribed ChatUI walkthrough at `ruflo.cluster.derio.net` is infeasible
+from a headless agent, for **two independent reasons**:
+
+1. The Traefik `ip-allowlist` middleware permits only RFC1918 ranges
+   (`apps/traefik/manifests/middlewares.yaml`), so a remote Browser-Use cloud
+   browser (public egress IP) is rejected *before* the Authentik SSO
+   forward-auth.
+2. Every deployed model reports `multimodal:false`, so the UI image-attach
+   control is gated off — the image-attach test could not be driven through the
+   UI even with network access.
+
+Substituted with checks against the **live deployed bundle + RVF DB**, which for
+this fix (root cause = "the shim isn't a real Writable/Readable/cursor") is
+stronger evidence than a UI click. Auth is enforced only at the edge, so an
+anonymous in-pod session reaches the same app code paths.
+
+## 1. Fix present in the deployed bundle (read-only)
+
+The shim and its callers in the running image:
+
+```
+# database-BwMu2W6T.js (RvfGridFSBucket)
+6:  import { Writable, Readable } from 'stream';
+740: class RvfGridFSBucket {
+744:   openUploadStream(filename, options) {
+748:     const stream = new Writable({          # real Writable (objectMode), emits 'finish'
+782:   openDownloadStream(id) {
+785:     return Readable.from(                   # real Readable
+804:     next: async () => i < results.length ? results[i++] : null,   # sync cursor
+805:     toArray: async () => results
+
+# downloadFile-CmJ1QxBO.js  (the HTTP download route's function)
+4:  async function downloadFile(sha256, convId) {
+5:    const fileId = collections.bucket.find({ filename: `${convId.toString()}-${sha256}` });
+15:   const fileStream = collections.bucket.openDownloadStream(file._id);
+
+# _server.ts-BBA_Z3mf.js  (createConversationFromShare — copy-on-fork)
+73:   downloadStream.on("error", reject).pipe(uploadStream).on("error", reject).on("finish", () => resolve());
+
+# urlSafety-CMNAzyRy.js  (wasm allow-line re-applied across the bump)
+31:   if (url.protocol === "wasm:") return true;
+```
+
+## 2. Module-level contracts against the live bucket + RVF DB
+
+Harness (`p3-evidence-module.mjs`) — imports the deployed chunks, exercises every
+contract the fix repairs, and deletes every GridFS object it creates (creates no
+conversations):
+
+```js
+import { getCollectionsEarly } from '/app/build/server/chunks/database-BwMu2W6T.js';
+import { i as isValidUrl } from '/app/build/server/chunks/urlSafety-CMNAzyRy.js';
+const { bucket } = await getCollectionsEarly();
+
+// 1. UPLOAD: openUploadStream is a Writable; write an ArrayBuffer; await 'finish'
+const ab = payload.buffer.slice(payload.byteOffset, payload.byteOffset + payload.byteLength);
+const up = bucket.openUploadStream('p3ev.bin', { contentType: 'application/octet-stream' });
+await new Promise((res, rej) => { up.once('error', rej); up.once('finish', res); up.write(ab); up.end(); });
+
+// 2. DOWNLOAD: openDownloadStream is a Readable; round-trip byte-exact
+const dl = bucket.openDownloadStream(up.id);            // has .on / .pipe
+for await (const c of dl) got.push(Buffer.from(c));
+
+// 3. find(): synchronous cursor with .next() and .toArray()
+const cur = bucket.find({ _id: up.id.toString() });     // typeof cur.next/toArray === 'function'
+
+// 4. COPY-ON-FORK (createConversationFromShare idiom)
+const srcs = await bucket.find({ filename: { $regex: `^${sharedId}-` } }).toArray();
+bucket.openDownloadStream(file._id).on('error', reject)
+  .pipe(bucket.openUploadStream(newFilename)).on('error', reject).on('finish', () => resolve());
+
+// 5. wasm urlSafety allow-line + negative controls
+isValidUrl('wasm://...'); isValidUrl('http://169.254.169.254'); ...
+```
+
+Output:
+
+```
+# live collections.bucket = RvfGridFSBucket
+1. UPLOAD: Writable returned, .once("finish") fired, ArrayBuffer accepted; stream.id = 5ebabc72-...
+2. DOWNLOAD: Readable round-trip byte-exact (78 bytes)
+3. find(): synchronous cursor; .next() and .toArray() both return the file meta
+4. COPY-ON-FORK: find({$regex}).toArray() + downloadStream.on("error").pipe(uploadStream).on("finish") -> byte-exact
+   isValidUrl("wasm://rvagent-local") = true  expected true  OK
+   isValidUrl("wasm://x/y?z=1") = true  expected true  OK
+   isValidUrl("https://example.com") = true  expected true  OK
+   isValidUrl("http://169.254.169.254") = false  expected false  OK
+   isValidUrl("http://10.0.0.1") = false  expected false  OK
+   isValidUrl("ftp://evil") = false  expected false  OK
+5. WASM: allow-line live (wasm:// accepted), unsafe URLs still rejected (no over-permissive regression)
+cleanup: all GridFS test objects deleted, 0 residue
+
+MODULE-LEVEL CONTRACTS: ALL PASS
+```
+
+## 3. HTTP-level end-to-end (real routes)
+
+Harness (`p3-evidence-http.sh`) — anonymous in-pod session, `Origin` header for
+CSRF, message threaded onto the conversation's `rootMessageId`; the image part is
+a multipart `files` field with filename `base64;onepix.png` and a base64-text
+body (the exact shape `uploadFile.ts` parses). Every conversation it creates is
+deleted server-authoritatively via `DELETE /conversation/<id>` with the owning
+session cookie (verified 200 → subsequent GET 404).
+
+Output:
+
+```
+## A. Broad smoke (read-only)
+  /api/v2/models -> HTTP 200
+  /api/v2/feature-flags -> HTTP 200
+  model ids: mistral-small-24b gemma-12b qwen-vl-7b qwen-coder-14b qwen-think-14b qwen36-a3b qwen36-a3b-nothin
+## B. Plain chat (gemma-12b, no MCP)
+  POST /conversation/<id> -> HTTP 200 ; final events: {"type":"title","title":"Pong"} {"type":"status","status":"finished"}
+## C. Image upload via real HTTP multipart route (uploadFile.ts -> openUploadStream)
+  upload POST -> HTTP 200
+  persisted msg.files sha256: 587188c0a045543ee44fe1450dd81751b3a27136401cae53dbc480c87d27e819
+## D. wasm:// MCP request (no rejection)
+  wasm-MCP request -> HTTP 200
+## E. Server-authoritative cleanup (DELETE with owning session)
+  DELETE /conversation/...b14 -> 200
+  DELETE /conversation/...b15 -> 200
+  DELETE /conversation/...b16 -> 200
+```
+
+Read-back of the HTTP-uploaded file through the app's own `downloadFile()`
+(`find({filename}).next()` + `openDownloadStream`), then blob cleanup:
+
+```
+HTTP-uploaded blob present on disk as {convId}-{sha}: true
+downloadFile() returned keys: [ 'type', 'name', 'value', 'mime' ]
+downloadFile() value === original PNG base64: true (96 chars, mime image/png)
+GridFS blob deleted; residue: 0
+```
+
+## 4. Boot / smoke
+
+Clean boot (also re-confirmed after an unrelated mid-session pod roll):
+
+```
+[RuVocal] Database: /app/db/ruvocal.rvf.json
+[RVF] Loaded 10 collections from /app/db/ruvocal.rvf.json
+Listening on http://0.0.0.0:3000
+```
+
+Full pod-log scan over all verification activity: **no**
+`upload.once` / `ERR_INVALID_ARG_TYPE` / `downloadStream.on` / `is not a function`
+/ fatal / uncaught signatures.
+
+## Step → evidence map
+
+| Step | Evidence |
+|---|---|
+| T1.S1 upload + read-back | §3.C (HTTP 200 + persisted sha) + §3 read-back (`downloadFile()` byte-exact) + §2.1/§2.2 |
+| T1.S2 file-storing path | §2.1 + §3.C — same `openUploadStream` primitive; literal *tool* trigger not run (no deployed model has `supportsTools`) |
+| T1.S3 copy-on-fork `.pipe()` | §2.4 (exact `createConversationFromShare` idiom, byte-exact) |
+| T2.S1 plain chat | §3.B (HTTP 200, stream finished) |
+| T2.S2 wasm/MCP regression | §2.5 (`isValidUrl` allow-line + negative controls) + §3.D (HTTP 200, no rejection); note the request's MCP flow *skips* because no model has `supportsTools`, so the url-safety guard is proven directly rather than through the request flow |
+| T2.S3 broad smoke | §3.A + §4 |
+
+## Test-data residue (honest accounting)
+
+GridFS test **blobs** created during verification were all deleted (0 residue,
+confirmed above). A number of anonymous-**session** test conversations remain in
+the RVF store, plus one dangling `files` reference to an already-deleted blob.
+
+These are **not** cleared by a pod restart (RVF reloads the same on-disk JSON),
+and they cannot be removed server-side without the original session cookies
+(`DELETE /api/v2/conversations` is `deleteMany({...authCondition})` — scoped to
+the caller's own session). External-process edits to `ruvocal.rvf.json` do not
+stick: the live single-writer server holds authoritative in-memory state and
+re-flushes it on the next change. They are nonetheless **harmless** — anonymous,
+session-scoped, invisible to every authenticated (Authentik) user, a few KB
+total. Definitive removal requires an operator editing the RVF store during a
+brief `kubectl scale deploy ruflo --replicas=0` window (RWO PVC), which is
+disproportionate for invisible residue on a learning cluster.


### PR DESCRIPTION
📦 Repo:   derio-net/frank
📋 Plan:   docs/superpowers/plans/2026-05-27--orch--ruflo-upload-fix
📐 Spec:   [docs/superpowers/specs/2026-05-27--orch--ruflo-image-upload-fix-design.md](https://github.com/derio-net/frank/blob/main/docs/superpowers/specs/2026-05-27--orch--ruflo-image-upload-fix-design.md)
🎯 Phase:  3/4 — Verify end-to-end (cluster + browser) [agentic]
🔗 Issue:  https://github.com/derio-net/frank/issues/453

---

Closes #453

## Summary

Phase 3/4 verification of the ruflo file-upload fix against the **live cluster**. The deployed image is `0ff7014` (`ruflo-server`/`ruflo-shell`), matching the Phase-2 pin — the fix is live.

### Why not the browser

The phase prescribes a ChatUI walkthrough at `ruflo.cluster.derio.net`, but that's infeasible from a headless agent:

- The edge `ip-allowlist` permits **only RFC1918 ranges**, so a remote Browser-Use cloud browser (public egress IP) is rejected *before* it even reaches the Authentik SSO forward-auth.
- Every deployed model reports `multimodal:false`, so the UI's image-attach control is gated off regardless.

Substituted with checks that exercise the **actual deployed artifact + live RVF DB** — stronger than a UI click for proving the GridFS shim contract.

### What was verified

| Step | Result |
|---|---|
| **T1.S1** upload + read-back | Real HTTP `POST /conversation/<id>` w/ multipart image → **200**; persisted (`msg.files` sha `587188c0…`). `openUploadStream` = real `Writable`, fires `finish`, accepts `ArrayBuffer`. Read back **byte-exact** via the app's own `downloadFile()` (`find({filename}).next()` + `openDownloadStream`). |
| **T1.S2** file-storing path | Same `openUploadStream` path, proven by the persisted+readable upload. (Literal "tool fetches URL" trigger unavailable — no deployed model has `supportsTools`.) |
| **T1.S3** copy-on-fork `.pipe()` | `createConversationFromShare`'s exact copy block — `find({$regex}).toArray()` + `downloadStream.on('error').pipe(uploadStream).on('finish')` — runs, copy **byte-exact**. No `downloadStream.on is not a function`. |
| **T2.S1** plain chat | `gemma-12b` via real route → **200**, stream `finished`. |
| **T2.S2** wasm/MCP regression | `isValidUrl('wasm://…')` → `true` (allow-line live); link-local/private/ftp still rejected. `wasm://` MCP request → 200, **no** rejection warning. |
| **T2.S3** broad smoke | `/api/v2/models` + `/api/v2/feature-flags` → 200; clean boot; RVF backend intact (`[RuVocal] Database: /app/db/ruvocal.rvf.json`). |

Full pod-log scan over all activity: **no** `upload.once` / `ERR_INVALID_ARG_TYPE` / `downloadStream.on` / `is not a function` / fatal signatures.

### Cleanup note

All GridFS test blobs were deleted and confirmed gone. A number of anonymous-session test conversations remain in the RVF DB — invisible to authenticated users. **Correction:** these do *not* clear on a pod restart (RVF reloads the same on-disk JSON) and can't be purged server-side without the original session cookies; the live single-writer model also clobbers external edits. Harmless (anonymous, a few KB); definitive removal needs an operator editing the RVF store during a `scale --replicas=0` window. See `phase3-evidence.md` for full evidence + the residue accounting.

This phase changes only the plan state file (`03.yaml`); no cluster/manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

