### PR TITLE
fix(cicd): allow internal service FQDN through Paperclip host guard (gh #444)

### DIFF
--- a/apps/paperclip/manifests/configmap.yaml
+++ b/apps/paperclip/manifests/configmap.yaml
@@ -11,6 +11,13 @@ data:
   PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
   PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
   PAPERCLIP_PUBLIC_URL: "http://192.168.55.212:3100"
+  # Allow the in-cluster service FQDN through the private-hostname guard so the
+  # live-mirror-sync Tekton Task (gh #444) can POST to the routine-trigger fire
+  # endpoint via service DNS. The guard (enabled for private+authenticated mode)
+  # otherwise 403s any Host not in {public-URL host, loopback} — the Task signs
+  # correctly but never reaches firePublicTrigger. envFrom CM change does NOT
+  # auto-roll the pod; a rollout restart is required after sync.
+  PAPERCLIP_ALLOWED_HOSTNAMES: "paperclip-lb.paperclip-system.svc.cluster.local"
   # Opt out of upstream telemetry added in v2026.403.0.
   DO_NOT_TRACK: "1"
   PAPERCLIP_TELEMETRY_DISABLED: "1"


### PR DESCRIPTION
Fixes the 403 that blocked the live-mirror-sync end-to-end test.

## Root cause
The first real test merge to `agentic-stoa/companies` fired the full chain (GitHub→Gitea sync → Gitea webhook → EventListener → `TaskRun live-mirror-sync-*` → POST to Paperclip). Paperclip returned **HTTP 403** — but **not** from HMAC: signature failures throw 401. The 403 comes from `privateHostnameGuard`, which runs *before* `firePublicTrigger`:

- Gate is on (`exposure=private` + `mode=authenticated`).
- Allow-set = `PAPERCLIP_ALLOWED_HOSTNAMES` (empty) ∪ public-URL host (`192.168.55.212`) ∪ loopback.
- The Task POSTs to `Host: paperclip-lb.paperclip-system.svc.cluster.local` (the §3a cluster-internal fire URL) → not allow-listed → 403 before any signature check.

So the HMAC chain is correct (secret aligned, `HMAC(secret, "{ts}.{body}")` matches Paperclip's timestamped verify path); the only gap is the host allowlist.

## Fix
Add the in-cluster service FQDN to `PAPERCLIP_ALLOWED_HOSTNAMES`. Keeps the idiomatic service-DNS fire URL.

**Post-merge:** ArgoCD syncs the CM, then `kubectl -n paperclip-system rollout restart deploy/paperclip` (envFrom CM change does not auto-roll), then re-drive the test merge → expect 202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)