### PR TITLE
feat(obs): health-bridge v0.3.0 — auto-close healed bug issues

### DIFF
--- a/apps/health-bridge/manifests/deployment.yaml
+++ b/apps/health-bridge/manifests/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: health-bridge
-          image: ghcr.io/derio-net/health-bridge:v0.2.0
+          image: ghcr.io/derio-net/health-bridge:v0.3.0
           ports:
             - name: http
               containerPort: 8080

--- a/blog/content/docs/building/23-health-bridge/index.md
+++ b/blog/content/docs/building/23-health-bridge/index.md
@@ -266,6 +266,14 @@ The Derio Ops board now self-updates. Every layer's tile shows its real, current
 
 Zero manual triage. And because the board finally reflects reality, it's useful again — which was the original point.
 
+## Closing the loop's other half (2026-06-06, v0.3.0)
+
+The original design had a blind spot I lived with for two months before admitting it: the Bridge files `[Bug] <alertname> is dead` issues when a layer dies, but when the layer heals, only the *tracker* gets the good news. The Lifecycle tile flips back to `healthy`, a comment lands on the tracker — and the bug issue sits there, open, forever. After a transient Traefik blip and a fluent-bit restart in early June, my frank-ops repo had accumulated a small graveyard of bugs for problems that had healed themselves within minutes (#38 resolved in 3 minutes, #39 in 45). I was the automatic issue *creator* and the manual issue *closer*.
+
+v0.3.0 makes the resolved webhook do the symmetric work: find every open bug matching the resolved alert, post a heal comment (resolution time, outage duration), close with `state_reason: completed`. No reconciler, no Grafana polling, no new credentials — the tracker comment history proved every resolved notification had arrived reliably, so a webhook-only close was the proportionate fix. If a stale bug ever survives a bridge-pod restart, the reconciler is the documented follow-up, not a speculative build-now.
+
+The interesting bug was in the *matching*. Grafana's synthetic `DatasourceError` alertname is shared by every rule whose datasource errors — L8 and L24 had both filed `[Bug] DatasourceError is dead` issues. Matching by title alone would let Traefik's recovery close Observability's bug. The fix rides on something v0.1.0 accidentally got right: every bug body embeds `**Feature Issue:** derio-net/frank-ops#24`, so close (and the creation dedup, which had the same collision lurking) now requires both the title prefix *and* that body ref — newline-terminated, because `#2` is a prefix of `#24` and substring matching is a liar.
+
 <!-- MEDIA: screenshot | Telegram alert from @agent_zero_cc_bot showing a per-pod labelled Layer failure | Screenshot a real alert message in the Telegram chat showing a message like "L3 Cilium: pod cilium-94msf NotReady" with severity tag -->
 <!-- {{</* screenshot src="telegram-per-pod-layer-alert.png" caption="Telegram notification from the Bridge: per-pod label makes the alert actionable" */>}} -->
 

--- a/blog/content/docs/operating/16-health-bridge/index.md
+++ b/blog/content/docs/operating/16-health-bridge/index.md
@@ -144,6 +144,44 @@ gh issue view 11 --repo derio-net/willikins --json comments \
   --jq '.comments[] | select(.body | contains("health-bridge")) | {createdAt, body}'
 ```
 
+## Auto-Close of Healed Bug Issues (v0.3.0)
+
+Since v0.3.0, the loop closes itself. When an alert **resolves**, the bridge
+finds every open `[Bug] <alertname> is dead — …` issue it created for that
+alert and closes it (`state_reason: completed`) with a heal comment carrying
+the resolution time and outage duration. A transient incident is now fully
+self-cleaning: dead → bug filed → healed → bug closed, no operator touch.
+
+Matching is deliberately strict — **both** conditions must hold:
+
+1. Title prefix: `[Bug] <alertname> is dead`
+2. Body contains the newline-terminated feature ref the bug was created
+   with: `**Feature Issue:** derio-net/<repo>#<N>`
+
+The second condition exists because Grafana's synthetic `DatasourceError`
+alertname is shared across layers — title-only matching would let an L24
+resolve close an L8 bug. The newline termination stops `#2` from matching
+`#24`.
+
+Operational notes:
+
+- The close path keys purely on `status: resolved` — it is **not** gated by
+  the per-tracker dedup (a repeated resolved notification is an idempotent
+  no-op) and **not** gated by severity (editing a rule's severity label
+  between fire and resolve won't strand a bug).
+- All matching open bugs close at once, which also sweeps historical
+  duplicates from the pre-dedup era.
+- A resolved webhook missed while the bridge pod is down means that bug
+  stays open — close it by hand. There is deliberately no Grafana-state
+  reconciler (resolved delivery has been reliable in practice); if stale
+  bugs recur, that's the documented follow-up.
+
+```bash
+# Verify recent auto-closes
+kubectl logs -n monitoring -l app=health-bridge --tail=50 | grep "Closed bug issue"
+gh issue list -R derio-net/frank-ops --label bug --state closed --limit 5
+```
+
 ## Troubleshooting
 
 ### Bridge not processing alerts
@@ -193,7 +231,9 @@ Bridge logs show `Alert <name> has no github_issue label, skipping`. Add the lab
 
 **If running v0.2.0+:** This can happen once after a pod restart (in-memory state is lost). The GitHub search safety net should prevent all but the first duplicate. If duplicates persist, check pod restart frequency.
 
-**Cleanup:** Close duplicates with `gh issue close <number> --repo derio-net/<repo> --comment "Duplicate"`, keeping the earliest one open.
+**v0.3.0 changes the search semantics:** the safety net (`FindOpenBugs`, replacing `HasOpenBug`) matches the title prefix **and** the `**Feature Issue:**` body ref. Two consequences: layers sharing an alertname (`DatasourceError`) no longer suppress each other's legitimate bugs, and any duplicates that do slip through are all closed together the next time the alert resolves.
+
+**Cleanup:** usually unnecessary on v0.3.0+ — wait for the resolve. To close by hand: `gh issue close <number> --repo derio-net/<repo> --comment "Duplicate"`, keeping the earliest one open.
 
 ### A Layer flaps to degraded after a Job or one-off pod runs
 

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/01.yaml
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/01.yaml
@@ -206,8 +206,8 @@ state:
       ticked_at: '2026-06-06T18:51:35+00:00'
       note: null
     P1.T4.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:59:21+00:00'
       note: null
   completion:
     at: null

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/01.yaml
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/01.yaml
@@ -162,48 +162,48 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:18+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:19+00:00'
       note: null
     P1.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:21+00:00'
       note: null
     P1.T1.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:23+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:25+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:26+00:00'
       note: null
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:28+00:00'
       note: null
     P1.T2.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:30+00:00'
       note: null
     P1.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:31+00:00'
       note: null
     P1.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:33+00:00'
       note: null
     P1.T3.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:51:35+00:00'
       note: null
     P1.T4.S1:
       state: ' '

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/01.yaml
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/01.yaml
@@ -1,0 +1,215 @@
+schema_version: 2
+phase:
+  number: 1
+  title: health-bridge v0.3.0 — auto-close healed bug issues (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: FindOpenBugs replaces HasOpenBug as the bug-matching primitive
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Working copy: `~/Docs/projects/DERIO_NET/health-bridge` (clone of
+      `derio-net/health-bridge`), branch `feat/auto-close-healed-bugs` off `main`.
+      ```bash
+      cd ~/Docs/projects/DERIO_NET/health-bridge
+      git checkout -b feat/auto-close-healed-bugs
+      go test ./...   # baseline: all green on main
+      ```
+  - id: P1.T1.S2
+    text: |-
+      RED: in `bridge_test.go` add `TestFindOpenBugs` using the existing
+      httptest-mock + `setGitHubURLs` pattern. Mock
+      `GET /repos/derio-net/frank-ops/issues` returning fixtures:
+      - #38 title `[Bug] DatasourceError is dead — L24…`, body contains
+        `**Feature Issue:** derio-net/frank-ops#24\n**Alert:** …`
+      - #39 title `[Bug] DatasourceError is dead — L8…`, body contains
+        `**Feature Issue:** derio-net/frank-ops#8\n**Alert:** …`
+      - #41 title `[Bug] DatasourceError is dead — L2x…`, body contains
+        `**Feature Issue:** derio-net/frank-ops#2\n**Alert:** …`
+      Assert:
+      - `FindOpenBugs("frank-ops", "DatasourceError", 24)` → `[38]` only
+        (shared-alertname disambiguation via feature ref).
+      - `FindOpenBugs("frank-ops", "DatasourceError", 2)` → `[41]` only
+        (newline-terminated needle — `#2` must NOT match `#24`).
+      - `FindOpenBugs("frank-ops", "OtherAlert", 24)` → `[]`.
+      - Two fixtures with the SAME alertname + feature ref → both numbers
+        returned (historical duplicates all close).
+      `go test ./...` → FAIL (FindOpenBugs undefined).
+  - id: P1.T1.S3
+    text: |-
+      GREEN: in `github.go` implement
+      `func (c *GitHubClient) FindOpenBugs(repo, alertName string, featureNumber int) ([]int, error)`:
+      same `GET /repos/{org}/{repo}/issues?labels=bug&state=open&per_page=50`
+      call as `HasOpenBug`, but parse `number`, `title`, `body` and match BOTH:
+      ```go
+      titlePrefix := fmt.Sprintf("[Bug] %s is dead", alertName)
+      refNeedle := fmt.Sprintf("**Feature Issue:** %s/%s#%d\n", c.org, repo, featureNumber)
+      // match: strings.HasPrefix(issue.Title, titlePrefix) && strings.Contains(issue.Body, refNeedle)
+      ```
+      The trailing `\n` in `refNeedle` is guaranteed by `CreateBugIssue`'s body
+      template (`#%d` is followed by `\n**Alert:**`) and prevents `#2` matching `#24`.
+      `go test ./...` → PASS.
+  - id: P1.T1.S4
+    text: |-
+      Switch the creation-dedup in `bridge.go` `processAlert` (the
+      `newState == "dead"` branch) from `HasOpenBug(repo, alertName)` to
+      `FindOpenBugs(repo, alertName, number)` (exists ⇔ `len > 0`), then DELETE
+      `HasOpenBug` from `github.go`. This fixes the latent shared-alertname
+      suppression bug (an open L24 `DatasourceError` bug no longer suppresses a
+      legitimate L8 one). Keep the existing fail-open posture: on lookup error,
+      log a warning and fall through to create.
+      `go test ./...` → PASS (the existing dedup test's mock GET returns `[]`,
+      so it exercises the new path unchanged).
+- number: 2
+  title: FormatHealComment + CloseBugIssue
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      RED: add `TestFormatHealComment` to `bridge_test.go`:
+      - alert with `StartsAt: "2026-06-04T16:52:58Z"`, `EndsAt: "2026-06-04T17:38:03Z"`
+        → comment contains `## Health Bridge: auto-close`, the alertname, the
+        EndsAt timestamp, a duration containing `45m`, and the
+        `*Automated by health-bridge*` footer.
+      - alert with unparseable `StartsAt` → comment still renders, duration line omitted.
+      `go test ./...` → FAIL.
+  - id: P1.T2.S2
+    text: |-
+      GREEN: implement `FormatHealComment(alert Alert) string` in `bridge.go`:
+      parse both timestamps with `time.Parse(time.RFC3339, …)`; on success include
+      `**Outage duration:** <d>` where `d = end.Sub(start).Round(time.Minute)`;
+      on any parse error omit the duration line. Body: alert name, severity,
+      summary, `**Resolved:** <EndsAt>`, closing line
+      `System healed — closing this bug automatically.` + standard footer.
+      `go test ./...` → PASS.
+  - id: P1.T2.S3
+    text: |-
+      RED: add `TestCloseBugIssue`: mock server asserts
+      (a) `POST /repos/derio-net/frank-ops/issues/38/comments` arrives first with
+      the heal comment, then
+      (b) `PATCH /repos/derio-net/frank-ops/issues/38` with JSON body
+      `{"state":"closed","state_reason":"completed"}`.
+      Also: comment endpoint returning 500 must NOT abort the close — PATCH still
+      sent (warn-and-continue, mirroring tracker-comment tolerance).
+      `go test ./...` → FAIL.
+  - id: P1.T2.S4
+    text: |-
+      GREEN: implement
+      `func (c *GitHubClient) CloseBugIssue(repo string, number int, comment string) error`
+      in `github.go`: call `AddIssueComment` (log warning on error, continue), then
+      `PATCH {rest}/repos/{org}/{repo}/issues/{number}` with
+      `{"state":"closed","state_reason":"completed"}`, expect 200.
+      `go test ./...` → PASS.
+- number: 3
+  title: Wire auto-close into processAlert
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      RED: add `TestProcessAlert_ResolvedClosesOpenBugs`:
+      mock GH where `GET …/issues` returns one matching open bug (#38, feature ref
+      `…#11` to reuse the willikins#11 alert fixture shape). Send a `resolved`
+      alert → assert exactly one heal-comment POST on #38 and one close PATCH.
+      Send the SAME resolved alert again (lastState dedup now says repeat) with the
+      mock now returning `[]` → assert NO further PATCH (idempotent no-op) and no
+      error. Send a resolved alert for an alertname with no open bugs → no PATCH.
+      `go test ./...` → FAIL.
+  - id: P1.T3.S2
+    text: |-
+      GREEN: in `processAlert`, immediately after the `UpdateLifecycleState` call
+      and BEFORE the `lastState` dedup early-return, add:
+      ```go
+      if alert.Status == "resolved" {
+          bugs, err := b.github.FindOpenBugs(repo, alert.Labels["alertname"], number)
+          if err != nil {
+              log.Printf("Warning: failed to find open bugs for %s: %v", issueRef, err)
+          }
+          for _, n := range bugs {
+              if err := b.github.CloseBugIssue(repo, n, FormatHealComment(alert)); err != nil {
+                  log.Printf("Warning: failed to close bug %s#%d: %v", repo, n, err)
+              } else {
+                  log.Printf("Closed bug issue %s#%d (alert %s resolved)", repo, n, alert.Labels["alertname"])
+              }
+          }
+      }
+      ```
+      Placement rationale (from spec): not gated by lastState dedup (dedup is
+      per-tracker, close must survive repeats — idempotent), not gated by severity
+      (a severity-label edit between fire and resolve must not strand a bug).
+      `go test ./...` → PASS.
+  - id: P1.T3.S3
+    text: |-
+      Full verification: `go test -v ./...` all green, `go vet ./...` clean,
+      `gofmt -l .` empty.
+- number: 4
+  title: Open the health-bridge PR
+  steps:
+  - id: P1.T4.S1
+    text: |-
+      Commit and open the PR (do NOT merge — operator gate):
+      ```bash
+      cd ~/Docs/projects/DERIO_NET/health-bridge
+      git add -A && git commit -m "feat: auto-close healed bug issues on resolved alerts"
+      git push -u origin feat/auto-close-healed-bugs
+      env -u GITHUB_TOKEN gh pr create -R derio-net/health-bridge \
+        --title "feat: auto-close healed bug issues on resolved alerts (v0.3.0)" \
+        --body "<summary + spec ref derio-net/frank:docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md + test output>"
+      ```
+      PR body must list: the FindOpenBugs matching rules (title prefix + newline-
+      terminated feature-ref), the HasOpenBug collision fix, and the full
+      `go test` output.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/02.yaml
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/02.yaml
@@ -1,0 +1,84 @@
+schema_version: 2
+phase:
+  number: 2
+  title: frank — image bump v0.3.0 + docs updates
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Bump health-bridge image
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      In `apps/health-bridge/manifests/deployment.yaml` change
+      `image: ghcr.io/derio-net/health-bridge:v0.2.0` →
+      `image: ghcr.io/derio-net/health-bridge:v0.3.0`.
+      Verify: `git grep -n "health-bridge:v" apps/` shows only `v0.3.0`.
+      (The tag exists only after manual Phase 3 — merge order is documented
+      in the PR body and _prose.md.)
+- number: 2
+  title: Update existing Layer 23 posts (fix/extension — no new post)
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      `blog/content/docs/operating/16-health-bridge/index.md`:
+      add an "Auto-close of healed bug issues (v0.3.0)" section after
+      "Verifying GitHub Integration": behavior (resolved alert → matching open
+      `[Bug] <alertname> is dead` issues closed with heal comment +
+      `state_reason: completed`), matching rules (title prefix AND
+      `**Feature Issue:**` body ref — shared alertnames like `DatasourceError`
+      cannot cross-close layers), and a verify command
+      (`gh issue list -R derio-net/frank-ops --label bug --state closed --limit 5`).
+  - id: P2.T2.S2
+    text: |-
+      Same file, "Duplicate bug issues appearing" troubleshooting section:
+      note that v0.3.0 replaced `HasOpenBug` with `FindOpenBugs` (feature-ref
+      aware) — creation dedup no longer collides across layers sharing an
+      alertname, and auto-close clears all historical duplicates for an alert
+      when it resolves.
+  - id: P2.T2.S3
+    text: |-
+      `blog/content/docs/building/23-health-bridge/index.md`: short retroactive
+      addendum (2-3 paragraphs max, Frank voice) — the loop the original design
+      left open (bugs filed on dead, never closed on heal), the #38/#39 evidence,
+      and the v0.3.0 close: webhook-close only, no reconciler (YAGNI — resolved
+      webhooks proved reliable), feature-ref matching for shared alertnames.
+- number: 3
+  title: Commit frank changes
+  steps:
+  - id: P2.T3.S1
+    text: |-
+      Commit on the isolation branch `feat/ops-issue-auto-close`:
+      ```bash
+      git add apps/health-bridge/manifests/deployment.yaml blog/content/docs/operating/16-health-bridge/index.md blog/content/docs/building/23-health-bridge/index.md
+      git commit -m "feat(obs): health-bridge v0.3.0 — auto-close healed bug issues"
+      ```
+      (PR opened at vk-goal delivery, carrying spec + plan + these changes.)
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/02.yaml
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/02.yaml
@@ -59,24 +59,24 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:53:08+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:53:10+00:00'
       note: null
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:53:12+00:00'
       note: null
     P2.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:53:13+00:00'
       note: null
     P2.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T18:53:15+00:00'
       note: null
   completion:
     at: null

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/03.yaml
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/03.yaml
@@ -1,0 +1,45 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Release health-bridge v0.3.0
+  tag: manual
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Merge, tag, verify GHCR build
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      ```yaml
+      # manual-operation
+      id: obs-health-bridge-release-v030
+      layer: obs
+      app: health-bridge
+      plan: 2026-06-06--obs--health-bridge-bug-auto-close
+      when: After reviewing/merging the health-bridge PR (Phase 1)
+      why_manual: PR merge is operator-gated; release is tag-driven (GitHub Actions on tag push builds GHCR image)
+      commands: |
+        # merge the PR (review first)
+        env -u GITHUB_TOKEN gh pr merge <PR#> -R derio-net/health-bridge --squash
+        # tag the release
+        cd ~/Docs/projects/DERIO_NET/health-bridge
+        git checkout main && git pull
+        git tag v0.3.0 && git push origin v0.3.0
+      verify: |
+        env -u GITHUB_TOKEN gh run list -R derio-net/health-bridge --limit 1   # release workflow green
+        # image exists:
+        docker manifest inspect ghcr.io/derio-net/health-bridge:v0.3.0 >/dev/null && echo OK
+      status: pending
+      ```
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/04.yaml
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/04.yaml
@@ -1,0 +1,77 @@
+schema_version: 2
+phase:
+  number: 4
+  title: Deploy verification + stale-issue cleanup
+  tag: manual
+  depends_on:
+  - 2
+  - 3
+  tracking_issue: null
+tasks:
+- number: 1
+  title: ArgoCD rollout + auto-close smoke test
+  steps:
+  - id: P4.T1.S1
+    text: |-
+      ```yaml
+      # manual-operation
+      id: obs-health-bridge-v030-smoke-auto-close
+      layer: obs
+      app: health-bridge
+      plan: 2026-06-06--obs--health-bridge-bug-auto-close
+      when: After the frank PR merges and ArgoCD syncs the v0.3.0 image
+      why_manual: End-to-end verification needs the live cluster, the real GitHub repo, and operator confirmation (a layer is not Deployed until its workflow is observed end-to-end)
+      commands: |
+        kubectl get pods -n monitoring -l app=health-bridge   # Running, image v0.3.0
+        export WEBHOOK_SECRET=$(kubectl get secret -n monitoring health-bridge-secrets -o jsonpath='{.data.WEBHOOK_SECRET}' | base64 -d)
+        kubectl port-forward -n monitoring svc/health-bridge 8080:8080 &
+        # fire: creates a bug issue in frank-ops
+        curl -s -X POST http://localhost:8080/webhook -H "Authorization: Bearer $WEBHOOK_SECRET" -H "Content-Type: application/json" \
+          -d '{"status":"firing","alerts":[{"status":"firing","labels":{"alertname":"smoke-auto-close","severity":"critical","github_issue":"frank-ops#13"},"annotations":{"summary":"Auto-close smoke test"},"startsAt":"2026-06-06T00:00:00Z"}]}'
+        # confirm bug created, then heal:
+        curl -s -X POST http://localhost:8080/webhook -H "Authorization: Bearer $WEBHOOK_SECRET" -H "Content-Type: application/json" \
+          -d '{"status":"resolved","alerts":[{"status":"resolved","labels":{"alertname":"smoke-auto-close","severity":"critical","github_issue":"frank-ops#13"},"annotations":{"summary":"Auto-close smoke test"},"startsAt":"2026-06-06T00:00:00Z","endsAt":"2026-06-06T00:05:00Z"}]}'
+      verify: |
+        # bug issue auto-closed with heal comment (state_reason completed):
+        env -u GITHUB_TOKEN gh issue list -R derio-net/frank-ops --label bug --state closed --limit 3
+        kubectl logs -n monitoring -l app=health-bridge --tail=20 | grep "Closed bug issue"
+        # tracker frank-ops#13 Lifecycle back to healthy
+      status: pending
+      ```
+- number: 2
+  title: One-time cleanup of pre-fix stale issues
+  steps:
+  - id: P4.T2.S1
+    text: |-
+      ```yaml
+      # manual-operation
+      id: obs-frank-ops-stale-bug-cleanup
+      layer: obs
+      app: health-bridge
+      plan: 2026-06-06--obs--health-bridge-bug-auto-close
+      when: Once, after the smoke test passes
+      why_manual: Issues #38/#39 predate the auto-close path; their alerts already resolved (2026-06-04), so no future resolved webhook will arrive for them
+      commands: |
+        env -u GITHUB_TOKEN gh issue close 38 -R derio-net/frank-ops --reason completed \
+          --comment "System healed 2026-06-04 16:55 UTC (alert resolved — see frank-ops#24 tracker comments). Closed manually as one-time cleanup; bugs filed after health-bridge v0.3.0 auto-close on heal. Spec: frank docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md"
+        env -u GITHUB_TOKEN gh issue close 39 -R derio-net/frank-ops --reason completed \
+          --comment "System healed 2026-06-04 17:38 UTC (alert resolved — see frank-ops#8 tracker comments). Closed manually as one-time cleanup; bugs filed after health-bridge v0.3.0 auto-close on heal. Spec: frank docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md"
+      verify: |
+        env -u GITHUB_TOKEN gh issue list -R derio-net/frank-ops --label bug --state open
+        # → empty (no stale transient bugs)
+      status: pending
+      ```
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-06--obs--health-bridge-bug-auto-close
+spec: docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-06-06'

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/_prose.md
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/_prose.md
@@ -1,0 +1,58 @@
+# Health Bridge — Auto-Close Healed Bug Issues
+
+**Spec:** `docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md`
+**Status:** In Progress
+
+## What this is
+
+Closes the loop the original Layer 23 design left open: health-bridge files
+`[Bug] <alertname> is dead — …` issues on dead transitions but never touches
+them when the alert resolves. Transient incidents (frank-ops #38, #39, #40)
+leave permanently-open bugs the operator closes by hand. This plan makes the
+resolved webhook close them automatically, with a heal comment carrying
+resolution time and outage duration.
+
+En route it fixes a latent collision: `HasOpenBug` matches by title prefix
+only, so layers sharing Grafana's synthetic `DatasourceError` alertname
+suppress each other's bug creation — and a naive close-by-alertname would
+close the wrong layer's bug. Both paths now disambiguate via the
+`**Feature Issue:**` ref embedded in every bug body (newline-terminated, so
+`#2` never matches `#24`).
+
+## Shape of the work
+
+Two repos, two PRs, one plan (precedent: the original
+`2026-04-04--obs--health-bridge-service` plan lived in frank while the Go
+code lives in `derio-net/health-bridge`):
+
+| Phase | Repo | Working copy | Deliverable |
+|-------|------|--------------|-------------|
+| 1 (agentic) | derio-net/health-bridge | `~/Docs/projects/DERIO_NET/health-bridge`, branch `feat/auto-close-healed-bugs` | code PR (TDD, httptest-mock pattern) |
+| 2 (agentic) | derio-net/frank | isolation worktree, branch `feat/ops-issue-auto-close` | image bump + doc updates (this PR carries spec + plan) |
+| 3 (manual) | derio-net/health-bridge | — | merge PR, tag `v0.3.0`, GHCR build |
+| 4 (manual) | cluster + frank-ops | — | smoke fire/heal, stale #38/#39 cleanup |
+
+**Merge order matters operationally, not structurally:** the frank PR can be
+authored and merged any time (the bump references tag `v0.3.0` by name), but
+ArgoCD can only pull the image after Phase 3 pushes the tag. Recommended
+order: merge health-bridge PR → tag → merge frank PR → ArgoCD syncs →
+Phase 4 smoke.
+
+## Design decisions (operator Q&A 2026-06-06, full detail in spec)
+
+- **Webhook-close only.** No Grafana-state reconciler, no new credentials.
+  Evidence: every recent incident's resolved webhook reached the bridge
+  (tracker `healthy` comments at +3 to +45 min). Revisit only if a stale bug
+  recurs.
+- **New issue per incident.** Flapping alerts file fresh bugs each time;
+  auto-close keeps the open count at zero between incidents.
+- **Close is not gated** by the per-tracker `lastState` dedup nor by
+  severity — it keys purely on `alert.Status == "resolved"` and is
+  idempotent (no open bugs ⇒ no-op).
+
+## Post-deploy checklist
+
+This is a **fix/extension** of deployed Layer 23 — per plan-config
+`skip_when`, no new blog posts and no README delta; the existing
+building/operating posts are updated in Phase 2. `/sync-runbook` after the
+plan lands (three `# manual-operation` blocks in Phases 3–4).

--- a/docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md
+++ b/docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md
@@ -1,0 +1,191 @@
+# Health Bridge — Auto-Close Healed Bug Issues — Design
+
+**Date:** 2026-06-06
+**Status:** Spec
+**Repo:** frank (deploy + docs) · derio-net/health-bridge (code)
+**Layer:** obs
+**Related:**
+- `docs/superpowers/implemented/plans/2026-04-04--obs--health-bridge-service/` (built the bridge; established the frank-hosts-the-plan / code-lives-in-health-bridge split this spec reuses)
+- `docs/superpowers/specs/2026-05-31--obs--feature-health-alert-resilience-design.md` (complementary: prevents *false* dead transitions at the Grafana layer; this spec closes *legitimate* bug issues after heal at the bridge layer — no file overlap)
+- `blog/content/docs/operating/16-health-bridge/index.md`, `blog/content/docs/building/23-health-bridge/index.md`
+- Evidence: `derio-net/frank-ops` issues #38, #39, #40
+
+## Problem
+
+When a feature-health alert transitions to `dead`, health-bridge files a
+`[Bug] <alertname> is dead — <summary>` issue in the tracker's repo
+(`frank-ops`, `willikins`). When the alert later **resolves**, the bridge
+flips the Lifecycle tile back to `healthy` and comments on the tracker —
+but **never touches the bug issue it created**. Transient incidents leave
+permanently-open bugs that the operator must close by hand.
+
+Evidence (frank-ops, tracker comment history):
+
+| Bug | Created (dead) | Alert resolved | Bug state today |
+|-----|----------------|----------------|-----------------|
+| #38 (L24 Traefik) | 2026-06-04 16:52:58 | 2026-06-04 16:55:59 (+3 min) | **still open** |
+| #39 (L8 fluent-bit) | 2026-06-04 16:53:04 | 2026-06-04 17:38:03 (+45 min) | **still open** |
+| #40 (L24 DatasourceError) | 2026-06-05 20:43:43 | 2026-06-05 20:46:34 (+3 min) | closed manually 2026-06-06 |
+
+Key observation: in **every** recent incident the `resolved` webhook
+reliably reached the bridge (the `healthy` tracker comments prove
+delivery, minutes after each dead transition). The gap is purely a missing
+code path, not missing signal.
+
+### Latent bug discovered en route: shared-alertname collision
+
+Grafana's synthetic `DatasourceError` alertname is shared across layers —
+L8 and L24 have both produced `[Bug] DatasourceError is dead — …` issues.
+The existing creation-dedup `HasOpenBug(repo, alertName)` matches **title
+prefix only** (`[Bug] DatasourceError is dead`), so:
+
+- an open L24 DatasourceError bug **suppresses creation** of a legitimate
+  L8 DatasourceError bug, and
+- a naive close-by-alertname would close the *wrong layer's* bug.
+
+Both creation-dedup and close must disambiguate by the **feature issue
+ref** already embedded in every bug body
+(`**Feature Issue:** derio-net/frank-ops#24`).
+
+## Goal
+
+When an alert resolves, the bridge automatically closes the open bug
+issue(s) it created for that alert — with a heal comment carrying the
+resolution time and outage duration — so transient incidents are
+self-cleaning end to end: dead → bug filed → healed → bug closed.
+
+## Decisions Captured (operator Q&A, 2026-06-06)
+
+1. **Mechanism: webhook-close only.** On each `resolved` alert, find and
+   close matching open bugs. No Grafana-state reconciler, no new
+   credentials — evidence shows resolved webhooks arrive reliably. Stale
+   #38/#39 get a one-time manual close in the post-merge Test Plan.
+2. **Flap handling: new issue per incident.** Creation logic unchanged;
+   each dead transition files a fresh bug. Auto-close keeps the open
+   count at zero between incidents.
+3. **health-bridge working copy:** clone at
+   `~/Docs/projects/DERIO_NET/health-bridge`.
+4. **Post-merge Test Plan: full smoke + cleanup** (synthetic dead →
+   bug created → resolved → bug auto-closed, then close #38/#39).
+
+## Design
+
+### health-bridge (Go) — v0.3.0
+
+All changes in `bridge.go` / `github.go` / `bridge_test.go`, following the
+existing httptest-mock + `setGitHubURLs` test pattern.
+
+**1. `FindOpenBugs(repo, alertName, featureRef string) ([]int, error)`**
+(github.go) — replaces `HasOpenBug` as the single bug-matching primitive:
+
+- `GET /repos/{org}/{repo}/issues?labels=bug&state=open&per_page=50`
+  (same call `HasOpenBug` makes today), parsing `number`, `title`, `body`.
+- An issue matches when **both**:
+  - title has prefix `[Bug] <alertName> is dead`, and
+  - body contains the exact line fragment
+    `**Feature Issue:** <org>/<repo>#<number>\n` — **newline-terminated**,
+    because `…#2` is a substring of `…#24`; the trailing `\n` is
+    guaranteed by `CreateBugIssue`'s body template (`#%d\n**Alert:**`).
+- Returns all matching issue numbers (closing all catches historical
+  duplicates from the pre-dedup era).
+
+**2. Creation dedup uses the same primitive** — the `newState == "dead"`
+path calls `FindOpenBugs` (exists ⇔ len > 0) instead of `HasOpenBug`,
+fixing the shared-alertname suppression bug. `HasOpenBug` is removed.
+
+**3. `CloseBugIssue(repo string, number int, comment string) error`**
+(github.go):
+
+- posts the heal comment via the existing `AddIssueComment`,
+- then `PATCH /repos/{org}/{repo}/issues/{number}` with
+  `{"state": "closed", "state_reason": "completed"}`.
+- Comment failure logs a warning but does not abort the close (mirrors
+  the existing comment-failure tolerance on the tracker path).
+
+**4. `FormatHealComment(alert Alert) string`** (bridge.go) — markdown:
+alert name, resolved time (`EndsAt`), outage duration computed from
+RFC3339 `StartsAt`→`EndsAt` (omitted if either fails to parse), and the
+standard `*Automated by health-bridge*` footer.
+
+**5. Wire into `processAlert`** (bridge.go): immediately after the
+lifecycle update — **before** the `lastState` dedup early-return — when
+`alert.Status == "resolved"`:
+
+```go
+for _, n := range FindOpenBugs(repo, alertName, featureRef) {
+    CloseBugIssue(repo, n, FormatHealComment(alert))
+}
+```
+
+- **Not gated by the `lastState` dedup**: dedup is keyed per *tracker*
+  (multiple alerts share one tracker), and a deduped repeat-resolved must
+  still close. The operation is naturally idempotent — no open bugs ⇒
+  no-op.
+- **Not gated by severity**: only critical alerts create bugs, but gating
+  the close on `severity == "critical"` would leave a stale bug if a
+  rule's severity label is edited between fire and resolve. The cost of
+  no gate is one GET per resolved alert (rare — a few per day at worst).
+- Errors in the close path log warnings and do not fail the alert
+  (lifecycle update already succeeded — same posture as comment/bug
+  creation failures today).
+
+**Out of scope (documented, deliberate):**
+- No reconciler/startup sweep (Q&A decision 1 — YAGNI given webhook
+  reliability; revisit only if a stale bug recurs).
+- No reopen-recent-issue flap handling (Q&A decision 2).
+- The pre-existing overlapping-alerts dedup limitation (two alerts on the
+  same tracker both going dead in the same window suppresses the second
+  bug's creation via `lastState`) is unchanged — separate concern, noted
+  for the record.
+
+### frank (deploy + docs)
+
+- `apps/health-bridge/manifests/deployment.yaml` — image
+  `ghcr.io/derio-net/health-bridge:v0.2.0` → `v0.3.0`.
+- `blog/content/docs/operating/16-health-bridge/index.md` — document the
+  auto-close behavior (new section), update the "Duplicate bug issues"
+  troubleshooting entry (`HasOpenBug` → `FindOpenBugs` semantics,
+  shared-alertname fix).
+- `blog/content/docs/building/23-health-bridge/index.md` — short
+  retroactive addendum noting the v0.3.0 close-the-loop fix (fix/extension
+  workflow: update existing posts, no new post).
+
+### Release flow (unchanged, tag-driven)
+
+PR to `derio-net/health-bridge` → operator merges → tag `v0.3.0` pushed →
+GitHub Actions builds `ghcr.io/derio-net/health-bridge:v0.3.0` → frank PR
+(image bump + docs) merges → ArgoCD syncs.
+
+## Test Plan (post-merge — operator-driven)
+
+After both PRs merge and ArgoCD rolls the new image:
+
+- [ ] Pod healthy on v0.3.0: `kubectl get pods -n monitoring -l app=health-bridge`
+- [ ] Smoke — fire: direct webhook (`status: firing`, `severity: critical`,
+      `github_issue: frank-ops#13`, alertname `smoke-auto-close`) →
+      verify a `[Bug] smoke-auto-close is dead — …` issue is created in
+      frank-ops.
+- [ ] Smoke — heal: same alert with `status: resolved` + `endsAt` →
+      verify the bug issue is **closed** with a heal comment (resolved
+      time + duration), `state_reason: completed`.
+- [ ] Tracker side-effects normal: frank-ops#13 Lifecycle back to
+      `healthy`, dead/healthy comments present.
+- [ ] One-time cleanup: close stale #38 and #39 with a manual healed
+      comment referencing this spec.
+- [ ] Bridge logs show `Closed bug issue` lines, no errors.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| Resolved webhook missed during bridge downtime → bug stays open | Accepted (Q&A): evidence shows reliable delivery; manual close remains possible; reconciler is the documented follow-up if it recurs. |
+| Shared alertname closes wrong layer's bug | Feature-ref body match, newline-terminated to avoid `#2`/`#24` prefix collision. |
+| Close fires on flapping alert that immediately re-fires | New dead transition files a fresh bug (Q&A decision 2) — nothing lost. |
+| GitHub API close fails | Logged warning; alert processing unaffected; next resolved event retries naturally. |
+| >50 open bugs paginate past the search | Open-bug count is single digits in practice; per_page=50 retained from `HasOpenBug`. |
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-06-06--obs--health-bridge-bug-auto-close | `derio-net/frank` (hosts plan; phases target both repos) | `docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/` | — |

--- a/docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md
+++ b/docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md
@@ -75,7 +75,7 @@ self-cleaning end to end: dead → bug filed → healed → bug closed.
 All changes in `bridge.go` / `github.go` / `bridge_test.go`, following the
 existing httptest-mock + `setGitHubURLs` test pattern.
 
-**1. `FindOpenBugs(repo, alertName, featureRef string) ([]int, error)`**
+**1. `FindOpenBugs(repo, alertName string, featureNumber int) ([]int, error)`**
 (github.go) — replaces `HasOpenBug` as the single bug-matching primitive:
 
 - `GET /repos/{org}/{repo}/issues?labels=bug&state=open&per_page=50`
@@ -112,7 +112,7 @@ lifecycle update — **before** the `lastState` dedup early-return — when
 `alert.Status == "resolved"`:
 
 ```go
-for _, n := range FindOpenBugs(repo, alertName, featureRef) {
+for _, n := range FindOpenBugs(repo, alertName, number) {
     CloseBugIssue(repo, n, FormatHealComment(alert))
 }
 ```


### PR DESCRIPTION
## Summary

Transient incidents create `[Bug] <alertname> is dead — …` issues in frank-ops (recently #38, #39, #40) but nothing closes them when the system heals — the bridge restores the Lifecycle tile and walks away. health-bridge v0.3.0 ([derio-net/health-bridge#1](https://github.com/derio-net/health-bridge/pull/1)) makes the resolved webhook close its own bugs with a heal comment (resolution time + outage duration). This PR carries the frank side: image bump, Layer 23 doc updates, spec, and plan.

- **Spec:** `docs/superpowers/specs/2026-06-06--obs--health-bridge-bug-auto-close-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/` (4 phases; 1–2 agentic ✅, 3–4 manual — see below)

Design decisions from the one batched Q&A: **webhook-close only** (no Grafana-state reconciler — every recent incident's resolved webhook demonstrably arrived), **new issue per incident** (no reopen-on-flap), full post-merge smoke + one-time #38/#39 cleanup.

## Changes (this repo)

- `apps/health-bridge/manifests/deployment.yaml` — image `v0.2.0` → `v0.3.0`
- `blog/content/docs/operating/16-health-bridge/index.md` — "Auto-Close of Healed Bug Issues (v0.3.0)" section; duplicates-troubleshooting updated for `FindOpenBugs` semantics
- `blog/content/docs/building/23-health-bridge/index.md` — retroactive addendum (fix/extension workflow — no new post)
- spec + v2 plan folder (steps ticked through phases 1–2)

## Review findings and fixes

Senior-reviewer pass over spec + plan + both diffs: **zero Critical / zero Important**.

| Finding (Minor) | Resolution |
|---|---|
| REST issues list includes PRs (`pull_request` key) — a coincidentally-matching PR could be closed | Fixed with test (health-bridge `7f23ea8`): PR entries skipped in `FindOpenBugs` |
| Clock-skewed `EndsAt < StartsAt` renders a negative outage duration | Fixed with test (`7f23ea8`): duration omitted unless `end >= start` |
| `TestFindOpenBugs` asserts result order (incidental contract) | Reviewer assessed fine-as-is (code preserves input order by construction); no change |

## Manual phases — unimplemented, operator-owned

- **Phase 3 — Release health-bridge v0.3.0:** merge [health-bridge#1](https://github.com/derio-net/health-bridge/pull/1), push tag `v0.3.0`, verify the GHCR build. **Merge order: health-bridge PR → tag → this PR** (ArgoCD can only pull the image after the tag builds).
- **Phase 4 — Deploy verification + stale-issue cleanup:** smoke test + close #38/#39 (commands in the plan's `# manual-operation` blocks; `/sync-runbook` after merge).

## Test Plan (post-merge — operator-driven)

- [ ] Pod healthy on v0.3.0: `kubectl get pods -n monitoring -l app=health-bridge`
- [ ] Smoke — fire: direct webhook (`status: firing`, `severity: critical`, `github_issue: frank-ops#13`, alertname `smoke-auto-close`) → verify a `[Bug] smoke-auto-close is dead — …` issue is created in frank-ops.
- [ ] Smoke — heal: same alert with `status: resolved` + `endsAt` → verify the bug issue is **closed** with a heal comment (resolved time + duration), `state_reason: completed`.
- [ ] Tracker side-effects normal: frank-ops#13 Lifecycle back to `healthy`, dead/healthy comments present.
- [ ] One-time cleanup: close stale #38 and #39 with a manual healed comment referencing the spec.
- [ ] Bridge logs show `Closed bug issue` lines, no errors.

## Verification (pre-PR)

```
health-bridge: go test ./... → 30 passed · go vet clean · gofmt clean
frank:         vk plan self-review → passed · phases 1–2 steps all ticked
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)