### PR TITLE
fix(stor): bump Longhorn chart 1.11.0 → 1.11.2 — IM anonymous-heap leak fix

### DIFF
--- a/apps/root/templates/longhorn.yaml
+++ b/apps/root/templates/longhorn.yaml
@@ -12,7 +12,12 @@ spec:
   sources:
     - repoURL: https://charts.longhorn.io
       chart: longhorn
-      targetRevision: "1.11.0"
+      # 1.11.2: fixes the v1.11.0 instance-manager anonymous-heap leak
+      # (proxy connection leak, longhorn#12575) that wedged raspi-1 on
+      # 2026-06-04 and loaded mini-1/gpu-1 with 48/72 GiB of leaked heap.
+      # NOTE: running engines stay on the old engine image until each
+      # volume is live-upgraded; old IMs (and their heap) retire only then.
+      targetRevision: "1.11.2"
       helm:
         releaseName: longhorn
         valueFiles:


### PR DESCRIPTION
## Summary

Bumps the Longhorn chart to **1.11.2** to pick up the v1.11.1 fix for the instance-manager **proxy-connection / anonymous-heap leak** ([longhorn#12575](https://github.com/longhorn/longhorn/issues/12575)) — the root cause behind the 2026-06-04 raspi-1 wedge (#462, #465). mini-1 (etcd member) is at ~3–4 days runway (48.3 GiB leaked, ~0.9 GiB/day); gpu-1 carries 72.5 GiB.

## Rollout shape

- **This sync = control plane only**: manager DS, CSI, UI roll; new v1.11.2 engine-image DS + new IM pods spawn **alongside** the old ones. PreSync `longhorn-pre-upgrade` Job gates the sync.
- **Zero data-path change on merge**: running volumes stay on their old engines in the old (leaky) IM pods.
- **Phase 2 (post-merge, operator-paced)**: per-volume engine live-upgrade, mini-1's volumes first → old IMs retire → leaked memory frees. Plan in `docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md`.

## Pre-flight (verified tonight)

- 27/27 attached volumes `healthy`, 0 degraded/rebuilding
- `daily-nas` backups completed 02:00 today
- K8s 1.35 ≥ required 1.25; upgrade path 1.11.0 → 1.11.2 supported
- ⚠️ Downgrade unsupported (one-way door) — accepted: 1.11.0 is the version with the node-killing bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)