### PR TITLE
feat(agents): retire clawdia PAT fallback — secure-agent-pod uses only the App token

### DIFF
--- a/apps/secure-agent-pod/manifests/externalsecret-github-token.yaml
+++ b/apps/secure-agent-pod/manifests/externalsecret-github-token.yaml
@@ -12,20 +12,14 @@ spec:
     name: agent-secrets-tier2
     creationPolicy: Owner
     deletionPolicy: Retain
+  # GITHUB_TOKEN is intentionally NOT sourced here. The agent's GitHub credential
+  # is now a short-lived GitHub App installation token minted by ESO
+  # (clustergenerator-github-app.yaml → externalsecret-github-app-token.yaml),
+  # mounted as a live-updated file at /var/run/github/token and read by the
+  # in-pod git credential helper + bashrc. The clawdia owner PAT (Infisical key
+  # GITHUB_SECURE_AGENT_POD) is retired; it should be deleted in Infisical and the
+  # clawdia account demoted owner→member.
   data:
-    # TRANSITION: GITHUB_TOKEN (clawdia owner PAT) is retained here as the
-    # fallback during cutover. The new path mints a short-lived GitHub App token
-    # (clustergenerator-github-app.yaml → externalsecret-github-app-token.yaml,
-    # mounted as a live-updated file); the in-pod credential helper prefers the
-    # file and falls back to this env value. REMOVE this entry (and retire
-    # Infisical key GITHUB_SECURE_AGENT_POD) only AFTER the App-token path is
-    # verified live — then demote clawdia.
-    - secretKey: GITHUB_TOKEN
-      remoteRef:
-        key: GITHUB_SECURE_AGENT_POD
-        conversionStrategy: Default
-        decodingStrategy: None
-        metadataPolicy: None
     - secretKey: TELEGRAM_BOT_TOKEN
       remoteRef:
         key: KALI_C2_TELEGRAM_BOT_TOKEN


### PR DESCRIPTION
## Retire the clawdia PAT fallback

The GitHub App installation-token path is **verified live, including a rotation cycle**:
- pod Running on `c084c4f1`; `agent-github-token` minted; `/var/run/github/token` populated; `git ls-remote` OK via the file-aware credential helper.
- ESO re-minted at the 45 m interval (`secret-created 12:53:35` → `refreshTime 13:38:35`), so token rotation works.

So drop `GITHUB_TOKEN` (the clawdia owner PAT, Infisical `GITHUB_SECURE_AGENT_POD`) from the tier2 ExternalSecret. The agent now authenticates **solely** with the short-lived App token.

### Safety
- The tier2 Secret keeps all its other keys (Telegram/Gemini/Grafana/R2/VK/Notion) — no empty-`data` issue.
- The running pod's `envFrom` `GITHUB_TOKEN` (old clawdia value) lingers until the next roll, but it's **unused** — the credential helper + bashrc read the App-token file. It's gone entirely on the next restart. No forced roll needed.

### Follow-ups (operator)
- Retire Infisical key `GITHUB_SECURE_AGENT_POD` (nothing pulls it after this merge).
- **Demote `clawdia-ai-assistant` owner→member on both orgs + revoke its PAT** (needs `admin:org`/UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
