### PR TITLE
feat(edge): ESO ExternalSecrets for live-mirror-sync trigger (#444)

### DIFF
--- a/apps/tekton/manifests/externalsecret-live-mirror-gitea-webhook.yaml
+++ b/apps/tekton/manifests/externalsecret-live-mirror-gitea-webhook.yaml
@@ -1,0 +1,25 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: live-mirror-gitea-webhook
+  namespace: tekton-pipelines
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: live-mirror-gitea-webhook
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    # Shared secret for the live-mirror-sync EventListener's `github` interceptor
+    # to verify the incoming gitea webhook HMAC. Free-choose random value
+    # (openssl rand -hex 32); the SAME value is configured on the gitea repo
+    # webhook for the agentic-stoa/companies mirror (push events).
+    - secretKey: webhookSecret
+      remoteRef:
+        key: /agentic-stoa/STOA_LIVE_MIRROR_GITEA_WEBHOOK_SECRET
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/apps/tekton/manifests/externalsecret-live-mirror-paperclip.yaml
+++ b/apps/tekton/manifests/externalsecret-live-mirror-paperclip.yaml
@@ -1,0 +1,36 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: live-mirror-paperclip
+  namespace: tekton-pipelines
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: live-mirror-paperclip
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    # The Paperclip routine-trigger hmac_sha256 secret. NOT free-choose: it must
+    # equal the secret stored on routine 2f4d361b's trigger
+    # (64c2aad2-b28c-48f4-b7bf-ded2785275db). Obtained by rotating that trigger
+    # (POST /api/routine-triggers/{id}/rotate-secret) and storing the RETURNED
+    # value here. The Task `fire-paperclip-webhook` signs the fire request with it
+    # (X-Paperclip-Signature) and Paperclip verifies against the trigger secret.
+    - secretKey: webhookSecret
+      remoteRef:
+        key: /agentic-stoa/STOA_LIVE_MIRROR_HMAC_SECRET
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
+    # Cluster-internal Paperclip fire URL (not secret, kept in the same k8s secret
+    # because the Task reads both via secretKeyRef):
+    #   <internal-paperclip-base>/api/routine-triggers/public/31cbc6fb3c8ac34e3f25d677/fire
+    - secretKey: fireUrl
+      remoteRef:
+        key: /agentic-stoa/STOA_LIVE_MIRROR_FIRE_URL
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
## What

Frank-side ESO `ExternalSecret`s that surface the three Infisical `/agentic-stoa` keys into the `tekton-pipelines` namespace for the `agentic-stoa/companies` **live-mirror-sync** Tekton trigger (gh #444). Mirrors the existing `stoa-github-webhook-secret` / `stoa-github-mirror` pattern exactly — same `infisical` `ClusterSecretStore`, same absolute-path convention.

- `externalsecret-live-mirror-paperclip.yaml` → k8s Secret `live-mirror-paperclip` (keys `webhookSecret`, `fireUrl`), consumed by the Stoa Task `fire-paperclip-webhook`.
- `externalsecret-live-mirror-gitea-webhook.yaml` → k8s Secret `live-mirror-gitea-webhook` (key `webhookSecret`), consumed by the EventListener's `github` interceptor.

This is **Frank's own secret glue** — it does **not** vendor the Stoa Tekton manifests (EventListener/TriggerBinding/TriggerTemplate/Task). Those stay canonical in `agentic-stoa/companies` and are applied separately from the gitea mirror source (next PR).

## Requires (before merge, to avoid ESO SecretSyncError)

Populate these in Infisical (`frank-cluster-iwpg`, env `prod`):

| Infisical key | Value |
|---|---|
| `/agentic-stoa/STOA_LIVE_MIRROR_HMAC_SECRET` | Paperclip routine `2f4d361b` trigger's `hmac_sha256` secret — **rotate** trigger `64c2aad2-b28c-48f4-b7bf-ded2785275db` and store the returned value (not free-choose) |
| `/agentic-stoa/STOA_LIVE_MIRROR_GITEA_WEBHOOK_SECRET` | `openssl rand -hex 32` (also set on the gitea webhook) |
| `/agentic-stoa/STOA_LIVE_MIRROR_FIRE_URL` | `<internal-paperclip-base>/api/routine-triggers/public/31cbc6fb3c8ac34e3f25d677/fire` |

## Next (not in this PR)

- ArgoCD Application sourcing the gitea mirror at `stoa/ci/tekton/live-mirror-sync` (no vendoring).
- gitea webhook on the `companies` mirror → EventListener Service.
- End-to-end verify (test merge → `202` + run-issue) before retiring the cron.
- Verify the `github` interceptor actually fires on gitea's `X-Gitea-Event` (Frank has a documented prior incident — may need a `cel` swap PR upstream).

Refs derio-net/frank#444
