### PR TITLE
feat(cicd): live-mirror-sync Tekton trigger for agentic-stoa/companies

### DIFF
--- a/apps/tekton/tasks/fire-paperclip-webhook.yaml
+++ b/apps/tekton/tasks/fire-paperclip-webhook.yaml
@@ -1,0 +1,113 @@
+# Signs and POSTs the Paperclip hmac_sha256 webhook fire request (frank#444).
+#
+# Vendored from agentic-stoa/companies@b61b374d stoa/ci/tekton/live-mirror-sync/
+# task-fire-webhook.yaml — that repo stays the Stoa-canonical source of truth
+# for the *contract*; this copy is the cluster-deployable adaptation.
+#
+# Divergences from upstream (all frank-side constraints):
+#   - python:3.12-alpine + stdlib instead of wolfi-base + runtime `apk add
+#     jq openssl curl`: runtime package installs write to the container upper
+#     layer and trip Falco's Critical "Drop and execute new binary in
+#     container" rule on every TaskRun (pages Telegram). Python stdlib covers
+#     json/hmac/http with zero installs.
+#   - hardened securityContext per this repo's task convention; HOME set
+#     explicitly (runAsUser 65534 resolves HOME=/, read-only — see
+#     frank-gotchas Tekton section).
+#
+# Signing contract (matches Paperclip firePublicTrigger, unchanged):
+#   X-Paperclip-Signature = "sha256=" + hex HMAC-SHA256(secret, "<ts>." + rawBody)
+#   X-Paperclip-Timestamp = unix seconds   (replay window 300 s)
+# The signature MUST cover the exact request body bytes (server HMACs rawBody).
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: fire-paperclip-webhook
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: stoa
+spec:
+  params:
+    - name: gitsha
+      type: string
+    - name: gitref
+      type: string
+    - name: reponame
+      type: string
+  steps:
+    - name: fire
+      image: python:3.12-alpine
+      env:
+        - name: HOME
+          value: /tekton/home
+        - name: FIRE_URL
+          valueFrom:
+            secretKeyRef:
+              name: live-mirror-paperclip
+              key: fireUrl
+        - name: WEBHOOK_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: live-mirror-paperclip
+              key: webhookSecret
+        - name: GIT_SHA
+          value: $(params.gitsha)
+        - name: GIT_REF
+          value: $(params.gitref)
+        - name: REPO_NAME
+          value: $(params.reponame)
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 65534
+        capabilities:
+          drop: ["ALL"]
+        seccompProfile:
+          type: RuntimeDefault
+      script: |
+        #!/usr/bin/env python3
+        import hashlib, hmac, json, os, sys, time, urllib.error, urllib.request
+
+        fire_url = os.environ["FIRE_URL"]
+        secret = os.environ["WEBHOOK_SECRET"].encode()
+
+        ts = str(int(time.time()))
+        # Compact separators => stable raw bytes; the signature covers exactly
+        # what is sent.
+        body = json.dumps(
+            {
+                "source": "gitea-tekton",
+                "repo": os.environ["REPO_NAME"],
+                "ref": os.environ["GIT_REF"],
+                "sha": os.environ["GIT_SHA"],
+            },
+            separators=(",", ":"),
+        ).encode()
+
+        sig = hmac.new(secret, ts.encode() + b"." + body, hashlib.sha256).hexdigest()
+
+        print(f"Firing live-mirror sync for {os.environ['GIT_SHA']} on {os.environ['GIT_REF']}")
+        req = urllib.request.Request(
+            fire_url,
+            data=body,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "X-Paperclip-Timestamp": ts,
+                "X-Paperclip-Signature": f"sha256={sig}",
+                "Idempotency-Key": f"live-mirror-{os.environ['GIT_SHA']}",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                code, payload = resp.status, resp.read()
+        except urllib.error.HTTPError as e:
+            code, payload = e.code, e.read()
+
+        print(f"Paperclip responded HTTP {code}")
+        if code != 202:
+            print(f"ERROR: webhook fire failed (HTTP {code})", file=sys.stderr)
+            sys.stderr.buffer.write(payload + b"\n")
+            sys.exit(1)
+
+        run = json.loads(payload)
+        print(f"run={run.get('id')} status={run.get('status')} issue={run.get('linkedIssueId')}")

--- a/apps/tekton/triggers/live-mirror-sync.yaml
+++ b/apps/tekton/triggers/live-mirror-sync.yaml
@@ -1,0 +1,118 @@
+# Live-mirror sync — gitea push (agentic-stoa/companies mirror, main) ->
+# Tekton TaskRun -> Paperclip hmac_sha256 webhook on routine 2f4d361b
+# (frank#444, Stoa-side STO-72/STO-75).
+#
+# Vendored from agentic-stoa/companies@b61b374d stoa/ci/tekton/live-mirror-sync/
+# {eventlistener,triggerbinding,triggertemplate}.yaml. Divergences from the
+# Stoa-canonical manifests (all frank-side, field-tested constraints):
+#   - namespace tekton-pipelines (this cluster's Tekton namespace; the issue
+#     guessed "tekton-triggers").
+#   - cel interceptor instead of the github interceptor: this gitea sends
+#     X-Gitea-Event, and the github ClusterInterceptor silently drops its
+#     webhooks (see frank-gotchas Tekton section + gitea-listener above it
+#     in this directory).
+#   - incoming-webhook HMAC verification omitted: the github interceptor was
+#     the only HMAC-capable interceptor and it can't be used (above). The
+#     EventListener service is ClusterIP-only — reachable only from inside
+#     the cluster — which is the same documented posture as the existing
+#     gitea-listener. The OUTGOING Paperclip HMAC signing is untouched.
+#     Consequence: the `live-mirror-gitea-webhook` secret from the upstream
+#     README is not needed; set a webhook secret on the gitea side anyway if
+#     you like — it is simply not validated here.
+#   - explicit repo filter (body.repository.full_name) since this listener
+#     exists only for the companies mirror; the shared gitea-listener
+#     deliberately excludes agentic-stoa/* (CI for those repos moved to the
+#     github-listener — this trigger is push-driven sync, not CI).
+#   - kubernetesResource nodeSelector pc-1, matching the other listeners.
+#
+# A separate EventListener (rather than a new trigger on gitea-listener)
+# keeps the Stoa-routed concern isolated and matches the upstream design.
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: live-mirror-sync
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: stoa
+    stoa.routine/id: "2f4d361b"
+spec:
+  serviceAccountName: tekton-triggers-sa
+  triggers:
+    - name: companies-main-push
+      interceptors:
+        # Only fire on pushes to main of the companies mirror. Path-level
+        # filtering is intentionally omitted — the sync is idempotent and
+        # cheap, so firing on every main push is harmless (a clean sync
+        # reports "Would update: 0").
+        - ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                header.match('X-Gitea-Event', 'push') &&
+                body.repository.full_name == 'agentic-stoa/companies' &&
+                body.ref == 'refs/heads/main'
+      bindings:
+        - ref: live-mirror-sync
+      template:
+        ref: live-mirror-sync
+  resources:
+    kubernetesResource:
+      spec:
+        template:
+          spec:
+            nodeSelector:
+              kubernetes.io/hostname: pc-1
+---
+# Extracts the merge commit + ref + repo from the gitea push payload.
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: live-mirror-sync
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: stoa
+spec:
+  params:
+    - name: gitsha
+      value: $(body.after)
+    - name: gitref
+      value: $(body.ref)
+    - name: reponame
+      value: $(body.repository.full_name)
+---
+# Spawns a one-shot TaskRun that fires the Paperclip webhook.
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: live-mirror-sync
+  namespace: tekton-pipelines
+  labels:
+    app.kubernetes.io/part-of: stoa
+spec:
+  params:
+    - name: gitsha
+      description: Merge commit SHA on companies/main
+    - name: gitref
+      description: Pushed ref (refs/heads/main)
+    - name: reponame
+      description: Repository full name
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: TaskRun
+      metadata:
+        generateName: live-mirror-sync-
+        labels:
+          app.kubernetes.io/part-of: stoa
+          stoa.routine/id: "2f4d361b"
+      spec:
+        taskRef:
+          name: fire-paperclip-webhook
+        params:
+          - name: gitsha
+            value: $(tt.params.gitsha)
+          - name: gitref
+            value: $(tt.params.gitref)
+          - name: reponame
+            value: $(tt.params.reponame)
+        timeout: "0h5m0s"

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -486,6 +486,31 @@ operations:
   verify:
   - Infisical → ZOT_PUSH_PASSWORD exists
   status: pending
+- id: cicd-live-mirror-gitea-webhook
+  layer: cicd
+  app: tekton
+  plan: docs/superpowers/plans/2026-06-11--cicd--live-mirror-sync-trigger.md
+  when: After the live-mirror-sync EventListener is Synced/Healthy (el-live-mirror-sync Service exists)
+  why_manual: Gitea repo webhooks are instance state, not declarative; created via UI or API token
+  commands:
+  - 'Gitea (192.168.55.209:3000) → agentic-stoa/companies mirror → Settings → Webhooks → Add webhook → Gitea'
+  - 'Target URL: http://el-live-mirror-sync.tekton-pipelines.svc.cluster.local:8080 — POST, application/json, Push events, branch filter main'
+  - 'NOTE: webhook.ALLOWED_HOST_LIST must include *.svc.cluster.local (already required by gitea-listener). A webhook secret MAY be set but is not validated cluster-side (cel interceptor cannot HMAC; EventListener is ClusterIP-only).'
+  verify:
+  - kubectl -n tekton-pipelines get svc el-live-mirror-sync
+  - Gitea webhook delivery log shows 2xx from the EventListener on a real main push
+  status: pending
+- id: cicd-live-mirror-paperclip-secret
+  layer: cicd
+  app: tekton
+  plan: docs/superpowers/plans/2026-06-11--cicd--live-mirror-sync-trigger.md
+  when: Before first webhook fire — TaskRuns fail env resolution until the secret exists
+  why_manual: Secret value is rotated Stoa-side and delivered out-of-band (frank#444 §3a); bootstrap secrets are never ArgoCD-managed
+  commands:
+  - kubectl -n tekton-pipelines create secret generic live-mirror-paperclip --from-literal=fireUrl='http://192.168.55.212:3100/api/routine-triggers/public/31cbc6fb3c8ac34e3f25d677/fire' --from-literal=webhookSecret='<VALUE DELIVERED OUT-OF-BAND — DO NOT PASTE ANYWHERE>'
+  verify:
+  - kubectl -n tekton-pipelines get secret live-mirror-paperclip -o jsonpath='{.data.fireUrl}' | base64 -d
+  status: pending
 - id: cicd-pc1-role-label
   layer: cicd
   app: longhorn

--- a/docs/superpowers/plans/2026-06-11--cicd--live-mirror-sync-trigger.md
+++ b/docs/superpowers/plans/2026-06-11--cicd--live-mirror-sync-trigger.md
@@ -1,0 +1,93 @@
+# Live-Mirror Sync Trigger Implementation Plan
+
+> **For VK agents:** Use vk-execute to implement assigned phases.
+> **For local execution:** Use subagent-driven-development or executing-plans.
+> **For dispatch:** Use vk-dispatch to create Issues from this plan.
+
+**Goal:** Replace the daily `0 6 * * *` Paperclip schedule on routine `2f4d361b` with a push-driven trigger: a merge to the `agentic-stoa/companies` gitea mirror's `main` fires a Tekton TaskRun that POSTs Paperclip's hmac_sha256 public-trigger endpoint (frank#444, Stoa-side STO-72/STO-75).
+
+**Architecture:** A dedicated `live-mirror-sync` EventListener (cel interceptor: `X-Gitea-Event: push` + repo `agentic-stoa/companies` + ref `refs/heads/main`) in `tekton-pipelines` spawns a `fire-paperclip-webhook` TaskRun (python:3.12-alpine, stdlib-only HMAC signing — no runtime package installs, so Falco's EXE_UPPER_LAYER rule stays quiet). Manifests vendored from `agentic-stoa/companies@b61b374d stoa/ci/tekton/live-mirror-sync/` with frank-side adaptations documented in each file header. The existing daily schedule stays armed until the webhook path is observed end-to-end — no coverage gap.
+
+**Tech Stack:** Tekton Triggers v1beta1 (cel interceptor), Tekton Task v1, gitea webhooks, Paperclip public routine triggers (HMAC-SHA256), ArgoCD (`tekton-extras` app, recursive `apps/tekton/`).
+
+**Status:** In Progress
+
+---
+
+## Task 1: Vendor + adapt the Tekton manifests
+
+- [x] **Step 1:** `apps/tekton/tasks/fire-paperclip-webhook.yaml` — Task, python stdlib signing, hardened securityContext, `HOME=/tekton/home`
+- [x] **Step 2:** `apps/tekton/triggers/live-mirror-sync.yaml` — EventListener + TriggerBinding + TriggerTemplate, cel interceptor (github interceptor silently drops gitea webhooks — see frank-gotchas Tekton), nodeSelector pc-1
+- [x] **Step 3:** Document divergences from the Stoa-canonical manifests in the file headers (namespace, interceptor, image, incoming-HMAC posture)
+
+## Task 2: Install the Paperclip trigger secret (operator)
+
+The HMAC value is rotated and delivered out-of-band by Stoa's CTO — it must never appear in git, issues, or chat (frank#444 §3a).
+
+```yaml
+# manual-operation
+id: cicd-live-mirror-paperclip-secret
+layer: cicd
+app: tekton
+plan: 2026-06-11--cicd--live-mirror-sync-trigger
+when: "Before first webhook fire — TaskRuns fail env resolution until the secret exists"
+why_manual: "Secret value is rotated Stoa-side and delivered out-of-band; bootstrap secrets are never ArgoCD-managed (repo principle)"
+commands: |
+  # fireUrl: cluster-internal Paperclip API base + the public trigger path.
+  # Paperclip LB is 192.168.55.212:3100 (frank-infrastructure.md).
+  kubectl -n tekton-pipelines create secret generic live-mirror-paperclip \
+    --from-literal=fireUrl='http://192.168.55.212:3100/api/routine-triggers/public/31cbc6fb3c8ac34e3f25d677/fire' \
+    --from-literal=webhookSecret='<VALUE DELIVERED OUT-OF-BAND — DO NOT PASTE ANYWHERE>'
+verify: |
+  kubectl -n tekton-pipelines get secret live-mirror-paperclip -o jsonpath='{.data.fireUrl}' | base64 -d
+status: pending
+```
+
+- [ ] **Step 1:** Receive the rotated HMAC value from Stoa's CTO (coordinate on frank#444)
+- [ ] **Step 2:** Create the secret per the manual-operation block
+- [ ] **Step 3:** Run `/sync-runbook` (done in this PR for the block itself; re-run if the block changes)
+
+## Task 3: Create the gitea webhook (operator)
+
+```yaml
+# manual-operation
+id: cicd-live-mirror-gitea-webhook
+layer: cicd
+app: tekton
+plan: 2026-06-11--cicd--live-mirror-sync-trigger
+when: "After the EventListener is Synced/Healthy (el-live-mirror-sync Service exists)"
+why_manual: "Gitea repo webhooks are instance state, not declarative; created via UI or API token"
+commands: |
+  # Gitea LB: 192.168.55.209:3000. Repo: the agentic-stoa/companies mirror.
+  # UI: Settings -> Webhooks -> Add webhook -> Gitea
+  #   Target URL: http://el-live-mirror-sync.tekton-pipelines.svc.cluster.local:8080
+  #   Method: POST, Content type: application/json
+  #   Trigger on: Push events, Branch filter: main
+  # NOTE: webhook.ALLOWED_HOST_LIST must include *.svc.cluster.local
+  # (frank-gotchas other-apps — already required by the existing gitea-listener).
+  # A webhook secret MAY be set but is not validated cluster-side (cel
+  # interceptor cannot HMAC; EventListener is ClusterIP-only — see the
+  # divergence note in apps/tekton/triggers/live-mirror-sync.yaml).
+verify: |
+  # Gitea: webhook delivery log shows 202/200 from the EventListener.
+  kubectl -n tekton-pipelines get svc el-live-mirror-sync
+status: pending
+```
+
+- [ ] **Step 1:** Add the webhook on the gitea mirror repo per the block
+- [ ] **Step 2:** Use gitea's "Test Delivery" — expect the cel filter to drop it (test payloads carry the real repo/ref, so a real merge is the true signal)
+
+## Task 4: End-to-end verification + handback (operator)
+
+- [ ] **Step 1:** Merge a test change to `agentic-stoa/companies` `main`; wait for the gitea mirror sync
+- [ ] **Step 2:** Confirm `kubectl -n tekton-pipelines get taskrun | grep live-mirror-sync-` shows a run; logs end with `Paperclip responded HTTP 202` and `run=… issue=…`
+- [ ] **Step 3:** Confirm the Paperclip run issue under routine `2f4d361b` carries the changed-file report
+- [ ] **Step 4:** Report the 202/run-issue signal back on frank#444 (Stoa CTO then retires the `0 6 * * *` schedule)
+- [ ] **Step 5:** Set this plan's `**Status:**` to `Deployed`
+
+## Post-Deploy Checklist
+
+Extension of the existing cicd layer, internal-only (no public domain, no homepage tile): skip exposure and blog posts per the fix/extension workflow. New gotchas, if any surface during verification, go to `agents/rules/frank-gotchas.md` + `docs/runbooks/frank-gotchas/tekton.md`.
+
+- [x] Runbook sync (`/sync-runbook`) — included in this PR
+- [ ] Plan status update on verification (Task 4, Step 5)


### PR DESCRIPTION
Implements the GitOps half of #444 (does NOT close it — end-to-end verification is the issue's acceptance gate and stays open until observed).

## What ships

Vendored from `agentic-stoa/companies@b61b374d stoa/ci/tekton/live-mirror-sync/` into the `tekton-extras` app (recursive `apps/tekton/`):

- `apps/tekton/triggers/live-mirror-sync.yaml` — dedicated EventListener + TriggerBinding + TriggerTemplate
- `apps/tekton/tasks/fire-paperclip-webhook.yaml` — TaskRun body that HMAC-signs and POSTs the Paperclip public-trigger fire URL
- plan `2026-06-11--cicd--live-mirror-sync-trigger` + runbook sync carrying the two **manual-operation** blocks left for you: the `live-mirror-paperclip` secret (HMAC value arrives out-of-band from Stoa's CTO — never in git/issues) and the gitea webhook on the mirror repo

## Divergences from the Stoa-canonical manifests (all field-tested frank constraints, documented in file headers)

1. **Namespace `tekton-pipelines`** — the issue assumed `tekton-triggers`; that's not this cluster's layout.
2. **cel interceptor, not github** — our gitea's webhooks are silently dropped by the github ClusterInterceptor (X-Gitea-Event gotcha, same reason gitea-listener uses cel).
3. **Incoming-webhook HMAC omitted** — the github interceptor was the only HMAC-capable one (see 2). Same ClusterIP-only posture as the existing gitea-listener; the **outgoing** Paperclip HMAC signing is untouched. Consequence: upstream's `live-mirror-gitea-webhook` secret isn't needed. Flagged for Stoa's CTO on the issue to veto if unacceptable.
4. **`python:3.12-alpine` + stdlib** instead of wolfi-base + runtime `apk add jq openssl curl` — runtime installs would page Telegram via Falco's Critical EXE_UPPER_LAYER rule on every TaskRun. Signing contract preserved byte-for-byte (`sha256=" + HMAC(secret, ts + "." + rawBody)`, compact JSON, Idempotency-Key).
5. **Dedicated EventListener** — the shared gitea-listener deliberately filters out `agentic-stoa/*`; separate listener matches the upstream design and keeps the Stoa concern isolated.
6. Hardened securityContext + `HOME=/tekton/home` (65534 gotcha), nodeSelector pc-1 like the other listeners.

## Validation

- All three trigger docs + Task YAML parse; embedded Python AST-parses.
- Runbook merge keeps the cicd slice alphabetically sorted; both new ops `status: pending`.

## After merge (operator, per the plan/runbook)

1. `live-mirror-paperclip` secret (out-of-band value) → 2. gitea webhook on the mirror → 3. test merge to `companies` main → expect `live-mirror-sync-*` TaskRun logging `HTTP 202` + Paperclip run issue → 4. report the signal on #444 (Stoa retires the cron).

🤖 Generated with [Claude Code](https://claude.com/claude-code)