### PR TITLE
fix(tekton): hum-ci must test the PR commit + make failures self-explanatory

### DIFF
--- a/apps/tekton/pipelines/hum-ci.yaml
+++ b/apps/tekton/pipelines/hum-ci.yaml
@@ -14,6 +14,12 @@
 #   - github-status is mandatory (failure of the post fails the run);
 #     gitea-status is best-effort (failure-tolerant).
 #
+# Correctness (2026-06-14): pull-and-push now `git checkout --detach`es the
+# PR sha after cloning. Previously the clone left the working tree on the
+# default branch (main) and only the gitea PUSH used the sha — so the gates
+# ran against main, never the PR's own changes. Every PR check reflected
+# main's state. The checkout realigns the tested tree with the sha.
+#
 # Observability (2026-06-14, hum-ci-observability):
 #   The status the contributor sees on the PR was a bare `tekton/ci` =
 #   success/failure with NO link — a red check gave zero path to the logs,
@@ -96,9 +102,16 @@ spec:
               git config --global --add safe.directory '*'
 
               cd "$(workspaces.source.path)"
-              # Clone into ./repo — the test task uses this same subdir.
+              # Clone into ./repo — the check task uses this same subdir.
               git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/$(params.github-repo).git" repo
               cd repo
+
+              # Test the PR commit, not the default branch. `git clone` lands on
+              # the default-branch HEAD; without this checkout the gates ran
+              # against main and a PR's OWN changes were never exercised (the
+              # check would pass/fail purely on main's state). `clone` fetches
+              # all branch refs, so the PR head sha is already local.
+              git checkout --detach "$(params.sha)"
 
               REPO_NAME="$(echo "$(params.gitea-repo)" | awk -F/ '{print $NF}')"
               ORG_NAME="$(echo "$(params.gitea-repo)" | awk -F/ '{print $1}')"

--- a/apps/tekton/pipelines/hum-ci.yaml
+++ b/apps/tekton/pipelines/hum-ci.yaml
@@ -13,6 +13,19 @@
 #     Gitea hold byte-identical commits for the same content).
 #   - github-status is mandatory (failure of the post fails the run);
 #     gitea-status is best-effort (failure-tolerant).
+#
+# Observability (2026-06-14, hum-ci-observability):
+#   The status the contributor sees on the PR was a bare `tekton/ci` =
+#   success/failure with NO link — a red check gave zero path to the logs,
+#   forcing a local `npm run check` repro to find which gate failed. Two fixes:
+#     1. target-url: every status now deep-links to the PipelineRun page on the
+#        Tekton dashboard (see dashboard-base-url param), so a red check is one
+#        click from the step logs. (LAN-only URL — reachable on the homelab
+#        net/mesh, which is where the operator debugs from.)
+#     2. The monolithic `npm run check` step is split into named steps
+#        (install / typecheck / lint / test) so the dashboard shows WHICH gate
+#        failed at a glance, before opening any log.
+#   See docs/runbooks/ci-observability.md.
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
@@ -32,6 +45,10 @@ spec:
     - name: ref-to
       type: string
       description: "Destination ref on Gitea (e.g. refs/heads/sync-pr-12 for PR-time runs)"
+    - name: dashboard-base-url
+      type: string
+      default: "http://192.168.55.217:9097"
+      description: "Tekton dashboard base URL (LAN). CI statuses deep-link to the PipelineRun page here so a red check links straight to the step logs."
   workspaces:
     - name: shared-workspace
     - name: ssh-creds
@@ -97,7 +114,7 @@ spec:
         - {name: gitea-repo,  value: "$(params.gitea-repo)"}
         - {name: sha,         value: "$(params.sha)"}
         - {name: ref-to,      value: "$(params.ref-to)"}
-    - name: test
+    - name: check
       runAfter: [pull-and-push]
       workspaces:
         - name: source
@@ -105,42 +122,64 @@ spec:
       taskSpec:
         workspaces:
           - name: source
+        # The monorepo `check` gate (typecheck && lint && test) is split into
+        # named steps so a red run names the FAILING gate at a glance in the
+        # dashboard, instead of one opaque `npm run check` you must open and
+        # read. Steps share the workspace, so the single `npm ci` in `install`
+        # persists node_modules to the gate steps. stepTemplate carries the
+        # common image/securityContext/env so each step stays a one-liner.
+        #
+        # npm-workspace monorepo: ONE root install (the previous per-directory
+        # `npm ci` shape built nested node_modules and could not resolve
+        # workspace deps like @hum/shared — the @hum/mobile workspace, added
+        # 2026-06-11, surfaces that immediately). The gates fan out via
+        # `--workspaces --if-present`, the guard against empty script entries.
+        stepTemplate:
+          image: node:22-alpine
+          workingDir: $(workspaces.source.path)/repo
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            # Match pull-and-push (UID 65534) to avoid cross-UID handoff on the
+            # shared RWO PVC. fsGroup (TriggerTemplate PodTemplate) also = 65534,
+            # so writes by either task are group-readable.
+            runAsUser: 65534
+            capabilities: {drop: ["ALL"]}
+            seccompProfile: {type: RuntimeDefault}
+          env:
+            - {name: HOME, value: /tekton/home}
+            - {name: npm_config_cache, value: /tekton/home/.npm}
         steps:
-          - name: npm-test
-            image: node:22-alpine
-            workingDir: $(workspaces.source.path)/repo
-            securityContext:
-              allowPrivilegeEscalation: false
-              runAsNonRoot: true
-              # Match pull-and-push (UID 65534) to avoid cross-UID handoff on
-              # the shared RWO PVC. fsGroup (set on the TriggerTemplate's
-              # PodTemplate) also = 65534, so writes by either step are
-              # group-readable.
-              runAsUser: 65534
-              capabilities: {drop: ["ALL"]}
-              seccompProfile: {type: RuntimeDefault}
-            env:
-              - {name: HOME, value: /tekton/home}
-              - {name: npm_config_cache, value: /tekton/home/.npm}
+          - name: install
+            computeResources:
+              requests: {cpu: "1", memory: 1Gi}
+              limits:   {memory: 2Gi}
+            script: |
+              #!/bin/sh
+              set -eu
+              npm ci
+          - name: typecheck
+            script: |
+              #!/bin/sh
+              set -eu
+              npm run typecheck
+          - name: lint
+            script: |
+              #!/bin/sh
+              set -eu
+              npm run lint
+          - name: test
             computeResources:
               # The @hum/mobile workspace runs an RN/jest-expo suite: heavier
               # transforms than the node workspaces (jest maxWorkers is capped
-              # at 2 in-repo for exactly this footprint).
+              # at 2 in-repo for exactly this footprint). Pod requests/limits
+              # are the max across steps, so this sets the task's footprint.
               requests: {cpu: "1", memory: 2Gi}
               limits:   {memory: 4Gi}
             script: |
               #!/bin/sh
-              # npm-workspace monorepo: ONE root install, then the repo's own
-              # `check` gate (typecheck && lint && test fanned out via
-              # `--workspaces --if-present`). The previous per-directory
-              # `npm ci` shape built nested node_modules inside each
-              # workspace and could not resolve workspace deps like
-              # @hum/shared — the @hum/mobile workspace (added 2026-06-11)
-              # surfaces that immediately. `--if-present` remains the guard
-              # against empty script entries (2026-05-13 rework smoke).
               set -eu
-              npm ci
-              npm run check
+              npm run test
   finally:
     # github-status — MANDATORY post (fails the run if the API call fails).
     - name: github-status-success
@@ -155,6 +194,7 @@ spec:
         - {name: state,          value: "success"}
         - {name: description,    value: "All checks passed"}
         - {name: context,        value: "tekton/ci"}
+        - {name: target-url,     value: "$(params.dashboard-base-url)/#/namespaces/tekton-pipelines/pipelineruns/$(context.pipelineRun.name)"}
     - name: github-status-failure
       when:
         - input: $(tasks.status)
@@ -165,8 +205,9 @@ spec:
         - {name: repo-full-name, value: $(params.github-repo)}
         - {name: revision,       value: $(params.sha)}
         - {name: state,          value: "failure"}
-        - {name: description,    value: "CI failed"}
+        - {name: description,    value: "CI failed — click Details for the failing gate"}
         - {name: context,        value: "tekton/ci"}
+        - {name: target-url,     value: "$(params.dashboard-base-url)/#/namespaces/tekton-pipelines/pipelineruns/$(context.pipelineRun.name)"}
     # gitea-status — best-effort secondary. `onError: continue` means a
     # failure here (e.g. tekton-bot not yet member of agentic-stoa Gitea
     # org, or Gitea API transient-down) does NOT fail the overall pipeline.

--- a/docs/runbooks/ci-observability.md
+++ b/docs/runbooks/ci-observability.md
@@ -12,8 +12,18 @@ the PR branch and reproduce `npm run check` locally. That's the systematic cost
 of an opaque pass/fail: every contributor re-derives what the pipeline already
 knew.
 
-Fixed 2026-06-14 (`hum-ci-observability`) with two changes to
+While wiring this up we also found a **correctness** bug it had been masking:
+`pull-and-push` cloned the repo (landing on the **default branch, main**) and
+only used the PR `sha` for the Gitea mirror push — it never checked the sha out.
+So the gates ran against **main**, not the PR's changes, and every PR's
+`tekton/ci` reflected main's state. (Concretely: hum#120's lint fix kept showing
+red because CI was linting main, which still had the errors the PR fixed.) Now
+`pull-and-push` does `git checkout --detach "$(params.sha)"` after cloning.
+
+Fixed 2026-06-14 (`hum-ci-observability`) with three changes to
 `apps/tekton/pipelines/hum-ci.yaml`:
+
+0. **Test the PR commit** (correctness, above) — checkout the sha after clone.
 
 1. **Deep-link the status.** Every `tekton/ci` status now sets `target_url` to
    the PipelineRun page on the Tekton dashboard. The "Details" link on the PR

--- a/docs/runbooks/ci-observability.md
+++ b/docs/runbooks/ci-observability.md
@@ -1,0 +1,85 @@
+# CI Observability Runbook (hum-ci)
+
+How to read a failed `tekton/ci` check on an `agentic-stoa/hum` PR, and the
+pipeline wiring that makes a red check actionable.
+
+## Why this exists
+
+The `tekton/ci` GitHub check used to be a bare `success`/`failure` with **no
+link and no breadcrumb**. A red check told you *that* CI failed, never *why* or
+*where the logs are* — so the only way to find the failing gate was to clone
+the PR branch and reproduce `npm run check` locally. That's the systematic cost
+of an opaque pass/fail: every contributor re-derives what the pipeline already
+knew.
+
+Fixed 2026-06-14 (`hum-ci-observability`) with two changes to
+`apps/tekton/pipelines/hum-ci.yaml`:
+
+1. **Deep-link the status.** Every `tekton/ci` status now sets `target_url` to
+   the PipelineRun page on the Tekton dashboard. The "Details" link on the PR
+   check goes straight to the run.
+2. **Name the failing gate.** The monolithic `npm run check` step is split into
+   named steps — `install → typecheck → lint → test`. The dashboard colours the
+   failing step red, so you see which gate broke before opening a single log.
+
+## When to use this runbook
+
+Any time `tekton/ci` is red (or stuck) on a hum PR.
+
+## How to read a failed run
+
+1. On the PR, click **Details** next to the red `tekton/ci` check. It links to
+   `http://192.168.55.217:9097/#/namespaces/tekton-pipelines/pipelineruns/<run>`.
+   - **LAN-only:** the dashboard is a LoadBalancer on `192.168.55.217:9097`
+     (`apps/tekton/manifests/dashboard-service.yaml`), reachable on the homelab
+     net / mesh — which is where debugging happens. Off-net, see "Reproduce
+     locally" below.
+2. In the run graph, find the red node:
+   - **`pull-and-push`** red → infra (GitHub fetch / Gitea push / SSH), not your
+     code. Check the step log; usually a token/SSH or Gitea-membership issue.
+   - **`check`** red → open it and read which **step** failed:
+     - `install` → `npm ci` (lockfile / registry / workspace-resolution).
+     - `typecheck` → `tsc` errors. The log names file:line.
+     - `lint` → ESLint errors. The log names file:line + rule.
+     - `test` → a failing workspace test (`@hum/mobile` jest-expo is the heavy,
+       slow one).
+3. The step log is the same output `npm run <gate>` prints locally.
+
+## Reproduce locally (off-LAN, or to fix)
+
+CI runs exactly this, so it reproduces 1:1:
+
+```sh
+npm ci
+npm run check          # = typecheck && lint && test, --workspaces --if-present
+# or a single gate:
+npm run lint
+```
+
+## What's wired up
+
+- **Pipeline:** `apps/tekton/pipelines/hum-ci.yaml`
+  - `params.dashboard-base-url` (default `http://192.168.55.217:9097`) — base
+    for the `target_url` deep-link; override per-run if the dashboard moves.
+  - `check` task: `stepTemplate` carries the shared image/securityContext/env;
+    steps `install/typecheck/lint/test` share the workspace PVC (one `npm ci`,
+    reused by the gates). Pod requests/limits = the max across steps, set by the
+    heavier `test` step (2Gi/4Gi for the RN/jest-expo suite).
+  - `finally`: dual status to GitHub (mandatory) + Gitea (best-effort), same
+    `tekton/ci` context and SHA. Both GitHub posts now carry `target-url`.
+    `gitea-status` has no `target-url` param, so its post is unchanged.
+- **Status task:** `apps/tekton/tasks/github-status.yaml` — already plumbs a
+  `target-url` param end-to-end to the Commit Status API's `target_url`; the
+  pipeline simply never passed it before.
+
+## Future enhancements (not in this change)
+
+- **Inline annotations.** The Commit Status API can't annotate files. A GitHub
+  **check-run** (via the GitHub App) could surface the failing file:line/rule
+  inline in the PR's Files tab. That's a larger change (different API + app
+  auth) and is deliberately out of scope here.
+- **Per-gate checks.** Splitting `tekton/ci` into `tekton/typecheck`,
+  `tekton/lint`, `tekton/test` would name the gate in the check list itself
+  (no click). Trade-off: multiple required checks to manage in branch
+  protection. The named-steps approach gives most of the benefit for none of
+  that cost.


### PR DESCRIPTION
## Why

Two problems with `hum-ci`, found while debugging why hum#120's CI stayed red:

1. **CI tested the wrong commit (correctness).** `pull-and-push` cloned `agentic-stoa/hum` — landing on the **default branch (main)** — and only used the PR `sha` for the Gitea mirror push. It **never checked the sha out**, so the `check` gates ran against **main's HEAD, not the PR's changes**. Every PR's `tekton/ci` reflected main's state; a PR's own fix was never exercised. (hum#120's lint fix kept showing red because CI was linting *main*, which still had the errors the PR fixes.)

2. **Failures were opaque (observability).** The `tekton/ci` check was a bare success/failure with **no link** — finding the failing gate meant cloning the branch and reproducing `npm run check` locally. (And because of #1, that local repro of the PR wouldn't even match what CI ran.)

## What

All in `apps/tekton/pipelines/hum-ci.yaml`:

- **Checkout the PR sha.** `pull-and-push` now `git checkout --detach "$(params.sha)"` after cloning (the clone already fetches all branch refs, so the sha is local). CI now tests the PR commit.
- **Deep-link the status.** Both GitHub status posts set `target-url` to the PipelineRun page on the Tekton dashboard (new `dashboard-base-url` param, LAN default `http://192.168.55.217:9097`). The `github-status` task already plumbed `target_url`; the pipeline never passed it.
- **Name the failing gate.** The monolithic `npm run check` step is split into named steps — `install → typecheck → lint → test` — via a `stepTemplate`. The dashboard colours the failing step red. Steps share the workspace PVC (one `npm ci`); pod footprint unchanged (max across steps = the heavy `@hum/mobile` jest-expo `test` step).

Plus `docs/runbooks/ci-observability.md` — how to read a failed run; future enhancements (GitHub check-run inline annotations; per-gate `tekton/*` checks) noted as out of scope.

## Impact

This is the root-cause fix for hum#120 being red: once deployed, CI will test #120's actual (fixed) code instead of main. Note the ordering implication — see the hum#120 discussion for how to break the chicken-and-egg (main currently carries the lint errors).

## Notes

- `gitea-status` has no `target-url` param, so its best-effort post is unchanged.
- `target_url` is LAN-only by nature (dashboard is a homelab LoadBalancer); matches where debugging happens. Off-net repro documented in the runbook.
- No change to the `tekton/ci` status contract (still one check).

## Validation

- YAML parses; structure verified (sha checkout present; `check` steps install/typecheck/lint/test; both GitHub posts carry target-url).
- End-to-end validated by the next hum PR run after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)