### PR TITLE
fix(comfyui): unblock LTXVideo (kornia) + FishSpeech (perms) — stoa3

### DIFF
--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -20,7 +20,9 @@ env:
   # repos publish no release tags) for reproducibility.
   # rev 2: pin torchaudio==torch (was resolving 2.11.0 vs torch 2.10.0, breaking
   #        libtorchaudio -> audio nodes + WanVideoWrapper + FishSpeech failed to load).
-  STOA_NODES: "2"
+  # rev 3: patch ComfyUI-LTXVideo's kornia `pad` import (kornia 0.8.3 dropped it);
+  #        pre-create FishSpeech's site-packages .pth as comfyui-owned.
+  STOA_NODES: "3"
   LTXVIDEO_REF: "229437c6b65796d6a7a63ae34be2bd5ba31fa543"
   GGUF_REF: "6ea2651e7df66d7585f6ffee804b20e92fb38b8a"
   WANVIDEO_REF: "088128b224242e110d3906c6750e9a3a348a659b"

--- a/apps/comfyui/docker/Dockerfile
+++ b/apps/comfyui/docker/Dockerfile
@@ -65,6 +65,11 @@ RUN pip install --no-cache-dir \
 RUN mkdir -p /opt/stoa-custom-nodes && cd /opt/stoa-custom-nodes \
     && git clone https://github.com/Lightricks/ComfyUI-LTXVideo.git \
     && git -C ComfyUI-LTXVideo checkout ${LTXVIDEO_REF} \
+    # kornia 0.8.3 dropped `pad` from kornia.geometry.transform.pyramid; the node
+    # still imports it (upstream bug) -> ImportError. Its calls match torch's
+    # F.pad signature, so source `pad` from torch instead.
+    && sed -i '/^    pad,$/d' ComfyUI-LTXVideo/pyramid_blending.py \
+    && sed -i '/^import torch.nn.functional as F$/a from torch.nn.functional import pad' ComfyUI-LTXVideo/pyramid_blending.py \
     && pip install --no-cache-dir -r ComfyUI-LTXVideo/requirements.txt \
     && git clone https://github.com/city96/ComfyUI-GGUF.git \
     && git -C ComfyUI-GGUF checkout ${GGUF_REF} \
@@ -83,6 +88,13 @@ RUN mkdir -p /opt/stoa-custom-nodes && cd /opt/stoa-custom-nodes \
 RUN groupadd -g 1000 comfyui \
     && useradd -u 1000 -g comfyui -d /app -s /bin/bash comfyui \
     && chown -R comfyui:comfyui /app
+
+# ComfyUI-FishSpeech's __init__.py writes a `fish_speech.pth` into site-packages
+# at import — fails as the non-root comfyui user (root-owned dir). Pre-create the
+# file owned by comfyui so the runtime open("w") (rewrite) succeeds.
+RUN SP="$(python -c 'import site; print(site.getsitepackages()[0])')" \
+    && touch "$SP/fish_speech.pth" \
+    && chown comfyui:comfyui "$SP/fish_speech.pth"
 
 # ── Entrypoint ──────────────────────────────────────────────────────
 COPY entrypoint.sh /app/entrypoint.sh

--- a/apps/comfyui/manifests/deployment.yaml
+++ b/apps/comfyui/manifests/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: comfyui
-          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa2
+          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa3
           # Overrides the image CMD to add VRAM/offload flags for the 16GB
           # RTX 5070 Ti. The stoa runner drives one clip at a time, so models
           # load serially: reserve a little VRAM for the OS and don't cache

--- a/apps/comfyui/manifests/job-model-download.yaml
+++ b/apps/comfyui/manifests/job-model-download.yaml
@@ -42,7 +42,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: download
-          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa2
+          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa3
           env:
             # Optional: lifts the anonymous-download throttle + reaches gated
             # weights. Absent Secret -> empty -> anonymous download still works.


### PR DESCRIPTION
Last two custom nodes failing after the torchaudio fix:
- **ComfyUI-LTXVideo**: `ImportError: cannot import name 'pad' from kornia.geometry.transform.pyramid` — kornia 0.8.3 dropped it; the node's HEAD == our pinned SHA (no upstream fix). Its `pad(x, padding, mode)` calls match `torch.nn.functional.pad`, so we source `pad` from torch (sed patch).
- **ComfyUI-FishSpeech**: `__init__.py` writes `fish_speech.pth` into root-owned site-packages at import → PermissionError as non-root `comfyui`. Pre-create it comfyui-owned.

`STOA_NODES` 2→3 → rebuild → redeploy (`-stoa3`). Restores LTX-2 (custom node) + Fish-Speech; Wan/audio/LTX-core/Kokoro already work on -stoa2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)