### PR TITLE
fix(obs): health-bridge image v0.3.1 — re-release at the real merge commit

### DIFF
--- a/apps/health-bridge/manifests/deployment.yaml
+++ b/apps/health-bridge/manifests/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: health-bridge
-          image: ghcr.io/derio-net/health-bridge:v0.3.0
+          image: ghcr.io/derio-net/health-bridge:v0.3.1
           ports:
             - name: http
               containerPort: 8080

--- a/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/_prose.md
+++ b/docs/superpowers/plans/2026-06-06--obs--health-bridge-bug-auto-close/_prose.md
@@ -50,6 +50,21 @@ Phase 4 smoke.
   severity — it keys purely on `alert.Status == "resolved"` and is
   idempotent (no open bugs ⇒ no-op).
 
+## Deployment Deviations
+
+- **2026-06-06 — v0.3.0 tag pushed at a stale SHA; superseded by v0.3.1.**
+  Phase 3's `git tag v0.3.0` ran from a local main that predated the PR merge
+  (tag → `460ab79c`, the pre-merge base), so GHCR's `v0.3.0` image was built
+  WITHOUT the auto-close code (verified: `git grep FindOpenBugs v0.3.0` is
+  empty; the release workflow's headSha matched the stale commit). Fix:
+  `v0.3.1` tagged at the merge commit `b6f9fe4` + a follow-up frank PR bumping
+  the Deployment `v0.3.0 → v0.3.1`. Re-pointing `v0.3.0` was rejected — with
+  the default `imagePullPolicy: IfNotPresent`, a node that had already pulled
+  the bad image would silently keep serving it under the same tag.
+  Lesson for the runbook: tag from `git rev-parse` of the **merge commit**
+  (or `git pull` first and verify `git grep <new-symbol> <tag>` non-empty
+  before pushing).
+
 ## Post-deploy checklist
 
 This is a **fix/extension** of deployed Layer 23 — per plan-config


### PR DESCRIPTION
## Why

The `v0.3.0` tag was pushed from a stale local main — it points at `460ab79c` (the pre-merge base), so the GHCR `v0.3.0` image was built **without** the auto-close feature (`git grep FindOpenBugs v0.3.0` → empty; release workflow headSha confirms). Nothing broken deployed (bad v0.3.0 ≡ v0.2.0 behavior), but the feature isn't live until the image actually contains it.

## Fix

- `v0.3.1` tagged at the merge commit `b6f9fe4` (operator pushes the tag — script provided in-session: `bash scripts/tmp/retag-health-bridge-v031.sh`)
- This PR: Deployment `v0.3.0` → `v0.3.1`
- Re-pointing `v0.3.0` was rejected: default `imagePullPolicy: IfNotPresent` would let any node that already pulled the bad image keep serving it under the same tag.
- Deviation recorded in the plan's `_prose.md`.

**Merge order: run the retag script first (build must be green), then merge this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)