### PR TITLE
feat(obs): cert-expiry canary — perpetual rule-fire heartbeat + absent() watchdog (#251)

### DIFF
--- a/apps/blackbox-exporter/manifests/configmap.yaml
+++ b/apps/blackbox-exporter/manifests/configmap.yaml
@@ -29,6 +29,23 @@ data:
           valid_status_codes: [200]
           follow_redirects: false
           preferred_ip_protocol: ip4
+      # Cert-expiry canary module (issue #251): identical to http_2xx_no_redirect
+      # plus insecure_skip_verify, so the TLS handshake against an EXPIRED cert
+      # completes and probe_ssl_earliest_cert_expiry is emitted (the default
+      # module aborts the handshake before cert inspection — empirically
+      # confirmed on v0.25.0, see the parent plan's Deployment Deviations).
+      http_2xx_insecure_tls:
+        prober: http
+        timeout: 10s
+        http:
+          # See note above — keep in sync with facts.PROBE_UA_TOKEN.
+          headers:
+            User-Agent: "Frank-Blackbox-Probe/1.0 (+https://blog.derio.net)"
+          valid_status_codes: [200]
+          follow_redirects: false
+          preferred_ip_protocol: ip4
+          tls_config:
+            insecure_skip_verify: true
       tcp_connect:
         prober: tcp
         timeout: 5s

--- a/apps/blackbox-exporter/manifests/vmprobe.yaml
+++ b/apps/blackbox-exporter/manifests/vmprobe.yaml
@@ -34,3 +34,27 @@ spec:
   module: http_2xx
   vmProberSpec:
     url: blackbox-exporter.monitoring.svc:9115
+---
+# Cert-expiry canary (issue #251, option 1): perpetually-expired cert keeps the
+# tls-cert-expiring-{14d,7d} rules exercised end-to-end. canary="true" flows
+# into the alert instance labels and is caught by the perma-muted first-position
+# notification-policy route — no Telegram, no health-bridge. The firing alert
+# instances in the Grafana alert list ARE the heartbeat; the
+# tls-cert-canary-absent watchdog covers metric disappearance.
+# Spec: docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMProbe
+metadata:
+  name: expired-cert-canary
+  namespace: monitoring
+spec:
+  targets:
+    staticConfig:
+      targets:
+        - https://expired.badssl.com/
+      labels:
+        probe_group: cert_canary   # distinct group — keeps feature-health dashboards clean
+        canary: "true"
+  module: http_2xx_insecure_tls
+  vmProberSpec:
+    url: blackbox-exporter.monitoring.svc:9115

--- a/apps/grafana-alerting/manifests/alert-rules-cm.yaml
+++ b/apps/grafana-alerting/manifests/alert-rules-cm.yaml
@@ -1444,6 +1444,54 @@ data:
               summary: "TLS cert for {{ $labels.instance }} expires in <7 days ({{ humanizeDuration $value }} remaining)"
               runbook: "See docs/investigations/2026-05-11--omni--cert-expiry-incident.md for renewal procedure."
 
+          # Watchdog for the expired-cert canary (issue #251): the canary's
+          # perpetually-firing alert instances are the heartbeat for the two
+          # rules above; this rule notices when the heartbeat metric itself
+          # disappears (badssl unreachable, module broken, VMProbe deleted).
+          # absent() returns EMPTY when the metric exists → noData is the
+          # HEALTHY path here (inverted vs the rules above). severity=critical
+          # + github_issue drive health-bridge's dead→bug-issue lifecycle
+          # (auto-closed on heal); canary_watchdog="true" is caught by the
+          # first-position notification-policy route so critical never reaches
+          # Telegram. Spec:
+          # docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
+          - uid: tls-cert-canary-absent
+            title: TLS cert-expiry canary absent
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: P4169E866C3094E38
+                model:
+                  refId: A
+                  expr: 'absent(probe_ssl_earliest_cert_expiry{canary="true"})'
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+              - refId: B
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: __expr__
+                model: { refId: B, type: reduce, expression: A, reducer: last, settings: { mode: dropNN } }
+              - refId: C
+                relativeTimeRange: { from: 3600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [0] }
+            noDataState: OK
+            execErrState: Error
+            for: 3h
+            labels:
+              severity: critical
+              github_issue: "frank-ops#8"
+              canary_watchdog: "true"
+            annotations:
+              summary: "Cert-expiry canary heartbeat lost: probe_ssl_earliest_cert_expiry{canary=\"true\"} absent >3h"
+              runbook: "Check https://expired.badssl.com/ reachability, the blackbox-exporter http_2xx_insecure_tls module, and VMProbe expired-cert-canary. Spec: docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md"
+
       # =====================================================================
       # blog-edge folder rules (obs layer phase 3+5) — fired alerts route to
       # the AI Helper Webhook (added in phase 5). For now they route through

--- a/apps/grafana-alerting/manifests/notification-policy-cm.yaml
+++ b/apps/grafana-alerting/manifests/notification-policy-cm.yaml
@@ -6,6 +6,17 @@ metadata:
 data:
   notification-policy.yaml: |
     apiVersion: 1
+    # Always-active interval used to permanently silence the cert-expiry canary
+    # route below (Grafana has no null receiver; an always-muted route is the
+    # idiomatic permanent mute). Spec:
+    # docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
+    muteTimes:
+      - orgId: 1
+        name: perma-mute
+        time_intervals:
+          - times:
+              - start_time: "00:00"
+                end_time: "24:00"
     policies:
       - orgId: 1
         receiver: "Telegram - Willikins"
@@ -13,6 +24,29 @@ data:
         group_interval: 3m
         repeat_interval: 3m
         routes:
+          # ROUTE ORDER IS LOAD-BEARING (issue #251 canary). The two canary
+          # routes must precede the severity routes (the canary fires BOTH
+          # tls-cert rules: warning + critical) and the feature-health route
+          # (health-bridge would mint a never-closing bug issue). The watchdog
+          # route must precede the mute route — the watchdog alert ALSO
+          # carries canary="true" (absent() propagates its selector's equality
+          # matchers) and would otherwise be swallowed by the mute.
+          #
+          # 1. Canary watchdog — health-bridge ONLY. severity=critical is
+          #    required for health-bridge's dead→bug-issue lifecycle (auto-
+          #    closed on heal) but must never reach Telegram.
+          - receiver: "Health Bridge Webhook"
+            matchers:
+              - canary_watchdog="true"
+            continue: false
+          # 2. Canary heartbeat instances — permanently muted, still visible
+          #    in the Grafana alert list (that visibility IS the heartbeat).
+          - receiver: "Telegram - Willikins"   # explicit for readability — never delivers (perma-muted)
+            matchers:
+              - canary="true"
+            mute_time_intervals:
+              - perma-mute
+            continue: false
           # blog-edge folder alerts go exclusively to the AI helper, which
           # builds a fact sheet, calls the LLM, and posts to Telegram itself.
           # Continue:false so the default Telegram contact point doesn't

--- a/docs/superpowers/plans/2026-06-07-cert-expiry-canary/01.yaml
+++ b/docs/superpowers/plans/2026-06-07-cert-expiry-canary/01.yaml
@@ -1,0 +1,55 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Canary probe path — blackbox module + VMProbe (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Failing manifest-invariant tests for the probe path
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Create `scripts/tests/test_cert_expiry_canary.py` (pytest, pyyaml) with probe-path assertions per spec §1–2: (a) `blackbox.yml` in `apps/blackbox-exporter/manifests/configmap.yaml` parses and contains module `http_2xx_insecure_tls` with `http.tls_config.insecure_skip_verify == True`, `valid_status_codes == [200]`, `follow_redirects == False`, and the `Frank-Blackbox-Probe/1.0` User-Agent header (sync with facts.PROBE_UA_TOKEN); (b) `apps/blackbox-exporter/manifests/vmprobe.yaml` contains a VMProbe named `expired-cert-canary` in `monitoring` with target `https://expired.badssl.com/`, staticConfig labels `canary: "true"` and `probe_group: cert_canary`, `module: http_2xx_insecure_tls`, and `vmProberSpec.url: blackbox-exporter.monitoring.svc:9115`.
+  - id: P1.T1.S2
+    text: |-
+      Run `fr isolation exec --branch feat/cert-expiry-canary-251 -- uv run --with pyyaml --with pytest pytest scripts/tests/test_cert_expiry_canary.py -q` and confirm the probe-path tests FAIL (module and VMProbe not yet present).
+- number: 2
+  title: Implement blackbox module + canary VMProbe
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Add the `http_2xx_insecure_tls` module to `apps/blackbox-exporter/manifests/configmap.yaml` exactly as in spec §1 (clone of `http_2xx_no_redirect` + `tls_config.insecure_skip_verify: true`), keeping the User-Agent sync comment.
+  - id: P1.T2.S2
+    text: |-
+      Append the `expired-cert-canary` VMProbe as a third document in `apps/blackbox-exporter/manifests/vmprobe.yaml` exactly as in spec §2 (labels `probe_group: cert_canary`, `canary: "true"`; module `http_2xx_insecure_tls`).
+  - id: P1.T2.S3
+    text: |-
+      Re-run the pytest command from P1.T1.S2 and confirm the probe-path tests PASS. Commit: `feat(obs): add http_2xx_insecure_tls module + expired-cert-canary VMProbe (#251)`.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-07-cert-expiry-canary/01.yaml
+++ b/docs/superpowers/plans/2026-06-07-cert-expiry-canary/01.yaml
@@ -30,26 +30,27 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:05:42+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:05:54+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:06:04+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:06:18+00:00'
       note: null
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:05:11+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-06-07T17:06:33+00:00'
+    note: 'TDD inline under fr-goal: 4 tests (2 red→green, 2 guards), module + VMProbe
+      landed, commit 0281371b'
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-07-cert-expiry-canary/02.yaml
+++ b/docs/superpowers/plans/2026-06-07-cert-expiry-canary/02.yaml
@@ -1,0 +1,55 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Alerting config — watchdog rule + notification-policy mute (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Failing tests for routing order, mute interval, and watchdog rule
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Extend `scripts/tests/test_cert_expiry_canary.py` with alerting assertions per spec §3–4: (a) notification-policy provisioning file declares mute time interval `perma-mute` (orgId 1, times 00:00–24:00); (b) route[0] matches `canary_watchdog="true"` → receiver `Health Bridge Webhook`, `continue: false`; (c) route[1] matches `canary="true"`, has `mute_time_intervals: [perma-mute]`, `continue: false`; (d) all pre-existing routes follow unchanged and in order (blog-edge, severity=critical, severity=warning, feature-health); (e) rule group `tls-cert-expiry-1h` contains rule uid `tls-cert-canary-absent` with expr `absent(probe_ssl_earliest_cert_expiry{canary="true"})`, `noDataState: OK`, `for: 3h`, labels `severity: critical`, `github_issue: "frank-ops#8"`, `canary_watchdog: "true"`, datasource `P4169E866C3094E38`, and 3-step A→B→C SSE shape (reduce last/dropNN, threshold gt 0).
+  - id: P2.T1.S2
+    text: |-
+      Run the pytest command and confirm the new alerting tests FAIL while the phase-1 probe-path tests still PASS.
+- number: 2
+  title: Implement notification-policy mute + watchdog rule
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      Edit `apps/grafana-alerting/manifests/notification-policy-cm.yaml`: add the `muteTimes` section (`perma-mute`, 00:00–24:00) and PREPEND the two routes from spec §3b in exact order — watchdog route FIRST (the watchdog alert also carries `canary="true"` from absent()'s selector; the mute route would swallow it), then the perma-muted `canary="true"` route. Existing routes unchanged below.
+  - id: P2.T2.S2
+    text: |-
+      Add rule `tls-cert-canary-absent` to the `tls-cert-expiry-1h` group in `apps/grafana-alerting/manifests/alert-rules-cm.yaml` per spec §4, following the existing 3-step A→B→C model of the neighbouring tls-cert rules (threshold `gt 0` instead of `lt`), `for: 3h`, the three labels, and the summary/runbook annotations.
+  - id: P2.T2.S3
+    text: |-
+      Re-run the full pytest file and confirm ALL tests PASS. Sanity-parse both CM payloads (`uv run --with pyyaml python3 -c` round-trip) to catch YAML indentation slips inside the `data:` block strings. Commit: `feat(obs): cert-expiry canary watchdog rule + perma-muted routing (#251)`.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-07-cert-expiry-canary/02.yaml
+++ b/docs/superpowers/plans/2026-06-07-cert-expiry-canary/02.yaml
@@ -30,26 +30,27 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:10:31+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:10:38+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:10:44+00:00'
       note: null
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:10:50+00:00'
       note: null
     P2.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T17:10:56+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-06-07T17:11:02+00:00'
+    note: 'TDD inline under fr-goal: 8 new tests (7 red→green, 1 guard), muteTimes
+      + 2 prepended routes + tls-cert-canary-absent rule, 12/12 passing, commit 47abcca6'
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-07-cert-expiry-canary/03.yaml
+++ b/docs/superpowers/plans/2026-06-07-cert-expiry-canary/03.yaml
@@ -28,7 +28,7 @@ tasks:
       Verify metric in VictoriaMetrics: `probe_ssl_earliest_cert_expiry{canary="true"}` ≈ 1.428883199e9 and `probe_success{canary="true"}` == 1.
   - id: P3.T2.S2
     text: |-
-      Verify provisioning via Grafana API: notification policy shows the two new first-position routes + `perma-mute` interval; rule `tls-cert-canary-absent` present with `health=ok`.
+      Verify provisioning via Grafana API: notification policy shows the two new first-position routes + `perma-mute` interval; rule `tls-cert-canary-absent` present with `health=ok`. Once the canary instances exist, also confirm via `/api/alertmanager/grafana/api/v2/alerts` that they are matched by the mute route (suppressed/muted state), not merely that the routes exist — the canary instances carry `grafana_folder="feature-health"`, so a route-match failure would double-route them to health-bridge (review finding).
   - id: P3.T2.S3
     text: |-
       Watch the canary instances of `tls-cert-expiring-14d` / `tls-cert-expiring-7d` reach `Pending` (≤ ~1h) then `Firing` (≤ ~2.5h) via `/api/prometheus/grafana/api/v1/rules`.

--- a/docs/superpowers/plans/2026-06-07-cert-expiry-canary/03.yaml
+++ b/docs/superpowers/plans/2026-06-07-cert-expiry-canary/03.yaml
@@ -1,0 +1,78 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Post-merge deploy verification (Test Plan)
+  tag: manual
+  depends_on:
+  - 1
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Sync + restarts
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      After PR merge: confirm ArgoCD synced `blackbox-exporter` and `grafana-alerting` apps — `kubectl get application -n argocd blackbox-exporter grafana-alerting -o wide`.
+  - id: P3.T1.S2
+    text: |-
+      `kubectl rollout restart deployment/blackbox-exporter -n monitoring` (config is loaded at startup only; no reloader sidecar). Wait Ready.
+  - id: P3.T1.S3
+    text: |-
+      Restart the Grafana pod (provisioning files are read at boot; subPath mounts never live-update). Wait Ready.
+- number: 2
+  title: Pipeline verification
+  steps:
+  - id: P3.T2.S1
+    text: |-
+      Verify metric in VictoriaMetrics: `probe_ssl_earliest_cert_expiry{canary="true"}` ≈ 1.428883199e9 and `probe_success{canary="true"}` == 1.
+  - id: P3.T2.S2
+    text: |-
+      Verify provisioning via Grafana API: notification policy shows the two new first-position routes + `perma-mute` interval; rule `tls-cert-canary-absent` present with `health=ok`.
+  - id: P3.T2.S3
+    text: |-
+      Watch the canary instances of `tls-cert-expiring-14d` / `tls-cert-expiring-7d` reach `Pending` (≤ ~1h) then `Firing` (≤ ~2.5h) via `/api/prometheus/grafana/api/v1/rules`.
+  - id: P3.T2.S4
+    text: |-
+      Confirm silence: no Telegram message for the canary instances; no new health-bridge comment on `frank-ops#8`; no new bug issue in `frank-ops`.
+  - id: P3.T2.S5
+    text: |-
+      Watchdog negative check: `tls-cert-canary-absent` evaluates `Normal` (absent() returns empty while the metric flows). Optional ≥3h destructive fire-test deferred per spec Test Plan step 9.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S5:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-07-cert-expiry-canary/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-07-cert-expiry-canary/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-07-cert-expiry-canary
+spec: docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-07'

--- a/docs/superpowers/plans/2026-06-07-cert-expiry-canary/_prose.md
+++ b/docs/superpowers/plans/2026-06-07-cert-expiry-canary/_prose.md
@@ -1,0 +1,57 @@
+# Cert-Expiry Canary (issue #251, option 1)
+
+**Spec:** `docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md`
+**Issue:** [frank#251](https://github.com/derio-net/frank/issues/251)
+**Parent plan:** `docs/superpowers/implemented/plans/2026-05-11--obs--cert-expiry-alerting/`
+**Layer:** obs (fix/extension of Layer 08 — tracker `frank-ops#8`)
+
+## Why
+
+The deployed `tls-cert-expiring-{14d,7d}` rules have never fired on real metric
+data — the default blackbox `http_2xx` module aborts TLS handshakes against
+expired certs before cert inspection, so the metric is never emitted and
+`noDataState: OK` keeps the rules silently inactive. This plan adds the
+permanent canary (issue option 1): an `insecure_skip_verify` blackbox module
+probing `https://expired.badssl.com/`, whose perpetually-firing alert instances
+ARE the heartbeat, muted at the notification-policy layer so neither Telegram
+nor health-bridge ever hears them — plus an `absent()` watchdog that turns a
+dead heartbeat into a self-healing health-bridge bug issue.
+
+## Load-bearing invariants (read before editing)
+
+1. **Route order is the whole design.** Watchdog route (`canary_watchdog="true"`
+   → Health Bridge, `continue: false`) MUST precede the mute route
+   (`canary="true"` → perma-muted, `continue: false`), which MUST precede all
+   existing routes. The watchdog alert also carries `canary="true"` (absent()
+   propagates its selector's equality matchers) — wrong order silently mutes
+   the watchdog. Both new routes must also precede the severity routes: the
+   canary fires BOTH tls-cert rules (warning + critical), and the watchdog
+   carries `severity: critical` (required for health-bridge's dead→bug-issue
+   lifecycle) that must never reach Telegram.
+2. **`noDataState: OK` is inverted for the watchdog.** absent() returns EMPTY
+   when the metric exists — noData is the healthy path.
+3. **health-bridge contract** (verified against bridge.go): no `github_issue`
+   label → alert skipped; firing+critical → `dead` → bug issue; resolved →
+   auto-close (v0.3.1).
+
+## Phases
+
+- **Phase 1 (agentic):** blackbox `http_2xx_insecure_tls` module +
+  `expired-cert-canary` VMProbe, TDD via
+  `scripts/tests/test_cert_expiry_canary.py` (pytest + pyyaml manifest
+  invariants).
+- **Phase 2 (agentic):** `perma-mute` time interval + two prepended routes +
+  `tls-cert-canary-absent` rule, same test file extended (routing-order
+  assertions included).
+- **Phase 3 (manual):** post-merge deploy verification — the spec's Test Plan
+  (ArgoCD sync, blackbox + Grafana restarts, metric check, Pending→Firing
+  watch, silence checks, watchdog Normal). Back-loaded per fr-goal; the PR
+  ships with this phase deliberately unimplemented.
+
+## Post-deploy checklist
+
+Skipped per `plan-config.yaml` `skip_when` (fix/extension plan): no blog
+posts, no README change, no external exposure (consistent with the parent
+plan's precedent). No `# manual-operation` blocks — the restarts are one-time
+deploy actions, not durable manual operations. A gotcha one-liner lands only
+if implementation surfaces a new non-obvious pattern.

--- a/docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
+++ b/docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
@@ -1,0 +1,287 @@
+# Cert-Expiry Canary — Design
+
+**Issue:** [frank#251](https://github.com/derio-net/frank/issues/251) (option 1 — permanent canary path)
+**Parent plan:** `docs/superpowers/implemented/plans/2026-05-11--obs--cert-expiry-alerting/` (Deployed, with documented verification gap)
+**Layer:** obs (extension — Layer 08, tracker `frank-ops#8`)
+**Date:** 2026-06-07
+
+## Problem
+
+The `tls-cert-expiring-14d` / `tls-cert-expiring-7d` rules are deployed but have
+never fired on real metric data: the default `http_2xx` blackbox module aborts
+the TLS handshake against expired certs before cert inspection, so
+`probe_ssl_earliest_cert_expiry` is never emitted and `noDataState: OK` keeps
+the rules inactive. Phase 3 of the parent plan verified rule machinery and the
+Telegram credential path, but not a rule-driven fire.
+
+**Empirical prerequisite (confirmed in parent plan deviations):** on
+`prom/blackbox-exporter:v0.25.0`, a module with
+`tls_config.insecure_skip_verify: true` DOES emit
+`probe_ssl_earliest_cert_expiry` for `https://expired.badssl.com/`
+(value `1.428883199e9` = 2015-04-12, `probe_success=1`).
+
+## Goal
+
+A permanent canary that keeps both tls-cert rules perpetually exercised
+(metric → eval → `for: 1h` → Firing), visible in the Grafana alert list as a
+heartbeat, with **zero Telegram noise and zero health-bridge bug issues** —
+plus a watchdog that notices when the heartbeat itself dies.
+
+## Design
+
+Four config changes, all in existing apps (no new ArgoCD Application):
+
+### 1. Blackbox module — `apps/blackbox-exporter/manifests/configmap.yaml`
+
+New module `http_2xx_insecure_tls`, identical in shape to `http_2xx_no_redirect`
+plus `tls_config.insecure_skip_verify: true`:
+
+```yaml
+http_2xx_insecure_tls:
+  prober: http
+  timeout: 10s
+  http:
+    # See note above — keep in sync with facts.PROBE_UA_TOKEN.
+    headers:
+      User-Agent: "Frank-Blackbox-Probe/1.0 (+https://blog.derio.net)"
+    valid_status_codes: [200]
+    follow_redirects: false
+    preferred_ip_protocol: ip4
+    tls_config:
+      insecure_skip_verify: true
+```
+
+Keeps the `Frank-Blackbox-Probe` UA for consistency with the edge-filter
+contract (irrelevant to badssl, but uniform across modules).
+
+### 2. Canary VMProbe — `apps/blackbox-exporter/manifests/vmprobe.yaml`
+
+Third VMProbe document in the existing file:
+
+```yaml
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMProbe
+metadata:
+  name: expired-cert-canary
+  namespace: monitoring
+spec:
+  targets:
+    staticConfig:
+      targets:
+        - https://expired.badssl.com/
+      labels:
+        probe_group: cert_canary   # distinct group — keeps feature-health dashboards clean
+        canary: "true"
+  module: http_2xx_insecure_tls
+  vmProberSpec:
+    url: blackbox-exporter.monitoring.svc:9115
+```
+
+The expired cert (2015) is permanently below both the 14d and 7d thresholds, so
+the canary produces **two perpetual alert instances**: one `severity=warning`
+(14d rule) and one `severity=critical` (7d rule). Both carry `canary="true"`
+(staticConfig labels flow into metric labels and then alert instance labels).
+
+### 3. Notification policy — `apps/grafana-alerting/manifests/notification-policy-cm.yaml`
+
+Two additions to the same provisioning file (`notification-policy.yaml` key —
+one file may carry multiple provisioning sections):
+
+**a. Always-active mute time interval** (Grafana has no null receiver; the
+idiomatic permanent mute is a route bound to an always-active interval):
+
+```yaml
+muteTimes:
+  - orgId: 1
+    name: perma-mute
+    time_intervals:
+      - times:
+          - start_time: "00:00"
+            end_time: "24:00"
+```
+
+**b. Two new routes, prepended in this exact order** (before all existing
+routes):
+
+```yaml
+routes:
+  # 1. Canary watchdog — health-bridge ONLY. severity=critical is required
+  #    for health-bridge's dead→bug-issue lifecycle, but must NOT reach the
+  #    Telegram severity routes below — hence first position + continue:false.
+  - receiver: "Health Bridge Webhook"
+    matchers:
+      - canary_watchdog="true"
+    continue: false
+  # 2. Canary heartbeat instances — permanently muted, but still visible in
+  #    the Grafana alert list (that visibility IS the heartbeat). Catches
+  #    BOTH the warning (14d) and critical (7d) instances before the
+  #    severity routes and before the feature-health → health-bridge route
+  #    (which would otherwise mint a never-closing bug issue).
+  - receiver: "Telegram - Willikins"   # explicit for readability — never delivers (perma-muted)
+    matchers:
+      - canary="true"
+    mute_time_intervals:
+      - perma-mute
+    continue: false
+  # ... existing routes unchanged ...
+```
+
+**Route-order analysis** (why this exact order):
+
+| Alert | Labels | First matching route | Outcome |
+|---|---|---|---|
+| canary 14d instance | `canary=true, severity=warning` | route 2 (mute) | suppressed, visible in alert list |
+| canary 7d instance | `canary=true, severity=critical` | route 2 (mute) | suppressed, visible in alert list |
+| watchdog | `canary=true, canary_watchdog=true, severity=critical, github_issue=frank-ops#8` | route 1 (health-bridge) | bug issue on fire, auto-close on heal, NO Telegram |
+| all existing alerts | unchanged | existing routes | unchanged |
+
+⚠️ The watchdog alert ALSO carries `canary="true"` — `absent()` propagates the
+equality matchers of its selector into the result vector's labels. If the mute
+route came first, it would swallow the watchdog. Watchdog route MUST precede
+the mute route.
+
+### 4. Watchdog rule — `apps/grafana-alerting/manifests/alert-rules-cm.yaml`
+
+New rule in the existing `tls-cert-expiry-1h` group (same 1h interval):
+
+```yaml
+- uid: tls-cert-canary-absent
+  title: TLS cert-expiry canary absent
+  condition: C
+  data:
+    - refId: A
+      relativeTimeRange: { from: 3600, to: 0 }
+      datasourceUid: P4169E866C3094E38
+      model:
+        refId: A
+        expr: 'absent(probe_ssl_earliest_cert_expiry{canary="true"})'
+        instant: true
+        intervalMs: 1000
+        maxDataPoints: 43200
+    - refId: B   # reduce, last, dropNN (3-step A→B→C per Grafana 12 SSE gotcha)
+    - refId: C   # threshold > 0
+  noDataState: OK      # absent() returns EMPTY when the metric exists → noData = healthy
+  execErrState: Error
+  for: 3h              # generous — tolerates transient badssl.com outages
+  labels:
+    severity: critical            # health-bridge: dead → bug issue (auto-closed on heal)
+    github_issue: "frank-ops#8"   # Layer 08 — Observability tracker
+    canary_watchdog: "true"       # routes to Health Bridge ONLY (first-position route)
+  annotations:
+    summary: "Cert-expiry canary heartbeat lost: probe_ssl_earliest_cert_expiry{canary=\"true\"} absent >3h"
+    runbook: "Check https://expired.badssl.com/ reachability, blackbox-exporter http_2xx_insecure_tls module, and VMProbe expired-cert-canary. See docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md"
+```
+
+`absent()` semantics: returns a 1-element vector when the metric is missing
+(→ threshold C fires), an EMPTY result when present (→ noData → `OK`). The
+inversion means `noDataState: OK` is the *healthy* path here, unlike the
+cert rules where it papers over a missing metric.
+
+### health-bridge contract (verified against `bridge.go`)
+
+- Alerts **without** a `github_issue` label are skipped entirely — the existing
+  tls-cert rules have none, so even if the mute route failed, health-bridge
+  would no-op on the canary instances. Defense in depth, not a reason to skip
+  the mute (Telegram would still fire).
+- `firing` + `severity=critical` → state `dead` → **creates a bug issue**
+  (deduped per alertname + feature ref).
+- `resolved` → auto-closes that bug with outage duration (v0.3.1, deployed
+  2026-06-06).
+- `frank-ops#8` ("Layer 08 — Observability") exists and follows the
+  per-layer-tracker convention used by all other `github_issue` labels.
+
+## Q&A decisions (2026-06-07)
+
+1. **Mute mechanism:** first-position `canary="true"` route + provisioned
+   always-active mute time interval, `continue: false`. No blackhole contact
+   point; health-bridge never sees the canary.
+2. **Watchdog:** yes — routed to health-bridge only (bug issue on death,
+   auto-close on heal), generous `for: 3h`, zero Telegram.
+   *Refinement vs the Q&A option text:* achieving the promised bug-issue
+   lifecycle requires `severity: critical` (health-bridge only creates bugs on
+   `dead`), so Telegram suppression comes from the dedicated first-position
+   route rather than from omitting the severity label.
+3. **Test Plan:** interactive, agent-driven post-merge (below).
+
+## Deployment notes
+
+- **Grafana** mounts each provisioning file via `subPath` (kubelet never
+  live-updates) and reads provisioning at boot only →
+  `kubectl rollout restart deployment` of the Grafana pod after sync.
+- **blackbox-exporter** has no config-reloader sidecar; the CM volume is
+  non-subPath (kubelet propagates in ~1min) but blackbox only loads config at
+  startup/SIGHUP → `kubectl rollout restart deployment/blackbox-exporter -n monitoring`
+  (or `POST /-/reload`).
+- ArgoCD picks up both apps from `main` after merge; restarts are post-sync
+  imperative steps (Test Plan), not manifest changes.
+- No new secrets, no new Application, no ingress, no homepage tile.
+
+## Acceptance (from issue #251, option 1, + watchdog)
+
+- [ ] `http_2xx_insecure_tls` module added; ArgoCD synced.
+- [ ] `expired-cert-canary` VMProbe picked up by vmagent;
+      `probe_ssl_earliest_cert_expiry{canary="true"}` ≈ `1.428883199e9`,
+      `probe_success == 1`.
+- [ ] Both tls-cert alert instances for the canary reach `Pending` then
+      `Firing` (rule interval 1h + `for: 1h` → ≤ ~2.5h wall clock).
+- [ ] No Telegram message for the canary instances; no health-bridge comment
+      or bug issue.
+- [ ] Watchdog rule `health=ok`, state `Normal` while the canary metric flows.
+- [ ] Closes the #251 verification gap: a Grafana rule fire driven by real
+      metric data crossing the threshold, including the `for` debounce and
+      notification-policy routing (delivery deliberately muted at the last
+      hop, which is itself part of what's verified).
+
+## Test Plan (post-merge — operator-driven, agent-assisted)
+
+1. Merge PR; confirm ArgoCD syncs `blackbox-exporter` and `grafana-alerting`
+   apps (`kubectl get application -n argocd -o wide`).
+2. `kubectl rollout restart deployment/blackbox-exporter -n monitoring`; wait
+   Ready.
+3. Restart the Grafana pod (provisioning re-read); wait Ready.
+4. Verify metric: query VictoriaMetrics for
+   `probe_ssl_earliest_cert_expiry{canary="true"}` → ≈1.428883199e9;
+   `probe_success{canary="true"}` → 1.
+5. Verify provisioning landed: Grafana API — notification policy shows the two
+   new first-position routes + `perma-mute` interval; rule
+   `tls-cert-canary-absent` present, `health=ok`.
+6. Watch `tls-cert-expiring-14d`/`-7d` canary instances: `Pending` within ~1h,
+   `Firing` within ~2.5h (`/api/prometheus/grafana/api/v1/rules`).
+7. Confirm silence: no Telegram message for the canary; no new comment on
+   `frank-ops#8`; no new bug issue in `frank-ops`.
+8. Watchdog negative check: rule evaluates `Normal` (absent() empty while
+   metric flows).
+9. (Optional, destructive, ≥3h) Watchdog fire test: live-delete the canary
+   VMProbe with root+leaf selfHeal suspended, wait `for: 3h` → bug issue on
+   `frank-ops`; restore, confirm auto-close. Deferred by default — the
+   absent() inversion is verified by step 8 and the rule shares its machinery
+   with the proven tls-cert rules.
+
+## Risks / trade-offs
+
+- **External dependency on badssl.com** — accepted by issue design; the
+  watchdog turns "badssl died" into a self-healing health-bridge bug issue
+  rather than silence. `for: 3h` absorbs transient outages.
+- **badssl cert renewal**: expired.badssl.com's cert is intentionally expired
+  (fixed at 2015-04-12); if badssl ever rotates it to a *valid* cert, the
+  canary instances resolve and only manual alert-list inspection notices (the
+  watchdog only covers metric absence). Low likelihood; documented here.
+- **Provisioning schema**: `muteTimes` + `mute_time_intervals` verified
+  against current Grafana file-provisioning docs; final verification is
+  Test Plan step 5 (12.x renamed the UI concept to "time intervals" but the
+  file-provisioning keys are unchanged).
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-06-07-cert-expiry-canary | `derio-net/frank` | `2026-06-07-cert-expiry-canary` | — |
+
+## Out of scope
+
+- Issue option 2 (time-bounded real-fire test with a self-hosted ~13-day
+  cert) — the canary closes the watchdog gap; option 2 remains available
+  later on the same `http_2xx_insecure_tls` module.
+- Blog posts / README (fix-extension of obs layer — parent-plan precedent);
+  a gotcha one-liner lands if implementation surfaces a new non-obvious
+  pattern.

--- a/docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
+++ b/docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
@@ -244,7 +244,11 @@ cert rules where it papers over a missing metric.
    `probe_success{canary="true"}` → 1.
 5. Verify provisioning landed: Grafana API — notification policy shows the two
    new first-position routes + `perma-mute` interval; rule
-   `tls-cert-canary-absent` present, `health=ok`.
+   `tls-cert-canary-absent` present, `health=ok`. Once instances exist,
+   confirm via `/api/alertmanager/grafana/api/v2/alerts` that the canary
+   instances are actually matched/suppressed by the mute route — they carry
+   `grafana_folder="feature-health"`, so a route-match failure would
+   double-route them to health-bridge (review finding).
 6. Watch `tls-cert-expiring-14d`/`-7d` canary instances: `Pending` within ~1h,
    `Firing` within ~2.5h (`/api/prometheus/grafana/api/v1/rules`).
 7. Confirm silence: no Telegram message for the canary; no new comment on

--- a/scripts/tests/test_cert_expiry_canary.py
+++ b/scripts/tests/test_cert_expiry_canary.py
@@ -19,6 +19,8 @@ import yaml
 REPO = Path(__file__).resolve().parents[2]
 BLACKBOX_CM = REPO / "apps/blackbox-exporter/manifests/configmap.yaml"
 VMPROBE_FILE = REPO / "apps/blackbox-exporter/manifests/vmprobe.yaml"
+NOTIF_POLICY_CM = REPO / "apps/grafana-alerting/manifests/notification-policy-cm.yaml"
+ALERT_RULES_CM = REPO / "apps/grafana-alerting/manifests/alert-rules-cm.yaml"
 
 # Keep in sync with facts.PROBE_UA_TOKEN in
 # apps/ai-alert-helper/src/ai_alert_helper/facts.py (see blackbox configmap note).
@@ -78,3 +80,110 @@ def test_canary_vmprobe_shape():
 def test_existing_vmprobes_untouched():
     names = {d["metadata"]["name"] for d in _vmprobe_docs()}
     assert {"feature-health-probes", "management-plane-probes"} <= names
+
+
+# --- Phase 2: notification-policy mute routing + watchdog rule ---------------
+
+
+def _notif_provisioning():
+    cm = yaml.safe_load(NOTIF_POLICY_CM.read_text())
+    return yaml.safe_load(cm["data"]["notification-policy.yaml"])
+
+
+def _routes():
+    return _notif_provisioning()["policies"][0]["routes"]
+
+
+def _rule_groups():
+    cm = yaml.safe_load(ALERT_RULES_CM.read_text())
+    return yaml.safe_load(cm["data"]["alert-rules.yaml"])["groups"]
+
+
+def test_perma_mute_interval_provisioned():
+    prov = _notif_provisioning()
+    mts = {m["name"]: m for m in prov.get("muteTimes", [])}
+    assert "perma-mute" in mts, "muteTimes perma-mute missing"
+    mt = mts["perma-mute"]
+    assert mt["orgId"] == 1
+    # 00:00–24:00 with no weekday/month restriction = always active
+    assert mt["time_intervals"][0]["times"] == [
+        {"start_time": "00:00", "end_time": "24:00"}
+    ]
+
+
+def test_watchdog_route_is_first():
+    """severity=critical on the watchdog must reach health-bridge, never Telegram."""
+    r = _routes()[0]
+    assert r["receiver"] == "Health Bridge Webhook"
+    assert r["matchers"] == ['canary_watchdog="true"']
+    assert r["continue"] is False
+
+
+def test_canary_mute_route_is_second():
+    """The watchdog also carries canary="true" (absent() propagates its selector's
+    equality matchers) — the mute route must come AFTER the watchdog route."""
+    r = _routes()[1]
+    assert r["matchers"] == ['canary="true"']
+    assert r["mute_time_intervals"] == ["perma-mute"]
+    assert r["continue"] is False
+
+
+def test_existing_routes_preserved_in_order():
+    tail = _routes()[2:]
+    expected = [
+        ("AI Helper Webhook", ['grafana_folder="blog-edge"'], False),
+        ("Telegram - Willikins", ["severity=critical"], True),
+        ("Telegram - Willikins", ["severity=warning"], True),
+        ("Health Bridge Webhook", ['grafana_folder="feature-health"'], False),
+    ]
+    actual = [(r["receiver"], r["matchers"], r["continue"]) for r in tail]
+    assert actual == expected
+
+
+def _watchdog_rule():
+    groups = {g["name"]: g for g in _rule_groups()}
+    assert "tls-cert-expiry-1h" in groups
+    rules = {r["uid"]: r for r in groups["tls-cert-expiry-1h"]["rules"]}
+    assert "tls-cert-canary-absent" in rules, "watchdog rule missing"
+    return rules["tls-cert-canary-absent"]
+
+
+def test_watchdog_rule_query_and_states():
+    rule = _watchdog_rule()
+    a = rule["data"][0]
+    assert a["model"]["expr"] == 'absent(probe_ssl_earliest_cert_expiry{canary="true"})'
+    assert a["datasourceUid"] == "P4169E866C3094E38"
+    # absent() returns EMPTY when the metric exists → noData is the HEALTHY path
+    assert rule["noDataState"] == "OK"
+    assert rule["execErrState"] == "Error"
+    assert rule["for"] == "3h"  # generous — tolerates transient badssl outages
+    assert rule["condition"] == "C"
+
+
+def test_watchdog_rule_sse_three_step_shape():
+    """Grafana 12 SSE gotcha: rules need the 3-step A→B→C shape."""
+    rule = _watchdog_rule()
+    refs = [d["refId"] for d in rule["data"]]
+    assert refs == ["A", "B", "C"]
+    b = rule["data"][1]["model"]
+    assert (b["type"], b["reducer"]) == ("reduce", "last")
+    c = rule["data"][2]["model"]
+    assert c["type"] == "threshold"
+    assert c["conditions"][0]["evaluator"] == {"type": "gt", "params": [0]}
+
+
+def test_watchdog_rule_labels_route_to_health_bridge():
+    labels = _watchdog_rule()["labels"]
+    # critical → health-bridge maps firing to dead → creates the bug issue
+    assert labels["severity"] == "critical"
+    # without github_issue, health-bridge skips the alert entirely (bridge.go)
+    assert labels["github_issue"] == "frank-ops#8"
+    # first-position route key — keeps critical away from Telegram
+    assert labels["canary_watchdog"] == "true"
+
+
+def test_existing_tls_cert_rules_untouched():
+    groups = {g["name"]: g for g in _rule_groups()}
+    rules = {r["uid"]: r for r in groups["tls-cert-expiry-1h"]["rules"]}
+    assert rules["tls-cert-expiring-14d"]["labels"]["severity"] == "warning"
+    assert rules["tls-cert-expiring-7d"]["labels"]["severity"] == "critical"

--- a/scripts/tests/test_cert_expiry_canary.py
+++ b/scripts/tests/test_cert_expiry_canary.py
@@ -1,0 +1,80 @@
+"""Manifest invariants for the cert-expiry canary (issue #251, option 1).
+
+Spec: docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md
+
+Guards the load-bearing config shape: the insecure-TLS blackbox module and the
+expired-cert canary VMProbe (phase 1); the notification-policy mute routing and
+the absent()-watchdog rule (phase 2). The routing-order assertions matter most:
+the watchdog alert also carries canary="true", so the watchdog route must
+precede the mute route or the watchdog is silently muted.
+
+Run:
+    uv run --with pyyaml --with pytest pytest scripts/tests/test_cert_expiry_canary.py -q
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+BLACKBOX_CM = REPO / "apps/blackbox-exporter/manifests/configmap.yaml"
+VMPROBE_FILE = REPO / "apps/blackbox-exporter/manifests/vmprobe.yaml"
+
+# Keep in sync with facts.PROBE_UA_TOKEN in
+# apps/ai-alert-helper/src/ai_alert_helper/facts.py (see blackbox configmap note).
+PROBE_UA = "Frank-Blackbox-Probe/1.0 (+https://blog.derio.net)"
+
+
+def _blackbox_modules():
+    cm = yaml.safe_load(BLACKBOX_CM.read_text())
+    return yaml.safe_load(cm["data"]["blackbox.yml"])["modules"]
+
+
+def _vmprobe_docs():
+    return [d for d in yaml.safe_load_all(VMPROBE_FILE.read_text()) if d]
+
+
+# --- Phase 1: blackbox module + canary VMProbe ------------------------------
+
+
+def test_insecure_tls_module_shape():
+    modules = _blackbox_modules()
+    assert "http_2xx_insecure_tls" in modules, "module http_2xx_insecure_tls missing"
+    http = modules["http_2xx_insecure_tls"]["http"]
+    assert http["tls_config"]["insecure_skip_verify"] is True
+    assert http["valid_status_codes"] == [200]
+    assert http["follow_redirects"] is False
+    assert http["preferred_ip_protocol"] == "ip4"
+    assert http["headers"]["User-Agent"] == PROBE_UA
+
+
+def test_existing_modules_untouched():
+    modules = _blackbox_modules()
+    for name in ("http_2xx", "http_2xx_no_redirect", "tcp_connect"):
+        assert name in modules, f"pre-existing module {name} went missing"
+    # insecure_skip_verify must stay scoped to the canary module only
+    for name, mod in modules.items():
+        if name == "http_2xx_insecure_tls":
+            continue
+        tls = mod.get("http", {}).get("tls_config", {})
+        assert not tls.get("insecure_skip_verify"), f"{name} must not skip TLS verify"
+
+
+def test_canary_vmprobe_shape():
+    probes = {d["metadata"]["name"]: d for d in _vmprobe_docs()}
+    assert "expired-cert-canary" in probes, "VMProbe expired-cert-canary missing"
+    probe = probes["expired-cert-canary"]
+    assert probe["metadata"]["namespace"] == "monitoring"
+    spec = probe["spec"]
+    static = spec["targets"]["staticConfig"]
+    assert static["targets"] == ["https://expired.badssl.com/"]
+    # canary="true" drives the mute route; probe_group keeps feature-health clean
+    assert static["labels"]["canary"] == "true"
+    assert static["labels"]["probe_group"] == "cert_canary"
+    assert spec["module"] == "http_2xx_insecure_tls"
+    assert spec["vmProberSpec"]["url"] == "blackbox-exporter.monitoring.svc:9115"
+
+
+def test_existing_vmprobes_untouched():
+    names = {d["metadata"]["name"] for d in _vmprobe_docs()}
+    assert {"feature-health-probes", "management-plane-probes"} <= names

--- a/scripts/tests/test_cert_expiry_canary.py
+++ b/scripts/tests/test_cert_expiry_canary.py
@@ -74,6 +74,10 @@ def test_canary_vmprobe_shape():
     assert static["labels"]["canary"] == "true"
     assert static["labels"]["probe_group"] == "cert_canary"
     assert spec["module"] == "http_2xx_insecure_tls"
+    # cross-file invariant: the probe's module must actually exist in the
+    # blackbox config — a rename on either side would otherwise pass both
+    # single-file tests yet emit nothing
+    assert spec["module"] in _blackbox_modules()
     assert spec["vmProberSpec"]["url"] == "blackbox-exporter.monitoring.svc:9115"
 
 
@@ -129,6 +133,9 @@ def test_canary_mute_route_is_second():
 
 
 def test_existing_routes_preserved_in_order():
+    # pin the total so a stray route inserted between the canary pair and the
+    # tail can't hide in the [2:] slice
+    assert len(_routes()) == 6
     tail = _routes()[2:]
     expected = [
         ("AI Helper Webhook", ['grafana_folder="blog-edge"'], False),


### PR DESCRIPTION
Closes #251 (option 1 — the permanent canary).

## Summary

A perpetually-expired-cert canary that keeps `tls-cert-expiring-{14d,7d}` exercised end-to-end on real metric data, closing the parent plan's Phase 3 verification gap:

- **`http_2xx_insecure_tls`** blackbox module (`apps/blackbox-exporter/manifests/configmap.yaml`) — `insecure_skip_verify` lets the TLS handshake against an expired cert complete so `probe_ssl_earliest_cert_expiry` is emitted (empirically confirmed on v0.25.0 in the parent plan's deviations).
- **`expired-cert-canary` VMProbe** (`apps/blackbox-exporter/manifests/vmprobe.yaml`) → `https://expired.badssl.com/`, labels `canary: "true"`, `probe_group: cert_canary`.
- **Notification policy** (`apps/grafana-alerting/manifests/notification-policy-cm.yaml`): always-active `perma-mute` time interval + two **prepended** routes. Route order is load-bearing: the canary fires BOTH tls-cert rules (warning + critical) and its instances carry `grafana_folder="feature-health"` — without the first-position mute they'd hit Telegram AND health-bridge (minting a never-closing bug issue). The firing-but-muted instances in the Grafana alert list ARE the heartbeat.
- **`tls-cert-canary-absent` watchdog** (`apps/grafana-alerting/manifests/alert-rules-cm.yaml`): `absent()` rule (`noDataState: OK` is the *healthy* path — inverted), `for: 3h`, routed via `canary_watchdog="true"` to health-bridge ONLY: `severity: critical` + `github_issue: "frank-ops#8"` drive the dead→bug-issue lifecycle (auto-closed on heal, v0.3.1) without ever reaching Telegram. Watchdog route precedes the mute route because the watchdog alert also carries `canary="true"` (absent() propagates its selector's equality matchers).
- **Tests**: `scripts/tests/test_cert_expiry_canary.py` — 12 manifest-invariant tests (TDD, red→green per phase), including route-order, SSE 3-step shape, and existing-config regression guards. `uv run --with pyyaml --with pytest pytest scripts/tests/test_cert_expiry_canary.py -q` → **12 passed**.

## Artifacts

- Spec: `docs/superpowers/specs/2026-06-07--obs--cert-expiry-canary-design.md`
- Plan: `docs/superpowers/plans/2026-06-07-cert-expiry-canary/` (`fr plan self-review` passing; phases 1–2 complete)

## Review findings → fixes (all applied)

Code review verdict: *Ready to merge — Yes*; zero Critical/Important. Minor findings, all fixed in `eb6bad33`:

1. **Cross-file invariant gap** — no test tied the VMProbe `module` to an actually-existing blackbox module (a rename on either side would pass both single-file tests). → Added `assert spec["module"] in _blackbox_modules()`.
2. **Route count not pinned** — a stray route inserted between the canary pair and the tail could hide in the `[2:]` slice. → Added `assert len(_routes()) == 6`.
3. **Test Plan enhancement** — verify post-deploy that canary instances are *actually matched* by the mute route via `/api/alertmanager/grafana/api/v2/alerts`, not merely that the routes exist (the `grafana_folder="feature-health"` label is the latent double-routing hazard). → Added to spec Test Plan step 5 and plan step P3.T2.S2.

The reviewer independently verified the two claims the design rests on: MetricsQL `absent()` selector-label propagation holds on VictoriaMetrics, and the pre-existing routes are byte-identical and order-preserved.

## Phase 3: unimplemented — operator pushes to this PR

`docs/superpowers/plans/2026-06-07-cert-expiry-canary/03.yaml` (manual, post-merge deploy verification) ships deliberately unimplemented per fr-goal back-loading. It is the Test Plan below; completion is recorded post-merge via `fr plan edit --complete-phase 3 --note ...`.

## Test Plan (post-merge — operator-driven)

1. Merge PR; confirm ArgoCD syncs `blackbox-exporter` and `grafana-alerting` apps (`kubectl get application -n argocd -o wide`).
2. `kubectl rollout restart deployment/blackbox-exporter -n monitoring`; wait Ready (config loaded at startup only, no reloader sidecar).
3. Restart the Grafana pod (provisioning read at boot; subPath mounts never live-update); wait Ready.
4. Verify metric in VictoriaMetrics: `probe_ssl_earliest_cert_expiry{canary="true"}` ≈ 1.428883199e9; `probe_success{canary="true"}` == 1.
5. Verify provisioning via Grafana API: two new first-position routes + `perma-mute` interval; rule `tls-cert-canary-absent` present, `health=ok`. Once instances exist, confirm via `/api/alertmanager/grafana/api/v2/alerts` that the canary instances are matched/suppressed by the mute route.
6. Watch the canary instances of `tls-cert-expiring-14d`/`-7d`: `Pending` ≤ ~1h, `Firing` ≤ ~2.5h (`/api/prometheus/grafana/api/v1/rules`).
7. Confirm silence: no Telegram message; no new health-bridge comment on `frank-ops#8`; no new bug issue in `frank-ops`.
8. Watchdog negative check: `tls-cert-canary-absent` evaluates `Normal` while the metric flows. (Optional ≥3h destructive watchdog fire-test deferred per spec.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
