### PR TITLE
feat(agents): stoa Frank infra — ComfyUI enablement + n8n agent-session sidecar

### DIFF
--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -14,6 +14,15 @@ env:
   MANAGER_REF: "4.0.5"
   PYTORCH_VERSION: "2.10.0"
   CUDA_VERSION_PIP: "cu128"
+  # stoa node-set revision — bump when the baked custom-node set changes so
+  # the image tag (and the Deployment pin) move together. Node refs are pinned
+  # to commit SHAs (these repos publish no release tags) for reproducibility.
+  STOA_NODES: "1"
+  LTXVIDEO_REF: "229437c6b65796d6a7a63ae34be2bd5ba31fa543"
+  GGUF_REF: "6ea2651e7df66d7585f6ffee804b20e92fb38b8a"
+  WANVIDEO_REF: "088128b224242e110d3906c6750e9a3a348a659b"
+  KOKORO_REF: "cfb59b5605b351e196182c836f0b48c1a784e52f"
+  FISHSPEECH_REF: "6d6cd7c0b00f07a057d9b799eeca80866a0d5ff7"
 
 jobs:
   build:
@@ -48,12 +57,17 @@ jobs:
           context: apps/comfyui/docker
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:comfyui-${{ env.COMFYUI_REF }}-pt${{ env.PYTORCH_VERSION }}-${{ env.CUDA_VERSION_PIP }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:comfyui-${{ env.COMFYUI_REF }}-pt${{ env.PYTORCH_VERSION }}-${{ env.CUDA_VERSION_PIP }}-stoa${{ env.STOA_NODES }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
           build-args: |
             COMFYUI_REF=${{ env.COMFYUI_REF }}
             MANAGER_REF=${{ env.MANAGER_REF }}
             PYTORCH_VERSION=${{ env.PYTORCH_VERSION }}
             CUDA_VERSION_PIP=${{ env.CUDA_VERSION_PIP }}
+            LTXVIDEO_REF=${{ env.LTXVIDEO_REF }}
+            GGUF_REF=${{ env.GGUF_REF }}
+            WANVIDEO_REF=${{ env.WANVIDEO_REF }}
+            KOKORO_REF=${{ env.KOKORO_REF }}
+            FISHSPEECH_REF=${{ env.FISHSPEECH_REF }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/apps/comfyui/docker/Dockerfile
+++ b/apps/comfyui/docker/Dockerfile
@@ -6,6 +6,15 @@ ARG MANAGER_REF=4.0.5
 ARG PYTORCH_VERSION=2.10.0
 ARG CUDA_VERSION_PIP=cu128
 
+# ── stoa custom-node refs ──────────────────────────────────────────
+# Pinned to commit SHAs (these repos publish no release tags) so the image is
+# reproducible. Bump deliberately + bump STOA_NODES with it.
+ARG LTXVIDEO_REF=229437c6b65796d6a7a63ae34be2bd5ba31fa543
+ARG GGUF_REF=6ea2651e7df66d7585f6ffee804b20e92fb38b8a
+ARG WANVIDEO_REF=088128b224242e110d3906c6750e9a3a348a659b
+ARG KOKORO_REF=cfb59b5605b351e196182c836f0b48c1a784e52f
+ARG FISHSPEECH_REF=6d6cd7c0b00f07a057d9b799eeca80866a0d5ff7
+
 # Prevent interactive prompts during apt-get
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -43,6 +52,28 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Manager 4.x doesn't have. Pip install makes it globally importable.
 RUN pip install --no-cache-dir \
     comfyui-manager==${MANAGER_REF}
+
+# ── stoa custom nodes (baked to a staging dir; entrypoint seeds PVC) ─
+# The runtime mounts the comfyui-custom-nodes PVC at /app/custom_nodes, which
+# SHADOWS anything baked there — so stage under /opt and have entrypoint.sh
+# seed the PVC on boot. Python deps install into the image env here; only the
+# node FILES are seeded at runtime. Refs pinned via ARGs (CONFIRM-AT-CI).
+RUN mkdir -p /opt/stoa-custom-nodes && cd /opt/stoa-custom-nodes \
+    && git clone https://github.com/Lightricks/ComfyUI-LTXVideo.git \
+    && git -C ComfyUI-LTXVideo checkout ${LTXVIDEO_REF} \
+    && pip install --no-cache-dir -r ComfyUI-LTXVideo/requirements.txt \
+    && git clone https://github.com/city96/ComfyUI-GGUF.git \
+    && git -C ComfyUI-GGUF checkout ${GGUF_REF} \
+    && pip install --no-cache-dir -r ComfyUI-GGUF/requirements.txt \
+    && git clone https://github.com/kijai/ComfyUI-WanVideoWrapper.git \
+    && git -C ComfyUI-WanVideoWrapper checkout ${WANVIDEO_REF} \
+    && pip install --no-cache-dir -r ComfyUI-WanVideoWrapper/requirements.txt \
+    && git clone https://github.com/stavsap/comfyui-kokoro.git ComfyUI-Kokoro \
+    && git -C ComfyUI-Kokoro checkout ${KOKORO_REF} \
+    && pip install --no-cache-dir -r ComfyUI-Kokoro/requirements.txt \
+    && git clone https://github.com/AIFSH/ComfyUI-FishSpeech.git \
+    && git -C ComfyUI-FishSpeech checkout ${FISHSPEECH_REF} \
+    && pip install --no-cache-dir -r ComfyUI-FishSpeech/requirements.txt
 
 # ── Non-root user ───────────────────────────────────────────────────
 RUN groupadd -g 1000 comfyui \

--- a/apps/comfyui/docker/entrypoint.sh
+++ b/apps/comfyui/docker/entrypoint.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
 set -e
 
+# Seed baked stoa custom nodes into the PVC-mounted custom_nodes dir.
+# The comfyui-custom-nodes PVC mounts at /app/custom_nodes and SHADOWS any
+# nodes baked into the image there, so copy them on boot. Idempotent: only
+# seed a node when it is absent in the PVC (operator edits / Manager installs
+# are preserved across restarts).
+STAGE=/opt/stoa-custom-nodes
+DEST=/app/custom_nodes
+if [ -d "$STAGE" ]; then
+  for node in "$STAGE"/*/; do
+    name="$(basename "$node")"
+    if [ ! -d "$DEST/$name" ]; then
+      cp -a "$node" "$DEST/$name"
+    fi
+  done
+fi
+
 exec python main.py "$@"

--- a/apps/comfyui/manifests/deployment.yaml
+++ b/apps/comfyui/manifests/deployment.yaml
@@ -33,7 +33,21 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: comfyui
-          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128
+          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa1
+          # Overrides the image CMD to add VRAM/offload flags for the 16GB
+          # RTX 5070 Ti. The stoa runner drives one clip at a time, so models
+          # load serially: reserve a little VRAM for the OS and don't cache
+          # models in RAM. Final values tuned on the live box (MO-2).
+          args:
+            - "--listen"
+            - "0.0.0.0"
+            - "--port"
+            - "8188"
+            - "--enable-manager"
+            - "--enable-manager-legacy-ui"
+            - "--reserve-vram"
+            - "1.0"
+            - "--cache-none"
           ports:
             - name: http
               containerPort: 8188

--- a/apps/comfyui/manifests/job-model-download.yaml
+++ b/apps/comfyui/manifests/job-model-download.yaml
@@ -1,0 +1,91 @@
+# Declarative model hydration for the stoa pipeline.
+#
+# Idempotent (skip-if-present) download of the stoa model weights into the
+# comfyui-models PVC. Runs on gpu-1 (where the PVC binds) using the comfyui
+# image (curl + the comfyui uid that owns the PVC); requests NO GPU.
+#
+# MANUAL (MO-1, Phase 5): the weight source URLs below are CONFIRM-LIVE —
+# HuggingFace repo paths / quant filenames drift, and gated repos need a token.
+# Confirm + lock the URLs on gpu-1, then run this Job. A re-run is a no-op for
+# artefacts already present.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: comfyui-stoa-model-download
+  namespace: comfyui
+  labels:
+    app.kubernetes.io/name: comfyui
+    app.kubernetes.io/component: model-download
+spec:
+  # Re-runnable: delete + re-apply to fetch newly-added artefacts.
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: comfyui
+        app.kubernetes.io/component: model-download
+    spec:
+      restartPolicy: OnFailure
+      nodeSelector:
+        kubernetes.io/hostname: gpu-1
+      tolerations:
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+      securityContext:
+        # Must match the comfyui Deployment's fsGroup (1000) — both write the
+        # shared comfyui-models PVC; a mismatch would EACCES the curl writes.
+        fsGroup: 1000
+      containers:
+        - name: download
+          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa1
+          command:
+            - /bin/bash
+            - -ec
+            - |
+              # download <dest-relative-to-/app/models> <url>
+              # Skip-if-present keeps the Job idempotent.
+              download() {
+                local dest="/app/models/$1" url="$2"
+                if [ -f "$dest" ]; then
+                  echo "skip (present): $1"
+                  return 0
+                fi
+                echo "fetch: $1"
+                mkdir -p "$(dirname "$dest")"
+                curl -fSL --retry 3 "$url" -o "$dest.part"
+                mv "$dest.part" "$dest"
+              }
+
+              # --- stoa model artefacts (CONFIRM-LIVE URLs at MO-1) ---------
+              # LTX-2 NVFP8 (video)
+              download "checkpoints/ltx-2-nvfp8.safetensors" \
+                "https://huggingface.co/Lightricks/LTX-2/resolve/main/ltx-2-nvfp8.safetensors"   # CONFIRM-LIVE
+              # LTX-Video 0.9.x (video)
+              download "checkpoints/ltx-video-0.9.safetensors" \
+                "https://huggingface.co/Lightricks/LTX-Video/resolve/main/ltx-video-0.9.safetensors"  # CONFIRM-LIVE
+              # Wan 2.2 14B Q8 GGUF (video)
+              download "unet/wan2.2-14b-Q8_0.gguf" \
+                "https://huggingface.co/city96/Wan2.2-14B-gguf/resolve/main/wan2.2-14b-Q8_0.gguf"  # CONFIRM-LIVE
+              # Kokoro (TTS)
+              download "tts/kokoro/kokoro-v1.0.onnx" \
+                "https://huggingface.co/hexgrad/Kokoro-82M/resolve/main/kokoro-v1_0.onnx"  # CONFIRM-LIVE
+              # Fish-Speech S2 (TTS)
+              download "tts/fish-speech/fish-speech-s2.safetensors" \
+                "https://huggingface.co/fishaudio/fish-speech-1.5/resolve/main/model.safetensors"  # CONFIRM-LIVE
+
+              echo "stoa model hydration complete"
+          volumeMounts:
+            - name: models
+              mountPath: /app/models
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 2Gi
+      volumes:
+        - name: models
+          persistentVolumeClaim:
+            claimName: comfyui-models

--- a/apps/n8n-01/manifests/agent-session-bootstrap.yaml
+++ b/apps/n8n-01/manifests/agent-session-bootstrap.yaml
@@ -31,21 +31,26 @@ metadata:
 data:
   session-bootstrap.sh: |
     #!/usr/bin/env bash
-    # Ensure the persistent stoa script-gen session exists. Always exit 0 so a
-    # postStart hiccup never blocks the pod. Retries because postStart has no
-    # ordering guarantee with the container ENTRYPOINT (tmux may not be ready).
+    # Start the agent-session HTTP server + pre-warm the script-gen session.
+    # Always exit 0 so a postStart hiccup never blocks the pod. Retries because
+    # postStart has no ordering guarantee with the container ENTRYPOINT.
     set -u
     SESSION="${STOA_SESSION_NAME:-stoa-script-claude}"
+    SERVER="stoa-session-server"
+    # The HTTP server n8n calls (POST 127.0.0.1/session/send), supervised by a
+    # restart-loop in its own tmux session. bash -lc so python3/mise are on PATH.
+    if ! tmux has-session -t "$SERVER" 2>/dev/null; then
+      tmux new-session -d -s "$SERVER" \
+        "bash -lc 'while true; do python3 /opt/stoa-bin/agent-session serve; sleep 2; done'" || true
+    fi
+    # Pre-warm an attachable default claude session. Interactive claude — never
+    # `claude -p`. n8n's session_id is auto-created on first send, so this is
+    # convenience (a known attach target) rather than load-bearing.
     for _ in $(seq 1 10); do
       if tmux has-session -t "$SESSION" 2>/dev/null; then
-        exit 0
+        break
       fi
-      # Interactive claude — continuity lives in-session, never `claude -p`.
-      # Unauthenticated on first boot: the session shows the login prompt until
-      # the operator attaches and runs `claude login` (MO-4).
-      if tmux new-session -d -s "$SESSION" "claude" 2>/dev/null; then
-        exit 0
-      fi
+      tmux new-session -d -s "$SESSION" "bash -lc claude" 2>/dev/null && break
       sleep 2
     done
     exit 0

--- a/apps/n8n-01/manifests/agent-session-bootstrap.yaml
+++ b/apps/n8n-01/manifests/agent-session-bootstrap.yaml
@@ -10,11 +10,13 @@
 #
 # KNOWN LIMITATION: a postStart hook has no ordering guarantee with the image's
 # own ENTRYPOINT, so tmux may not be usable the instant it fires. The script
-# retries (below) and always exit-0s, so a transient miss never blocks the pod —
-# but if the session is still absent after boot, the first `agent-session send`
-# returns `no_session`. Recovery: re-run by hand —
+# retries (below) and always exit-0s, so a transient miss never blocks the pod.
+# send() auto-creates the script-gen session on demand, so the residual risk is
+# the HTTP SERVER not coming up. Diagnose / recover:
 #   kubectl exec -n n8n-01 deploy/n8n-01 -c multi-agent-shell -- \
-#     /opt/stoa-bootstrap/session-bootstrap.sh
+#     tmux capture-pane -pt stoa-session-server   # why the serve loop is spinning
+#   kubectl exec -n n8n-01 deploy/n8n-01 -c multi-agent-shell -- \
+#     /opt/stoa-bootstrap/session-bootstrap.sh    # re-run the bootstrap
 # (The operator attaches anyway at MO-4 to `claude login`, so this is benign on
 # first boot.)
 #

--- a/apps/n8n-01/manifests/agent-session-bootstrap.yaml
+++ b/apps/n8n-01/manifests/agent-session-bootstrap.yaml
@@ -1,0 +1,51 @@
+# Bootstrap for the persistent stoa script-gen session in the sidecar.
+#
+# Ensures a long-lived, interactive `claude` session in a named tmux session —
+# NEVER `claude -p` (print mode throws away the continuity the serialized
+# pipeline depends on). Idempotent: a restart that finds the session already
+# running is a no-op (tmux-resurrect also restores it).
+#
+# Invoked from the sidecar's postStart hook. The session name is generic /
+# configurable (STOA_SESSION_NAME); n8n drives whatever session_id it sends.
+#
+# KNOWN LIMITATION: a postStart hook has no ordering guarantee with the image's
+# own ENTRYPOINT, so tmux may not be usable the instant it fires. The script
+# retries (below) and always exit-0s, so a transient miss never blocks the pod —
+# but if the session is still absent after boot, the first `agent-session send`
+# returns `no_session`. Recovery: re-run by hand —
+#   kubectl exec -n n8n-01 deploy/n8n-01 -c multi-agent-shell -- \
+#     /opt/stoa-bootstrap/session-bootstrap.sh
+# (The operator attaches anyway at MO-4 to `claude login`, so this is benign on
+# first boot.)
+#
+# NOTE: this is a raw (non-Kustomize) ConfigMap — editing the script needs a
+# `kubectl rollout restart deployment/n8n-01 -n n8n-01` to reach the pod.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-session-bootstrap
+  namespace: n8n-01
+  labels:
+    app.kubernetes.io/name: n8n-01
+    app.kubernetes.io/component: agent-session
+data:
+  session-bootstrap.sh: |
+    #!/usr/bin/env bash
+    # Ensure the persistent stoa script-gen session exists. Always exit 0 so a
+    # postStart hiccup never blocks the pod. Retries because postStart has no
+    # ordering guarantee with the container ENTRYPOINT (tmux may not be ready).
+    set -u
+    SESSION="${STOA_SESSION_NAME:-stoa-script-claude}"
+    for _ in $(seq 1 10); do
+      if tmux has-session -t "$SESSION" 2>/dev/null; then
+        exit 0
+      fi
+      # Interactive claude — continuity lives in-session, never `claude -p`.
+      # Unauthenticated on first boot: the session shows the login prompt until
+      # the operator attaches and runs `claude login` (MO-4).
+      if tmux new-session -d -s "$SESSION" "claude" 2>/dev/null; then
+        exit 0
+      fi
+      sleep 2
+    done
+    exit 0

--- a/apps/n8n-01/manifests/agent-session-driver.yaml
+++ b/apps/n8n-01/manifests/agent-session-driver.yaml
@@ -1,7 +1,10 @@
 # agent-session driver — n8n's pod-local interface to the persistent claude
-# session. Mounted into the multi-agent-shell sidecar at /opt/stoa-bin; n8n
-# invokes it by absolute path over the sidecar's localhost sshd (see
-# agent-session.README in this ConfigMap).
+# session. Mounted into the multi-agent-shell sidecar at /opt/stoa-bin.
+#
+# Two entry points, ONE send() core:
+#   * `agent-session serve` — a tiny HTTP server on 127.0.0.1 serving
+#     POST /session/send (what content-factory's n8n httpRequest node calls).
+#   * `agent-session send '<json>'` — the same logic as a CLI (debug/manual).
 #
 # It drives the RUNNING interactive session (never `claude -p`): send a message,
 # wait for a NEW fenced-JSON reply (not a prior turn's), emit the
@@ -21,12 +24,15 @@ data:
 
     Never `claude -p`: feed a message to the long-lived interactive session and
     read the reply, emitting {session_id, agent, status, turn, payload} with a
-    per-session turn counter (evidence of continuity). n8n calls this over the
-    sidecar's local sshd in a LOGIN shell (so PATH/mise are set).
+    per-session turn counter (evidence of continuity).
 
-    Stale-reply safety: the session pane already holds PRIOR turns' fenced-JSON
-    replies, so we baseline the count of complete ```json blocks BEFORE sending
-    and only accept a reply once a NEW block appears — then take the newest one.
+    `serve` runs the HTTP endpoint n8n calls (POST /session/send); `send` is the
+    same core as a CLI. The session is auto-created for whatever session_id
+    arrives, so the driver is agnostic to the caller's chosen name.
+
+    Stale-reply safety: the pane already holds PRIOR turns' fenced-JSON replies,
+    so we baseline the count of complete ```json blocks BEFORE sending and only
+    accept a reply once a NEW block appears — then take the newest one.
     """
     import fcntl
     import json
@@ -40,9 +46,10 @@ data:
         "STOA_TURN_DIR", os.path.join(os.path.expanduser("~"), ".stoa")
     )
     POLL_S = float(os.environ.get("STOA_POLL_S", "2"))
-    # How much scrollback to scan — bounded so a long session stays cheap, but
-    # deep enough that a multi-clip shot-list's closing fence isn't missed.
+    # Bounded scrollback: deep enough for a multi-clip shot-list's closing fence,
+    # cheap enough on a long session.
     SCROLLBACK = os.environ.get("STOA_SCROLLBACK", "-2000")
+    PORT = int(os.environ.get("STOA_SESSION_PORT", "8765"))
 
     JSON_BLOCK = re.compile(r"```json\s*(.*?)```", re.DOTALL)
 
@@ -51,8 +58,15 @@ data:
         return subprocess.run(["tmux", *args], capture_output=True, text=True)
 
 
+    def ensure_session(session_id):
+        # Auto-create the session (interactive claude, never -p) if absent, so
+        # the caller's session_id drives whatever it names. Unauthenticated until
+        # the operator runs `claude login` (MO-4).
+        if tmux("has-session", "-t", session_id).returncode != 0:
+            tmux("new-session", "-d", "-s", session_id, "claude")
+
+
     def capture(session):
-        # Include scrollback (-S): a long reply can scroll past the viewport.
         r = tmux("capture-pane", "-p", "-S", SCROLLBACK, "-t", session)
         return r.stdout if r.returncode == 0 else ""
 
@@ -101,8 +115,7 @@ data:
         message = req["message"]
         timeout_s = float(req.get("timeout_s", 300))
 
-        if tmux("has-session", "-t", session_id).returncode != 0:
-            return response(session_id, agent, "no_session", read_turn(session_id), None)
+        ensure_session(session_id)
 
         # Baseline BEFORE sending so we can tell this turn's reply from prior ones.
         baseline = len(json_blocks(capture(session_id)))
@@ -112,7 +125,6 @@ data:
         while time.monotonic() < deadline:
             blocks = json_blocks(capture(session_id))
             if len(blocks) > baseline:
-                # A NEW complete block exists — the newest is this turn's reply.
                 try:
                     payload = json.loads(blocks[-1].strip())
                 except json.JSONDecodeError:
@@ -125,35 +137,74 @@ data:
         return response(session_id, agent, "timeout", read_turn(session_id), None)
 
 
+    def serve():
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class Handler(BaseHTTPRequestHandler):
+            def _json(self, code, obj):
+                body = json.dumps(obj).encode()
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self):
+                if self.path == "/healthz":
+                    self._json(200, {"status": "ok"})
+                else:
+                    self._json(404, {"status": "error", "error": "not found"})
+
+            def do_POST(self):
+                if self.path != "/session/send":
+                    self._json(404, {"status": "error", "error": "not found"})
+                    return
+                n = int(self.headers.get("Content-Length", "0") or 0)
+                try:
+                    req = json.loads(self.rfile.read(n) or b"{}")
+                except json.JSONDecodeError:
+                    self._json(400, {"status": "error", "error": "bad json"})
+                    return
+                self._json(200, send(req))
+
+            def log_message(self, *a):  # quiet
+                pass
+
+        # Pod-local only: n8n is in the same pod (shared netns) — bind loopback,
+        # never the wildcard address.
+        HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+
+
     def main(argv):
         cmd = argv[1] if len(argv) > 1 else ""
-        if cmd != "send":
-            print(json.dumps({"status": "error", "error": "usage: agent-session send '<json>'"}))
-            return 2
-        raw = argv[2] if len(argv) > 2 else sys.stdin.read()
-        print(json.dumps(send(json.loads(raw))))
-        return 0
+        if cmd == "serve":
+            serve()
+            return 0
+        if cmd == "send":
+            raw = argv[2] if len(argv) > 2 else sys.stdin.read()
+            print(json.dumps(send(json.loads(raw))))
+            return 0
+        print(json.dumps({"status": "error", "error": "usage: agent-session serve|send"}))
+        return 2
 
 
     if __name__ == "__main__":
         sys.exit(main(sys.argv))
   agent-session.README: |
-    Pod-local transport (Option 1 — script over exec, NO long-running server).
+    Pod-local transport (HTTP — matches content-factory's n8n httpRequest node).
 
-    n8n and this sidecar share the pod's network namespace (n8n binds 5678, the
-    sidecar's sshd binds 22), so n8n drives the session by invoking the script
-    over the sidecar's OWN sshd on localhost, via n8n's SSH node:
+    n8n and this sidecar share the pod's network namespace, so the sidecar runs a
+    tiny HTTP server on 127.0.0.1:${STOA_SESSION_PORT:-8765} (started by the
+    session bootstrap in a tmux restart-loop). n8n's httpRequest node calls:
 
-      ssh -i <key> agent@127.0.0.1 \
-        'bash -lc "/opt/stoa-bin/agent-session send <json>"'
+      POST http://localhost:8765/session/send
+      body: {session_id, agent, message, expect?, timeout_s?}
+      -> {session_id, agent, status, turn, payload}
 
-    - A LOGIN shell (`bash -lc`) is REQUIRED so PATH/mise (python3) are set — a
-      bare `ssh host -- cmd` skips profile.d (agent-shells gotcha).
-    - The keypair is a SOPS-managed bootstrap Secret `n8n-01-agent-ssh`: public
-      key -> the sidecar's /etc/ssh-keys/authorized_keys, private key -> the n8n
-      container. Secrets are NOT ArgoCD-managed, so this is a manual op (MO-7).
+    Set the workflow's AGENT_SIDECAR_URL=http://localhost:8765. There is no
+    Service and no SSH keypair — localhost-only, in-pod. `GET /healthz` returns
+    200. The session named by session_id is auto-created on first send (so the
+    caller's chosen name just works); the operator attaches with
+    `tmux attach -t <session_id>` (or the pre-warmed default session).
 
-    Fallback (only if localhost-sshd proves unworkable): a shared-volume
-    file-drop — n8n writes the request JSON to a shared emptyDir; a small
-    supercronic job in the sidecar runs `agent-session send` and writes the
-    response file. Heavier; still Option-1-shaped (no network server).
+    `agent-session send '<json>'` is the same logic as a CLI for debug/manual use.

--- a/apps/n8n-01/manifests/agent-session-driver.yaml
+++ b/apps/n8n-01/manifests/agent-session-driver.yaml
@@ -1,0 +1,159 @@
+# agent-session driver — n8n's pod-local interface to the persistent claude
+# session. Mounted into the multi-agent-shell sidecar at /opt/stoa-bin; n8n
+# invokes it by absolute path over the sidecar's localhost sshd (see
+# agent-session.README in this ConfigMap).
+#
+# It drives the RUNNING interactive session (never `claude -p`): send a message,
+# wait for a NEW fenced-JSON reply (not a prior turn's), emit the
+# agent_session.receive.response shape with a per-session turn counter.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agent-session-driver
+  namespace: n8n-01
+  labels:
+    app.kubernetes.io/name: n8n-01
+    app.kubernetes.io/component: agent-session
+data:
+  agent-session: |
+    #!/usr/bin/env python3
+    """agent-session — drive the persistent claude tmux session (send/receive).
+
+    Never `claude -p`: feed a message to the long-lived interactive session and
+    read the reply, emitting {session_id, agent, status, turn, payload} with a
+    per-session turn counter (evidence of continuity). n8n calls this over the
+    sidecar's local sshd in a LOGIN shell (so PATH/mise are set).
+
+    Stale-reply safety: the session pane already holds PRIOR turns' fenced-JSON
+    replies, so we baseline the count of complete ```json blocks BEFORE sending
+    and only accept a reply once a NEW block appears — then take the newest one.
+    """
+    import fcntl
+    import json
+    import os
+    import re
+    import subprocess
+    import sys
+    import time
+
+    TURN_DIR = os.environ.get(
+        "STOA_TURN_DIR", os.path.join(os.path.expanduser("~"), ".stoa")
+    )
+    POLL_S = float(os.environ.get("STOA_POLL_S", "2"))
+    # How much scrollback to scan — bounded so a long session stays cheap, but
+    # deep enough that a multi-clip shot-list's closing fence isn't missed.
+    SCROLLBACK = os.environ.get("STOA_SCROLLBACK", "-2000")
+
+    JSON_BLOCK = re.compile(r"```json\s*(.*?)```", re.DOTALL)
+
+
+    def tmux(*args):
+        return subprocess.run(["tmux", *args], capture_output=True, text=True)
+
+
+    def capture(session):
+        # Include scrollback (-S): a long reply can scroll past the viewport.
+        r = tmux("capture-pane", "-p", "-S", SCROLLBACK, "-t", session)
+        return r.stdout if r.returncode == 0 else ""
+
+
+    def json_blocks(pane):
+        return JSON_BLOCK.findall(pane)
+
+
+    def read_turn(session_id):
+        path = os.path.join(TURN_DIR, session_id + ".turn")
+        try:
+            with open(path) as fh:
+                return int(fh.read().strip() or 0)
+        except (OSError, ValueError):
+            return 0
+
+
+    def bump_turn(session_id):
+        # Atomic + locked: the turn counter is the contract's continuity
+        # evidence, so a concurrent/aborted write must not corrupt it.
+        os.makedirs(TURN_DIR, exist_ok=True)
+        path = os.path.join(TURN_DIR, session_id + ".turn")
+        with open(path + ".lock", "w") as lk:
+            fcntl.flock(lk, fcntl.LOCK_EX)
+            turn = read_turn(session_id) + 1
+            tmp = path + ".tmp"
+            with open(tmp, "w") as fh:
+                fh.write(str(turn))
+            os.replace(tmp, path)
+        return turn
+
+
+    def response(session_id, agent, status, turn, payload):
+        return {
+            "session_id": session_id,
+            "agent": agent,
+            "status": status,
+            "turn": turn,
+            "payload": payload,
+        }
+
+
+    def send(req):
+        session_id = req["session_id"]
+        agent = req.get("agent", "claude")
+        message = req["message"]
+        timeout_s = float(req.get("timeout_s", 300))
+
+        if tmux("has-session", "-t", session_id).returncode != 0:
+            return response(session_id, agent, "no_session", read_turn(session_id), None)
+
+        # Baseline BEFORE sending so we can tell this turn's reply from prior ones.
+        baseline = len(json_blocks(capture(session_id)))
+        tmux("send-keys", "-t", session_id, message, "Enter")
+
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            blocks = json_blocks(capture(session_id))
+            if len(blocks) > baseline:
+                # A NEW complete block exists — the newest is this turn's reply.
+                try:
+                    payload = json.loads(blocks[-1].strip())
+                except json.JSONDecodeError:
+                    return response(
+                        session_id, agent, "bad_payload", read_turn(session_id), None
+                    )
+                return response(session_id, agent, "ok", bump_turn(session_id), payload)
+            time.sleep(POLL_S)
+
+        return response(session_id, agent, "timeout", read_turn(session_id), None)
+
+
+    def main(argv):
+        cmd = argv[1] if len(argv) > 1 else ""
+        if cmd != "send":
+            print(json.dumps({"status": "error", "error": "usage: agent-session send '<json>'"}))
+            return 2
+        raw = argv[2] if len(argv) > 2 else sys.stdin.read()
+        print(json.dumps(send(json.loads(raw))))
+        return 0
+
+
+    if __name__ == "__main__":
+        sys.exit(main(sys.argv))
+  agent-session.README: |
+    Pod-local transport (Option 1 — script over exec, NO long-running server).
+
+    n8n and this sidecar share the pod's network namespace (n8n binds 5678, the
+    sidecar's sshd binds 22), so n8n drives the session by invoking the script
+    over the sidecar's OWN sshd on localhost, via n8n's SSH node:
+
+      ssh -i <key> agent@127.0.0.1 \
+        'bash -lc "/opt/stoa-bin/agent-session send <json>"'
+
+    - A LOGIN shell (`bash -lc`) is REQUIRED so PATH/mise (python3) are set — a
+      bare `ssh host -- cmd` skips profile.d (agent-shells gotcha).
+    - The keypair is a SOPS-managed bootstrap Secret `n8n-01-agent-ssh`: public
+      key -> the sidecar's /etc/ssh-keys/authorized_keys, private key -> the n8n
+      container. Secrets are NOT ArgoCD-managed, so this is a manual op (MO-7).
+
+    Fallback (only if localhost-sshd proves unworkable): a shared-volume
+    file-drop — n8n writes the request JSON to a shared emptyDir; a small
+    supercronic job in the sidecar runs `agent-session send` and writes the
+    response file. Heavier; still Option-1-shaped (no network server).

--- a/apps/n8n-01/manifests/agent-session-driver.yaml
+++ b/apps/n8n-01/manifests/agent-session-driver.yaml
@@ -61,7 +61,8 @@ data:
     def ensure_session(session_id):
         # Auto-create the session (interactive claude, never -p) if absent, so
         # the caller's session_id drives whatever it names. Unauthenticated until
-        # the operator runs `claude login` (MO-4).
+        # the operator runs `claude login` (MO-4). Concurrency-safe under threading:
+        # a racing duplicate `new-session` errors harmlessly (tmux refuses the dup).
         if tmux("has-session", "-t", session_id).returncode != 0:
             tmux("new-session", "-d", "-s", session_id, "claude")
 
@@ -138,7 +139,7 @@ data:
 
 
     def serve():
-        from http.server import BaseHTTPRequestHandler, HTTPServer
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
         class Handler(BaseHTTPRequestHandler):
             def _json(self, code, obj):
@@ -171,8 +172,17 @@ data:
                 pass
 
         # Pod-local only: n8n is in the same pod (shared netns) — bind loopback,
-        # never the wildcard address.
-        HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+        # never the wildcard address. Threaded so a long send() (up to timeout_s)
+        # never head-of-line-blocks /healthz or a concurrent request.
+        try:
+            server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+        except OSError as exc:
+            # Surface bind failures (the bootstrap restart-loop silences handler
+            # logs, not stderr): inspect via `tmux capture-pane -t stoa-session-server`.
+            print(f"agent-session serve: bind 127.0.0.1:{PORT} failed: {exc}", file=sys.stderr)
+            raise
+        server.daemon_threads = True
+        server.serve_forever()
 
 
     def main(argv):

--- a/apps/n8n-01/manifests/deployment.yaml
+++ b/apps/n8n-01/manifests/deployment.yaml
@@ -117,11 +117,10 @@ spec:
               value: /home/agent
           resources:
             requests:
-              cpu: 250m
-              memory: 1Gi
+              cpu: "1000m"
+              memory: 2Gi
             limits:
-              cpu: 1000m
-              memory: 4Gi
+              memory: 8Gi
           volumeMounts:
             - name: agent-home
               mountPath: /home/agent

--- a/apps/n8n-01/manifests/deployment.yaml
+++ b/apps/n8n-01/manifests/deployment.yaml
@@ -106,7 +106,49 @@ spec:
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 3
+        # multi-agent-shell sidecar — hosts the persistent, operator-attachable
+        # `claude` session that n8n drives (never `claude -p`). Subscription
+        # OAuth only: NO API keys here; the credential lands on the agent-home
+        # PVC at first `claude login` (MO-4). s6-overlay v3 runs sshd + tmux.
+        - name: multi-agent-shell
+          image: ghcr.io/derio-net/multi-agent-shell:9635df9a0984b5bc1155a043d3a872bb3403524a
+          env:
+            - name: HOME
+              value: /home/agent
+          resources:
+            requests:
+              cpu: 250m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 4Gi
+          volumeMounts:
+            - name: agent-home
+              mountPath: /home/agent
+            - name: agent-session-bootstrap
+              mountPath: /opt/stoa-bootstrap
+            - name: agent-session-driver
+              mountPath: /opt/stoa-bin
+          # Ensure the persistent stoa script-gen tmux session on (re)start.
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - /opt/stoa-bootstrap/session-bootstrap.sh
       volumes:
         - name: data
           persistentVolumeClaim:
             claimName: n8n-01-data
+        - name: agent-home
+          persistentVolumeClaim:
+            claimName: n8n-01-agent-home
+        - name: agent-session-bootstrap
+          configMap:
+            name: agent-session-bootstrap
+            defaultMode: 0755
+        - name: agent-session-driver
+          configMap:
+            name: agent-session-driver
+            defaultMode: 0755

--- a/apps/n8n-01/manifests/deployment.yaml
+++ b/apps/n8n-01/manifests/deployment.yaml
@@ -75,6 +75,11 @@ spec:
               value: "https://n8n-01.frank.derio.net/"
             - name: N8N_SECURE_COOKIE
               value: "false"
+            # The stoa workflow's httpRequest node posts to
+            # $AGENT_SIDECAR_URL/session/send — the multi-agent-shell sidecar's
+            # HTTP server on pod-localhost (same pod, shared netns).
+            - name: AGENT_SIDECAR_URL
+              value: "http://localhost:8765"
           resources:
             requests:
               cpu: 500m

--- a/apps/n8n-01/manifests/pvc-agent-home.yaml
+++ b/apps/n8n-01/manifests/pvc-agent-home.yaml
@@ -1,0 +1,15 @@
+# PV-resident $HOME for the multi-agent-shell sidecar — holds the per-harness
+# OAuth credentials (claude login, MO-4), tmux-resurrect session state, and the
+# stoa session turn-counter. Kept off the image so secrets never bake in.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: n8n-01-agent-home
+  namespace: n8n-01
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/01.yaml
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/01.yaml
@@ -1,0 +1,92 @@
+schema_version: 2
+phase:
+  number: 1
+  title: ComfyUI image — bake stoa custom nodes + model-download Job (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Tag-consistency + Dockerfile node-pin guards, test-first
+  steps:
+  - id: P1.T1.S1
+    text: |
+      Write scripts/tests/test_comfyui_stoa_image.py FIRST (red), pyyaml + re,
+      no network. Assert:
+      - .github/workflows/build-comfyui.yml exposes a stoa node-set dimension
+        (env var, e.g. STOA_NODES_REF) AND the produced image tag string
+        embeds it (e.g. ...-cu128-stoa<N>).
+      - apps/comfyui/manifests/deployment.yaml image tag == the tag the workflow
+        renders from its env (parse both; assert equality — the health-bridge
+        tag-drift guard).
+      - apps/comfyui/docker/Dockerfile contains a PINNED `git clone` + `git
+        checkout <ref>` (or `--branch <ref>`) for each required node repo:
+        Lightricks/ComfyUI-LTXVideo, city96/ComfyUI-GGUF,
+        kijai/ComfyUI-WanVideoWrapper, a Kokoro TTS node, a Fish-Speech TTS node;
+        and a `pip install -r requirements.txt` per node (no floating `main`).
+      Run: `uv run --with pytest --with pyyaml pytest scripts/tests/test_comfyui_stoa_image.py -v`
+      Expected: failures (image not updated yet).
+  - id: P1.T1.S2
+    text: |
+      Edit apps/comfyui/docker/Dockerfile: after the ComfyUI clone, add a
+      `# stoa custom nodes` block cloning each node repo into custom_nodes/ at
+      a PINNED ref via build ARGs (LTXVIDEO_REF, GGUF_REF, WANVIDEO_REF,
+      KOKORO_REF, FISHSPEECH_REF — real upstream tags/commits, locked here), each
+      followed by its `pip install --no-cache-dir -r requirements.txt`. Keep the
+      non-root chown after.
+  - id: P1.T1.S3
+    text: |
+      Edit .github/workflows/build-comfyui.yml: add the node-ref ARGs to env +
+      build-args, and add a STOA_NODES rev (e.g. STOA_NODES: "1") embedded in
+      the pushed tag (`...-cu128-stoa${{ env.STOA_NODES }}`). Edit
+      apps/comfyui/manifests/deployment.yaml image: to the SAME new tag.
+      Re-run the pytest. Expected: green.
+- number: 2
+  title: Model-download Job manifest (idempotent, gpu-1, PVC)
+  steps:
+  - id: P1.T2.S1
+    text: |
+      Extend scripts/tests/test_comfyui_stoa_image.py (red): assert
+      apps/comfyui/manifests/job-model-download.yaml is a batch/v1 Job in ns
+      comfyui with: nodeSelector kubernetes.io/hostname=gpu-1, the nvidia.com/gpu
+      NoSchedule toleration, a volume binding claimName comfyui-models mounted at
+      /app/models, restartPolicy OnFailure, and a command whose script is
+      IDEMPOTENT (contains a skip-if-present guard, e.g. `[ -f "$dest" ] && continue`
+      or an `if [ ! -f ]` wrapper) downloading the five model artefacts (LTX-2
+      NVFP8, Wan 2.2 14B Q8 GGUF, LTX-Video 0.9.x, Kokoro, Fish-Speech S2) into
+      the model subdirs. Run pytest → red.
+  - id: P1.T2.S2
+    text: |
+      Write apps/comfyui/manifests/job-model-download.yaml. Use a small image
+      with curl/python (e.g. the comfyui image itself or curlimages/curl with
+      runAsUser 100). Each artefact: `dest=...; url="..." # CONFIRM-LIVE; mkdir
+      -p; [ -f "$dest" ] || curl -fSL "$url" -o "$dest"`. Add a header comment:
+      weight source URLs are confirmed on gpu-1 at MO-1 (Phase 5); the run is a
+      manual op. BEGIN/END nothing — plain YAML. Re-run pytest → green. Commit:
+      `feat(comfyui): bake stoa nodes + model-download Job (TDD)`.
+state:
+  steps:
+    P1.T1.S1:
+      state: x
+      ticked_at: '2026-06-14T19:58:42+00:00'
+      note: null
+    P1.T1.S2:
+      state: x
+      ticked_at: '2026-06-14T20:00:59+00:00'
+      note: null
+    P1.T1.S3:
+      state: x
+      ticked_at: '2026-06-14T20:01:01+00:00'
+      note: null
+    P1.T2.S1:
+      state: x
+      ticked_at: '2026-06-14T20:01:02+00:00'
+      note: null
+    P1.T2.S2:
+      state: x
+      ticked_at: '2026-06-14T20:08:49+00:00'
+      note: null
+  completion:
+    at: '2026-06-14T20:08:51+00:00'
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/02.yaml
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/02.yaml
@@ -1,0 +1,68 @@
+schema_version: 2
+phase:
+  number: 2
+  title: ComfyUI VRAM flags + Authentik-gated Traefik route + homepage tile (TDD)
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: VRAM/offload launch flags on the Deployment, test-first
+  steps:
+  - id: P2.T1.S1
+    text: |
+      Write scripts/tests/test_comfyui_stoa_route.py FIRST (red), pyyaml:
+      assert apps/comfyui/manifests/deployment.yaml container `command`/`args`
+      include a 16GB-bounding offload flag (one of --reserve-vram / --lowvram /
+      --cache-none) AND keeps --listen 0.0.0.0 --port 8188. Run pytest → red.
+  - id: P2.T1.S2
+    text: |
+      Edit apps/comfyui/manifests/deployment.yaml: set the container args to the
+      existing listen/port flags PLUS the offload flag(s) (comment: final values
+      tuned at MO-2). Re-run → green.
+- number: 2
+  title: Traefik IngressRoute + Authentik proxy provider + homepage tile
+  steps:
+  - id: P2.T2.S1
+    text: |
+      Extend scripts/tests/test_comfyui_stoa_route.py (red): assert
+      - apps/traefik/manifests/ingressroutes.yaml has an IngressRoute for host
+        `comfyui.cluster.derio.net` routing to the comfyui Service:8188 with the
+        `authentik-forwardauth` middleware referenced and a tls section.
+      - apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml
+        gained a proxy provider entry for comfyui (mode forward_single, external
+        host comfyui.cluster.derio.net, has invalidation_flow) following the
+        existing entries' shape.
+      - apps/homepage/manifests/files/services.yaml has a ComfyUI tile (href
+        https://comfyui.cluster.derio.net, an icon, a description, in a category).
+      Run pytest → red.
+  - id: P2.T2.S2
+    text: |
+      Implement the three edits matching existing siblings in each file (copy an
+      adjacent IngressRoute / provider / tile and adapt). Do NOT touch the
+      embedded-outpost assignment (that is MO-3, manual). Re-run → green. Commit:
+      `feat(comfyui): VRAM flags + Authentik-gated comfyui.cluster.derio.net route + tile (TDD)`.
+state:
+  steps:
+    P2.T1.S1:
+      state: x
+      ticked_at: '2026-06-14T20:14:17+00:00'
+      note: null
+    P2.T1.S2:
+      state: x
+      ticked_at: '2026-06-14T20:14:22+00:00'
+      note: null
+    P2.T2.S1:
+      state: x
+      ticked_at: '2026-06-14T20:14:29+00:00'
+      note: null
+    P2.T2.S2:
+      state: '-'
+      ticked_at: '2026-06-14T20:14:37+00:00'
+      note: route + Authentik provider + homepage tile already present in repo; replaced
+        implement step with a presence/shape regression guard test
+  completion:
+    at: '2026-06-14T20:14:46+00:00'
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/03.yaml
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/03.yaml
@@ -1,0 +1,68 @@
+schema_version: 2
+phase:
+  number: 3
+  title: n8n-01 multi-agent-shell sidecar + persistent claude tmux session (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Sidecar container + agent-home PVC, test-first
+  steps:
+  - id: P3.T1.S1
+    text: |
+      Write scripts/tests/test_n8n_agent_sidecar.py FIRST (red), pyyaml. Assert
+      apps/n8n-01/manifests/deployment.yaml:
+      - has a second container named `multi-agent-shell`, image
+        `ghcr.io/derio-net/multi-agent-shell:<sha-or-pin>` (NOT :latest).
+      - that container has NO ANTHROPIC_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY
+        in env (subscription OAuth per the multi-harness standard), sets an
+        explicit HOME, and mounts a volume `agent-home` at that HOME.
+      - the pod does NOT set shareProcessNamespace: true (s6 incompatibility).
+      - a PVC manifest apps/n8n-01/manifests/pvc-agent-home.yaml exists (longhorn,
+        RWO).
+      Run pytest → red.
+  - id: P3.T1.S2
+    text: |
+      Add the sidecar container + agent-home volume to the n8n-01 Deployment and
+      write apps/n8n-01/manifests/pvc-agent-home.yaml. Bound the sidecar's
+      resources (requests/limits) so it can't starve n8n; keep strategy Recreate.
+      Re-run → green.
+- number: 2
+  title: Persistent session bootstrap (interactive claude in tmux, never -p)
+  steps:
+  - id: P3.T2.S1
+    text: |
+      Extend test_n8n_agent_sidecar.py (red): assert a ConfigMap manifest
+      apps/n8n-01/manifests/agent-session-bootstrap.yaml mounts a script that
+      ensures a tmux session named `stoa-script-claude` running INTERACTIVE
+      `claude` (assert the script starts `claude` with NO `-p`/`--print`, and
+      creates/guards the named tmux session idempotently). Assert the sidecar
+      container references the ConfigMap + runs the bootstrap. Run pytest → red.
+  - id: P3.T2.S2
+    text: |
+      Write the bootstrap ConfigMap + wire it (volume + mount + an init/command
+      that runs it under the image's shell). Re-run → green. Commit:
+      `feat(n8n): multi-agent-shell sidecar + persistent claude tmux session (TDD)`.
+state:
+  steps:
+    P3.T1.S1:
+      state: x
+      ticked_at: '2026-06-14T20:17:51+00:00'
+      note: null
+    P3.T1.S2:
+      state: x
+      ticked_at: '2026-06-14T20:17:53+00:00'
+      note: null
+    P3.T2.S1:
+      state: x
+      ticked_at: '2026-06-14T20:17:55+00:00'
+      note: null
+    P3.T2.S2:
+      state: x
+      ticked_at: '2026-06-14T20:20:01+00:00'
+      note: null
+  completion:
+    at: '2026-06-14T20:20:06+00:00'
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/04.yaml
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/04.yaml
@@ -1,0 +1,90 @@
+schema_version: 2
+phase:
+  number: 4
+  title: agent-session send/receive driver + n8n pod-local transport (TDD)
+  tag: agentic
+  depends_on:
+  - 3
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Vendor fixtures + driver unit tests (tmux mocked), test-first
+  steps:
+  - id: P4.T1.S1
+    text: |
+      Vendor the two technical fixtures into
+      scripts/tests/fixtures/stoa/agent_session_send_request.json and
+      agent_session_receive_response.json (copy the shapes from the content-factory
+      agent_session fixtures; strip `_note`/`_contract` if noisy but keep the field
+      set; use a generic session id like `stoa-script-claude`). Add a README line:
+      source-of-truth is content-factory (private); these pin the SHAPE frank's
+      driver must emit (no business context — technical only).
+  - id: P4.T1.S2
+    text: |
+      Write scripts/tests/test_agent_session_driver.py FIRST (red). Put a FAKE
+      `tmux` on PATH (a temp script) that records send-keys args and, on
+      capture-pane, prints a canned claude reply containing a fenced JSON
+      shot-list. Drive apps/n8n-01/manifests/files/agent-session (the driver).
+      Assert:
+      - `agent-session send '<json>'` issues a tmux send-keys to session
+        stoa-script-claude with the message text.
+      - `agent-session receive` (or the send→reply round-trip) emits JSON with
+        EXACTLY keys {session_id, agent, status, turn, payload}; status=="ok";
+        payload == the parsed shot-list object.
+      - the turn counter persists across two invocations (turn N then N+1) under
+        $HOME/.stoa/<session_id>.turn.
+      - a no-reply/timeout path emits status!="ok" (not a crash).
+      Run: `uv run --with pytest pytest scripts/tests/test_agent_session_driver.py -v`
+      Expected: red.
+  - id: P4.T1.S3
+    text: |
+      Implement the driver script apps/n8n-01/manifests/files/agent-session
+      (bash; uses tmux send-keys + capture-pane, a reply-end marker, a persisted
+      turn counter, jq/python to extract the fenced JSON payload). Re-run pytest
+      → green. Refactor for clarity; still green.
+- number: 2
+  title: Wire the driver into the sidecar + n8n pod-local transport
+  steps:
+  - id: P4.T2.S1
+    text: |
+      Extend test_agent_session_driver.py / test_n8n_agent_sidecar.py (red):
+      assert the driver is mounted into the sidecar (ConfigMap files entry +
+      volumeMount, on PATH), and that the n8n→driver transport is wired pod-local
+      WITHOUT a long-running server: the sidecar's sshd reachable on localhost
+      (shared netns) with an authorized key sourced from the agent-home PVC / a
+      Secret, documented for n8n's SSH node to run `agent-session send`. Assert no
+      new Service/port is exposed for this (local only). Run pytest → red.
+  - id: P4.T2.S2
+    text: |
+      Add the ConfigMap files entry + volumeMount for the driver, and the
+      localhost-sshd transport wiring (authorized-key wiring; a short
+      `apps/n8n-01/manifests/files/agent-session.README` documenting the exact
+      n8n SSH-node call, with a shared-volume file-drop noted as the fallback).
+      Re-run pytest → green. Commit:
+      `feat(n8n): agent-session send/receive driver + pod-local transport (TDD)`.
+state:
+  steps:
+    P4.T1.S1:
+      state: x
+      ticked_at: '2026-06-14T20:30:01+00:00'
+      note: null
+    P4.T1.S2:
+      state: x
+      ticked_at: '2026-06-14T20:30:03+00:00'
+      note: null
+    P4.T1.S3:
+      state: x
+      ticked_at: '2026-06-14T20:30:04+00:00'
+      note: null
+    P4.T2.S1:
+      state: x
+      ticked_at: '2026-06-14T20:33:45+00:00'
+      note: null
+    P4.T2.S2:
+      state: x
+      ticked_at: '2026-06-14T20:33:49+00:00'
+      note: null
+  completion:
+    at: '2026-06-14T20:33:54+00:00'
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/04.yaml
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/04.yaml
@@ -43,24 +43,24 @@ tasks:
       turn counter, jq/python to extract the fenced JSON payload). Re-run pytest
       → green. Refactor for clarity; still green.
 - number: 2
-  title: Wire the driver into the sidecar + n8n pod-local transport
+  title: Wire the driver into the sidecar + n8n pod-local HTTP transport
   steps:
   - id: P4.T2.S1
     text: |
       Extend test_agent_session_driver.py / test_n8n_agent_sidecar.py (red):
-      assert the driver is mounted into the sidecar (ConfigMap files entry +
-      volumeMount, on PATH), and that the n8n→driver transport is wired pod-local
-      WITHOUT a long-running server: the sidecar's sshd reachable on localhost
-      (shared netns) with an authorized key sourced from the agent-home PVC / a
-      Secret, documented for n8n's SSH node to run `agent-session send`. Assert no
-      new Service/port is exposed for this (local only). Run pytest → red.
+      assert the driver is mounted into the sidecar (ConfigMap volumeMount at
+      /opt/stoa-bin), and that the n8n→driver transport is a pod-local HTTP server
+      matching content-factory's n8n httpRequest node: `agent-session serve` binds
+      127.0.0.1 (never the wildcard) and answers POST /session/send (+ /healthz);
+      the bootstrap starts it; no Service/containerPort (localhost only); the
+      README documents AGENT_SIDECAR_URL=http://localhost:8765. Run pytest → red.
+      [Deviation: supersedes the original script-over-SSH transport — the other
+      half (content-factory PR #67) committed to HTTP POST /session/send.]
   - id: P4.T2.S2
     text: |
-      Add the ConfigMap files entry + volumeMount for the driver, and the
-      localhost-sshd transport wiring (authorized-key wiring; a short
-      `apps/n8n-01/manifests/files/agent-session.README` documenting the exact
-      n8n SSH-node call, with a shared-volume file-drop noted as the fallback).
-      Re-run pytest → green. Commit:
+      Add the driver ConfigMap volumeMount + the `serve` HTTP entry point (reuses
+      send()), start it from the bootstrap (tmux restart-loop), and document the
+      HTTP transport in the driver ConfigMap README. Re-run pytest → green. Commit:
       `feat(n8n): agent-session send/receive driver + pod-local transport (TDD)`.
 state:
   steps:

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/05.yaml
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/05.yaml
@@ -1,0 +1,91 @@
+schema_version: 2
+phase:
+  number: 5
+  title: '[manual] Live readiness, contract verification, content-factory writeback'
+  tag: manual
+  depends_on:
+  - 2
+  - 4
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Provision + verify on gpu-1, then write back and close
+  steps:
+  - id: P5.T1.S1
+    text: |
+      [manual] MO-1 — After merge (CI builds the comfyui image), run the
+      model-download Job on gpu-1; confirm LTX-2 NVFP8, Wan 2.2 14B Q8 GGUF,
+      LTX-Video 0.9.x, Kokoro, Fish-Speech S2 are present on the comfyui-models
+      PVC. Confirm/lock the weight source URLs in job-model-download.yaml.
+  - id: P5.T1.S2
+    text: |
+      [manual] MO-2 — Activate ComfyUI via the GPU Switcher and tune the
+      VRAM/offload flags under a real generation on the 16GB box; record the
+      final flag values back into deployment.yaml (one-model-at-a-time fit).
+  - id: P5.T1.S3
+    text: |
+      [manual] MO-3 — Assign the comfyui proxy provider to the Authentik embedded
+      outpost via the Django ORM step (per frank-argocd.md); confirm
+      comfyui.cluster.derio.net presents SSO.
+  - id: P5.T1.S4
+    text: |
+      [manual] MO-4 — One-time `claude login` (subscription OAuth) inside the
+      multi-agent-shell sidecar; confirm the credential lands on the agent-home
+      PVC and the `stoa-script-claude` tmux session is live.
+  - id: P5.T1.S5
+    text: |
+      [manual] MO-5 — Live contract verification (the Phase-2 S2 checks):
+      (a) in-cluster POST comfyui.comfyui.svc:8188/prompt with a stoa graph →
+      prompt_id + node_errors {}; GET /history/{id} → status.completed true with
+      outputs.<node>.gifs[]; GET /view → bytes.
+      (b) `agent-session send` for session stoa-script-claude → {status:ok,
+      turn:N, payload:{…}}; a second send → turn:N+1; `tmux attach` works.
+  - id: P5.T1.S6
+    text: |
+      [manual] MO-6 — Second-repo writeback (agentic-stoa/content-factory,
+      PRIVATE): record the live endpoints/route + this Frank PR URL in the
+      Frank-request runbook; tick the Phase-2 steps in the content-factory pipeline
+      plan; close content-factory#55. Technical only — no business context leaves
+      into frank.
+  - id: P5.T1.S7
+    text: |
+      [manual] MO-7 — n8n→sidecar transport keypair (prerequisite for MO-5b).
+      Create the SOPS-managed Secret `n8n-01-agent-ssh` (ssh keypair); mount the
+      public key into the sidecar's /etc/ssh-keys/authorized_keys and the private
+      key into the n8n container; verify n8n can `ssh agent@127.0.0.1 'bash -lc
+      "/opt/stoa-bin/agent-session send …"'`. See the agent-session.README in the
+      driver ConfigMap.
+state:
+  steps:
+    P5.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S5:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S6:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S7:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/05.yaml
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/05.yaml
@@ -36,10 +36,12 @@ tasks:
     text: |
       [manual] MO-5 — Live contract verification (the Phase-2 S2 checks):
       (a) in-cluster POST comfyui.comfyui.svc:8188/prompt with a stoa graph →
-      prompt_id + node_errors {}; GET /history/{id} → status.completed true with
-      outputs.<node>.gifs[]; GET /view → bytes.
-      (b) `agent-session send` for session stoa-script-claude → {status:ok,
-      turn:N, payload:{…}}; a second send → turn:N+1; `tmux attach` works.
+      prompt_id + node_errors {}; GET /history/{prompt_id} → body keyed by
+      prompt_id, body[prompt_id].status.completed true with outputs.<node>.gifs[];
+      GET /view → bytes.
+      (b) POST http://localhost:8765/session/send (n8n AGENT_SIDECAR_URL) →
+      {status:ok, turn:N, payload:{…}}; a second send → turn:N+1; `tmux attach`
+      to the session works.
   - id: P5.T1.S6
     text: |
       [manual] MO-6 — Second-repo writeback (agentic-stoa/content-factory,
@@ -47,14 +49,6 @@ tasks:
       Frank-request runbook; tick the Phase-2 steps in the content-factory pipeline
       plan; close content-factory#55. Technical only — no business context leaves
       into frank.
-  - id: P5.T1.S7
-    text: |
-      [manual] MO-7 — n8n→sidecar transport keypair (prerequisite for MO-5b).
-      Create the SOPS-managed Secret `n8n-01-agent-ssh` (ssh keypair); mount the
-      public key into the sidecar's /etc/ssh-keys/authorized_keys and the private
-      key into the n8n container; verify n8n can `ssh agent@127.0.0.1 'bash -lc
-      "/opt/stoa-bin/agent-session send …"'`. See the agent-session.README in the
-      driver ConfigMap.
 state:
   steps:
     P5.T1.S1:
@@ -78,10 +72,6 @@ state:
       ticked_at: null
       note: null
     P5.T1.S6:
-      state: ' '
-      ticked_at: null
-      note: null
-    P5.T1.S7:
       state: ' '
       ticked_at: null
       note: null

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-14-stoa-frank-infra
+spec: docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-14'

--- a/docs/superpowers/plans/2026-06-14-stoa-frank-infra/_prose.md
+++ b/docs/superpowers/plans/2026-06-14-stoa-frank-infra/_prose.md
@@ -1,0 +1,72 @@
+# Stoa Frank Infra — Plan
+
+Land the two additive Frank infrastructure changes that satisfy
+`agentic-stoa/content-factory#55` (stoa-pipeline Phase 2 contract):
+ComfyUI stoa enablement on `gpu-1`, and a persistent, operator-attachable
+`claude` session sidecar on `n8n-01`.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md`
+
+## Strategy
+
+**EXTEND, not BUILD-NEW.** The substrate already exists (operator-directed
+investigation of `agent-images` and `runs-fr` confirmed it):
+
+- ComfyUI's native API (`POST /prompt`, `GET /history/{id}`, `GET /view`)
+  already matches the contract shapes — Component 1 is pure provisioning
+  (custom nodes baked into the image, weights via a download Job, VRAM flags,
+  an Authentik-gated Traefik route). No API shim.
+- The `multi-agent-shell` image (the k8s-native-runs design's **L1** layer)
+  carries `claude` + tmux + sshd. The persistent-session interface is the
+  design's already-blessed **`tmux send-keys` → `capture-pane`** pattern
+  (never `claude -p`); the stoa driver is a thin script over it + a turn
+  counter. Operator-attach is SSH/`kubectl exec` + `tmux attach` (the
+  `runs-fr` browser gateway is the future path — not yet deployed).
+
+## TDD posture for GitOps
+
+The deterministic artifacts are unit-tested in `scripts/tests/` (pytest,
+the repo's `dev`-profile check) — `pyyaml` assertions over manifests, a
+**tag-consistency guard** (deployment image tag == the tag the build
+workflow renders, closing the health-bridge tag-drift hole), and the real
+centerpiece: the **agent-session driver** tested against the vendored
+contract fixtures with `tmux` mocked (turn-counter persistence, exact
+`{session_id, agent, status, turn, payload}` output). Generative quality is
+NOT unit-asserted — that is measured at the live `[manual]` gates.
+
+## Phase map
+
+```text
+1 ComfyUI image + model-Job ──► 2 ComfyUI VRAM + route + tile ─┐
+3 n8n sidecar + tmux session ──► 4 agent-session driver ───────┴─► 5 [manual] verify + writeback
+```
+
+Phases 1→2 (ComfyUI) and 3→4 (agent session) are two independent agentic
+tracks (parallel-able roots); the `[manual]` phase 5 fans in from both.
+
+## Manual is back-loaded (fr-goal placement policy)
+
+Every cluster/secret/UI/verify operation lives in **Phase 5** and nothing
+agentic depends on it. The PR ships Phase 5 deliberately **unimplemented**,
+marked for the operator: MO-1 model download (gpu-1), MO-2 VRAM tune, MO-3
+Authentik outpost assignment, MO-4 `claude` OAuth login, MO-5 live contract
+verification (both interfaces), MO-6 content-factory writeback + close #55.
+MO-1 also confirms-and-locks the model weight source URLs against the live
+box (HF paths/quant filenames drift).
+
+## Privacy boundary
+
+`derio-net/frank` is public; `content-factory` is private. This plan and the
+PR carry **technical detail only** — no business context (OPSEC).
+
+## Notes for the implementing agent
+
+- The comfyui image only rebuilds on `push:main` touching
+  `apps/comfyui/docker/**`, so the new tag's image exists **after merge**;
+  ComfyUI is `replicas: 0` (GPU-Switcher-gated), so nothing serves a missing
+  tag in the meantime.
+- Do NOT author any manual step into phases 1–4 — `fr plan self-review`
+  fails agentic-purity violations with error severity.
+- Vendoring the `agent_session` fixtures into frank is fine: they are
+  generic technical shapes (session id, turn, shot-list schema), no business
+  content.

--- a/docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+++ b/docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
@@ -63,9 +63,9 @@ this repo.
   P3–P7 in `content-factory`, built against the fixtures, not here.
 - **Quality calibration** of the models (does LTX-2 look good, is the audio acceptable) —
   measured at the content-factory manual gates (G2/G3/G5), not asserted here.
-- A standalone **agent-session HTTP server** image in `agent-images` (the rejected Option 2).
-  The driver is a thin frank-side script over the established `tmux send-keys`/`capture-pane`
-  pattern.
+- A separate **agent-session image/build in `agent-images`**. The HTTP `/session/send` server
+  is a thin **frank-side ConfigMap script** over the established `tmux send-keys`/`capture-pane`
+  pattern — no new upstream image.
 - Deploying / depending on **`runs-fr`** (Component C is a walking skeleton, not yet deployed
   — runs-fr#9). It is the *future* browser-attach path; operator-attach here is SSH/`kubectl
   exec` + `tmux attach`.
@@ -179,21 +179,28 @@ implementing the `agent_session.*` contract:
 - **send**: input `{session_id, agent, message, expect?, timeout_s?}` → selects the tmux
   session, `tmux send-keys` the message, waits (bounded by `timeout_s`) for the reply marker.
 - **receive**: `tmux capture-pane` the reply, extract the structured `payload` (the shot-list
-  JSON the agent emits), increment a **persisted per-session turn counter** (`$HOME/.stoa/
-  <session_id>.turn`), emit `{session_id, agent, status:"ok", turn, payload}`.
+  JSON the agent emits), increment a **persisted, locked, atomic per-session turn counter**
+  (`$HOME/.stoa/<session_id>.turn`), emit `{session_id, agent, status:"ok", turn, payload}`.
+- **Stale-reply safety:** the pane already holds prior turns' fenced-JSON, so the driver
+  baselines the `json`-block count **before** sending and only accepts a **new** block.
+- **Auto-create:** the session named by `session_id` is created on first send if absent, so the
+  driver is agnostic to the caller's chosen name (content-factory sends its own `session_id`;
+  Frank never hard-codes it).
 - The driver matches `agent_session_send_request.json` / `agent_session_receive_response.json`
   exactly. The `turn` increment across calls is the evidence-of-persistence the contract wants
   (a fresh `claude -p` could never advance it).
 
-**2d. Pod-local interface n8n reaches (your choice: Option 1 — script over exec, no HTTP
-server).** n8n and the sidecar share the pod (and its network namespace). n8n drives the driver
-over the sidecar's **own `sshd` on `localhost:22`** using the **n8n SSH node**: n8n SSHes to
-`localhost` (the sidecar, since n8n's container binds 5678 not 22) and runs
-`agent-session send …`, receiving the JSON on stdout. Auth via a key on the agent PVC. This
-keeps the interface a **script invocation** (Option 1), not a long-running HTTP service.
+**2d. Pod-local interface n8n reaches — HTTP (`POST /session/send`).** content-factory's merged
+n8n workflow drives the session with an **httpRequest node** → `POST {AGENT_SIDECAR_URL}/session/send`,
+so Frank exposes exactly that: `agent-session serve` runs a tiny HTTP server bound to
+**`127.0.0.1:${STOA_SESSION_PORT:-8765}`** (started by the bootstrap in a tmux restart-loop),
+serving `POST /session/send` (same `send()` core as the CLI) + `GET /healthz`. n8n and the
+sidecar share the pod's network namespace, so `AGENT_SIDECAR_URL=http://localhost:8765` reaches
+it directly — **no Service, no SSH keypair** (this supersedes the earlier script-over-SSH
+option once the other half committed to HTTP).
 - *Constraint:* `shareProcessNamespace` is **incompatible with the image's s6-overlay v3**
-  (PID-1 must be `suexec`) — so cross-container drive uses the shared **network** namespace
-  (localhost sshd) or a shared workspace volume, **never** `shareProcessNamespace`.
+  (PID-1 must be `suexec`) — the HTTP server reaches the tmux session within the **same
+  container**, so no cross-container namespace sharing is needed.
 
 **2e. Operator-attach.** `kubectl exec -it -c multi-agent-shell n8n-01-… -- tmux attach -t
 stoa-script-claude`, or `ssh` into the sidecar (image is SSH-able) + `tmux attach`. The
@@ -208,12 +215,12 @@ credential on `n8n-01-agent-home`; survives restarts. `# manual-operation`.
 
 The live infra is conformant when, run from inside the cluster:
 1. `POST comfyui.comfyui.svc:8188/prompt` with a stoa graph returns `prompt_id` +
-   `node_errors: {}`; `GET /history/{id}` reaches `status.completed: true` with an
-   `outputs.<node>.gifs[]` descriptor; `GET /view?…` returns the clip bytes. (Models LTX-2 /
-   Wan 2.2 / LTX-Video / Kokoro / Fish present; target list visible.)
-2. `agent-session send {session_id:"stoa-script-claude", agent:"claude", message:"…",
+   `node_errors: {}`; `GET /history/{prompt_id}` returns a body **keyed by `prompt_id`** with
+   `body[prompt_id].status.completed: true` and an `outputs.<node>.gifs[]` descriptor; `GET
+   /view?…` returns the clip bytes. (Models LTX-2 / Wan 2.2 / LTX-Video / Kokoro / Fish present.)
+2. `POST http://localhost:8765/session/send {session_id, agent:"claude", message:"…",
    expect:"shotlist"}` returns `{status:"ok", turn:N, payload:{…}}`; a **second** call returns
-   `turn:N+1` (persistence proof); the operator can `tmux attach` to the same session.
+   `turn:N+1` (persistence proof); the operator can `tmux attach` to the session.
 
 These are the content-factory Phase-2 S2 checks; their results + the live endpoints/route get
 recorded back in the **Frank-request runbook** in content-factory (private), and #55 closed.
@@ -230,13 +237,14 @@ the live box and push to the same PR / drive post-merge:
 - **MO-3 Authentik outpost assignment** — add the ComfyUI proxy provider to the embedded
   outpost (Django ORM).
 - **MO-4 claude OAuth login** — `claude login` in the sidecar; credential on the PVC.
-- **MO-5 Live contract verification** — run the two conformance checks above end-to-end.
+- **MO-5 Live contract verification** — run the two conformance checks above end-to-end (the
+  ComfyUI submit→poll→fetch keyed by `prompt_id`, and `POST /session/send` returning an advancing
+  `turn`). Set the n8n workflow's `AGENT_SIDECAR_URL=http://localhost:8765`.
 - **MO-6 content-factory writeback** — record endpoints/route + Frank PR URL in the
   Frank-request runbook (content-factory, private); mark Phase-2 steps; close content-factory#55.
-- **MO-7 n8n→sidecar transport keypair** — SOPS-managed `n8n-01-agent-ssh` Secret (public key
-  → sidecar `authorized_keys`, private key → n8n container) so n8n's SSH node can reach the
-  driver on localhost. Prerequisite for MO-5b. Secrets aren't ArgoCD-managed (declarative-only
-  exception), hence manual.
+
+The HTTP transport is pod-local (n8n → `localhost:8765`), so **no SSH keypair / Secret is
+needed** — the earlier MO-7 was dropped when the transport moved to HTTP.
 
 ## Test plan (post-merge, operator-driven)
 

--- a/docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+++ b/docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
@@ -1,0 +1,263 @@
+# Stoa Frank Infra — Design
+
+**Status:** Draft
+**Layer:** agents (12 — Agentic Control Plane) / gpu (4 — AI Compute)
+**Date:** 2026-06-14
+**Repos touched:** `frank` (this spec + ComfyUI/n8n-01 wiring, the PR this run delivers),
+`agentic-stoa/content-factory` (private — Phase-2 verify writeback only, no code)
+
+## Implementation Plans
+
+| Plan | Target repo | Slug | Status |
+|------|-------------|------|--------|
+| 2026-06-14-stoa-frank-infra | `derio-net/frank` | `2026-06-14-stoa-frank-infra` | — |
+
+## Context
+
+The **stoa** content pipeline (private, `agentic-stoa/content-factory`) is a standing local AI
+pipeline producing serialized short-form video. Its pipeline plan, Phase 2 (issue
+[content-factory#55](https://github.com/agentic-stoa/content-factory/issues/55), tagged
+`manual`) is a **Frank-readiness gate**: it requests two **additive** infrastructure changes
+on Frank and then verifies the live contract once Frank lands them.
+
+The operator runs *as Frank* here, so there is **no separate request issue** — this PR **is**
+Frank landing the request. The two changes:
+
+1. **ComfyUI on `gpu-1`** enabled for stoa video/audio generation: custom nodes + model
+   weights (LTX-2 NVFP8, Wan 2.2 14B Q8 GGUF, LTX-Video 0.9.x, TTS), VRAM/offload tuned for
+   the 16 GB RTX 5070 Ti, the API reachable, and an Authentik-gated Traefik route.
+2. A **`multi-agent-shell` sidecar** on the `n8n-01` pod hosting a **persistent,
+   operator-attachable `claude` session** that n8n drives over a pod-local interface — never
+   `claude -p`.
+
+The interface shapes Frank must satisfy are pinned in the content-factory **interface-contracts
+decision record**, with machine-checkable fixtures alongside it in that private repo. The
+content-factory build proceeds against those fixtures/mocks; only its measurement gates and the
+pilot need this live infra.
+
+### Privacy boundary (load-bearing)
+
+`derio-net/frank` is **public**; `content-factory` is **private**. This spec and the PR it
+drives carry **technical detail only — no business context** (OPSEC). "stoa" here means a
+serialized-video generation workload; nothing about titles, market, or strategy belongs in
+this repo.
+
+## Goals
+
+- ComfyUI on `gpu-1` serves the stoa generation workflows through its **native API**
+  (`POST /prompt`, `GET /history/{id}`, `GET /view`), with the required custom nodes + model
+  weights present and VRAM bounded to run one model at a time on 16 GB.
+- A `multi-agent-shell` sidecar on `n8n-01` exposes a **persistent** `claude` session via a
+  send/receive driver conforming to the `agent_session.*` contract (turn counter evidencing
+  continuity), driven by n8n over a pod-local transport and attachable by the operator.
+- **Declarative-only:** every artifact reproducible from this repo (ArgoCD). The only
+  out-of-band steps are the documented `# manual-operation` blocks (model weights, OAuth
+  login, Authentik outpost, live verification).
+- **Reuse, not reinvention:** align with the existing **k8s-native agentic-runs** design
+  (`docs/superpowers/specs/2026-06-07--agents--k8s-native-runs-design.md`) rather than fork a
+  parallel session mechanism.
+
+## Non-goals (out of scope for this run)
+
+- The stoa **application code** (runner, registry, gates, assembly, n8n graphs) — that is
+  P3–P7 in `content-factory`, built against the fixtures, not here.
+- **Quality calibration** of the models (does LTX-2 look good, is the audio acceptable) —
+  measured at the content-factory manual gates (G2/G3/G5), not asserted here.
+- A standalone **agent-session HTTP server** image in `agent-images` (the rejected Option 2).
+  The driver is a thin frank-side script over the established `tmux send-keys`/`capture-pane`
+  pattern.
+- Deploying / depending on **`runs-fr`** (Component C is a walking skeleton, not yet deployed
+  — runs-fr#9). It is the *future* browser-attach path; operator-attach here is SSH/`kubectl
+  exec` + `tmux attach`.
+- **Cloud generation fallback** — stays off; not provisioned here.
+
+## Architecture
+
+Two independent components. They share nothing except the pod (`n8n-01`) the sidecar joins
+and the GPU node (`gpu-1`) both ultimately run on.
+
+### Reuse map (why this is EXTEND, not BUILD-NEW)
+
+Investigation (operator-directed: check `agent-images` and `runs-fr`) established the
+substrate already exists:
+
+| Need | Existing artifact | Action |
+|------|-------------------|--------|
+| ComfyUI API (submit/poll/fetch) | stock ComfyUI on `gpu-1` (`apps/comfyui`) | **reuse as-is** — the contract shapes are native ComfyUI; no shim |
+| Shell + `claude` + tmux + sshd | `agent-images/multi-agent-shell` (the design's **L1** image) | **reuse as the sidecar image** |
+| Persistent-session drive pattern | the k8s-native-runs design's Tier-2 mechanism: interactive tmux session + `tmux send-keys`→`capture-pane`, **never `claude -p`** | **extend** into a thin send/receive driver + turn counter |
+| Operator browser-attach | `runs-fr` (Component C) | **note as future** — not deployed; attach via SSH/`kubectl exec` now |
+
+The `kali` `session-manager.sh`/`wrap-claude.py` machinery was evaluated and **rejected** as a
+base: it drives `claude remote-control`, coupled to the willikins remote-control bridge, not a
+clean pod-local send/receive driver.
+
+### Component 1 — ComfyUI stoa enablement (`apps/comfyui`)
+
+Current state: `apps/comfyui` is a stock ComfyUI Deployment on `gpu-1`, `replicas: 0`
+(GPU-Switcher-gated), image `ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128` built by
+`.github/workflows/build-comfyui.yml` from `apps/comfyui/docker/`, with a 100 Gi `comfyui-models`
+PVC and a 10 Gi `comfyui-custom-nodes` PVC, exposed at LB `192.168.55.213:8188` and ClusterIP
+`comfyui.comfyui.svc:8188`. The Traefik route, Authentik proxy provider, and homepage tile for
+`comfyui.cluster.derio.net` **already exist** in the repo (gated live only by the embedded-outpost
+assignment, MO-3). **Missing: the stoa nodes/models and the VRAM/offload flags.**
+
+**1a. Custom nodes — baked into the image (your choice: bake + pin).** Extend
+`apps/comfyui/docker/Dockerfile` to `git clone` the required custom nodes at pinned refs and
+install their `requirements.txt`, gated behind a new `NODES_REF`/per-node `ARG` so the build is
+reproducible. Nodes (pinned to real upstreams; exact refs locked in the plan):
+- **LTX-Video** (`Lightricks/ComfyUI-LTXVideo`) — LTX-Video 0.9.x **and** LTX-2 NVFP8 sampler
+  nodes.
+- **GGUF loader** (`city96/ComfyUI-GGUF`) — for Wan 2.2 14B **Q8 GGUF**.
+- **WanVideo wrapper** (`kijai/ComfyUI-WanVideoWrapper`) — Wan 2.2 nodes.
+- **TTS** — both engines (your choice "Both"): a **Kokoro** node (`stavsap/comfyui-kokoro` or
+  equivalent) and a **Fish-Speech** node (`AIFSH/ComfyUI-FishSpeech` or equivalent).
+
+The image tag gains a node-set dimension (e.g. `…-cu128-stoa<N>`) so the Deployment's pinned
+tag moves only when the node set changes (mirrors the repo's digest-pin philosophy and the
+Falco "no runtime binary installs" posture). `build-comfyui.yml` env + the Deployment image tag
+bump together.
+
+> **Rejected:** runtime install via ComfyUI-Manager onto the PVC — non-reproducible and trips
+> the runtime-install Falco rule.
+
+**1b. Model weights — declarative download Job (your choice: download Job).** A new idempotent
+`Job` (`apps/comfyui/manifests/job-model-download.yaml`) hydrates the `comfyui-models` PVC:
+LTX-2 NVFP8, Wan 2.2 14B Q8 GGUF, LTX-Video 0.9.x, Kokoro, Fish-Speech S2. Idempotent
+(skip-if-present by target path + size/sha), `nodeSelector: gpu-1`, mounts the same PVC, runs
+once. Weight **source URLs are confirmed on the live box** (HF repo paths / quant filenames may
+move) → the Job ships with sourced-and-commented URLs but the **actual download run is a
+back-loaded `# manual-operation`** (GB-scale pull, gpu-1).
+
+**1c. VRAM / offload for 16 GB.** The stoa runner drives **one clip at a time** (submit →
+poll → fetch), so models load serially. Set ComfyUI launch flags in the Deployment `CMD` for a
+16 GB ceiling (candidate: `--lowvram` / `--reserve-vram <GiB>` / `--cache-none`; exact flags
+validated on the live box and recorded). This is config, not code; final values are tuned at
+the live gate.
+
+**1d. Traefik route + auth (your choice: Authentik SSO + ClusterIP runner) — ALREADY PRESENT.**
+The declarative pieces for `comfyui.cluster.derio.net` already exist in the repo and are kept as-is
+(a regression guard test asserts their presence + shape):
+- IngressRoute in `apps/traefik/manifests/ingressroutes.yaml` (`authentik-forwardauth` middleware).
+- Proxy provider in `apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml`
+  (`forward_single`, `invalidation_flow`).
+- Homepage tile in `apps/homepage/manifests/files/services.yaml`.
+- **Manual (MO-3):** outpost-provider assignment (Django ORM, per `frank-argocd.md`) — the one
+  non-declarative piece; verify SSO actually presents and run it if not.
+
+The **in-cluster runner + n8n call the ClusterIP** (`comfyui.comfyui.svc:8188`) with no SSO;
+the Traefik route is the human/ops surface only. (If the runner is ever moved outside the
+cluster, that's a separate decision — not provisioned here.)
+
+**1e. API contract.** Native ComfyUI already serves `POST /prompt` →
+`{prompt_id, number, node_errors}`, `GET /history/{prompt_id}` →
+`{status:{completed,status_str,…}, outputs:{<node>:{gifs:[…]}}}`, `GET /view?filename&subfolder&type`.
+These match the fixtures (`comfyui_submit_response.json`, `comfyui_status_response.json`,
+`comfyui_view_request.json`) verbatim — **no shim**. Conformance is proven by a live
+submit→poll→fetch at the manual gate.
+
+### Component 2 — `multi-agent-shell` sidecar on `n8n-01` (`apps/n8n-01`)
+
+Current state: `apps/n8n-01/manifests/deployment.yaml` is a single-container `n8nio/n8n:2.13.4`
+Deployment on `gpu-1`, `strategy: Recreate`, data PVC `n8n-01-data`.
+
+**2a. Sidecar container.** Add a `multi-agent-shell` container to the `n8n-01` Deployment, image
+`ghcr.io/derio-net/multi-agent-shell:<pinned>`, with:
+- A **dedicated PVC** (`n8n-01-agent-home`) at the agent `$HOME` for PV-resident OAuth creds +
+  tmux-resurrect session state (the image's documented contract — creds never in the image).
+- `securityContext` honoring the image's non-root agent uid; explicit `HOME`.
+- No `ANTHROPIC_API_KEY` in `env:` — subscription OAuth per the multi-harness standard.
+
+**2b. Persistent session bootstrap.** A small bootstrap (ConfigMap-mounted, run by the image's
+`cont-init.d`/s6 convention or an explicit command) ensures a **tmux session named
+`stoa-script-claude`** running **interactive `claude`** (never `-p`), started once and kept
+alive (tmux-resurrect/continuum already in the L0 base). This is the same "agent in a named
+tmux session" shape the k8s-native-runs design uses.
+
+**2c. Send/receive driver (the EXTEND).** A ConfigMap-mounted script `agent-session`
+implementing the `agent_session.*` contract:
+- **send**: input `{session_id, agent, message, expect?, timeout_s?}` → selects the tmux
+  session, `tmux send-keys` the message, waits (bounded by `timeout_s`) for the reply marker.
+- **receive**: `tmux capture-pane` the reply, extract the structured `payload` (the shot-list
+  JSON the agent emits), increment a **persisted per-session turn counter** (`$HOME/.stoa/
+  <session_id>.turn`), emit `{session_id, agent, status:"ok", turn, payload}`.
+- The driver matches `agent_session_send_request.json` / `agent_session_receive_response.json`
+  exactly. The `turn` increment across calls is the evidence-of-persistence the contract wants
+  (a fresh `claude -p` could never advance it).
+
+**2d. Pod-local interface n8n reaches (your choice: Option 1 — script over exec, no HTTP
+server).** n8n and the sidecar share the pod (and its network namespace). n8n drives the driver
+over the sidecar's **own `sshd` on `localhost:22`** using the **n8n SSH node**: n8n SSHes to
+`localhost` (the sidecar, since n8n's container binds 5678 not 22) and runs
+`agent-session send …`, receiving the JSON on stdout. Auth via a key on the agent PVC. This
+keeps the interface a **script invocation** (Option 1), not a long-running HTTP service.
+- *Constraint:* `shareProcessNamespace` is **incompatible with the image's s6-overlay v3**
+  (PID-1 must be `suexec`) — so cross-container drive uses the shared **network** namespace
+  (localhost sshd) or a shared workspace volume, **never** `shareProcessNamespace`.
+
+**2e. Operator-attach.** `kubectl exec -it -c multi-agent-shell n8n-01-… -- tmux attach -t
+stoa-script-claude`, or `ssh` into the sidecar (image is SSH-able) + `tmux attach`. The
+operator inspects/redirects/re-rolls a beat by hand — the creative analog of the editable n8n
+graph. (Future: surface the same tmux session in the `runs-fr` browser gateway once it is
+deployed, by labeling the pod `fr.run/*`.)
+
+**2f. Auth (manual).** One-time `claude login` (subscription OAuth) inside the sidecar lands the
+credential on `n8n-01-agent-home`; survives restarts. `# manual-operation`.
+
+## Conformance contract (what "satisfied" means)
+
+The live infra is conformant when, run from inside the cluster:
+1. `POST comfyui.comfyui.svc:8188/prompt` with a stoa graph returns `prompt_id` +
+   `node_errors: {}`; `GET /history/{id}` reaches `status.completed: true` with an
+   `outputs.<node>.gifs[]` descriptor; `GET /view?…` returns the clip bytes. (Models LTX-2 /
+   Wan 2.2 / LTX-Video / Kokoro / Fish present; target list visible.)
+2. `agent-session send {session_id:"stoa-script-claude", agent:"claude", message:"…",
+   expect:"shotlist"}` returns `{status:"ok", turn:N, payload:{…}}`; a **second** call returns
+   `turn:N+1` (persistence proof); the operator can `tmux attach` to the same session.
+
+These are the content-factory Phase-2 S2 checks; their results + the live endpoints/route get
+recorded back in the **Frank-request runbook** in content-factory (private), and #55 closed.
+
+## Manual / back-loaded operations (all in the final phase; nothing agentic depends on them)
+
+Per fr-goal placement policy, the PR ships these **unimplemented**, for the operator to run on
+the live box and push to the same PR / drive post-merge:
+
+- **MO-1 ComfyUI model download** — run the download Job on `gpu-1`; confirm weights present.
+  (Source URLs confirmed live.)
+- **MO-2 ComfyUI VRAM tune** — validate the launch flags actually bound 16 GB under a real
+  generation; record final flags.
+- **MO-3 Authentik outpost assignment** — add the ComfyUI proxy provider to the embedded
+  outpost (Django ORM).
+- **MO-4 claude OAuth login** — `claude login` in the sidecar; credential on the PVC.
+- **MO-5 Live contract verification** — run the two conformance checks above end-to-end.
+- **MO-6 content-factory writeback** — record endpoints/route + Frank PR URL in the
+  Frank-request runbook (content-factory, private); mark Phase-2 steps; close content-factory#55.
+- **MO-7 n8n→sidecar transport keypair** — SOPS-managed `n8n-01-agent-ssh` Secret (public key
+  → sidecar `authorized_keys`, private key → n8n container) so n8n's SSH node can reach the
+  driver on localhost. Prerequisite for MO-5b. Secrets aren't ArgoCD-managed (declarative-only
+  exception), hence manual.
+
+## Test plan (post-merge, operator-driven)
+
+The deterministic artifacts (manifests, Dockerfile, Job YAML, driver script, ConfigMaps) are
+validated in-repo (YAML/manifest validation, driver script unit tests against the fixtures —
+`tmux` mocked). The **behavioral** proof is MO-5 above: the two live conformance checks on
+`gpu-1`, run interactively the production way (in-session, not `claude -p`), mirroring the
+k8s-native-runs Tier-2 doctrine. A layer is not "Deployed" until those run end-to-end.
+
+## Risks & open considerations
+
+- **16 GB VRAM fit is unproven for LTX-2 NVFP8 + Wan 2.2 14B.** One-model-at-a-time + offload
+  flags are the mitigation; the live tune (MO-2) is the real test. If a model can't fit, that's
+  a content-factory gate decision (G2/G3), not a Frank blocker — the API still conforms.
+- **Model source churn.** HF repo paths / quant filenames move; the Job's URLs are confirmed
+  live at MO-1, not assumed at author time.
+- **gpu-1 is the only GPU node and hosts pinned agent pods.** ComfyUI is `replicas: 0`
+  (GPU-Switcher-gated) so it contends only when activated; the sidecar is CPU-only (no GPU
+  request). No new hard GPU pin is added.
+- **Sidecar inflates the `n8n-01` pod** (memory/restart coupling — `Recreate` strategy means
+  both restart together). Bound the sidecar's resources; keep n8n's own limits intact.
+- **`runs-fr` not deployed.** Operator-attach must not depend on it; SSH/`kubectl exec` is the
+  baseline. Browser-attach is a future nicety.
+- **Privacy.** Keep business context out of this public repo; technical only.

--- a/scripts/tests/fixtures/stoa/README.md
+++ b/scripts/tests/fixtures/stoa/README.md
@@ -1,0 +1,10 @@
+# Vendored agent_session fixtures
+
+Source of truth: the `agent_session` contract fixtures in
+`agentic-stoa/content-factory` (private). These copies pin the **shape** the
+Frank-side `agent-session` driver must emit — `{session_id, agent, status,
+turn, payload}` for receive, `{session_id, agent, message, expect?,
+timeout_s?}` for send.
+
+Values are generic placeholders (no business context — technical only); only
+the field set + types are load-bearing.

--- a/scripts/tests/fixtures/stoa/agent_session_receive_response.json
+++ b/scripts/tests/fixtures/stoa/agent_session_receive_response.json
@@ -1,0 +1,13 @@
+{
+  "session_id": "stoa-script-claude",
+  "agent": "claude",
+  "status": "ok",
+  "turn": 37,
+  "payload": {
+    "schema_version": "1.0",
+    "series_id": "series-x",
+    "episode_id": "ep-012",
+    "characters": ["char-a", "char-b"],
+    "clips": []
+  }
+}

--- a/scripts/tests/fixtures/stoa/agent_session_send_request.json
+++ b/scripts/tests/fixtures/stoa/agent_session_send_request.json
@@ -1,0 +1,7 @@
+{
+  "session_id": "stoa-script-claude",
+  "agent": "claude",
+  "message": "Write the next episode from the series bible and current series-state, then decompose it into a clip-granular shot-list conforming to shotlist.schema.json v1.0.",
+  "expect": "shotlist",
+  "timeout_s": 300
+}

--- a/scripts/tests/test_agent_session_driver.py
+++ b/scripts/tests/test_agent_session_driver.py
@@ -1,0 +1,142 @@
+"""Unit tests for the agent-session send/receive driver.
+
+The driver drives the persistent claude tmux session (never `claude -p`): it
+sends a message, waits for a NEW fenced-JSON reply (not a prior turn's), and
+emits the agent_session.receive.response shape with a per-session turn counter.
+tmux is mocked: send-keys makes the agent "respond" (the reply pane replaces the
+baseline pane), capture-pane echoes the current pane — so the count-based
+new-block detection is actually exercised.
+
+Contract source of truth:
+docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+Shape fixtures: scripts/tests/fixtures/stoa/
+"""
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+DRIVER_CM = REPO / "apps/n8n-01/manifests/agent-session-driver.yaml"
+FIXTURES = REPO / "scripts/tests/fixtures/stoa"
+
+SEND_REQ = json.loads((FIXTURES / "agent_session_send_request.json").read_text())
+RECV_KEYS = set(json.loads((FIXTURES / "agent_session_receive_response.json").read_text()))
+
+NEW_REPLY = """\
+I'll write the episode and decompose it.
+
+```json
+{"schema_version": "1.0", "series_id": "series-x", "episode_id": "ep-012",
+ "characters": ["char-a", "char-b"], "clips": []}
+```
+Done.
+"""
+
+PRIOR_TURN = """\
+(previous turn still in the pane)
+```json
+{"schema_version": "1.0", "episode_id": "ep-OLD", "clips": []}
+```
+"""
+
+
+def _driver_script() -> str:
+    doc = next(
+        d for d in yaml.safe_load_all(DRIVER_CM.read_text())
+        if d and d.get("kind") == "ConfigMap"
+    )
+    return doc["data"]["agent-session"]
+
+
+@pytest.fixture
+def driver(tmp_path):
+    """Materialize the driver + a fake tmux on PATH; return a runner.
+
+    The fake tmux models a real session: `capture-pane` echoes the pane file;
+    `send-keys` simulates the agent replying by overwriting the pane with the
+    reply text. So a capture BEFORE send sees only the baseline, and captures
+    AFTER send see the reply — exactly the timing the driver must handle.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    drv = bindir / "agent-session"
+    drv.write_text(_driver_script())
+    drv.chmod(drv.stat().st_mode | stat.S_IEXEC)
+
+    pane = tmp_path / "pane.txt"
+    reply = tmp_path / "reply.txt"
+    sendlog = tmp_path / "sendkeys.log"
+    faketmux = bindir / "tmux"
+    faketmux.write_text(
+        "#!/usr/bin/env bash\n"
+        "case \"$1\" in\n"
+        "  has-session) exit 0 ;;\n"
+        f"  send-keys) shift; echo \"$*\" >> '{sendlog}'; cat '{reply}' > '{pane}' ;;\n"
+        f"  capture-pane) cat '{pane}' 2>/dev/null ;;\n"
+        "  *) exit 0 ;;\n"
+        "esac\n"
+    )
+    faketmux.chmod(faketmux.stat().st_mode | stat.S_IEXEC)
+    turns = tmp_path / "turns"
+
+    def run(req, initial_pane="", reply_pane=NEW_REPLY):
+        pane.write_text(initial_pane)
+        reply.write_text(reply_pane)
+        env = dict(os.environ)
+        env["PATH"] = f"{bindir}:{env['PATH']}"
+        env["STOA_TURN_DIR"] = str(turns)
+        env["STOA_POLL_S"] = "0.05"
+        p = subprocess.run(
+            [sys.executable, str(drv), "send", json.dumps(req)],
+            capture_output=True, text=True, env=env, timeout=30,
+        )
+        return p, sendlog
+
+    return run
+
+
+def test_send_keys_carries_the_message(driver):
+    p, sendlog = driver(SEND_REQ)
+    assert p.returncode == 0, p.stderr
+    assert "decompose" in sendlog.read_text()
+
+
+def test_receive_shape_matches_contract(driver):
+    p, _ = driver(SEND_REQ)
+    out = json.loads(p.stdout)
+    assert set(out) == RECV_KEYS, f"keys {set(out)} != contract {RECV_KEYS}"
+    assert out["status"] == "ok"
+    assert out["session_id"] == SEND_REQ["session_id"]
+    assert out["agent"] == "claude"
+    assert out["payload"]["episode_id"] == "ep-012"
+
+
+def test_returns_new_reply_not_prior_turn(driver):
+    """C1 regression: a prior turn's json is already in the pane; the driver
+    must wait for and return THIS turn's reply, not the stale one."""
+    p, _ = driver(SEND_REQ, initial_pane=PRIOR_TURN, reply_pane=PRIOR_TURN + NEW_REPLY)
+    out = json.loads(p.stdout)
+    assert out["status"] == "ok"
+    assert out["payload"]["episode_id"] == "ep-012", "must not return the prior turn's payload"
+
+
+def test_turn_counter_persists_and_increments(driver):
+    p1, _ = driver(SEND_REQ)
+    p2, _ = driver(SEND_REQ)
+    t1 = json.loads(p1.stdout)["turn"]
+    t2 = json.loads(p2.stdout)["turn"]
+    assert t2 == t1 + 1, f"turn must advance across calls (got {t1} then {t2})"
+
+
+def test_timeout_when_no_new_reply(driver):
+    # The agent produces no new json block within the window.
+    req = dict(SEND_REQ, timeout_s=0.2)
+    p, _ = driver(req, initial_pane="thinking...", reply_pane="thinking... still no json")
+    out = json.loads(p.stdout)
+    assert out["status"] != "ok", "no new reply within timeout must NOT be ok"

--- a/scripts/tests/test_agent_session_driver.py
+++ b/scripts/tests/test_agent_session_driver.py
@@ -3,9 +3,11 @@
 The driver drives the persistent claude tmux session (never `claude -p`): it
 sends a message, waits for a NEW fenced-JSON reply (not a prior turn's), and
 emits the agent_session.receive.response shape with a per-session turn counter.
+It exposes the same core as `agent-session serve` (HTTP POST /session/send, what
+content-factory's n8n calls) and `agent-session send` (CLI).
+
 tmux is mocked: send-keys makes the agent "respond" (the reply pane replaces the
-baseline pane), capture-pane echoes the current pane — so the count-based
-new-block detection is actually exercised.
+baseline pane); has-session is controllable so auto-create can be exercised.
 
 Contract source of truth:
 docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
@@ -13,9 +15,14 @@ Shape fixtures: scripts/tests/fixtures/stoa/
 """
 import json
 import os
+import socket
 import stat
 import subprocess
 import sys
+import time
+import types
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -54,15 +61,17 @@ def _driver_script() -> str:
     return doc["data"]["agent-session"]
 
 
-@pytest.fixture
-def driver(tmp_path):
-    """Materialize the driver + a fake tmux on PATH; return a runner.
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
 
-    The fake tmux models a real session: `capture-pane` echoes the pane file;
-    `send-keys` simulates the agent replying by overwriting the pane with the
-    reply text. So a capture BEFORE send sees only the baseline, and captures
-    AFTER send see the reply — exactly the timing the driver must handle.
-    """
+
+@pytest.fixture
+def harness(tmp_path):
+    """Materialize the driver + a controllable fake tmux on PATH."""
     bindir = tmp_path / "bin"
     bindir.mkdir()
     drv = bindir / "agent-session"
@@ -72,11 +81,14 @@ def driver(tmp_path):
     pane = tmp_path / "pane.txt"
     reply = tmp_path / "reply.txt"
     sendlog = tmp_path / "sendkeys.log"
+    newlog = tmp_path / "newsession.log"
+    hasfile = tmp_path / "has.code"  # exit code for has-session (default 0)
     faketmux = bindir / "tmux"
     faketmux.write_text(
         "#!/usr/bin/env bash\n"
         "case \"$1\" in\n"
-        "  has-session) exit 0 ;;\n"
+        f"  has-session) exit $(cat '{hasfile}' 2>/dev/null || echo 0) ;;\n"
+        f"  new-session) shift; echo \"$*\" >> '{newlog}' ;;\n"
         f"  send-keys) shift; echo \"$*\" >> '{sendlog}'; cat '{reply}' > '{pane}' ;;\n"
         f"  capture-pane) cat '{pane}' 2>/dev/null ;;\n"
         "  *) exit 0 ;;\n"
@@ -85,31 +97,35 @@ def driver(tmp_path):
     faketmux.chmod(faketmux.stat().st_mode | stat.S_IEXEC)
     turns = tmp_path / "turns"
 
-    def run(req, initial_pane="", reply_pane=NEW_REPLY):
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["STOA_TURN_DIR"] = str(turns)
+    env["STOA_POLL_S"] = "0.05"
+
+    def run(req, initial_pane="", reply_pane=NEW_REPLY, session_exists=True):
         pane.write_text(initial_pane)
         reply.write_text(reply_pane)
-        env = dict(os.environ)
-        env["PATH"] = f"{bindir}:{env['PATH']}"
-        env["STOA_TURN_DIR"] = str(turns)
-        env["STOA_POLL_S"] = "0.05"
+        hasfile.write_text("0" if session_exists else "1")
         p = subprocess.run(
             [sys.executable, str(drv), "send", json.dumps(req)],
             capture_output=True, text=True, env=env, timeout=30,
         )
-        return p, sendlog
+        return p
 
-    return run
+    return types.SimpleNamespace(
+        drv=drv, env=env, pane=pane, reply=reply, sendlog=sendlog,
+        newlog=newlog, hasfile=hasfile, run=run,
+    )
 
 
-def test_send_keys_carries_the_message(driver):
-    p, sendlog = driver(SEND_REQ)
+def test_send_keys_carries_the_message(harness):
+    p = harness.run(SEND_REQ)
     assert p.returncode == 0, p.stderr
-    assert "decompose" in sendlog.read_text()
+    assert "decompose" in harness.sendlog.read_text()
 
 
-def test_receive_shape_matches_contract(driver):
-    p, _ = driver(SEND_REQ)
-    out = json.loads(p.stdout)
+def test_receive_shape_matches_contract(harness):
+    out = json.loads(harness.run(SEND_REQ).stdout)
     assert set(out) == RECV_KEYS, f"keys {set(out)} != contract {RECV_KEYS}"
     assert out["status"] == "ok"
     assert out["session_id"] == SEND_REQ["session_id"]
@@ -117,26 +133,74 @@ def test_receive_shape_matches_contract(driver):
     assert out["payload"]["episode_id"] == "ep-012"
 
 
-def test_returns_new_reply_not_prior_turn(driver):
+def test_returns_new_reply_not_prior_turn(harness):
     """C1 regression: a prior turn's json is already in the pane; the driver
     must wait for and return THIS turn's reply, not the stale one."""
-    p, _ = driver(SEND_REQ, initial_pane=PRIOR_TURN, reply_pane=PRIOR_TURN + NEW_REPLY)
-    out = json.loads(p.stdout)
+    out = json.loads(
+        harness.run(SEND_REQ, initial_pane=PRIOR_TURN, reply_pane=PRIOR_TURN + NEW_REPLY).stdout
+    )
     assert out["status"] == "ok"
     assert out["payload"]["episode_id"] == "ep-012", "must not return the prior turn's payload"
 
 
-def test_turn_counter_persists_and_increments(driver):
-    p1, _ = driver(SEND_REQ)
-    p2, _ = driver(SEND_REQ)
-    t1 = json.loads(p1.stdout)["turn"]
-    t2 = json.loads(p2.stdout)["turn"]
+def test_auto_creates_missing_session(harness):
+    """The session_id the caller sends (e.g. content-factory's name) is
+    auto-created if absent — the driver is agnostic to the chosen name."""
+    out = json.loads(harness.run(SEND_REQ, session_exists=False).stdout)
+    assert out["status"] == "ok"
+    newlog = harness.newlog.read_text()
+    assert SEND_REQ["session_id"] in newlog, "missing session must be auto-created"
+
+
+def test_turn_counter_persists_and_increments(harness):
+    t1 = json.loads(harness.run(SEND_REQ).stdout)["turn"]
+    t2 = json.loads(harness.run(SEND_REQ).stdout)["turn"]
     assert t2 == t1 + 1, f"turn must advance across calls (got {t1} then {t2})"
 
 
-def test_timeout_when_no_new_reply(driver):
-    # The agent produces no new json block within the window.
+def test_timeout_when_no_new_reply(harness):
     req = dict(SEND_REQ, timeout_s=0.2)
-    p, _ = driver(req, initial_pane="thinking...", reply_pane="thinking... still no json")
-    out = json.loads(p.stdout)
+    out = json.loads(
+        harness.run(req, initial_pane="thinking...", reply_pane="thinking... still no json").stdout
+    )
     assert out["status"] != "ok", "no new reply within timeout must NOT be ok"
+
+
+def test_http_server_serves_session_send(harness):
+    """`agent-session serve` answers POST /session/send — the shape n8n calls."""
+    port = _free_port()
+    harness.pane.write_text("")
+    harness.reply.write_text(NEW_REPLY)
+    harness.hasfile.write_text("0")
+    env = dict(harness.env)
+    env["STOA_SESSION_PORT"] = str(port)
+    proc = subprocess.Popen(
+        [sys.executable, str(harness.drv), "serve"],
+        env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    try:
+        base = f"http://127.0.0.1:{port}"
+        # Wait for readiness via /healthz.
+        for _ in range(50):
+            try:
+                with urllib.request.urlopen(base + "/healthz", timeout=1) as r:
+                    if r.status == 200:
+                        break
+            except (urllib.error.URLError, ConnectionError):
+                time.sleep(0.1)
+        else:
+            raise AssertionError("server did not become ready")
+        # POST a send-request like the n8n httpRequest node does.
+        body = json.dumps(SEND_REQ).encode()
+        req = urllib.request.Request(
+            base + "/session/send", data=body,
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as r:
+            out = json.loads(r.read())
+        assert set(out) == RECV_KEYS
+        assert out["status"] == "ok"
+        assert out["payload"]["episode_id"] == "ep-012"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)

--- a/scripts/tests/test_comfyui_stoa_image.py
+++ b/scripts/tests/test_comfyui_stoa_image.py
@@ -1,0 +1,142 @@
+"""Tests for the stoa ComfyUI image + model-download Job.
+
+Component 1 of the stoa Frank infra: the ComfyUI image bakes the stoa
+custom nodes (pinned), the build workflow embeds a stoa node-set dimension
+in the image tag, the Deployment pins the SAME tag (tag-drift guard), and a
+declarative Job hydrates the models PVC.
+
+Contract source of truth:
+docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+
+These assert SHAPE only (no network, no cluster). Generative quality is
+measured at the live [manual] gates, not here.
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO / "apps/comfyui/docker/Dockerfile"
+WORKFLOW = REPO / ".github/workflows/build-comfyui.yml"
+DEPLOYMENT = REPO / "apps/comfyui/manifests/deployment.yaml"
+ENTRYPOINT = REPO / "apps/comfyui/docker/entrypoint.sh"
+JOB = REPO / "apps/comfyui/manifests/job-model-download.yaml"
+
+# Nodes are baked into a staging dir (NOT /app/custom_nodes, which the PVC
+# shadows at runtime) and seeded into the PVC at boot by the entrypoint.
+NODE_STAGE = "/opt/stoa-custom-nodes"
+
+# The stoa custom-node upstreams that must be baked + pinned.
+NODE_REPOS = [
+    "Lightricks/ComfyUI-LTXVideo",
+    "city96/ComfyUI-GGUF",
+    "kijai/ComfyUI-WanVideoWrapper",
+]
+# At least one Kokoro node and one Fish-Speech node (repo name varies).
+TTS_MARKERS = ["kokoro", "fish"]
+
+
+def _workflow_env() -> dict:
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    return doc["env"]
+
+
+def _deployment_image_tag() -> str:
+    for doc in yaml.safe_load_all(DEPLOYMENT.read_text()):
+        if doc and doc.get("kind") == "Deployment":
+            img = doc["spec"]["template"]["spec"]["containers"][0]["image"]
+            return img.rsplit(":", 1)[1]
+    raise AssertionError("no Deployment found in deployment.yaml")
+
+
+def test_workflow_exposes_stoa_node_dimension():
+    env = _workflow_env()
+    assert "STOA_NODES" in env, "build-comfyui.yml env must pin a STOA_NODES rev"
+
+
+def test_image_tag_embeds_stoa_dimension_and_matches_deployment():
+    env = _workflow_env()
+    expected = (
+        f"comfyui-{env['COMFYUI_REF']}-pt{env['PYTORCH_VERSION']}"
+        f"-{env['CUDA_VERSION_PIP']}-stoa{env['STOA_NODES']}"
+    )
+    # The workflow's pushed tag template must embed the stoa dimension.
+    assert "stoa" in WORKFLOW.read_text(), "workflow tag must embed -stoa<N>"
+    # The Deployment must pin the exact same tag the workflow renders (no drift).
+    assert _deployment_image_tag() == expected, (
+        f"deployment image tag {_deployment_image_tag()!r} != workflow tag {expected!r}"
+    )
+
+
+NODE_REF_KEYS = ["LTXVIDEO_REF", "GGUF_REF", "WANVIDEO_REF", "KOKORO_REF", "FISHSPEECH_REF"]
+# A real pin: a 40-hex commit SHA or a version tag (vN.N / N.N). NOT a branch.
+PINNED_RE = re.compile(r"^([0-9a-f]{40}|v?\d+\.\d+(\.\d+)?)$")
+FLOATING = {"main", "master", "HEAD", "latest", "trunk", "develop"}
+
+
+def test_dockerfile_bakes_pinned_video_nodes():
+    text = DOCKERFILE.read_text()
+    for repo in NODE_REPOS:
+        assert repo in text, f"Dockerfile must clone {repo}"
+    assert re.search(r"git .*checkout|--branch", text), "nodes must be checked out at a ref"
+    assert "requirements.txt" in text, "node requirements.txt must be installed"
+
+
+def test_node_refs_are_pinned_not_floating():
+    """The 'never a floating default branch' guarantee, actually enforced."""
+    env = _workflow_env()
+    for key in NODE_REF_KEYS:
+        ref = str(env[key])
+        assert ref not in FLOATING, f"{key}={ref!r} is a floating branch — pin it"
+        assert PINNED_RE.match(ref), f"{key}={ref!r} must be a 40-hex SHA or a version tag"
+    # The Dockerfile ARG defaults must match the workflow pins (build determinism).
+    dtext = DOCKERFILE.read_text()
+    for key in NODE_REF_KEYS:
+        assert f"ARG {key}={env[key]}" in dtext, f"Dockerfile ARG {key} must match the workflow pin"
+
+
+def test_dockerfile_bakes_both_tts_engines():
+    text = DOCKERFILE.read_text().lower()
+    for marker in TTS_MARKERS:
+        assert marker in text, f"Dockerfile must bake a {marker} TTS node"
+
+
+def test_dockerfile_stages_nodes_outside_pvc_mount():
+    text = DOCKERFILE.read_text()
+    # Nodes must be cloned into the staging dir, not /app/custom_nodes (the PVC
+    # mount shadows that path at runtime).
+    assert NODE_STAGE in text, f"nodes must be baked into {NODE_STAGE} (PVC-shadow guard)"
+
+
+def test_entrypoint_seeds_custom_nodes_from_stage():
+    body = ENTRYPOINT.read_text()
+    assert NODE_STAGE in body, "entrypoint must seed nodes from the staging dir"
+    assert "custom_nodes" in body, "entrypoint must seed into /app/custom_nodes (the PVC)"
+    # Idempotent seed: only copy a node when it's absent in the PVC.
+    assert re.search(r"\[ -d|\[ ! -d|test -d", body), "node seed must be idempotent"
+
+
+def test_model_download_job_shape():
+    assert JOB.exists(), "apps/comfyui/manifests/job-model-download.yaml must exist"
+    doc = next(
+        d for d in yaml.safe_load_all(JOB.read_text()) if d and d.get("kind") == "Job"
+    )
+    spec = doc["spec"]["template"]["spec"]
+    assert (
+        spec["nodeSelector"]["kubernetes.io/hostname"] == "gpu-1"
+    ), "model download must run on gpu-1"
+    assert spec.get("restartPolicy") in ("OnFailure", "Never")
+    # Mounts the comfyui-models PVC.
+    claims = [
+        v.get("persistentVolumeClaim", {}).get("claimName")
+        for v in spec.get("volumes", [])
+    ]
+    assert "comfyui-models" in claims, "Job must mount the comfyui-models PVC"
+    # Idempotent: the download script skips artefacts already present.
+    body = JOB.read_text()
+    assert re.search(r"\[ -f|\[ ! -f|test -f", body), "download must be skip-if-present"
+    # All five stoa artefacts referenced.
+    low = body.lower()
+    for marker in ["ltx", "wan", "kokoro", "fish"]:
+        assert marker in low, f"Job must download the {marker} artefact"

--- a/scripts/tests/test_comfyui_stoa_route.py
+++ b/scripts/tests/test_comfyui_stoa_route.py
@@ -1,0 +1,71 @@
+"""Tests for ComfyUI VRAM flags + the (pre-existing) Authentik-gated route.
+
+Component 1c/1d of the stoa Frank infra:
+- 1c VRAM/offload flags on the Deployment (NEW — TDD red→green here).
+- 1d The Traefik route, Authentik proxy provider, and homepage tile for
+  comfyui.cluster.derio.net ALREADY EXIST in the repo; these are regression
+  guards asserting they stay present + correctly shaped (the live SSO outpost
+  assignment is the manual MO-3, not declarative).
+
+Contract source of truth:
+docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+"""
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+DEPLOYMENT = REPO / "apps/comfyui/manifests/deployment.yaml"
+INGRESSROUTES = REPO / "apps/traefik/manifests/ingressroutes.yaml"
+BLUEPRINT = REPO / "apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml"
+HOMEPAGE = REPO / "apps/homepage/manifests/files/services.yaml"
+
+HOST = "comfyui.cluster.derio.net"
+
+OFFLOAD_FLAGS = ("--reserve-vram", "--lowvram", "--novram", "--cache-none")
+
+
+def _comfyui_container():
+    for doc in yaml.safe_load_all(DEPLOYMENT.read_text()):
+        if doc and doc.get("kind") == "Deployment":
+            return doc["spec"]["template"]["spec"]["containers"][0]
+    raise AssertionError("no Deployment found")
+
+
+def test_deployment_has_vram_offload_flags():
+    c = _comfyui_container()
+    args = c.get("args") or c.get("command") or []
+    argstr = " ".join(str(a) for a in args)
+    assert any(f in argstr for f in OFFLOAD_FLAGS), (
+        f"deployment must set a 16GB offload flag ({OFFLOAD_FLAGS}); got {args!r}"
+    )
+    # Must keep serving the API on 8188.
+    assert "--listen" in argstr and "8188" in argstr, "must keep --listen / --port 8188"
+
+
+def test_ingressroute_present_and_sso_gated():
+    routes = [
+        d
+        for d in yaml.safe_load_all(INGRESSROUTES.read_text())
+        if d and d.get("kind") == "IngressRoute"
+    ]
+    match = None
+    for r in routes:
+        for route in r["spec"].get("routes", []):
+            if HOST in route.get("match", ""):
+                match = route
+    assert match is not None, f"no IngressRoute for {HOST}"
+    mws = [m["name"] for m in match.get("middlewares", [])]
+    assert "authentik-forwardauth" in mws, "route must be SSO-gated"
+    svc = match["services"][0]
+    assert svc["name"] == "comfyui" and svc["port"] == 8188
+
+
+def test_authentik_proxy_provider_present():
+    text = BLUEPRINT.read_text()
+    assert f"https://{HOST}" in text, "Authentik blueprint must carry the comfyui provider"
+    assert "forward_single" in text and "invalidation_flow" in text
+
+
+def test_homepage_tile_present():
+    assert f"https://{HOST}" in HOMEPAGE.read_text(), "homepage must carry a comfyui tile"

--- a/scripts/tests/test_n8n_agent_sidecar.py
+++ b/scripts/tests/test_n8n_agent_sidecar.py
@@ -1,0 +1,154 @@
+"""Tests for the n8n-01 multi-agent-shell sidecar + persistent claude session.
+
+Component 2 of the stoa Frank infra: a multi-agent-shell sidecar on the n8n-01
+pod hosts a persistent, operator-attachable `claude` tmux session (never
+`claude -p`), with PV-resident OAuth creds and no API keys in the manifest.
+
+Contract source of truth:
+docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+"""
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+DEPLOYMENT = REPO / "apps/n8n-01/manifests/deployment.yaml"
+PVC_AGENT_HOME = REPO / "apps/n8n-01/manifests/pvc-agent-home.yaml"
+BOOTSTRAP = REPO / "apps/n8n-01/manifests/agent-session-bootstrap.yaml"
+DRIVER_CM = REPO / "apps/n8n-01/manifests/agent-session-driver.yaml"
+
+SIDECAR = "multi-agent-shell"
+API_KEY_ENVS = {"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"}
+
+
+def _deploy():
+    for doc in yaml.safe_load_all(DEPLOYMENT.read_text()):
+        if doc and doc.get("kind") == "Deployment":
+            return doc
+    raise AssertionError("no Deployment found")
+
+
+def _sidecar():
+    pod = _deploy()["spec"]["template"]["spec"]
+    for c in pod["containers"]:
+        if c["name"] == SIDECAR:
+            return c, pod
+    raise AssertionError(f"no {SIDECAR} container in n8n-01 Deployment")
+
+
+def test_sidecar_container_present_and_pinned():
+    c, _ = _sidecar()
+    assert c["image"].startswith("ghcr.io/derio-net/multi-agent-shell:")
+    assert not c["image"].endswith(":latest"), "pin the sidecar image, never :latest"
+
+
+def test_sidecar_has_no_api_keys():
+    c, _ = _sidecar()
+    names = {e["name"] for e in c.get("env", [])}
+    assert not (names & API_KEY_ENVS), (
+        f"sidecar must use subscription OAuth, not API keys; found {names & API_KEY_ENVS}"
+    )
+
+
+def test_sidecar_has_explicit_home_on_agent_pvc():
+    c, _ = _sidecar()
+    env = {e["name"]: e.get("value") for e in c.get("env", [])}
+    assert "HOME" in env, "sidecar needs an explicit HOME"
+    home = env["HOME"]
+    mounts = {m["name"]: m["mountPath"] for m in c.get("volumeMounts", [])}
+    assert "agent-home" in mounts, "sidecar must mount the agent-home volume"
+    assert mounts["agent-home"] == home, "agent-home must mount at HOME (PV-resident creds)"
+
+
+def test_no_share_process_namespace():
+    pod = _deploy()["spec"]["template"]["spec"]
+    assert not pod.get("shareProcessNamespace"), (
+        "shareProcessNamespace is incompatible with the image's s6-overlay v3"
+    )
+
+
+def test_agent_home_pvc_manifest():
+    assert PVC_AGENT_HOME.exists(), "apps/n8n-01/manifests/pvc-agent-home.yaml must exist"
+    doc = next(
+        d for d in yaml.safe_load_all(PVC_AGENT_HOME.read_text())
+        if d and d.get("kind") == "PersistentVolumeClaim"
+    )
+    assert doc["spec"]["storageClassName"] == "longhorn"
+    assert "ReadWriteOnce" in doc["spec"]["accessModes"]
+
+
+# --- Task 2: persistent session bootstrap ------------------------------------
+
+def _bootstrap_cm():
+    doc = next(
+        d for d in yaml.safe_load_all(BOOTSTRAP.read_text())
+        if d and d.get("kind") == "ConfigMap"
+    )
+    return doc
+
+
+def test_bootstrap_starts_interactive_claude_in_named_tmux():
+    assert BOOTSTRAP.exists(), "agent-session-bootstrap.yaml must exist"
+    script = "\n".join(_bootstrap_cm()["data"].values())
+    assert "tmux" in script and "new-session" in script, "bootstrap must start a tmux session"
+    assert "stoa-script-claude" in script, "session name must be stoa-script-claude"
+    # Interactive claude — NEVER print mode.
+    assert "claude" in script
+    assert "-p " not in script and "--print" not in script, "never `claude -p`"
+    # Idempotent: don't double-create the session.
+    assert "has-session" in script, "bootstrap must be idempotent (has-session guard)"
+
+
+def test_sidecar_references_bootstrap():
+    c, _ = _sidecar()
+    vol_mounts = {m["name"] for m in c.get("volumeMounts", [])}
+    pod = _deploy()["spec"]["template"]["spec"]
+    vols = {v["name"]: v for v in pod["volumes"]}
+    # A volume sourced from the bootstrap ConfigMap is mounted into the sidecar.
+    cm_vols = {
+        name for name, v in vols.items()
+        if v.get("configMap", {}).get("name", "").startswith("agent-session-bootstrap")
+    }
+    assert cm_vols, "a bootstrap ConfigMap volume must exist"
+    assert cm_vols & vol_mounts, "sidecar must mount the bootstrap ConfigMap"
+    # And it actually runs the bootstrap (postStart hook or command references it).
+    blob = yaml.safe_dump(c)
+    assert "lifecycle" in blob or "command" in blob, "sidecar must invoke the bootstrap"
+
+
+# --- Task 2: driver mount + pod-local transport ------------------------------
+
+def _driver_cm():
+    return next(
+        d for d in yaml.safe_load_all(DRIVER_CM.read_text())
+        if d and d.get("kind") == "ConfigMap"
+    )
+
+
+def test_driver_mounted_into_sidecar():
+    assert DRIVER_CM.exists(), "agent-session-driver.yaml must exist"
+    c, pod = _sidecar()
+    vols = {v["name"]: v for v in pod["volumes"]}
+    cm_vols = {
+        name for name, v in vols.items()
+        if v.get("configMap", {}).get("name", "") == "agent-session-driver"
+    }
+    mounts = {m["name"] for m in c.get("volumeMounts", [])}
+    assert cm_vols & mounts, "sidecar must mount the agent-session-driver ConfigMap"
+
+
+def test_transport_is_script_not_a_server():
+    # Option 1 (script over exec), NOT a long-running HTTP session server:
+    # the sidecar exposes no extra container port for this.
+    c, _ = _sidecar()
+    assert not c.get("ports"), "sidecar must not expose a session-server port (Option 1)"
+
+
+def test_transport_documented():
+    data = _driver_cm()["data"]
+    doc = "\n".join(data.values())
+    # The pod-local transport (n8n SSH node -> localhost sshd -> login shell)
+    # and a fallback must be documented somewhere in the driver ConfigMap.
+    assert "ssh" in doc.lower(), "must document the localhost-sshd transport"
+    assert "agent-session send" in doc, "must document the driver invocation"
+    assert "bash -lc" in doc, "must document the LOGIN-shell call (PATH/mise)"

--- a/scripts/tests/test_n8n_agent_sidecar.py
+++ b/scripts/tests/test_n8n_agent_sidecar.py
@@ -137,18 +137,34 @@ def test_driver_mounted_into_sidecar():
     assert cm_vols & mounts, "sidecar must mount the agent-session-driver ConfigMap"
 
 
-def test_transport_is_script_not_a_server():
-    # Option 1 (script over exec), NOT a long-running HTTP session server:
-    # the sidecar exposes no extra container port for this.
+def test_session_server_is_pod_local():
+    # The HTTP server binds 127.0.0.1 (n8n is in the same pod) — never 0.0.0.0,
+    # and no Service/containerPort exposes it beyond the pod.
+    driver = _driver_cm()["data"]["agent-session"]
+    assert '"127.0.0.1"' in driver, "session HTTP server must bind 127.0.0.1 (pod-local)"
+    assert "0.0.0.0" not in driver, "session HTTP server must not bind 0.0.0.0"
     c, _ = _sidecar()
-    assert not c.get("ports"), "sidecar must not expose a session-server port (Option 1)"
+    assert not c.get("ports"), "no containerPort — the server is localhost-only, not a Service"
 
 
-def test_transport_documented():
-    data = _driver_cm()["data"]
-    doc = "\n".join(data.values())
-    # The pod-local transport (n8n SSH node -> localhost sshd -> login shell)
-    # and a fallback must be documented somewhere in the driver ConfigMap.
-    assert "ssh" in doc.lower(), "must document the localhost-sshd transport"
-    assert "agent-session send" in doc, "must document the driver invocation"
-    assert "bash -lc" in doc, "must document the LOGIN-shell call (PATH/mise)"
+def test_transport_documented_as_http():
+    doc = "\n".join(_driver_cm()["data"].values())
+    # content-factory's n8n httpRequest node posts to /session/send on localhost.
+    assert "/session/send" in doc, "must document the POST /session/send endpoint"
+    assert "127.0.0.1" in doc or "localhost" in doc, "must document the pod-local host"
+    assert "AGENT_SIDECAR_URL" in doc, "must document the n8n env var it satisfies"
+
+
+def test_bootstrap_starts_http_server():
+    script = "\n".join(_bootstrap_cm()["data"].values())
+    assert "agent-session serve" in script, "bootstrap must start the HTTP session server"
+
+
+def test_n8n_container_points_at_sidecar_url():
+    # The n8n container must expose AGENT_SIDECAR_URL so the workflow's
+    # httpRequest node resolves it to the sidecar's pod-local endpoint.
+    pod = _deploy()["spec"]["template"]["spec"]
+    n8n = next(c for c in pod["containers"] if c["name"] == "n8n")
+    env = {e["name"]: e.get("value") for e in n8n.get("env", [])}
+    assert "AGENT_SIDECAR_URL" in env, "n8n must set AGENT_SIDECAR_URL"
+    assert "localhost" in env["AGENT_SIDECAR_URL"] or "127.0.0.1" in env["AGENT_SIDECAR_URL"]


### PR DESCRIPTION
## Summary

Lands the two **additive** Frank infrastructure changes that satisfy the `stoa`
content pipeline's Frank-readiness contract (`agentic-stoa/content-factory#55`,
a private-repo Phase-2 manual gate). Frank *is* the provider here, so this PR is
Frank landing the request — no separate request issue is filed.

1. **ComfyUI on `gpu-1`** enabled for video/audio generation: custom nodes baked
   into the image (pinned to commit SHAs) + seeded past the PVC mount-shadow,
   an idempotent model-download Job, and VRAM/offload flags for the 16 GB GPU.
   The Authentik-gated `comfyui.cluster.derio.net` route/provider/tile already
   existed → kept as regression guards.
2. **`multi-agent-shell` sidecar on `n8n-01`** hosting a persistent,
   operator-attachable `claude` tmux session (never `claude -p`) + an
   `agent-session` send/receive driver with a per-session turn counter, served
   over a pod-local HTTP endpoint (`POST localhost:8765/session/send`).

**Cross-half alignment:** content-factory PR #67 (merged) drives the session
from n8n via an httpRequest node → `POST $AGENT_SIDECAR_URL/session/send` and
fixed the `/history` fixture to be keyed by `prompt_id`. This PR matches both:
the sidecar serves that HTTP endpoint (no Service, no SSH keypair); stock
ComfyUI already emits the keyed `/history` shape. The session is auto-created
for whatever `session_id` n8n sends.

**Reuse, not reinvention:** aligns with the existing k8s-native agentic-runs
design (stock ComfyUI API; the multi-agent-shell L1 image; the tmux
send-keys/capture session pattern) rather than forking a parallel mechanism.

- **Spec:** `docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-14-stoa-frank-infra/` (4 agentic phases ✅ + 1 manual phase, below)

**Privacy:** `frank` is public; business context is kept out (technical only).

## Verification

- TDD throughout; **88 tests pass** (`pytest scripts/tests/`), self-review passes.
- ComfyUI API shapes are stock; the contract needs no shim.

## Code review — findings fixed in this PR

A senior-reviewer pass ran over the diff; every finding was fixed:

- **Critical — stale-reply race:** the driver baselined the `json`-block count
  *before* send and only accepts a **new** block (closing the "returns prior
  turn's payload with status:ok" race). + a regression test seeding a prior
  block. Capture now includes scrollback.
- **Important — atomic turn counter** (flock + temp+`os.replace`); **real ref
  pins** (commit SHAs; upstreams publish no tags) + a test that **rejects
  floating refs**; **bootstrap retries** + documented `kubectl exec` recovery.
- **Minor —** doc/`fsGroup` notes.
- *Out of scope (noted):* the pre-existing legacy `WEBHOOK_URL:
  n8n-01.frank.derio.net` is left untouched.

## ⚠️ Phase 5 — manual, intentionally UNIMPLEMENTED (operator pushes to this PR)

All cluster/secret/UI/verify work is back-loaded; nothing agentic depends on it:

- **MO-1** run the model-download Job on `gpu-1`; confirm + lock the weight URLs.
- **MO-2** activate ComfyUI + tune VRAM flags under a real generation.
- **MO-3** assign the ComfyUI proxy provider to the Authentik embedded outpost.
- **MO-4** one-time `claude login` in the sidecar (creds land on the PVC).
- **MO-5** live contract verification (below).
- **MO-6** content-factory writeback + close agentic-stoa/content-factory#55.

## Test Plan (post-merge — operator-driven)

After merge (CI builds the `-stoa1` ComfyUI image) and after MO-1..4,7:

1. **ComfyUI API** (in-cluster): `POST comfyui.comfyui.svc:8188/prompt` →
   `prompt_id` + `node_errors {}`; `GET /history/{prompt_id}` → body keyed by
   `prompt_id`, `body[prompt_id].status.completed: true` with
   `outputs.<node>.gifs[]`; `GET /view` → bytes.
2. **agent-session**: `POST http://localhost:8765/session/send` (the n8n
   `AGENT_SIDECAR_URL`) → `{status:ok, turn:N, payload:{…}}`; a second send →
   `turn:N+1`; `tmux attach` to the session works.
3. Record live endpoints/route + this PR URL in the content-factory Frank-request
   runbook; close agentic-stoa/content-factory#55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
