### PR TITLE
fix(n8n): pre-trust the workspace so the autonomous claude session skips the trust gate (MO-5b)

### DIFF
--- a/apps/n8n-01/manifests/agent-session-bootstrap.yaml
+++ b/apps/n8n-01/manifests/agent-session-bootstrap.yaml
@@ -45,6 +45,11 @@ data:
       tmux new-session -d -s "$SERVER" \
         "bash -lc 'while true; do python3 /opt/stoa-bin/agent-session serve; sleep 2; done'" || true
     fi
+    # Pre-trust the workspace in ~/.claude.json so claude never blocks on the
+    # folder-trust gate — an abrupt `tmux kill-session` never lets claude flush
+    # an acceptance, so the gate would otherwise re-appear and hang the
+    # autonomous session (verified live, MO-5b 2026-06-15).
+    python3 -c 'import json,os; p=os.path.expanduser("~/.claude.json"); d=(json.load(open(p)) if os.path.exists(p) else {}); d.setdefault("projects",{}).setdefault(os.path.expanduser("~"),{})["hasTrustDialogAccepted"]=True; json.dump(d,open(p,"w"))' 2>/dev/null || true
     # Pre-warm an attachable default claude session. Interactive claude — never
     # `claude -p`. n8n's session_id is auto-created on first send, so this is
     # convenience (a known attach target) rather than load-bearing.

--- a/apps/n8n-01/manifests/agent-session-driver.yaml
+++ b/apps/n8n-01/manifests/agent-session-driver.yaml
@@ -54,6 +54,24 @@ data:
         return subprocess.run(["tmux", *args], input=stdin, capture_output=True, text=True)
 
 
+    def pretrust():
+        # Mark the workspace trusted in ~/.claude.json so claude never blocks on
+        # the folder-trust gate (an abrupt kill never flushes an acceptance, so
+        # it would otherwise re-appear and hang the session). Idempotent.
+        path = os.path.expanduser("~/.claude.json")
+        try:
+            d = json.load(open(path)) if os.path.exists(path) else {}
+        except (OSError, json.JSONDecodeError):
+            d = {}
+        home = os.path.expanduser("~")
+        d.setdefault("projects", {}).setdefault(home, {})["hasTrustDialogAccepted"] = True
+        try:
+            with open(path, "w") as fh:
+                json.dump(d, fh)
+        except OSError:
+            pass
+
+
     def ensure_session(session_id):
         # Auto-create the session (interactive claude, never -p) if absent, so
         # the caller's session_id drives whatever it names. Unauthenticated until
@@ -62,6 +80,7 @@ data:
         # file) without a prompt, short of a full permissions bypass. Concurrency-
         # safe: a racing dup new-session errors harmlessly.
         if tmux("has-session", "-t", session_id).returncode != 0:
+            pretrust()
             tmux("new-session", "-d", "-s", session_id,
                  "claude --permission-mode auto")
 

--- a/scripts/tests/test_agent_session_driver.py
+++ b/scripts/tests/test_agent_session_driver.py
@@ -100,9 +100,11 @@ def harness(tmp_path):
     faketmux = bindir / "tmux"; faketmux.write_text(FAKE_TMUX)
     faketmux.chmod(faketmux.stat().st_mode | stat.S_IEXEC)
     fdir = tmp_path / "fake"; fdir.mkdir()
+    home = tmp_path / "home"; home.mkdir()  # isolate HOME so pretrust() never touches real ~/.claude.json
 
     env = dict(os.environ)
     env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(home)
     env["FAKE_DIR"] = str(fdir)
     env["STOA_TURN_DIR"] = str(tmp_path / "turns")
     env["STOA_OUT_DIR"] = str(tmp_path / "out")
@@ -119,7 +121,7 @@ def harness(tmp_path):
                            capture_output=True, text=True, env=e, timeout=30)
         return p
 
-    return types.SimpleNamespace(drv=drv, env=env, fdir=fdir, run=run)
+    return types.SimpleNamespace(drv=drv, env=env, fdir=fdir, home=home, run=run)
 
 
 def test_receive_shape_matches_contract(harness):
@@ -166,6 +168,16 @@ def test_auto_creates_missing_session(harness):
     # The session must be able to write its output file unprompted (auto-approve
     # safe ops — not a full permissions bypass).
     assert "--permission-mode auto" in newlog
+
+
+def test_auto_create_pretrusts_workspace(harness):
+    # Creating a session pre-trusts $HOME in ~/.claude.json so claude never
+    # blocks on the folder-trust gate (verified live, MO-5b).
+    harness.run(SEND_REQ, session_exists=False)
+    cfg = harness.home / ".claude.json"
+    assert cfg.exists(), "pretrust must write ~/.claude.json"
+    proj = json.loads(cfg.read_text()).get("projects", {})
+    assert proj.get(str(harness.home), {}).get("hasTrustDialogAccepted") is True
 
 
 def test_timeout_when_no_file(harness):

--- a/scripts/tests/test_n8n_agent_sidecar.py
+++ b/scripts/tests/test_n8n_agent_sidecar.py
@@ -98,6 +98,8 @@ def test_bootstrap_starts_interactive_claude_in_named_tmux():
     # Must be able to write its per-turn output file without a permission prompt
     # (auto-approve safe ops — not a full permissions bypass).
     assert "--permission-mode auto" in script
+    # Pre-trust the workspace so claude never blocks on the folder-trust gate.
+    assert "hasTrustDialogAccepted" in script, "bootstrap must pre-trust the workspace"
     # Idempotent: don't double-create the session.
     assert "has-session" in script, "bootstrap must be idempotent (has-session guard)"
 


### PR DESCRIPTION
## Summary

Follow-up to the agent-session driver (#540). Live MO-5b verification found the
autonomous session **re-prompting claude's folder-trust gate on every restart**,
which hangs an unattended `POST /session/send`.

**Root cause:** `~/.claude.json` kept `/home/agent` at `hasTrustDialogAccepted:
false` — an abrupt `tmux kill-session` (how the bootstrap recreates the session)
never lets claude flush a trust acceptance, so the gate re-appears each launch.

**Fix:** the bootstrap **and** the driver's `ensure_session` now pre-seed
`hasTrustDialogAccepted: true` for `$HOME` in `~/.claude.json` **before** launching
claude (idempotent). The session then lands on the chat prompt with no manual step.

## Not a bug: auth

`claude auth status` was `loggedIn: true` the whole time — the `✗ not logged in`
banner is the image's **stale MOTD detector**, not claude's real state. No auth
change needed.

## Verified live (MO-5b) after this fix

```
auto mode on   (chat prompt, no gate)
POST 1 -> {"status":"ok","turn":2,"payload":{"episode_id":"ep-test","clips":[]}}
POST 2 -> {"status":"ok","turn":3,"payload":{"episode_id":"ep-test2","clips":[]}}
```

The full chain proven: n8n HTTP `POST /session/send` → driver → claude (auth'd,
`--permission-mode auto`, pre-trusted) → claude writes the JSON file → driver reads
it → payload returned, `turn` advancing, correct per-turn replies.

Tests isolate `HOME` so `pretrust()` never touches the real `~/.claude.json`; a new
assertion checks auto-create pre-trusts the workspace. **20 tests pass.**

This closes the **agent-session half of the Test Plan (MO-4/5b)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
