### PR TITLE
fix(infer): litellm amd64 affinity (gateway + migrations Job) + README sync — closes out #474/#476/#478

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Enterprise-grade Kubernetes cluster on Talos Linux across heterogeneous hardware
 | Secrets | Infisical + External Secrets Operator | Self-hosted secret store, ExternalSecret → K8s Secret sync |
 | RGB | OpenRGB | GitOps-managed LED control on gpu-1 via USB HID (IT5701 V3.5.14.0 firmware lock under investigation) |
 | Local Inference | Ollama | LLM serving on gpu-1's RTX 5070 Ti 16GB — multimodal (Gemma 4 12B, Qwen2.5-VL 7B), general (Mistral Small 3.2 24B, Qwen3 14B), code (Qwen2.5-Coder 14B), MoE flagship (Qwen3.6 35B-A3B, CPU-offloaded experts) |
-| API Gateway | LiteLLM | Unified OpenAI-compatible proxy routing to local Ollama models (local-only since 2026-06-04; 14 aliases incl. 64k-context + no-think variants), amd64-pinned pods + migrations Job |
+| API Gateway | LiteLLM | Unified OpenAI-compatible proxy routing to local Ollama models (local-only since 2026-06-04; 12 aliases incl. 64k-context + no-think variants), amd64-pinned pods + migrations Job |
 | Agentic Control Plane | Sympozium | K8s-native agents — every agent is a Pod, every policy a CRD, every execution a Job |
 | Identity & Auth | Authentik | Self-hosted IdP — OIDC SSO for ArgoCD, Grafana; forward-auth proxy for Longhorn, Hubble, Sympozium |
 | Multi-tenancy | vCluster | Virtual K8s clusters inside Frank — disposable sandboxes via ArgoCD |

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Enterprise-grade Kubernetes cluster on Talos Linux across heterogeneous hardware
 | Blog Analytics | GoatCounter | Cookieless, single-binary; mesh-only admin at counter.cluster.derio.net, public beacon at counter.derio.net (LB 192.168.55.224, Caddy reverse-proxy from Hop) |
 | Edge HTTP Security | CrowdSec | Agent on Hop tailing Caddy access logs; caddy-crowdsec-bouncer enforces decisions at the edge (no Frank dep on request path) |
 | Runtime Security | Falco (modern_ebpf) + Falcosidekick | DaemonSet on Hop; syscall events → VictoriaLogs (Loki protocol) + direct Telegram for priority:critical |
-| AI Alert Helper | ai-alert-helper (FastAPI) | LiteLLM-backed digest/investigate/surge-check; LLM swap contract for future Sympozium move |
+| AI Alert Helper | ai-alert-helper (FastAPI) | LiteLLM-backed digest/investigate/surge-check + Telegram trace-analyst (0.2.0): ad-hoc security Q&A over VictoriaLogs/CrowdSec evidence, allowlisted chat, long-poll consumer |
 | Health Probes | Blackbox Exporter | HTTP endpoint probing for feature health (n8n, Paperclip, Grafana, Blog) |
 | Heartbeat Ingestion | Pushgateway | Receives heartbeat metrics from cron jobs, scraped by VictoriaMetrics |
-| Alert Bridge | Health Bridge | Grafana webhook → GitHub Project lifecycle state updates (healthy/degraded/dead) |
+| Alert Bridge | Health Bridge | Grafana webhook → GitHub Project lifecycle state updates (healthy/degraded/dead); v0.3.0 auto-closes healed bug issues |
 | Backup | Longhorn → Cloudflare R2 | Daily + weekly PVC backup, SOPS-encrypted credentials |
 | Secrets | Infisical + External Secrets Operator | Self-hosted secret store, ExternalSecret → K8s Secret sync |
 | RGB | OpenRGB | GitOps-managed LED control on gpu-1 via USB HID (IT5701 V3.5.14.0 firmware lock under investigation) |
-| Local Inference | Ollama | LLM serving on gpu-1's RTX 5070 Ti 16GB — multimodal (Gemma 3 12B, Qwen2.5-VL 7B), general (Mistral Small 3.2 24B, Qwen3 14B), code (Qwen2.5-Coder 14B) |
-| API Gateway | LiteLLM | Unified OpenAI-compatible proxy routing to Ollama + OpenRouter cloud models |
+| Local Inference | Ollama | LLM serving on gpu-1's RTX 5070 Ti 16GB — multimodal (Gemma 4 12B, Qwen2.5-VL 7B), general (Mistral Small 3.2 24B, Qwen3 14B), code (Qwen2.5-Coder 14B), MoE flagship (Qwen3.6 35B-A3B, CPU-offloaded experts) |
+| API Gateway | LiteLLM | Unified OpenAI-compatible proxy routing to local Ollama models (local-only since 2026-06-04; 14 aliases incl. 64k-context + no-think variants), amd64-pinned pods + migrations Job |
 | Agentic Control Plane | Sympozium | K8s-native agents — every agent is a Pod, every policy a CRD, every execution a Job |
 | Identity & Auth | Authentik | Self-hosted IdP — OIDC SSO for ArgoCD, Grafana; forward-auth proxy for Longhorn, Hubble, Sympozium |
 | Multi-tenancy | vCluster | Virtual K8s clusters inside Frank — disposable sandboxes via ArgoCD |
@@ -90,6 +90,7 @@ frank/
 │   ├── pushgateway/manifests/                     # Heartbeat metric ingestion from cron jobs
 │   ├── grafana-alerting/manifests/                  # File-provisioned alerting (rules, contacts, policy, dashboard)
 │   ├── health-bridge/manifests/                   # Grafana alert → GitHub lifecycle bridge
+│   ├── ai-alert-helper/manifests/                 # LLM digest/surge-check + Telegram trace-analyst
 │   ├── fluent-bit/values.yaml                     # Log shipping
 │   ├── external-secrets/values.yaml              # ESO operator
 │   ├── infisical/values.yaml + manifests/         # Infisical + ClusterSecretStore
@@ -153,8 +154,8 @@ frank/
 ├── secrets/                   # SOPS/age-encrypted bootstrap secrets (applied out-of-band)
 ├── blog/                      # Hugo blog (Hextra theme)
 │   ├── hugo.toml
-│   ├── content/docs/building/       # 30 posts documenting the build
-│   ├── content/docs/operating/      # 25 companion operations guides
+│   ├── content/docs/building/       # 33 posts documenting the build
+│   ├── content/docs/operating/      # 28 companion operations guides
 │   ├── content/docs/papers/         # Frank Papers — research-grade landscape reviews (gated)
 │   ├── assets/js/mermaid-frank.js   # Mermaid Frank theme (loads on .paper-post pages)
 │   ├── layouts/partials/papers-*    # papers-backlink + papers-forwardlinks (cross-series)
@@ -284,7 +285,7 @@ argocd app list
 | blackbox-exporter | monitoring | HTTP endpoint probes for feature health (VMProbe → VictoriaMetrics) |
 | pushgateway | monitoring | Heartbeat metric ingestion from Willikins cron jobs (VMServiceScrape) |
 | grafana-alerting | monitoring | File-provisioned alerting: 5 rules, 2 contact points, notification policy, Feature Health dashboard |
-| health-bridge | monitoring | Grafana webhook → GitHub Project lifecycle updates (ghcr.io/derio-net/health-bridge:v0.1.0) |
+| health-bridge | monitoring | Grafana webhook → GitHub Project lifecycle updates + healed-issue auto-close (ghcr.io/derio-net/health-bridge:v0.3.0) |
 | traefik | traefik-system | In-cluster ingress controller (192.168.55.220), ACME wildcard TLS for `*.cluster.derio.net` |
 | traefik-extras | traefik-system | Middleware CRDs (security headers, IP allowlist, Authentik forward-auth) + 16 IngressRoutes |
 | homepage | homepage | Cluster dashboard at `master.cluster.derio.net`, HTTP health indicators, service catalog |
@@ -298,7 +299,7 @@ argocd app list
 | tekton-extras | tekton-pipelines | CI Tasks, gitea-ci Pipeline, Gitea EventListener, ExternalSecrets, RBAC |
 | longhorn-cicd | longhorn-system | Single-replica StorageClass for CI/CD workloads on pc-1 |
 | goatcounter | goatcounter-system | Blog analytics (arp242/goatcounter:2.7.0); LB 192.168.55.224, mesh-only admin via Authentik forward-auth |
-| ai-alert-helper | ai-alert-helper-system | FastAPI service — daily digest CronJob + surge-check + Grafana webhook receiver |
+| ai-alert-helper | ai-alert-helper-system | FastAPI service (0.2.0) — daily digest CronJob + surge-check + Grafana webhook receiver + Telegram trace-analyst (single replica, Recreate — one getUpdates consumer per bot token) |
 | awx | awx | AWX Operator + AWX CR (Ansible controller); OIDC SSO via Authentik; smoke-ping Job Template green vs non-Talos home-lab hosts |
 
 ### Hop Cluster Applications

--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -4,8 +4,9 @@
 # Exposed at 192.168.55.206:4000 as OpenAI-compatible API
 #
 # ─────────────────────────────────────────────────────────────────────────────
-# TODO ON NEXT IMAGE BUMP — fold in the chart-config improvements PR #210
-# discovered we don't have. Don't ship a bump without these:
+# TODO ON NEXT IMAGE BUMP — chart-config improvements PR #210 discovered we
+# didn't have. Items 1–3 below are now shipped/resolved; the one remainder
+# before the next bump is item 1's `resources` requests/limits:
 #
 # 1. ✅ affinity SHIPPED 2026-06-06 (#478) — top-level `affinity:` block below
 #    requires amd64 on the pod template. Background: PR #210's final promote

--- a/apps/litellm/values.yaml
+++ b/apps/litellm/values.yaml
@@ -7,12 +7,15 @@
 # TODO ON NEXT IMAGE BUMP — fold in the chart-config improvements PR #210
 # discovered we don't have. Don't ship a bump without these:
 #
-# 1. Pod-template `affinity` requiring amd64. PR #210's final promote landed
-#    one of 5 pods on raspi-1 (RPi 4, ARM, low-power) by scheduler tiebreaker
-#    — there's NO config protecting LiteLLM from the slow ARM node, every
-#    prior amd64 placement was luck. T2 documented this in
+# 1. ✅ affinity SHIPPED 2026-06-06 (#478) — top-level `affinity:` block below
+#    requires amd64 on the pod template. Background: PR #210's final promote
+#    landed one of 5 pods on raspi-1 (RPi 4, ARM, low-power) by scheduler
+#    tiebreaker — every prior amd64 placement was luck. T2 documented this in
 #    docs/agentic-discussion/2026-05-04--litellm-canary-for-real/terminal-2.md.
-#    Suggested block (verify cpu/memory numbers from `kubectl top pod` first):
+#    STILL TODO: `resources` requests/limits — blocked on the dead Metrics
+#    API (#394; `kubectl top` unavailable). Verify numbers from
+#    VictoriaMetrics (container_memory_working_set_bytes / CPU rate for the
+#    litellm pods) before setting. Draft from PR #210:
 #
 #      resources:
 #        requests:
@@ -20,22 +23,16 @@
 #          memory: 512Mi
 #        limits:
 #          memory: 1Gi
-#      affinity:
-#        nodeAffinity:
-#          requiredDuringSchedulingIgnoredDuringExecution:
-#            nodeSelectorTerms:
-#            - matchExpressions:
-#              - key: kubernetes.io/arch
-#                operator: In
-#                values: [amd64]
 #
-# 2. PreSync migration Job pinned to amd64 (separate from the main pod
-#    template — chart may need migrationJob.nodeSelector or equivalent).
-#    PR #220 had to bump v1.83.14-stable → v1.83.14-stable.patch.1 because
-#    the upstream arm64 layer for v1.83.14-stable was broken, and the Job
-#    landed on raspi-1 by default. T2 flagged this in the rehearsal as
-#    optimization (avoid the 4-7 min cold-pull tax on raspi-1); PR #210
-#    promoted it to "would have prevented an entire class of failure mode."
+# 2. ✅ RESOLVED 2026-06-06 (#478) — the same top-level `affinity:` covers the
+#    PreSync migration Job: chart 1.81.13 templates `.Values.affinity` and
+#    `.Values.tolerations` into BOTH the Deployment (deployment.yaml:226/:230)
+#    and the migrations Job (migrations-job.yaml:106/:110). Issue #478's
+#    premise ("no scheduling support on the Job") only holds for
+#    `nodeSelector` / migrationJob-scoped values. Background: PR #220 had to
+#    bump v1.83.14-stable → .patch.1 because the upstream arm64 layer was
+#    broken and the Job landed on raspi-1 by default; on 2026-06-04 the Job
+#    hit raspi-1 minutes before the node wedged (7+ min Prisma run on a Pi).
 #
 # 3. ✅ DONE in this PR — qwen-vl-7b dropped from q8_0 to default Q4_K_M.
 #    The Q8_0 tag was 9.4GB on disk; once loaded with 128K-context KV cache
@@ -66,6 +63,21 @@ environmentSecrets:
 
 envVars:
   STORE_MODEL_IN_DB: "True"
+
+# Keep LiteLLM off the ARM Pi nodes — gateway pods AND the PreSync Prisma
+# migrations Job (#478). Chart 1.81.13 templates this top-level value into
+# both pod templates (deployment.yaml:226, migrations-job.yaml:106).
+# amd64 = mini-1/2/3, gpu-1, pc-1; excludes raspi-1/raspi-2. Arch (not
+# hostname) is the real constraint: broken upstream arm64 image layers were
+# a prior failure mode (PR #220).
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/arch
+          operator: In
+          values: [amd64]
 
 # LiteLLM proxy configuration (rendered as config.yaml)
 #

--- a/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/01.yaml
+++ b/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/01.yaml
@@ -36,30 +36,31 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T19:34:41+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T19:34:42+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T19:34:44+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T19:34:46+00:00'
       note: null
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T19:34:47+00:00'
       note: null
     P1.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T19:34:15+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-06-06T19:34:49+00:00'
+    note: 'amd64 affinity shipped; render-asserted red→green against pinned chart
+      1.81.13; resources deferred on #394'
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/01.yaml
+++ b/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/01.yaml
@@ -1,0 +1,65 @@
+schema_version: 2
+phase:
+  number: 1
+  title: LiteLLM amd64 affinity — Deployment + migrations Job (#478)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Red — render-check harness proves no affinity today
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Write scripts/tmp/litellm-render-check.sh (gitignored scratch): set -euo pipefail; helm pull oci://docker.litellm.ai/berriai/litellm-helm --version 1.81.13 into a mktemp dir; helm template litellm <chart> -f apps/litellm/values.yaml; assert via yq/python that BOTH the rendered Deployment (name litellm) and the migrations Job carry spec.template.spec.affinity.nodeAffinity requiring kubernetes.io/arch In [amd64]. Print PASS/FAIL per object; exit non-zero on any FAIL.
+  - id: P1.T1.S2
+    text: |-
+      Run bash scripts/tmp/litellm-render-check.sh — expect RED: both objects report FAIL (no affinity rendered). Capture output.
+- number: 2
+  title: Green — add top-level affinity + rewrite TODO block
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Edit apps/litellm/values.yaml: add the top-level affinity block from the spec (nodeAffinity requiredDuringSchedulingIgnoredDuringExecution requiring kubernetes.io/arch In [amd64]), placed with the other top-level chart values (not under proxy_config).
+  - id: P1.T2.S2
+    text: |-
+      Rewrite the "TODO ON NEXT IMAGE BUMP" comment block in apps/litellm/values.yaml: item 1 affinity = SHIPPED 2026-06-06 (#478) with resources still deferred — blocked on dead Metrics API (#394), note VictoriaMetrics as the verification path; item 2 migration-Job pinning = RESOLVED by the same top-level block — cite chart 1.81.13 templates/migrations-job.yaml:106 (affinity) and :110 (tolerations) as evidence correcting issue #478's premise.
+  - id: P1.T2.S3
+    text: |-
+      Re-run bash scripts/tmp/litellm-render-check.sh — expect GREEN: both Deployment and migrations Job PASS. Capture output.
+- number: 3
+  title: Commit
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      git add apps/litellm/values.yaml and commit: "fix(infer): pin litellm pods + migrations Job to amd64 via top-level affinity (#478)". Body notes the chart-1.81.13 template finding and the gated-canary consequence.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/02.yaml
+++ b/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/02.yaml
@@ -1,0 +1,31 @@
+schema_version: 2
+phase:
+  number: 2
+  title: README sync — trace-analyst close-out remainder (#476)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Run /update-readme and commit
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Follow agents/skills/update-readme/SKILL.md in the worktree: sync README.md Technology Stack, Service Access, and Current Status against repo state — the ai-alert-helper 0.2.0 Telegram analyst (PR #469) is the known-stale item; sweep for anything else stale since (hermes shell .226 row, gemma alias work).
+  - id: P2.T1.S2
+    text: |-
+      Review git diff README.md — only intended sections changed, no masked-identifier or stale-IP regressions. Commit: "docs(repo): update-readme — trace-analyst close-out remainder (#476)".
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/02.yaml
+++ b/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/02.yaml
@@ -18,14 +18,15 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T19:38:02+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-06T19:38:03+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-06-06T19:38:05+00:00'
+    note: 'README synced: analyst 0.2.0, health-bridge v0.3.0, inference lineup, post
+      counts'
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/03.yaml
+++ b/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/03.yaml
@@ -1,0 +1,84 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Post-merge verification + issue close-outs
+  tag: manual
+  depends_on:
+  - 1
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Canary rollout to Healthy on amd64
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      After merge + root sync: kubectl argo rollouts get rollout litellm -n litellm --watch (or kubectl get rollout litellm -n litellm -o wide). The values change triggers a canary. Evidence- gate: kubectl get pod -n litellm -o wide — canary pod is on an amd64 node (mini-*/gpu-1/pc-1, NOT raspi-*).
+  - id: P3.T1.S2
+    text: |-
+      Operator promotes both indefinite manual gates (kubectl argo rollouts promote litellm -n litellm, twice as gated; or the status-subresource patch recipe if the plugin is absent). Rollout reaches Healthy; all stable pods on amd64.
+- number: 2
+  title: Migrations Job placement
+  steps:
+  - id: P3.T2.S1
+    text: |-
+      On the post-merge sync, confirm the PreSync migrations Job pod scheduled non-Pi: kubectl get pods -n litellm -o wide --selector=job-name --sort-by=.metadata.creationTimestamp | tail — NODE column must be amd64. If no fresh Job ran, trigger a no-op sync of the litellm Application and re-check.
+- number: 3
+  title: README + ArgoCD cosmetic
+  steps:
+  - id: P3.T3.S1
+    text: |-
+      Confirm README.md renders correctly on main (GitHub UI) — tables intact, no broken anchors.
+  - id: P3.T3.S2
+    text: |-
+      Check ai-alert-helper Application health (kubectl get application ai-alert-helper -n argocd -o wide). If still stale Degraded (appTree cache gotcha, docs/runbooks/frank-gotchas/argocd.md): kubectl rollout restart statefulset argocd-application-controller -n argocd, then confirm Healthy.
+- number: 4
+  title: Close issues with evidence
+  steps:
+  - id: P3.T4.S1
+    text: |-
+      Close #474: cite commit ce2fcd9e (building 33-hermes-shell, operating 28-hermes-shell, series index, cluster-roadmap entries all shipped).
+  - id: P3.T4.S2
+    text: |-
+      Close #476: cite operator-confirmed 2026-06-06 08:00 digest arrival in Telegram (item 10), the merged README sync commit, and the P3.T3.S2 ArgoCD-health result.
+  - id: P3.T4.S3
+    text: |-
+      Close #478: cite the chart-1.81.13 template finding (affinity/ tolerations ARE templated into migrations-job.yaml — premise correction), the merged values change, and the observed P3.T1/ P3.T2 placements.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T4.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T4.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-06-litellm-amd64-affinity-closeouts
+spec: docs/superpowers/specs/2026-06-06--infer--litellm-amd64-affinity-closeouts-design.md
+target_repo: derio-net/frank
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-06-06'

--- a/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/_prose.md
+++ b/docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/_prose.md
@@ -1,0 +1,65 @@
+# LiteLLM amd64 Affinity + Open-Issue Close-outs
+
+**Spec:** `docs/superpowers/specs/2026-06-06--infer--litellm-amd64-affinity-closeouts-design.md`
+**Issues:** #478 (primary code change), #476 (README remainder + verifications), #474 (close-only)
+**Branch:** `feat/issue-cleanup-474-476-478`
+
+## Why this shape
+
+Issue #478 proposed four remediations on the premise that chart
+`litellm-helm 1.81.13` supports no scheduling control on the Prisma
+migrations Job. Pulling the pinned chart from `docker.litellm.ai/berriai`
+disproved that premise for `affinity`/`tolerations`:
+
+- `templates/migrations-job.yaml:106` — `{{- with .Values.affinity }}`
+- `templates/migrations-job.yaml:110` — `{{- with .Values.tolerations }}`
+- `templates/deployment.yaml:226/:230` — the same top-level values
+
+So one top-level `affinity` block (require `kubernetes.io/arch=amd64`) fixes
+both the main gateway pods (the values.yaml TODO's item 1, minus resources)
+and the migrations Job (TODO item 2 / #478). No Pi taint, no upstream PR, no
+chart bump. Arch — not hostname — is the chosen key: the Pis are ARM, and a
+broken upstream arm64 image layer was a prior failure mode (PR #220), so
+amd64 encodes the actual constraint rather than the current node names.
+
+**Deliberately deferred:** resources requests/limits (TODO item 1's other
+half) stay TODO — the numbers need live usage data and the Metrics API is
+dead (#394). The rewritten TODO notes VictoriaMetrics as the verification
+path.
+
+## Rollout consequence (accepted)
+
+litellm is an Argo Rollouts canary (`workloadRef` → the chart Deployment)
+with two indefinite manual gates. The affinity edit changes the pod template,
+so merging triggers a gated canary that an operator must promote (Phase 3).
+The migrations Job needs no gate — it picks the affinity up on the next
+ArgoCD sync (PreSync hook).
+
+## TDD shape
+
+Phase 1 uses an offline render assertion (`helm template` of the pinned chart
+against the repo values file) as the red/green check: red proves neither the
+Deployment nor the Job currently renders affinity; green proves both do after
+the one-block edit. The script lives in gitignored `scripts/tmp/` — it's a
+one-shot structural assertion for this change, not a CI suite.
+
+## Phase 2 — README
+
+The only #476 remainder that is repo work: run the `update-readme` skill so
+Current Status / Service Access reflect the ai-alert-helper 0.2.0 analyst
+(PR #469) and anything else stale since. Digest item 10 is already closed by
+operator evidence (2026-06-06 08:00 digest arrived in Telegram — Q&A,
+2026-06-06); the cosmetic ArgoCD `Degraded` check moves to Phase 3.
+
+## Phase 3 — manual, back-loaded
+
+Post-merge verification and ceremony: promote the canary with the canary pod
+evidence-gated onto amd64 first, confirm the next migrations Job pod lands
+non-Pi, confirm README rendering, clear the appTree-cache `Degraded` if still
+present, then close #474/#476/#478 with the evidence trail. #474 needs no
+code at all — building `33-hermes-shell`, operating `28-hermes-shell`, the
+series index, and the cluster-roadmap entries all shipped in `ce2fcd9e`.
+
+No `# manual-operation` blocks: nothing here creates non-declarative cluster
+state — Phase 3 is one-time verification/promotion, already covered by the
+Rollouts gotcha docs, not a reproducibility-critical setup step.

--- a/docs/superpowers/specs/2026-06-06--infer--litellm-amd64-affinity-closeouts-design.md
+++ b/docs/superpowers/specs/2026-06-06--infer--litellm-amd64-affinity-closeouts-design.md
@@ -1,0 +1,141 @@
+# LiteLLM amd64 Affinity + Open-Issue Close-outs — Design Spec
+
+**Date:** 2026-06-06
+**Layer:** infer (primary), obs/orch (close-out only)
+**Status:** Draft
+**Issues:** [#478](https://github.com/derio-net/frank/issues/478), [#476](https://github.com/derio-net/frank/issues/476), [#474](https://github.com/derio-net/frank/issues/474)
+**Branch:** `feat/issue-cleanup-474-476-478`
+
+## Goal
+
+Close three hand-opened GitHub issues in one pass:
+
+1. **#478** — keep LiteLLM (gateway pods AND Prisma migrations Job) off the
+   Raspberry Pi nodes, declaratively.
+2. **#476** — execute the last trace-analyst close-out remainder that is repo
+   work (`/update-readme`); fold the two cluster-side verifications into the
+   post-merge Test Plan.
+3. **#474** — no work: the hermes blog posts already shipped (commit
+   `ce2fcd9e`, building `33-hermes-shell` + operating `28-hermes-shell` +
+   series index + roadmap). Close with evidence at close-out.
+
+## Key finding that reshapes #478
+
+Issue #478 claims chart `litellm-helm 1.81.13` "supports NO
+nodeSelector/affinity/tolerations" on the migrations Job. **Verified false for
+affinity/tolerations** by pulling the pinned chart from
+`docker.litellm.ai/berriai`:
+
+- `templates/migrations-job.yaml:106` — `{{- with .Values.affinity }}`
+- `templates/migrations-job.yaml:110` — `{{- with .Values.tolerations }}`
+- `templates/deployment.yaml:226/230` — same top-level values
+
+Only `nodeSelector` (and migrationJob-scoped scheduling values) are absent.
+A single **top-level `affinity` block** therefore fixes both the main
+Deployment placement (values.yaml TODO item 1) and the migrations Job (TODO
+item 2 / #478) with the chart as-pinned. No Pi taint, no upstream PR, no
+chart bump.
+
+## Decisions (operator Q&A, 2026-06-06)
+
+| Decision | Choice |
+|---|---|
+| #478 remediation | Top-level `affinity` requiring `kubernetes.io/arch=amd64` (the block the values.yaml TODO already drafted) |
+| Resources requests/limits | **Deferred** — numbers unverifiable while the Metrics API is dead (#394); TODO stays with a note |
+| #476 digest item 10 | **Closed** — operator confirms the 2026-06-06 08:00 digest arrived in Telegram |
+| Test Plan | Full five-step post-merge plan (below) |
+
+## Design
+
+### 1. `apps/litellm/values.yaml` — affinity (#478)
+
+Add at top level (consumed by both Deployment and migrations Job templates):
+
+```yaml
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/arch
+          operator: In
+          values: [amd64]
+```
+
+Rationale: arch (not hostname) is the documented intent — the Pis are ARM and
+a broken upstream arm64 image layer was a prior failure mode (PR #220).
+`amd64` still allows mini-1/2/3, gpu-1, pc-1.
+
+Rewrite the values.yaml `TODO ON NEXT IMAGE BUMP` comment block:
+
+- Item 1 (pod affinity): **shipped** (this change) except resources —
+  resources remain TODO, blocked on #394 (no Metrics API; `kubectl top`
+  dead). Alternative noted: verify numbers from VictoriaMetrics.
+- Item 2 (migration Job pinning): **resolved** by the same top-level block;
+  record the chart-template line numbers as evidence.
+
+**Rollout interaction (known, accepted):** litellm is an Argo Rollouts canary
+(`workloadRef` → chart Deployment) with two indefinite manual gates. The pod
+template change triggers a gated canary; promotion is operator-driven
+post-merge (Test Plan step 1). The migrations Job picks up the affinity on
+the next ArgoCD sync (PreSync hook) with no gate.
+
+### 2. README sync (#476)
+
+Run `/update-readme` in the worktree: sync Technology Stack / Service Access /
+Current Status to reflect ai-alert-helper 0.2.0 (Telegram analyst) and
+anything else stale since the trace-analyst deploy.
+
+### 3. Validation approach (TDD shape)
+
+The affinity change is assertable offline — `helm template` against the
+pinned chart with the repo's values file:
+
+- **Red:** render currently emits NO `affinity` in either
+  `Deployment/litellm` or `Job/litellm-migrations`.
+- **Green:** after the values edit, both rendered manifests carry the
+  `kubernetes.io/arch in [amd64]` nodeAffinity term.
+
+The render check lives in a gitignored scratch script for the run (not CI) —
+this is a one-shot structural assertion, not a regression suite.
+
+### 4. Issue close-outs (manual phase / post-merge)
+
+- **#474**: close citing commit `ce2fcd9e` + the four shipped artifacts.
+- **#476**: close citing operator-confirmed digest arrival (item 10), the
+  README PR, and the ArgoCD-cosmetic check result.
+- **#478**: close citing the chart-template finding (correcting the issue's
+  premise) + the merged affinity change + observed Job placement.
+
+## Out of scope
+
+- Resources requests/limits on litellm pods (blocked on #394 / VM-sourced
+  verification — TODO comment retained).
+- Cluster-wide Pi taint for heavy one-shot Jobs (bigger blast radius; would
+  be its own brainstorm if a second app exhibits the same failure).
+- Upstream `migrationJob.nodeSelector` PR (unnecessary — affinity suffices).
+- The remaining #477 rework items (separate issue, separate plan).
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-06-06-litellm-amd64-affinity-closeouts | `derio-net/frank` | `2026-06-06-litellm-amd64-affinity-closeouts` | — |
+
+## Test Plan
+
+> Post-merge — operator-driven. Agent runs cluster queries where it has
+> access; operator promotes gates and confirms Telegram-side evidence.
+
+1. **Canary rollout:** watch `kubectl argo rollouts get rollout litellm -n litellm`
+   (or `kubectl get rollout`); evidence-gate the canary pod onto an amd64
+   node (`kubectl get pod -n litellm -o wide`); operator promotes both
+   manual gates; rollout reaches Healthy with all pods on amd64.
+2. **Migrations Job placement:** on the sync that follows the merge, confirm
+   the `litellm-migrations` Job pod scheduled on a non-Pi node
+   (`kubectl get pod -n litellm -l job-name -o wide` or the Job's pod events).
+3. **README:** confirm the `/update-readme` changes render correctly on main.
+4. **ArgoCD cosmetic:** check ai-alert-helper Application health; if still
+   stale `Degraded` (appTree cache gotcha), restart
+   `argocd-application-controller` and confirm it clears.
+5. **Close-outs:** close #474, #476, #478 with the evidence above.


### PR DESCRIPTION
## Summary

vk-goal run closing three hand-opened issues in one pass.

- **#478** — top-level `affinity:` in `apps/litellm/values.yaml` requiring `kubernetes.io/arch=amd64`. **Premise correction:** the pinned chart `litellm-helm 1.81.13` already templates `.Values.affinity`/`.Values.tolerations` into BOTH the Deployment (`deployment.yaml:226/:230`) and the PreSync migrations Job (`migrations-job.yaml:106/:110`) — only `nodeSelector`/migrationJob-scoped values are missing. One block fixes gateway placement (values TODO item 1, minus resources) and the Job (item 2). No Pi taint, no upstream PR, no chart bump. Resources requests/limits stay deferred on #394 (dead Metrics API; verify from VictoriaMetrics when tackled).
- **#476** — `/update-readme` executed: ai-alert-helper 0.2.0 Telegram trace-analyst, health-bridge v0.3.0 healed-issue auto-close, Gemma 4 / Qwen3.6 MoE lineup, LiteLLM local-only + 12 aliases, post counts 33/28. Digest item 10 already closed by operator evidence (2026-06-06 08:00 digest arrived in Telegram).
- **#474** — verified already shipped in `ce2fcd9e` (building `33-hermes-shell`, operating `28-hermes-shell`, series index, roadmap). Close-only.

**Spec:** `docs/superpowers/specs/2026-06-06--infer--litellm-amd64-affinity-closeouts-design.md`
**Plan:** `docs/superpowers/plans/2026-06-06-litellm-amd64-affinity-closeouts/` (phases 1–2 complete, ticked)

## Validation

Offline red→green render assertion (gitignored scratch, `scripts/tmp/litellm-render-check.sh`): `helm template` of the pinned 1.81.13 chart with this values file — RED before the edit (both objects missing affinity), GREEN after (amd64 nodeAffinity present on **both** `Deployment/litellm` and `Job/litellm-migrations`). Re-verified after rebase onto main (64k-alias commits) and after review fixes.

## Review findings → fixes

| Severity | Finding | Resolution |
|---|---|---|
| Important | README claimed "14 aliases"; file has 12 (initial count hit rtk-grep summary lines) | Fixed → 12 (`c32b5f60`) |
| Minor | values.yaml TODO header "Don't ship a bump without these" stale after check-offs | Reworded — sole remainder is item 1's resources (`c32b5f60`) |
| Minor | Spec `Status: Draft` | Deliberate — flips at Phase 3 close-out, post-merge |
| Minor | Post counts 33/28 questioned | Reviewer self-confirmed correct (matches prior convention) |

## ⚠️ Phase 3 — manual, unimplemented by design

`03.yaml` (post-merge verification + close-outs) ships deliberately unimplemented — operator + agent drive it after merge, recording via `vk plan edit --complete-phase 3 --note`.

## Test Plan (post-merge — operator-driven)

1. **Canary rollout:** the pod-template change triggers the gated litellm canary. Watch `kubectl argo rollouts get rollout litellm -n litellm`; evidence-gate the canary pod onto an amd64 node (`kubectl get pod -n litellm -o wide`); operator promotes both indefinite manual gates; Rollout Healthy, all pods amd64.
2. **Migrations Job placement:** on the post-merge sync, confirm the PreSync Job pod scheduled non-Pi (`kubectl get pods -n litellm -o wide --selector=job-name`).
3. **README:** confirm rendering on main.
4. **ArgoCD cosmetic:** if ai-alert-helper Application still shows stale `Degraded` (appTree cache gotcha), restart `argocd-application-controller`, confirm clear.
5. **Close-outs:** close #474 (evidence `ce2fcd9e`), #476 (digest arrival + README commit + step 4 result), #478 (premise correction + observed placements). Then `vk plan edit --complete-phase 3`, flip spec to Complete, `vk archive`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)