### PR TITLE
orch(hermes-agent-shell): PVC-resident venv + auto-continue patch — spec/plan (#496)

### DIFF
--- a/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/01.yaml
+++ b/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/01.yaml
@@ -121,42 +121,45 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:33+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:35+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:37+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:38+00:00'
       note: null
     P1.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:40+00:00'
       note: null
     P1.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:41+00:00'
       note: null
     P1.T4.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:43+00:00'
       note: null
     P1.T5.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:44+00:00'
       note: null
     P1.T5.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-07T22:15:46+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-06-07T22:15:47+00:00'
+    note: 'agent-images PR #110 open. Deviations: patch test = build git-apply + smoke
+      grep (not a network wheel-download bats); seed-hook bats is a local dev test,
+      CI teeth via the docker smoke test; build uses git apply (patch not in base
+      image). Real-package relocatable seed+cp+run verified locally.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/01.yaml
+++ b/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/01.yaml
@@ -1,0 +1,162 @@
+schema_version: 2
+phase:
+  number: 1
+  title: 'agent-images: PVC-resident Hermes venv + baked auto-continue patch (TDD)'
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Auto-continue gate-widening patch (chat_completions)
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      In the agent-images repo, create a failing test
+      `hermes-agent-shell/tests/test_autocontinue_patch.bats` that: (a)
+      curls the pinned Hermes wheel
+      `hermes_agent-0.15.2-py3-none-any.whl` from the stable pythonhosted
+      URL (files.pythonhosted.org/packages/71/20/…/hermes_agent-0.15.2-py3-none-any.whl)
+      into `$BATS_TMPDIR`, unzips it, (b) applies
+      `hermes-agent-shell/patches/hermes-autocontinue-chat-completions.patch`
+      with `patch -p1 --forward` against the unpacked tree, and (c)
+      asserts the patched `agent/conversation_loop.py` contains the exact
+      string `in ("codex_responses", "chat_completions")`. Run it and
+      confirm it FAILS (patch file does not exist yet).
+  - id: P1.T1.S2
+    text: |-
+      Create `hermes-agent-shell/patches/hermes-autocontinue-chat-completions.patch`
+      (unified diff, `-p1`) that widens the single gate in
+      `agent/conversation_loop.py` from `agent.api_mode == "codex_responses"`
+      to `agent.api_mode in ("codex_responses", "chat_completions")` in the
+      auto-continue block (the `codex_ack_continuations < 2` /
+      `_looks_like_codex_intermediate_ack(...)` condition, ~line 4183).
+      Include ≥3 lines of context so it applies unambiguously. Header
+      comment block in the patch explains why (LiteLLM path resolves to
+      api_mode `chat_completions` via `determine_api_mode`'s default; the
+      ack heuristic is provider-agnostic). Re-run the bats test from
+      P1.T1.S1 and confirm it now PASSES.
+- number: 2
+  title: First-boot seed hook + bats unit test (PVC venv)
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Create a failing bats test
+      `hermes-agent-shell/tests/test_venv_seed.bats` driving the seed
+      hook logic against fake `$SEED`/`$LIVE` tmpdirs (no Docker): (1)
+      first boot with no `$LIVE` → hook copies seed and writes the
+      version marker; (2) same-version re-run → no-op AND a sentinel file
+      written into `$LIVE` survives (in-pod patch preserved); (3)
+      version-mismatch re-run → `$LIVE` replaced and sentinel gone. The
+      hook script is parameterised by `SEED`/`LIVE` env (default to the
+      real paths) so the test can point them at tmpdirs. Run it; confirm
+      FAIL (hook script absent).
+  - id: P1.T2.S2
+    text: |-
+      Create `hermes-agent-shell/rootfs/etc/cont-init.d/35-hermes-venv-seed`
+      with shebang `#!/command/with-contenv bash` implementing the
+      version-aware seed: `SEED=${SEED:-/opt/hermes-agent}`,
+      `LIVE=${LIVE:-/home/agent/.local/opt/hermes-agent}`; compare
+      `$SEED/.seed-version` vs `$LIVE/.seed-version`; on mismatch `mkdir -p
+      $(dirname $LIVE)`, `cp -a $SEED $LIVE.new`, `rm -rf $LIVE`, `mv
+      $LIVE.new $LIVE`; fail-loud (non-zero + log) if `cp` fails; no-op on
+      match. Re-run test_venv_seed.bats and confirm PASS.
+- number: 3
+  title: Dockerfile — relocatable seed venv, apply patch, version marker, repoint
+    launcher
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      Edit `hermes-agent-shell/Dockerfile` venv RUN (lines ~44-48): use
+      `uv venv --relocatable --python 3.11 /opt/hermes-agent`; keep `uv
+      pip install hermes-agent==${HERMES_VERSION}`; `COPY patches/` into
+      the build and `patch -p1 --forward` the installed
+      site-packages/agent/conversation_loop.py (build FAILS if it does not
+      apply); write `/opt/hermes-agent/.seed-version` =
+      `${HERMES_VERSION}+autocontinue1`; repoint
+      `ln -sf /home/agent/.local/opt/hermes-agent/bin/hermes
+      /usr/local/bin/hermes`; `chown -R ${AGENT_UID}:${AGENT_GID}
+      /opt/hermes-agent` in the SAME RUN; replace the build-time
+      `/usr/local/bin/hermes --version` check with
+      `/opt/hermes-agent/bin/hermes --version` (the symlink target is the
+      not-yet-seeded PVC path at build time).
+  - id: P1.T3.S2
+    text: |-
+      Add `chmod +x /etc/cont-init.d/35-hermes-venv-seed` to the
+      Dockerfile's existing chmod block (alongside the
+      `40-shell-inventory` chmod), so the new hook is executable in the
+      image. Confirm the patches dir is in the COPY/build context.
+- number: 4
+  title: Extend CI smoke test for the PVC venv + live patch
+  steps:
+  - id: P1.T4.S1
+    text: |-
+      In `.github/workflows/build.yaml`, extend
+      `smoke-test-hermes-agent-shell` (after cont-init has run): assert
+      (a) `test -w /home/agent/.local/opt/hermes-agent/bin/python` and
+      `test -O .../bin/hermes` (uid-1000 writable+owned); (b) `hermes
+      --version` resolves through the symlink to the PVC venv and runs;
+      (c) the live `conversation_loop.py` under the PVC venv contains
+      `("codex_responses", "chat_completions")` (baked patch present); (d)
+      a re-seed check: overwrite the live `.seed-version`, re-run
+      `/etc/cont-init.d/35-hermes-venv-seed`, assert the venv was
+      replaced. Keep the existing inventory/MOTD assertions.
+- number: 5
+  title: README — document PVC-resident venv + seed model
+  steps:
+  - id: P1.T5.S1
+    text: |-
+      Update `hermes-agent-shell/README.md`: the live Hermes venv is now
+      PVC-resident at `/home/agent/.local/opt/hermes-agent`, seeded on
+      first boot from a relocatable image seed at `/opt/hermes-agent`,
+      version-gated re-seed on image bump, uid-1000-writable (so `hermes
+      update` / in-pod patches work and persist). Note the baked
+      auto-continue patch. Update the layer-1 baseline row accordingly.
+  - id: P1.T5.S2
+    text: |-
+      Open the agent-images PR (`feat/hermes-pvc-venv-496`): commit all
+      Phase-1 changes, push, `gh pr create`. PR body: summary, link to
+      frank#496, the spec design decisions, and the post-merge note that
+      frank's image pin must be bumped (frank Phase 2). This PR is the
+      primary deliverable.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T5.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T5.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/02.yaml
+++ b/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/02.yaml
@@ -1,0 +1,61 @@
+schema_version: 2
+phase:
+  number: 2
+  title: '[manual] frank: bump image pin + runbook + blog (post-merge, operator)'
+  tag: manual
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Bump the hermes-agent-shell image pin to the new agent-images SHA
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      AFTER the agent-images PR merges and CI publishes
+      `ghcr.io/derio-net/hermes-agent-shell:<new-agent-images-sha>`, run
+      `/bump-image hermes-agent-shell <new-sha>` — updates
+      `apps/hermes-agent-shell/manifests/deployment.yaml:38`, watches the
+      ArgoCD `Recreate` rollout, and verifies the pod comes up and `hermes
+      --version` works. (Manual: depends on a merged cross-repo PR + CI
+      artifact that does not exist until then.)
+- number: 2
+  title: Runbook gotcha — PVC-resident venv
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      Add a one-liner to `agents/rules/frank-gotchas.md` (Agent shells
+      section) and full prose to
+      `docs/runbooks/frank-gotchas/agent-shells.md`: Hermes venv is
+      PVC-resident (`/home/agent/.local/opt/hermes-agent`), seeded from a
+      relocatable image seed on first boot, version-gated re-seed on image
+      bump; in-pod patches persist across restart but are superseded by an
+      image bump; the auto-continue patch (chat_completions gate) is baked
+      in. Run `/sync-runbook` if any manual-operation blocks were added.
+- number: 3
+  title: Retroactive blog update (fix/extension — no new post)
+  steps:
+  - id: P2.T3.S1
+    text: |-
+      Update the existing hermes-agent-shell building + operating posts
+      with the PVC-venv note and the auto-continue fix (gotcha/correction
+      in building; new operational note in operating). No new post per the
+      fix/extension workflow. Push to the same frank PR branch.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-07--orch--hermes-agent-shell-pvc-venv
+spec: docs/superpowers/specs/2026-06-07--orch--hermes-agent-shell-pvc-venv-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-08'

--- a/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/_prose.md
+++ b/docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/_prose.md
@@ -1,0 +1,43 @@
+# Plan — hermes-agent-shell: PVC-resident venv + baked auto-continue patch (#496)
+
+Implements [frank#496](https://github.com/derio-net/frank/issues/496) per the
+design spec `docs/superpowers/specs/2026-06-07--orch--hermes-agent-shell-pvc-venv-design.md`.
+
+## Why
+
+The `agent` user (uid 1000) in the `hermes-agent-shell` pod cannot patch or
+maintain the root-owned `/opt/hermes-agent` Hermes venv (no privesc;
+`fsGroup` doesn't touch image-baked files). Operator-chosen fix (Q&A):
+
+1. **PVC-resident venv** — the live venv moves to `/home/agent/.local/opt/hermes-agent`
+   (uid-1000-owned, writable, persists across restarts), seeded on first boot
+   from a **relocatable** image seed at `/opt/hermes-agent`. Proven:
+   `uv venv --relocatable` + `cp -a` runs at the new path.
+2. **Bake the auto-continue patch** — widen Hermes' announce-only countermeasure
+   gate from `codex_responses` to also fire on `chat_completions` (the LiteLLM
+   path Frank uses), permanently fixing the qwen36-a3b "announce then idle"
+   stall.
+
+## Cross-repo shape
+
+- **Phase 1 (agentic, agent-images)** is the substantive deliverable: Dockerfile
+  relocatable seed venv, first-boot version-aware seed hook, baked patch,
+  tests, README. Ships as its **own PR** in `derio-net/agent-images`. (agent-images
+  is not fr-enabled — it holds no plan folder; this frank plan tracks the work.)
+- **Phase 2 (manual, back-loaded, frank)** can only run after Phase 1 merges and
+  CI publishes the new commit-SHA image tag. The operator runs `/bump-image`,
+  adds the runbook gotcha, and updates the existing blog posts. It ships in the
+  **frank PR deliberately unimplemented**, marked for the operator.
+
+`depends_on` is within-plan only; the real Phase-2-after-Phase-1 dependency is a
+cross-PR ordering enforced by the build chain (frank's target SHA does not exist
+until agent-images CI builds it).
+
+## Verification
+
+TDD throughout Phase 1 (bats tests red→green for the patch and the seed hook;
+the Docker build + extended `smoke-test-hermes-agent-shell` are the integration
+gate — build fails loudly if the patch does not apply; smoke asserts the live
+PVC venv is uid-1000-writable, `hermes` runs from it, and the widened gate is
+present). The post-merge Test Plan (spec `## Test Plan`) confirms live-pod
+behaviour and the stall fix via the operator's session-replay matrix.

--- a/docs/superpowers/specs/2026-06-07--orch--hermes-agent-shell-pvc-venv-design.md
+++ b/docs/superpowers/specs/2026-06-07--orch--hermes-agent-shell-pvc-venv-design.md
@@ -253,6 +253,12 @@ the operator.
 
 ---
 
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-06-07--orch--hermes-agent-shell-pvc-venv | `derio-net/frank` | `2026-06-07--orch--hermes-agent-shell-pvc-venv` | — |
+
 ## Test Plan (post-merge — operator-driven)
 
 Run after the frank pin-bump rolls the new image onto the pod.

--- a/docs/superpowers/specs/2026-06-07--orch--hermes-agent-shell-pvc-venv-design.md
+++ b/docs/superpowers/specs/2026-06-07--orch--hermes-agent-shell-pvc-venv-design.md
@@ -1,0 +1,276 @@
+# Design — hermes-agent-shell: PVC-resident Hermes venv + baked auto-continue patch
+
+**Issue:** [frank#496](https://github.com/derio-net/frank/issues/496)
+**Layer:** `orch` (extension of the existing `hermes-agent-shell` layer)
+**Status:** ready
+**Repos in scope:**
+- `derio-net/agent-images` — image build (primary deliverable PR)
+- `derio-net/frank` — image SHA pin bump + runbook/blog (back-loaded, post-merge)
+
+---
+
+## Problem
+
+The `agent` user (uid 1000) inside the `hermes-agent-shell` pod cannot modify
+the Hermes runtime. The venv at `/opt/hermes-agent` is baked `root:root 0644`
+in the image, and the pod's securityContext forbids privilege escalation
+(`allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`,
+`runAsNonRoot: true`). Only `/home/agent` (the PVC) is writable.
+
+`fsGroup: 1000` does **not** help: it re-groups *mounted volumes* at attach
+time, never image-baked files. So the in-pod operator has no path to
+hot-patch or maintain Hermes — which was needed to fix a real stall (below).
+
+### Motivating incident — the qwen36-a3b "announce then idle" stall
+
+1. Qwen3-A3B stochastically emits an intent-only message (*"Got it. Let me
+   wire everything up:"*) with `finish_reason=stop` and **no tool call**
+   (~5–20% of turns at ~16k ctx). Once one announce-only message is in
+   history, the model imitates it and the turn dies.
+2. Hermes v0.15.2 ships a countermeasure — when the model returns a
+   planning/ack message with no tool call, it injects
+   `[System: Continue now. Execute the required tool calls…]` and loops
+   (`agent/conversation_loop.py`, ~line 4183). **But it is gated on
+   `api_mode == "codex_responses"`**, so it never fires on the
+   OpenAI-compatible LiteLLM path Frank uses (`api_mode == "chat_completions"`).
+
+The countermeasure's detection heuristic
+(`agent.agent_runtime_helpers.looks_like_codex_intermediate_ack`) is fully
+provider-agnostic — it inspects only message structure and text. So
+widening the gate to also fire on `chat_completions` is safe and is the
+exact fix the issue calls for.
+
+---
+
+## Decisions (from the operator Q&A)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| Q1 | Write-access approach | **Option 1+2: PVC-resident venv.** The live Hermes venv lives on the `/home/agent` PVC (uid-1000 owned, writable). Patches persist across pod restarts. |
+| Q2 | Scope | **Also bake the auto-continue patch** into the image so the qwen stall is fixed permanently, not just made patchable. |
+| Q3 | Cross-repo delivery | **agent-images PR now** (the fix). **frank pin-bump + runbook + blog back-loaded** as a manual phase the operator runs via `/bump-image` *after* agent-images merges and CI publishes the new commit-SHA-tagged image. |
+
+### Reconciling Q1 with reality (recorded default)
+
+The Q1 preview said "minimal image, no baked venv; installer creates the venv
+on first boot." Two facts make a *pure* runtime-install fragile:
+
+- A venv cannot be baked directly at `/home/agent/.local/opt/hermes-agent` —
+  the PVC mount at `/home/agent` **shadows** anything baked under it
+  (documented gotcha: "PVC mounts at /home/agent hide all image-baked files").
+- Installing fresh from PyPI on every first boot needs network at pod start,
+  is slow, non-reproducible, and risks Falco "new binary" noise.
+
+**Robust interpretation (the design below):** the image bakes a **relocatable
+seed venv** at `/opt/hermes-agent` (a read-only build artifact, NOT the live
+runtime). On first boot a cont-init hook `cp -a`'s the seed onto the PVC at
+`/home/agent/.local/opt/hermes-agent` — the *live* venv. This satisfies the
+operator's intent (venv on PVC, uid-1000-writable, patches persist) while
+staying offline, deterministic, and fast. If the operator wants a true
+zero-baked-venv runtime install instead, that is a flag on plan/PR review.
+
+**Relocatability is proven, not assumed:** `uv venv --relocatable` writes
+console scripts with a `#!/bin/sh` polyglot shebang that re-execs the venv
+python by *relative* path; a `cp -a` to a new directory runs unchanged
+(verified locally 2026-06-07: relocatable venv copied to a new path ran its
+console entry-point correctly). The base interpreter path (`pyvenv.cfg
+home =`) stays stable because the image is immutable.
+
+---
+
+## Solution — agent-images (primary PR)
+
+All changes in `derio-net/agent-images`, directory `hermes-agent-shell/`.
+
+### 1. Auto-continue patch (Q2)
+
+New file `hermes-agent-shell/patches/hermes-autocontinue-chat-completions.patch`
+(follows the existing `ruflo-server/patches/` idiom). It widens one gate in
+`agent/conversation_loop.py`:
+
+```diff
+                 if (
+-                    agent.api_mode == "codex_responses"
++                    agent.api_mode in ("codex_responses", "chat_completions")
+                     and agent.valid_tool_names
+                     and codex_ack_continuations < 2
+                     and agent._looks_like_codex_intermediate_ack(
+```
+
+`codex_ack_continuations < 2` caps the auto-continue at 2 injections/turn
+(unchanged) so the widening cannot loop unboundedly. The variable name stays
+`codex_ack_continuations` (renaming is out of scope — minimal patch).
+
+### 2. Dockerfile — relocatable seed venv + apply patch + version marker
+
+Replace the current single `RUN uv venv … && uv pip install …` (lines 44–48)
+with a build that:
+
+- `uv venv --relocatable --python 3.11 /opt/hermes-agent`
+- `uv pip install --python /opt/hermes-agent/bin/python "hermes-agent==${HERMES_VERSION}"`
+- copies `patches/` into the build context and applies the patch against the
+  installed `site-packages/agent/conversation_loop.py`
+  (`patch -p1 --forward` or `git apply`), failing the build if it does not
+  apply cleanly (catches a silent upstream-refactor drift on the next bump)
+- writes a **seed-version marker** `/opt/hermes-agent/.seed-version`
+  containing `${HERMES_VERSION}+autocontinue1` (bump the suffix whenever the
+  patch set changes)
+- repoints the launcher symlink to the **PVC** path:
+  `ln -sf /home/agent/.local/opt/hermes-agent/bin/hermes /usr/local/bin/hermes`
+  (the first-boot hook guarantees the target exists before any login shell)
+- `chown -R ${AGENT_UID}:${AGENT_GID} /opt/hermes-agent` *inside the same RUN*
+  (so the seed copies cleanly as uid 1000; same-layer chown = no duplication)
+
+`hermes --version` can no longer run at build time against the symlink (its
+target is the not-yet-seeded PVC path). Smoke validation moves to the
+post-first-boot assertions (below); the build instead asserts
+`/opt/hermes-agent/bin/hermes --version` directly against the seed.
+
+### 3. First-boot seed hook — `rootfs/etc/cont-init.d/35-hermes-venv-seed`
+
+Runs in s6 cont-init (as uid 1000, the pod user). Numbered `35` so it
+precedes the inventory installer (`40-shell-inventory`) and the MOTD
+profile.d scripts that may reference the live `hermes`. Logic:
+
+```sh
+SEED=/opt/hermes-agent
+LIVE=/home/agent/.local/opt/hermes-agent
+want="$(cat "$SEED/.seed-version")"
+have="$(cat "$LIVE/.seed-version" 2>/dev/null || true)"
+if [ "$want" != "$have" ]; then
+    rm -rf "$LIVE.new"
+    mkdir -p "$(dirname "$LIVE")"
+    cp -a "$SEED" "$LIVE.new"         # relocatable → runs at the new path
+    rm -rf "$LIVE"
+    mv "$LIVE.new" "$LIVE"            # atomic-ish swap on the PVC
+fi
+```
+
+- **Version-aware** so an image/Hermes bump re-seeds (replacing the stale
+  PVC venv + carrying the new baked patch). Equal versions = no-op, which
+  **preserves any in-pod hot-patches** the operator made — the whole point.
+- `cp -a` preserves perms; the copy is created by uid 1000 on the PVC, so it
+  is uid-1000-owned and writable. `hermes update` / site-packages edits work
+  in place and survive restarts.
+- Idempotent; fail-loud to the cont-init log if `cp` fails (don't fake-succeed).
+
+### 4. Smoke tests — `.github/workflows/build.yaml` (`smoke-test-hermes-agent-shell`)
+
+Extend the existing job. After the container is up and `cont-init` ran:
+
+- `docker exec has-smoke test -w /home/agent/.local/opt/hermes-agent/bin/python`
+  — uid 1000 can write the live venv.
+- `docker exec has-smoke hermes --version` — the PATH launcher resolves
+  through the symlink → PVC venv and runs (proves relocatable copy works).
+- `docker exec has-smoke test -O /home/agent/.local/opt/hermes-agent/bin/hermes`
+  — owned by the calling uid (1000).
+- **Patch assertion:** grep the *live* `conversation_loop.py` for
+  `("codex_responses", "chat_completions")` — the baked patch is present.
+- **Re-seed assertion:** write a sentinel into the live venv, bump nothing
+  and re-run the hook → sentinel survives (same-version no-op); then simulate
+  a version bump (overwrite the live `.seed-version`) and re-run → venv
+  replaced. (Kept lightweight; the core guarantee is the version compare.)
+
+### 5. bats unit tests — `hermes-agent-shell/tests/`
+
+New `test_venv_seed.bats` exercising the hook script's branch logic with a
+fake `$SEED`/`$LIVE` (tmpdirs): first-boot seeds, same-version no-ops and
+preserves a sentinel, version-mismatch re-seeds. Pure shell, no Docker.
+
+### Files touched (agent-images)
+
+```
+hermes-agent-shell/Dockerfile
+hermes-agent-shell/patches/hermes-autocontinue-chat-completions.patch   (new)
+hermes-agent-shell/rootfs/etc/cont-init.d/35-hermes-venv-seed           (new)
+hermes-agent-shell/tests/test_venv_seed.bats                            (new)
+hermes-agent-shell/README.md   (venv now PVC-resident; document seed/first-boot)
+.github/workflows/build.yaml   (extend smoke-test-hermes-agent-shell)
+```
+
+### Integration note — the inventory `hermes update` reconcile
+
+`install-inventory.sh` reconciles a pinned harness by calling
+`hermes update` (its CLI self-update). Against the old **root-owned** seed
+this could not write the venv — one of the very frictions #496 names. With
+the venv now PVC-resident and uid-1000-owned, `hermes update` writes in
+place and persists. No code change needed here; the seed design fixes this
+path as a side effect. (Whether upstream Hermes ships an `update` subcommand
+is a pre-existing question, untouched by this work.)
+
+### Spec-review findings (verified against source, 2026-06-07)
+
+- ✅ The LiteLLM BYOK path resolves to `api_mode == "chat_completions"`:
+  `hermes_cli/providers.determine_api_mode` falls through to the
+  `"chat_completions"` default for a custom provider on
+  `http://litellm.litellm.svc:4000/v1` (no anthropic/kimi/openai/bedrock
+  host match). The patch target is correct.
+- ✅ `looks_like_codex_intermediate_ack` (in `agent.agent_runtime_helpers`)
+  inspects only message structure/text — provider-agnostic, safe to widen.
+- ✅ cont-init hooks use `#!/command/with-contenv bash` and run as uid 1000
+  (s6 v3 non-root). `35-` precedes `40-shell-inventory`, so the live venv
+  exists before the inventory installer / MOTD reference `hermes`.
+- ✅ No rootfs/profile.d script hardcodes `/opt/hermes-agent` on PATH; the
+  `/usr/local/bin/hermes` symlink is the only launcher. Repointing it to the
+  PVC path is sufficient.
+- ✅ Relocatable-venv copy proven locally (`uv venv --relocatable` + `cp -a`
+  runs at the new path).
+
+---
+
+## Solution — frank (back-loaded, post-merge, manual)
+
+Cannot run until agent-images merges and CI publishes
+`ghcr.io/derio-net/hermes-agent-shell:<new-agent-images-sha>`. The operator
+runs these after the agent-images PR merges:
+
+1. **Bump the pin** — `/bump-image hermes-agent-shell <new-sha>` updates
+   `apps/hermes-agent-shell/manifests/deployment.yaml:38`, watches the
+   ArgoCD rollout (`Recreate` strategy → brief downtime = image pull), and
+   verifies the pod comes up.
+2. **Runbook gotcha** — one-liner in `agents/rules/frank-gotchas.md`
+   (Agent shells section) + full prose in
+   `docs/runbooks/frank-gotchas/agent-shells.md`: the Hermes venv is now
+   PVC-resident (`/home/agent/.local/opt/hermes-agent`), seeded from a
+   relocatable image seed on first boot, version-gated re-seed on image bump;
+   in-pod patches persist but are superseded by an image bump.
+3. **Blog (retroactive, fix/extension)** — update the existing
+   hermes-agent-shell building + operating posts with the PVC-venv note and
+   the auto-continue fix; **no new post** (fix/extension workflow).
+
+This phase ships in the frank PR **deliberately unimplemented**, marked for
+the operator.
+
+---
+
+## Out of scope / rejected
+
+- **Option 3 (sudo + `allowPrivilegeEscalation: true`)** — the issue itself
+  judges it overkill; biggest blast radius. Not pursued.
+- **PYTHONPATH shadow-copy wrapper** — the fragile workaround the issue names;
+  superseded by the PVC venv.
+- **Renaming `codex_ack_continuations`** — cosmetic; keep the patch minimal.
+
+---
+
+## Test Plan (post-merge — operator-driven)
+
+Run after the frank pin-bump rolls the new image onto the pod.
+
+1. **Writability** — `kubectl exec -n hermes-agent-shell deploy/hermes-agent-shell -- \
+   sh -c 'ls -ld /home/agent/.local/opt/hermes-agent && touch /home/agent/.local/opt/hermes-agent/.wtest && rm /home/agent/.local/opt/hermes-agent/.wtest && echo WRITABLE'`
+   → expect `WRITABLE`, dir owned by uid 1000.
+2. **hermes runs from PVC** — `kubectl exec … -- hermes --version` returns
+   the version; `kubectl exec … -- readlink -f $(command -v hermes)` resolves
+   under `/home/agent/.local/opt/hermes-agent`.
+3. **Patch is live** — `kubectl exec … -- grep -n '"codex_responses", "chat_completions"' \
+   /home/agent/.local/opt/hermes-agent/lib/python3.11/site-packages/agent/conversation_loop.py`
+   returns the widened gate.
+4. **Persistence across restart** — write a sentinel into the live venv,
+   `kubectl rollout restart deploy/hermes-agent-shell`, confirm the sentinel
+   survives (same-version no-op) and `hermes` still runs.
+5. **Stall fixed (behavioral)** — replay the operator's session-matrix repro
+   (the `/tmp` scripts referenced in the issue) against the LiteLLM path on
+   `qwen36-a3b-64k`; confirm an announce-only turn now triggers the
+   `[System: Continue now…]` injection and the agent proceeds instead of
+   idling.


### PR DESCRIPTION
Closes #496 (paired with **agent-images PR [derio-net/agent-images#110](https://github.com/derio-net/agent-images/pull/110)**, which carries the actual image fix).

## Summary

The `agent` user (uid 1000) in `hermes-agent-shell` had no way to patch the root-owned `/opt/hermes-agent` venv. This frank PR carries the **design spec + implementation plan**; the image change ships in agent-images#110.

Operator-chosen design (Q&A):
1. **PVC-resident venv** — relocatable seed at `/opt/hermes-agent` → copied to `/home/agent/.local/opt/hermes-agent` (uid-1000 writable) on first boot via a version-aware `cont-init.d/35-hermes-venv-seed` hook; in-pod patches persist across restarts.
2. **Baked auto-continue patch** — widens Hermes' announce-only countermeasure gate to fire on the LiteLLM `chat_completions` path, permanently fixing the qwen36-a3b "announce then idle" stall.

## Artifacts
- Spec: `docs/superpowers/specs/2026-06-07--orch--hermes-agent-shell-pvc-venv-design.md`
- Plan: `docs/superpowers/plans/2026-06-07--orch--hermes-agent-shell-pvc-venv/` (Phase 1 complete → agent-images#110; Phase 2 back-loaded)

## Review findings & fixes (this run)
- **Spec review (verified against Hermes 0.15.2 source):** confirmed the LiteLLM BYOK path resolves to `api_mode == "chat_completions"` (`determine_api_mode` default) — the patch target is correct; the ack heuristic is provider-agnostic; cont-init runs as uid 1000 with `#!/command/with-contenv bash`; no rootfs script hardcodes `/opt/hermes-agent` on PATH; the inventory `hermes update` reconcile now works (writable venv) instead of failing.
- **Relocatability de-risked empirically:** built a real relocatable hermes-0.15.2 seed, applied the patch, `cp -a`'d to a new path, ran `hermes --version` from the copy with the patch intact.
- **Smoke-test fix:** `test -w $LIVE/bin/python` would follow the symlink to the root-owned base interpreter and mislead → assert writability on the venv dir + a real site-packages file instead.
- **Build-env fix:** `patch` is not in the base image → switched the build to `git apply` (git is present; zero-fuzz, fails on drift).
- **Scope-discipline deviations:** the patch's automated gate is the build `git apply` + smoke grep (not a network-flaky wheel-download test); the seed-hook bats is a local dev test with CI teeth via the docker smoke test; not wiring the pre-existing orphaned bats into CI (env-dependent, out of scope).

## ⚠️ Phase 2 — back-loaded, UNIMPLEMENTED (operator pushes to this PR)
Can only run after agent-images#110 merges and CI publishes `ghcr.io/derio-net/hermes-agent-shell:<new-sha>`:
1. `/bump-image hermes-agent-shell <new-sha>` — update `apps/hermes-agent-shell/manifests/deployment.yaml` pin + watch the ArgoCD `Recreate` rollout.
2. Runbook gotcha (`frank-gotchas.md` + `agent-shells.md`): PVC-resident venv, version-gated re-seed, baked patch.
3. Retroactive blog update to the existing hermes building/operating posts (fix/extension — no new post).

## Test Plan (post-merge — operator-driven)
After the pin-bump rolls the new image onto the pod:
1. **Writability** — `kubectl exec -n hermes-agent-shell deploy/hermes-agent-shell -- sh -c 'touch /home/agent/.local/opt/hermes-agent/.wtest && rm ... && echo WRITABLE'` (dir owned by uid 1000).
2. **hermes from PVC** — `kubectl exec … -- hermes --version`; `readlink -f $(command -v hermes)` resolves under `/home/agent/.local/opt/hermes-agent`.
3. **Patch live** — `grep '"codex_responses", "chat_completions"' .../agent/conversation_loop.py`.
4. **Persistence** — write a sentinel into the live venv, `kubectl rollout restart`, confirm it survives (same-version no-op) and `hermes` still runs.
5. **Stall fixed** — replay the operator's session-matrix repro against `qwen36-a3b-64k`; confirm an announce-only turn now triggers `[System: Continue now…]` and the agent proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)