### PR TITLE
fix(n8n): robust agent-session driver — bracketed-paste submit + file payload (MO-5b)

### DIFF
--- a/apps/n8n-01/manifests/agent-session-bootstrap.yaml
+++ b/apps/n8n-01/manifests/agent-session-bootstrap.yaml
@@ -52,7 +52,8 @@ data:
       if tmux has-session -t "$SESSION" 2>/dev/null; then
         break
       fi
-      tmux new-session -d -s "$SESSION" "bash -lc claude" 2>/dev/null && break
+      tmux new-session -d -s "$SESSION" \
+        "bash -lc 'claude --permission-mode acceptEdits'" 2>/dev/null && break
       sleep 2
     done
     exit 0

--- a/apps/n8n-01/manifests/agent-session-bootstrap.yaml
+++ b/apps/n8n-01/manifests/agent-session-bootstrap.yaml
@@ -53,7 +53,7 @@ data:
         break
       fi
       tmux new-session -d -s "$SESSION" \
-        "bash -lc 'claude --permission-mode acceptEdits'" 2>/dev/null && break
+        "bash -lc 'claude --permission-mode auto'" 2>/dev/null && break
       sleep 2
     done
     exit 0

--- a/apps/n8n-01/manifests/agent-session-driver.yaml
+++ b/apps/n8n-01/manifests/agent-session-driver.yaml
@@ -6,9 +6,13 @@
 #     POST /session/send (what content-factory's n8n httpRequest node calls).
 #   * `agent-session send '<json>'` — the same logic as a CLI (debug/manual).
 #
-# It drives the RUNNING interactive session (never `claude -p`): send a message,
-# wait for a NEW fenced-JSON reply (not a prior turn's), emit the
-# agent_session.receive.response shape with a per-session turn counter.
+# It drives the RUNNING interactive claude session (never `claude -p`):
+#   submit via BRACKETED PASTE (load-buffer + paste-buffer -p + a SEPARATE Enter
+#   — a one-shot `send-keys <text> Enter` has its Enter swallowed, and bracketed
+#   paste is multi-line safe), and read the reply from a FILE the agent writes
+#   (claude's TUI doesn't emit literal ```json fences and soft-wraps long output,
+#   so pane-scraping the payload is unreliable). A unique per-turn nonce path
+#   makes a prior turn's reply impossible to mistake for this one.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,58 +26,54 @@ data:
     #!/usr/bin/env python3
     """agent-session — drive the persistent claude tmux session (send/receive).
 
-    Never `claude -p`: feed a message to the long-lived interactive session and
-    read the reply, emitting {session_id, agent, status, turn, payload} with a
-    per-session turn counter (evidence of continuity).
-
-    `serve` runs the HTTP endpoint n8n calls (POST /session/send); `send` is the
-    same core as a CLI. The session is auto-created for whatever session_id
-    arrives, so the driver is agnostic to the caller's chosen name.
-
-    Stale-reply safety: the pane already holds PRIOR turns' fenced-JSON replies,
-    so we baseline the count of complete ```json blocks BEFORE sending and only
-    accept a reply once a NEW block appears — then take the newest one.
+    Never `claude -p`. Submit via bracketed paste; receive the structured payload
+    from a per-turn file the agent writes (the file appearing + parsing is the
+    completion signal). Emits {session_id, agent, status, turn, payload} with a
+    locked, atomic per-session turn counter (continuity evidence). `serve` runs
+    the HTTP endpoint n8n calls; `send` is the same core as a CLI.
     """
     import fcntl
     import json
     import os
-    import re
+    import secrets
     import subprocess
     import sys
     import time
 
-    TURN_DIR = os.environ.get(
-        "STOA_TURN_DIR", os.path.join(os.path.expanduser("~"), ".stoa")
-    )
+    HOME = os.path.expanduser("~")
+    TURN_DIR = os.environ.get("STOA_TURN_DIR", os.path.join(HOME, ".stoa"))
+    OUT_DIR = os.environ.get("STOA_OUT_DIR", os.path.join(HOME, ".stoa", "out"))
     POLL_S = float(os.environ.get("STOA_POLL_S", "2"))
-    # Bounded scrollback: deep enough for a multi-clip shot-list's closing fence,
-    # cheap enough on a long session.
-    SCROLLBACK = os.environ.get("STOA_SCROLLBACK", "-2000")
+    # Delay between pasting the message and pressing Enter — the TUI needs to
+    # render the paste before the submit, or the Enter is dropped.
+    SETTLE_S = float(os.environ.get("STOA_SETTLE_S", "0.5"))
     PORT = int(os.environ.get("STOA_SESSION_PORT", "8765"))
 
-    JSON_BLOCK = re.compile(r"```json\s*(.*?)```", re.DOTALL)
 
-
-    def tmux(*args):
-        return subprocess.run(["tmux", *args], capture_output=True, text=True)
+    def tmux(*args, stdin=None):
+        return subprocess.run(["tmux", *args], input=stdin, capture_output=True, text=True)
 
 
     def ensure_session(session_id):
         # Auto-create the session (interactive claude, never -p) if absent, so
         # the caller's session_id drives whatever it names. Unauthenticated until
-        # the operator runs `claude login` (MO-4). Concurrency-safe under threading:
-        # a racing duplicate `new-session` errors harmlessly (tmux refuses the dup).
+        # the operator runs `claude login` (MO-4). `--permission-mode acceptEdits`
+        # auto-accepts FILE WRITES only (so the session writes its per-turn output
+        # file unprompted) while still gating bash/other tools — narrower than a
+        # full permissions bypass. Concurrency-safe: a racing dup new-session errors
+        # harmlessly.
         if tmux("has-session", "-t", session_id).returncode != 0:
-            tmux("new-session", "-d", "-s", session_id, "claude")
+            tmux("new-session", "-d", "-s", session_id,
+                 "claude --permission-mode acceptEdits")
 
 
-    def capture(session):
-        r = tmux("capture-pane", "-p", "-S", SCROLLBACK, "-t", session)
-        return r.stdout if r.returncode == 0 else ""
-
-
-    def json_blocks(pane):
-        return JSON_BLOCK.findall(pane)
+    def submit(session_id, text):
+        # Bracketed paste so a multi-line message lands without premature submit,
+        # then a SEPARATE Enter after the paste renders.
+        tmux("load-buffer", "-b", "stoa-msg", "-", stdin=text)
+        tmux("paste-buffer", "-d", "-p", "-b", "stoa-msg", "-t", session_id)
+        time.sleep(SETTLE_S)
+        tmux("send-keys", "-t", session_id, "Enter")
 
 
     def read_turn(session_id):
@@ -86,8 +86,7 @@ data:
 
 
     def bump_turn(session_id):
-        # Atomic + locked: the turn counter is the contract's continuity
-        # evidence, so a concurrent/aborted write must not corrupt it.
+        # Atomic + locked: the turn counter is the contract's continuity evidence.
         os.makedirs(TURN_DIR, exist_ok=True)
         path = os.path.join(TURN_DIR, session_id + ".turn")
         with open(path + ".lock", "w") as lk:
@@ -101,13 +100,8 @@ data:
 
 
     def response(session_id, agent, status, turn, payload):
-        return {
-            "session_id": session_id,
-            "agent": agent,
-            "status": status,
-            "turn": turn,
-            "payload": payload,
-        }
+        return {"session_id": session_id, "agent": agent, "status": status,
+                "turn": turn, "payload": payload}
 
 
     def send(req):
@@ -118,20 +112,38 @@ data:
 
         ensure_session(session_id)
 
-        # Baseline BEFORE sending so we can tell this turn's reply from prior ones.
-        baseline = len(json_blocks(capture(session_id)))
-        tmux("send-keys", "-t", session_id, message, "Enter")
+        # Per-turn output file (unique nonce → no stale-reply ambiguity).
+        os.makedirs(OUT_DIR, exist_ok=True)
+        nonce = secrets.token_hex(4)
+        outfile = os.path.join(OUT_DIR, "{}.{}.json".format(session_id, nonce))
+        try:
+            os.remove(outfile)
+        except OSError:
+            pass
 
+        driven = (
+            message
+            + "\n\n[stoa] When done, write ONLY the JSON result to the file "
+            + outfile
+            + " — raw JSON, overwrite it, nothing else in that file."
+        )
+        submit(session_id, driven)
+
+        # The file appearing + parsing IS the completion signal (robust to TUI
+        # rendering / soft-wrapping). Tolerate a partial write by retrying.
         deadline = time.monotonic() + timeout_s
         while time.monotonic() < deadline:
-            blocks = json_blocks(capture(session_id))
-            if len(blocks) > baseline:
+            if os.path.exists(outfile):
                 try:
-                    payload = json.loads(blocks[-1].strip())
-                except json.JSONDecodeError:
-                    return response(
-                        session_id, agent, "bad_payload", read_turn(session_id), None
-                    )
+                    with open(outfile) as fh:
+                        payload = json.load(fh)
+                except (OSError, json.JSONDecodeError):
+                    time.sleep(POLL_S)
+                    continue
+                try:
+                    os.remove(outfile)
+                except OSError:
+                    pass
                 return response(session_id, agent, "ok", bump_turn(session_id), payload)
             time.sleep(POLL_S)
 
@@ -172,13 +184,13 @@ data:
                 pass
 
         # Pod-local only: n8n is in the same pod (shared netns) — bind loopback,
-        # never the wildcard address. Threaded so a long send() (up to timeout_s)
-        # never head-of-line-blocks /healthz or a concurrent request.
+        # never the wildcard address. Threaded so a long send() never head-of-line-
+        # blocks /healthz or a concurrent request.
         try:
             server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
         except OSError as exc:
-            # Surface bind failures (the bootstrap restart-loop silences handler
-            # logs, not stderr): inspect via `tmux capture-pane -t stoa-session-server`.
+            # Surface bind failures (handler logs are silenced, not stderr):
+            # inspect via `tmux capture-pane -t stoa-session-server`.
             print(f"agent-session serve: bind 127.0.0.1:{PORT} failed: {exc}", file=sys.stderr)
             raise
         server.daemon_threads = True
@@ -215,6 +227,10 @@ data:
     Service and no SSH keypair — localhost-only, in-pod. `GET /healthz` returns
     200. The session named by session_id is auto-created on first send (so the
     caller's chosen name just works); the operator attaches with
-    `tmux attach -t <session_id>` (or the pre-warmed default session).
+    `tmux attach -t <session_id>`.
+
+    Internally the driver asks the agent to write its JSON reply to a per-turn
+    file and reads that file (claude's TUI doesn't emit literal ```json fences) —
+    invisible to the caller, which only sees the response payload.
 
     `agent-session send '<json>'` is the same logic as a CLI for debug/manual use.

--- a/apps/n8n-01/manifests/agent-session-driver.yaml
+++ b/apps/n8n-01/manifests/agent-session-driver.yaml
@@ -57,14 +57,13 @@ data:
     def ensure_session(session_id):
         # Auto-create the session (interactive claude, never -p) if absent, so
         # the caller's session_id drives whatever it names. Unauthenticated until
-        # the operator runs `claude login` (MO-4). `--permission-mode acceptEdits`
-        # auto-accepts FILE WRITES only (so the session writes its per-turn output
-        # file unprompted) while still gating bash/other tools — narrower than a
-        # full permissions bypass. Concurrency-safe: a racing dup new-session errors
-        # harmlessly.
+        # the operator runs `claude login` (MO-4). `--permission-mode auto` lets the
+        # session auto-approve safe operations (incl. writing its per-turn output
+        # file) without a prompt, short of a full permissions bypass. Concurrency-
+        # safe: a racing dup new-session errors harmlessly.
         if tmux("has-session", "-t", session_id).returncode != 0:
             tmux("new-session", "-d", "-s", session_id,
-                 "claude --permission-mode acceptEdits")
+                 "claude --permission-mode auto")
 
 
     def submit(session_id, text):

--- a/docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+++ b/docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
@@ -176,13 +176,22 @@ tmux session" shape the k8s-native-runs design uses.
 
 **2c. Send/receive driver (the EXTEND).** A ConfigMap-mounted script `agent-session`
 implementing the `agent_session.*` contract:
-- **send**: input `{session_id, agent, message, expect?, timeout_s?}` → selects the tmux
-  session, `tmux send-keys` the message, waits (bounded by `timeout_s`) for the reply marker.
-- **receive**: `tmux capture-pane` the reply, extract the structured `payload` (the shot-list
-  JSON the agent emits), increment a **persisted, locked, atomic per-session turn counter**
-  (`$HOME/.stoa/<session_id>.turn`), emit `{session_id, agent, status:"ok", turn, payload}`.
-- **Stale-reply safety:** the pane already holds prior turns' fenced-JSON, so the driver
-  baselines the `json`-block count **before** sending and only accepts a **new** block.
+- **send**: input `{session_id, agent, message, expect?, timeout_s?}` → submit the message to
+  the tmux session via **bracketed paste** (`load-buffer` + `paste-buffer -p` + a SEPARATE
+  `send-keys Enter` after a settle delay — a one-shot `send-keys <text> Enter` has its Enter
+  swallowed, and bracketed paste is multi-line safe).
+- **receive**: the driver appends an instruction to **write the JSON reply to a per-turn file**
+  (a unique nonce path under `$HOME/.stoa/out/`) and reads that file — the file appearing +
+  parsing IS the completion signal. It then increments a **persisted, locked, atomic per-session
+  turn counter** (`$HOME/.stoa/<session_id>.turn`) and emits `{session_id, agent, status:"ok",
+  turn, payload}`.
+  > **Live correction (MO-5b):** the original design scraped a `` ```json `` fence from
+  > `capture-pane`, but claude's TUI renders replies **inline after `●` with no literal fences**
+  > and soft-wraps long output — pane-scraping the payload is unreliable. The file-based delivery
+  > is robust and invisible to the caller (content-factory still POSTs a message and reads
+  > `payload`).
+- **Stale-reply safety:** the unique per-turn nonce **filename** makes a prior turn's reply
+  structurally impossible to mistake for this one.
 - **Auto-create:** the session named by `session_id` is created on first send if absent, so the
   driver is agnostic to the caller's chosen name (content-factory sends its own `session_id`;
   Frank never hard-codes it).

--- a/scripts/tests/test_agent_session_driver.py
+++ b/scripts/tests/test_agent_session_driver.py
@@ -1,16 +1,24 @@
 """Unit tests for the agent-session send/receive driver.
 
-The driver drives the persistent claude tmux session (never `claude -p`): it
-sends a message, waits for a NEW fenced-JSON reply (not a prior turn's), and
-emits the agent_session.receive.response shape with a per-session turn counter.
-It exposes the same core as `agent-session serve` (HTTP POST /session/send, what
-content-factory's n8n calls) and `agent-session send` (CLI).
+The driver drives a persistent claude TUI session (never `claude -p`). Live
+verification (MO-5b) showed two realities the old mock missed:
+  * claude's TUI does NOT echo literal ```json fences — replies render inline
+    after a `●`, and a large payload soft-wraps. Pane-scraping the JSON is
+    unreliable.
+  * `send-keys <text> Enter` in ONE call types the text but the Enter is
+    swallowed (bracketed-paste). The message must be pasted, then submitted.
 
-tmux is mocked: send-keys makes the agent "respond" (the reply pane replaces the
-baseline pane); has-session is controllable so auto-create can be exercised.
+So the driver now:
+  * submits via bracketed paste — `load-buffer` (stdin) + `paste-buffer -p` +
+    a SEPARATE `send-keys Enter` after a settle delay (multi-line safe).
+  * tells the agent to WRITE the JSON to a per-turn file (unique nonce path);
+    the driver polls for that file to exist + parse, and that IS the payload.
+    The unique path makes a prior turn's reply structurally impossible to
+    mistake for this one.
 
-Contract source of truth:
-docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+The fake tmux below models that: paste stages the message, `send-keys Enter`
+makes the "agent" write the file the message names.
+
 Shape fixtures: scripts/tests/fixtures/stoa/
 """
 import json
@@ -21,7 +29,6 @@ import subprocess
 import sys
 import time
 import types
-import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -35,93 +42,84 @@ FIXTURES = REPO / "scripts/tests/fixtures/stoa"
 SEND_REQ = json.loads((FIXTURES / "agent_session_send_request.json").read_text())
 RECV_KEYS = set(json.loads((FIXTURES / "agent_session_receive_response.json").read_text()))
 
-NEW_REPLY = """\
-I'll write the episode and decompose it.
+PAYLOAD = {"schema_version": "1.0", "series_id": "series-x", "episode_id": "ep-012",
+           "characters": ["char-a", "char-b"], "clips": []}
 
-```json
-{"schema_version": "1.0", "series_id": "series-x", "episode_id": "ep-012",
- "characters": ["char-a", "char-b"], "clips": []}
-```
-Done.
-"""
-
-PRIOR_TURN = """\
-(previous turn still in the pane)
-```json
-{"schema_version": "1.0", "episode_id": "ep-OLD", "clips": []}
-```
-"""
+# Fake tmux: load-buffer stages the message, paste-buffer holds it, send-keys
+# Enter makes the "agent" write FAKE_PAYLOAD to the file the message names.
+FAKE_TMUX = r'''#!/usr/bin/env python3
+import sys, os, re
+D = os.environ["FAKE_DIR"]
+def p(n): return os.path.join(D, n)
+a = sys.argv[1:]
+cmd = a[0] if a else ""
+open(p("calls.log"), "a").write(cmd + " " + " ".join(a[1:]) + "\n")
+if cmd == "has-session":
+    try: code = int((open(p("has.code")).read().strip() or "0"))
+    except Exception: code = 0
+    sys.exit(code)
+if cmd == "new-session":
+    open(p("new.log"), "a").write(" ".join(a) + "\n"); sys.exit(0)
+if cmd == "load-buffer":
+    open(p("buffer.txt"), "w").write(sys.stdin.read()); sys.exit(0)
+if cmd == "paste-buffer":
+    buf = open(p("buffer.txt")).read() if os.path.exists(p("buffer.txt")) else ""
+    open(p("pending.txt"), "w").write(buf); sys.exit(0)
+if cmd == "send-keys":
+    if "Enter" in a and os.environ.get("FAKE_NO_REPLY") != "1":
+        msg = open(p("pending.txt")).read() if os.path.exists(p("pending.txt")) else ""
+        m = re.search(r"to the file (\S+)", msg)
+        if m:
+            outfile = m.group(1)
+            os.makedirs(os.path.dirname(outfile), exist_ok=True)
+            open(outfile, "w").write(os.environ.get("FAKE_PAYLOAD", "{}"))
+    sys.exit(0)
+if cmd == "capture-pane":
+    sys.stdout.write(open(p("pane.txt")).read() if os.path.exists(p("pane.txt")) else "")
+    sys.exit(0)
+sys.exit(0)
+'''
 
 
 def _driver_script() -> str:
-    doc = next(
-        d for d in yaml.safe_load_all(DRIVER_CM.read_text())
-        if d and d.get("kind") == "ConfigMap"
-    )
+    doc = next(d for d in yaml.safe_load_all(DRIVER_CM.read_text())
+               if d and d.get("kind") == "ConfigMap")
     return doc["data"]["agent-session"]
 
 
 def _free_port() -> int:
-    s = socket.socket()
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-    s.close()
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); port = s.getsockname()[1]; s.close()
     return port
 
 
 @pytest.fixture
 def harness(tmp_path):
-    """Materialize the driver + a controllable fake tmux on PATH."""
-    bindir = tmp_path / "bin"
-    bindir.mkdir()
-    drv = bindir / "agent-session"
-    drv.write_text(_driver_script())
+    bindir = tmp_path / "bin"; bindir.mkdir()
+    drv = bindir / "agent-session"; drv.write_text(_driver_script())
     drv.chmod(drv.stat().st_mode | stat.S_IEXEC)
-
-    pane = tmp_path / "pane.txt"
-    reply = tmp_path / "reply.txt"
-    sendlog = tmp_path / "sendkeys.log"
-    newlog = tmp_path / "newsession.log"
-    hasfile = tmp_path / "has.code"  # exit code for has-session (default 0)
-    faketmux = bindir / "tmux"
-    faketmux.write_text(
-        "#!/usr/bin/env bash\n"
-        "case \"$1\" in\n"
-        f"  has-session) exit $(cat '{hasfile}' 2>/dev/null || echo 0) ;;\n"
-        f"  new-session) shift; echo \"$*\" >> '{newlog}' ;;\n"
-        f"  send-keys) shift; echo \"$*\" >> '{sendlog}'; cat '{reply}' > '{pane}' ;;\n"
-        f"  capture-pane) cat '{pane}' 2>/dev/null ;;\n"
-        "  *) exit 0 ;;\n"
-        "esac\n"
-    )
+    faketmux = bindir / "tmux"; faketmux.write_text(FAKE_TMUX)
     faketmux.chmod(faketmux.stat().st_mode | stat.S_IEXEC)
-    turns = tmp_path / "turns"
+    fdir = tmp_path / "fake"; fdir.mkdir()
 
     env = dict(os.environ)
     env["PATH"] = f"{bindir}:{env['PATH']}"
-    env["STOA_TURN_DIR"] = str(turns)
+    env["FAKE_DIR"] = str(fdir)
+    env["STOA_TURN_DIR"] = str(tmp_path / "turns")
+    env["STOA_OUT_DIR"] = str(tmp_path / "out")
     env["STOA_POLL_S"] = "0.05"
+    env["STOA_SETTLE_S"] = "0"
+    env["FAKE_PAYLOAD"] = json.dumps(PAYLOAD)
 
-    def run(req, initial_pane="", reply_pane=NEW_REPLY, session_exists=True):
-        pane.write_text(initial_pane)
-        reply.write_text(reply_pane)
-        hasfile.write_text("0" if session_exists else "1")
-        p = subprocess.run(
-            [sys.executable, str(drv), "send", json.dumps(req)],
-            capture_output=True, text=True, env=env, timeout=30,
-        )
+    def run(req, session_exists=True, no_reply=False):
+        (fdir / "has.code").write_text("0" if session_exists else "1")
+        e = dict(env)
+        if no_reply:
+            e["FAKE_NO_REPLY"] = "1"
+        p = subprocess.run([sys.executable, str(drv), "send", json.dumps(req)],
+                           capture_output=True, text=True, env=e, timeout=30)
         return p
 
-    return types.SimpleNamespace(
-        drv=drv, env=env, pane=pane, reply=reply, sendlog=sendlog,
-        newlog=newlog, hasfile=hasfile, run=run,
-    )
-
-
-def test_send_keys_carries_the_message(harness):
-    p = harness.run(SEND_REQ)
-    assert p.returncode == 0, p.stderr
-    assert "decompose" in harness.sendlog.read_text()
+    return types.SimpleNamespace(drv=drv, env=env, fdir=fdir, run=run)
 
 
 def test_receive_shape_matches_contract(harness):
@@ -130,77 +128,74 @@ def test_receive_shape_matches_contract(harness):
     assert out["status"] == "ok"
     assert out["session_id"] == SEND_REQ["session_id"]
     assert out["agent"] == "claude"
-    assert out["payload"]["episode_id"] == "ep-012"
+    assert out["payload"] == PAYLOAD, "payload must come from the file the agent wrote"
 
 
-def test_returns_new_reply_not_prior_turn(harness):
-    """C1 regression: a prior turn's json is already in the pane; the driver
-    must wait for and return THIS turn's reply, not the stale one."""
-    out = json.loads(
-        harness.run(SEND_REQ, initial_pane=PRIOR_TURN, reply_pane=PRIOR_TURN + NEW_REPLY).stdout
-    )
-    assert out["status"] == "ok"
-    assert out["payload"]["episode_id"] == "ep-012", "must not return the prior turn's payload"
+def test_submits_via_bracketed_paste_not_send_keys_text(harness):
+    harness.run(SEND_REQ)
+    calls = (harness.fdir / "calls.log").read_text()
+    assert "load-buffer" in calls and "paste-buffer" in calls, "must paste the message"
+    # The message must NOT be typed as send-keys literal text (the swallowed-Enter
+    # bug): the only send-keys call is the bare Enter submit.
+    sk_lines = [l for l in calls.splitlines() if l.startswith("send-keys")]
+    assert sk_lines, "must submit with send-keys Enter"
+    assert all("Enter" in l for l in sk_lines), f"send-keys must only send Enter, got {sk_lines}"
+
+
+def test_payload_from_file_not_pane(harness):
+    # The driver never depends on ```json fences (real claude renders inline) —
+    # the payload comes from the file. No pane content is needed for success.
+    out = json.loads(harness.run(SEND_REQ).stdout)
+    assert out["status"] == "ok" and out["payload"] == PAYLOAD
+
+
+def test_unique_file_per_turn(harness):
+    # Each turn names a fresh nonce'd outfile, so a prior turn's reply can't be
+    # mistaken for this one. Both succeed; the turn advances.
+    a = json.loads(harness.run(SEND_REQ).stdout)
+    b = json.loads(harness.run(SEND_REQ).stdout)
+    assert a["status"] == "ok" and b["status"] == "ok"
+    assert b["turn"] == a["turn"] + 1
 
 
 def test_auto_creates_missing_session(harness):
-    """The session_id the caller sends (e.g. content-factory's name) is
-    auto-created if absent — the driver is agnostic to the chosen name."""
     out = json.loads(harness.run(SEND_REQ, session_exists=False).stdout)
     assert out["status"] == "ok"
-    newlog = harness.newlog.read_text()
-    assert SEND_REQ["session_id"] in newlog, "missing session must be auto-created"
+    newlog = (harness.fdir / "new.log").read_text()
+    assert SEND_REQ["session_id"] in newlog
+    # The session must be able to write its output file unprompted (file writes
+    # only — not a full permissions bypass).
+    assert "acceptEdits" in newlog
 
 
-def test_turn_counter_persists_and_increments(harness):
-    t1 = json.loads(harness.run(SEND_REQ).stdout)["turn"]
-    t2 = json.loads(harness.run(SEND_REQ).stdout)["turn"]
-    assert t2 == t1 + 1, f"turn must advance across calls (got {t1} then {t2})"
-
-
-def test_timeout_when_no_new_reply(harness):
-    req = dict(SEND_REQ, timeout_s=0.2)
-    out = json.loads(
-        harness.run(req, initial_pane="thinking...", reply_pane="thinking... still no json").stdout
-    )
-    assert out["status"] != "ok", "no new reply within timeout must NOT be ok"
+def test_timeout_when_no_file(harness):
+    req = dict(SEND_REQ, timeout_s=0.3)
+    out = json.loads(harness.run(req, no_reply=True).stdout)
+    assert out["status"] != "ok"
 
 
 def test_http_server_serves_session_send(harness):
-    """`agent-session serve` answers POST /session/send — the shape n8n calls."""
     port = _free_port()
-    harness.pane.write_text("")
-    harness.reply.write_text(NEW_REPLY)
-    harness.hasfile.write_text("0")
-    env = dict(harness.env)
-    env["STOA_SESSION_PORT"] = str(port)
-    proc = subprocess.Popen(
-        [sys.executable, str(harness.drv), "serve"],
-        env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-    )
+    (harness.fdir / "has.code").write_text("0")
+    env = dict(harness.env); env["STOA_SESSION_PORT"] = str(port)
+    proc = subprocess.Popen([sys.executable, str(harness.drv), "serve"],
+                            env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     try:
         base = f"http://127.0.0.1:{port}"
-        # Wait for readiness via /healthz.
         for _ in range(50):
             try:
                 with urllib.request.urlopen(base + "/healthz", timeout=1) as r:
                     if r.status == 200:
                         break
-            except (urllib.error.URLError, ConnectionError):
+            except Exception:
                 time.sleep(0.1)
         else:
             raise AssertionError("server did not become ready")
-        # POST a send-request like the n8n httpRequest node does.
         body = json.dumps(SEND_REQ).encode()
-        req = urllib.request.Request(
-            base + "/session/send", data=body,
-            headers={"Content-Type": "application/json"}, method="POST",
-        )
+        req = urllib.request.Request(base + "/session/send", data=body,
+                                     headers={"Content-Type": "application/json"}, method="POST")
         with urllib.request.urlopen(req, timeout=10) as r:
             out = json.loads(r.read())
-        assert set(out) == RECV_KEYS
-        assert out["status"] == "ok"
-        assert out["payload"]["episode_id"] == "ep-012"
+        assert out["status"] == "ok" and out["payload"] == PAYLOAD
     finally:
-        proc.terminate()
-        proc.wait(timeout=5)
+        proc.terminate(); proc.wait(timeout=5)

--- a/scripts/tests/test_agent_session_driver.py
+++ b/scripts/tests/test_agent_session_driver.py
@@ -163,9 +163,9 @@ def test_auto_creates_missing_session(harness):
     assert out["status"] == "ok"
     newlog = (harness.fdir / "new.log").read_text()
     assert SEND_REQ["session_id"] in newlog
-    # The session must be able to write its output file unprompted (file writes
-    # only — not a full permissions bypass).
-    assert "acceptEdits" in newlog
+    # The session must be able to write its output file unprompted (auto-approve
+    # safe ops — not a full permissions bypass).
+    assert "--permission-mode auto" in newlog
 
 
 def test_timeout_when_no_file(harness):

--- a/scripts/tests/test_n8n_agent_sidecar.py
+++ b/scripts/tests/test_n8n_agent_sidecar.py
@@ -96,8 +96,8 @@ def test_bootstrap_starts_interactive_claude_in_named_tmux():
     assert "claude" in script
     assert "-p " not in script and "--print" not in script, "never `claude -p`"
     # Must be able to write its per-turn output file without a permission prompt
-    # (file writes only — not a full permissions bypass).
-    assert "acceptEdits" in script
+    # (auto-approve safe ops — not a full permissions bypass).
+    assert "--permission-mode auto" in script
     # Idempotent: don't double-create the session.
     assert "has-session" in script, "bootstrap must be idempotent (has-session guard)"
 

--- a/scripts/tests/test_n8n_agent_sidecar.py
+++ b/scripts/tests/test_n8n_agent_sidecar.py
@@ -95,6 +95,9 @@ def test_bootstrap_starts_interactive_claude_in_named_tmux():
     # Interactive claude — NEVER print mode.
     assert "claude" in script
     assert "-p " not in script and "--print" not in script, "never `claude -p`"
+    # Must be able to write its per-turn output file without a permission prompt
+    # (file writes only — not a full permissions bypass).
+    assert "acceptEdits" in script
     # Idempotent: don't double-create the session.
     assert "has-session" in script, "bootstrap must be idempotent (has-session guard)"
 


### PR DESCRIPTION
## Summary

Follow-up to #539. Live MO-5b verification (driving the real `claude` session in
the deployed n8n-01 sidecar) surfaced two integration realities the unit mocks
couldn't — exactly the mock-vs-reality drift the contract-first approach is meant
to catch at the gate:

1. **No `\`\`\`json` fences.** claude's TUI renders replies **inline after a `●`**
   (no literal code fences), and a large payload **soft-wraps** mid-string. The
   old driver scraped `\`\`\`json…\`\`\`` from `capture-pane` → it would never
   match real output.
2. **Swallowed Enter.** `tmux send-keys <text> Enter` in one call types the
   message but the Enter is dropped (bracketed-paste) → the message is never
   submitted.

## Fix

- **Submit via bracketed paste:** `load-buffer` + `paste-buffer -p` + a **separate**
  `send-keys Enter` after a settle delay. Multi-line safe; submits reliably.
- **Receive via file, not pane:** the driver appends an instruction to **write the
  JSON reply to a per-turn nonce file**, then polls for that file to exist + parse
  — robust to TUI rendering/wrapping. The unique nonce path makes a prior turn's
  reply structurally impossible to mistake for this one (replaces the fence-count
  baseline). Invisible to the caller — content-factory still POSTs a message and
  reads `payload`.
- **Permission posture:** the session launches with **`--permission-mode auto`**
  (auto-approves safe operations, incl. writing the per-turn output file, without a
  prompt) — operator-chosen, and narrower than a full `--dangerously-skip-permissions`
  bypass.

Tests rewritten to model the real flow (paste staging + file write, no fences).
**92 tests pass.**

- Spec updated (`2c`) with a live-correction note.

## Live verification status (MO-5b)

The transport itself is already verified live on #539 (`/healthz` ok, both tmux
sessions up, message round-trips once submitted). This PR's driver logic is
unit-verified; the live round-trip (`POST /session/send` → claude writes file →
`payload` returned, `turn` advances) will be re-run against the deployed sidecar
after merge (ArgoCD syncs the ConfigMap; the session server restarts to pick it
up). Two cluster actions there are operator-gated by the auto-mode classifier
(launching `claude`, restarting the server) — driven with the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
