### PR TITLE
fix(comfyui): pin torchaudio==torch — restores audio + Wan + Fish nodes (MO-5a)

### DIFF
--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -13,11 +13,14 @@ env:
   COMFYUI_REF: "v0.9.2"
   MANAGER_REF: "4.0.5"
   PYTORCH_VERSION: "2.10.0"
+  TORCHVISION_VERSION: "0.25.0"
   CUDA_VERSION_PIP: "cu128"
-  # stoa node-set revision — bump when the baked custom-node set changes so
-  # the image tag (and the Deployment pin) move together. Node refs are pinned
-  # to commit SHAs (these repos publish no release tags) for reproducibility.
-  STOA_NODES: "1"
+  # stoa image revision — bump to move the image tag (and the Deployment pin)
+  # together so a rebuild redeploys. Node refs are pinned to commit SHAs (these
+  # repos publish no release tags) for reproducibility.
+  # rev 2: pin torchaudio==torch (was resolving 2.11.0 vs torch 2.10.0, breaking
+  #        libtorchaudio -> audio nodes + WanVideoWrapper + FishSpeech failed to load).
+  STOA_NODES: "2"
   LTXVIDEO_REF: "229437c6b65796d6a7a63ae34be2bd5ba31fa543"
   GGUF_REF: "6ea2651e7df66d7585f6ffee804b20e92fb38b8a"
   WANVIDEO_REF: "088128b224242e110d3906c6750e9a3a348a659b"
@@ -63,6 +66,7 @@ jobs:
             COMFYUI_REF=${{ env.COMFYUI_REF }}
             MANAGER_REF=${{ env.MANAGER_REF }}
             PYTORCH_VERSION=${{ env.PYTORCH_VERSION }}
+            TORCHVISION_VERSION=${{ env.TORCHVISION_VERSION }}
             CUDA_VERSION_PIP=${{ env.CUDA_VERSION_PIP }}
             LTXVIDEO_REF=${{ env.LTXVIDEO_REF }}
             GGUF_REF=${{ env.GGUF_REF }}

--- a/apps/comfyui/docker/Dockerfile
+++ b/apps/comfyui/docker/Dockerfile
@@ -4,6 +4,7 @@ FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
 ARG COMFYUI_REF=v0.9.2
 ARG MANAGER_REF=4.0.5
 ARG PYTORCH_VERSION=2.10.0
+ARG TORCHVISION_VERSION=0.25.0
 ARG CUDA_VERSION_PIP=cu128
 
 # ── stoa custom-node refs ──────────────────────────────────────────
@@ -31,10 +32,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── PyTorch (cached layer — only rebuilds on version/CUDA change) ───
+# Pin torchaudio to torch's version — unpinned, pip resolves a NEWER torchaudio
+# (e.g. 2.11.0 vs torch 2.10.0) whose libtorchaudio.abi3.so fails to load,
+# silently breaking ComfyUI's audio nodes + WanVideoWrapper + FishSpeech.
 RUN pip install --no-cache-dir \
     torch==${PYTORCH_VERSION} \
-    torchvision \
-    torchaudio \
+    torchvision==${TORCHVISION_VERSION} \
+    torchaudio==${PYTORCH_VERSION} \
     --index-url https://download.pytorch.org/whl/${CUDA_VERSION_PIP}
 
 # ── ComfyUI ──────────────────────────────────────────────────────────

--- a/apps/comfyui/manifests/deployment.yaml
+++ b/apps/comfyui/manifests/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: comfyui
-          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa1
+          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa2
           # Overrides the image CMD to add VRAM/offload flags for the 16GB
           # RTX 5070 Ti. The stoa runner drives one clip at a time, so models
           # load serially: reserve a little VRAM for the OS and don't cache

--- a/apps/comfyui/manifests/job-model-download.yaml
+++ b/apps/comfyui/manifests/job-model-download.yaml
@@ -42,7 +42,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: download
-          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa1
+          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa2
           env:
             # Optional: lifts the anonymous-download throttle + reaches gated
             # weights. Absent Secret -> empty -> anonymous download still works.


### PR DESCRIPTION
## Summary

Live MO-5a (activating ComfyUI + the submit→poll→fetch check) found three custom-node
groups failing to load: **ComfyUI core audio nodes**, **WanVideoWrapper**, and
**FishSpeech** — all from one broken shared library:

```
Could not load: torchaudio/lib/libtorchaudio.abi3.so   (ldd: libc10.so/libtorch.so not found)
torch       2.10.0+cu128   (pinned)
torchaudio  2.11.0+cu128   ← unpinned -> pip resolved a torch-incompatible version
```

The Dockerfile pinned `torch==2.10.0` but left `torchaudio`/`torchvision` unpinned, so
pip pulled torchaudio **2.11.0**, whose `libtorchaudio` is ABI-incompatible with torch
2.10 and fails to load — cascading to every node that imports torchaudio (audio,
WanVideoWrapper via HuMo/multitalk, FishSpeech).

## Fix

- Pin `torchaudio==${PYTORCH_VERSION}` and `torchvision==0.25.0` (the torch-2.10 set).
- Bump `STOA_NODES` 1→2 so the rebuilt image tag (`...-stoa2`) **redeploys** — re-pointing
  the same tag would keep the stale cached image (`IfNotPresent`).
- Deployment + model-download Job tags bumped to `-stoa2`.

## What MO-5a established (unaffected by this bug)

- **Frank API contract PASSES:** ComfyUI reachable, **all target models listed**
  (LTX-Video + LTX-2 NVFP8/GGUF + Wan 2.2 + encoders/VAEs + Kokoro/Fish), and
  `POST /prompt → GET /history/{id} → GET /view` composes with the exact contract shapes
  (`prompt_id`, `node_errors:{}`, `status.completed`, `outputs.<node>`, view bytes).
- **LTX video path + Kokoro TTS work** (no torchaudio dep). This PR restores Wan-video +
  Fish-TTS + audio once the image rebuilds and the deployment rolls to `-stoa2`.

## Deploy note

CI rebuilds on merge (push touching `apps/comfyui/docker/**`); ArgoCD then rolls the
`replicas:0`-gated ComfyUI Deployment to `-stoa2`. Re-verify node loading after the roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
