### PR TITLE
feat(cicd): hum-ci — root workspace check gate + resources for @hum/mobile

### DIFF
--- a/apps/tekton/pipelines/hum-ci.yaml
+++ b/apps/tekton/pipelines/hum-ci.yaml
@@ -123,31 +123,24 @@ spec:
               - {name: HOME, value: /tekton/home}
               - {name: npm_config_cache, value: /tekton/home/.npm}
             computeResources:
-              requests: {cpu: 500m, memory: 1Gi}
-              limits:   {memory: 2Gi}
+              # The @hum/mobile workspace runs an RN/jest-expo suite: heavier
+              # transforms than the node workspaces (jest maxWorkers is capped
+              # at 2 in-repo for exactly this footprint).
+              requests: {cpu: "1", memory: 2Gi}
+              limits:   {memory: 4Gi}
             script: |
               #!/bin/sh
-              # `set -eu` doesn't propagate into && / || chains. We use
-              # `npm run <script> --if-present`, npm's canonical "run if
-              # defined, succeed silently otherwise" flag. This avoids the
-              # previous `has_script` heuristic which returned true for
-              # entries like `scripts.test: ""` and then crashed on
-              # "Missing script: test" — surfaced in the 2026-05-13 rework
-              # smoke against the @hum/shared workspace.
+              # npm-workspace monorepo: ONE root install, then the repo's own
+              # `check` gate (typecheck && lint && test fanned out via
+              # `--workspaces --if-present`). The previous per-directory
+              # `npm ci` shape built nested node_modules inside each
+              # workspace and could not resolve workspace deps like
+              # @hum/shared — the @hum/mobile workspace (added 2026-06-11)
+              # surfaces that immediately. `--if-present` remains the guard
+              # against empty script entries (2026-05-13 rework smoke).
               set -eu
-              run_in() {
-                d="$1"
-                echo "=== $d ==="
-                cd "$d"
-                if [ -f package-lock.json ]; then npm ci; else npm install; fi
-                npm run typecheck --if-present
-                npm run test --if-present
-                cd - >/dev/null
-              }
-              run_in .
-              for ws in backend shared; do
-                [ -f "$ws/package.json" ] && run_in "$ws"
-              done
+              npm ci
+              npm run check
   finally:
     # github-status — MANDATORY post (fails the run if the API call fails).
     - name: github-status-success


### PR DESCRIPTION
## Why

`agentic-stoa/hum` grew an **@hum/mobile** Expo workspace (stacked PRs agentic-stoa/hum#112–#114). The current `npm-test` step loops `for ws in backend shared` with a per-directory `npm ci` — that shape can't cover the new workspace (a nested install inside a workspace misses workspace deps like `@hum/shared`), so `tekton/ci` currently green-lights PRs whose mobile suite it never ran.

## What

- Replace the per-directory loop with **one root `npm ci` + `npm run check`** — the repo's own gate (typecheck && lint && test fanned out via `--workspaces --if-present`). New workspaces are covered automatically.
- Bump `npm-test` resources: limits `2Gi → 4Gi`, request `cpu: 1` — the RN/jest-expo suite is transform-heavy (the repo caps jest at `maxWorkers: 2` for exactly this footprint).
- `--if-present` semantics (the 2026-05-13 empty-script guard) are preserved by the root scripts themselves.

## Verification

Same commands green in the hum devcontainer against the stack head (89 mobile + 166 backend/shared tests). After merge, the next push to any open hum PR should show `tekton/ci` exercising all three workspaces — recommend re-running it on agentic-stoa/hum#114 as the smoke.

Requested in agentic-stoa/hum#111 (whose remaining scope — registry push, APK task, namespace/ingress — stays for the M8 phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)