### PR TITLE
chore(obs): health-bridge blind-state — Phase 4 verified, status Deployed

### DIFF
--- a/docs/superpowers/plans/2026-06-08--obs--health-bridge-blind-state/04.yaml
+++ b/docs/superpowers/plans/2026-06-08--obs--health-bridge-blind-state/04.yaml
@@ -36,18 +36,18 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-08T06:44:33+00:00'
       note: null
     P4.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-08T06:44:35+00:00'
       note: null
     P4.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-08T06:44:37+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-08T06:44:38+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/specs/2026-06-08--obs--health-bridge-blind-state-design.md
+++ b/docs/superpowers/specs/2026-06-08--obs--health-bridge-blind-state-design.md
@@ -2,7 +2,7 @@
 
 **Layer:** obs (fix/extension of the health-bridge layer)
 **Date:** 2026-06-08
-**Status:** ready
+**Status:** Deployed
 **Code repo:** `derio-net/health-bridge` (Go) — `bridge.go`, `github.go`, `bridge_test.go`
 **Deploy/docs repo:** `derio-net/frank` — `apps/health-bridge/`, blog Layer 23/16
 
@@ -10,7 +10,7 @@
 
 | Plan | Target repo | Slug | Status |
 |------|-------------|------|--------|
-| 2026-06-08--obs--health-bridge-blind-state | `derio-net/frank` | `2026-06-08--obs--health-bridge-blind-state` | — |
+| 2026-06-08--obs--health-bridge-blind-state | `derio-net/frank` | `2026-06-08--obs--health-bridge-blind-state` | Deployed |
 
 ## Motivation — 2026-06-08 power-outage incident
 


### PR DESCRIPTION
Closes out `2026-06-08--obs--health-bridge-blind-state` (Phase 4/4).

- ArgoCD rolled health-bridge to `v0.4.0` (pod `659d978778`, ready).
- **Cross-alertname heal verified in prod:** smoke bug `frank-ops#49` (titled `[Bug] smoke-blind is dead`) was closed by a `resolved` under the *different* alertname `Phase4 Smoke Different Name` — the exact path that was impossible pre-v0.4.0.
- Plan: all 4 phases complete; spec **Status: Deployed**.

No `# manual-operation` blocks → no runbook sync needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)