### PR TITLE
feat(cicd): staging-vCluster e2e release gate — design spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .env
 *.env.local
 
+# staging-gate: locally-provisioned manifest-validation tooling (ensure-tools.sh)
+/.bin/
+
 # Talos configs (contain sensitive cluster info)
 .talos/
 

--- a/apps/root/templates/ns-vcluster-staging.yaml
+++ b/apps/root/templates/ns-vcluster-staging.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vcluster-staging
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted

--- a/apps/root/templates/project.yaml
+++ b/apps/root/templates/project.yaml
@@ -12,6 +12,11 @@ spec:
   destinations:
     - namespace: '*'
       server: {{ .Values.destination.server }}
+    # staging-gate: permit deploying into the staging vCluster, registered as an
+    # ArgoCD external cluster. The cluster credential (kubeconfig-derived Secret) is
+    # created out-of-band — see the staging-gate plan's manual phase.
+    - namespace: '*'
+      server: https://staging.vcluster-staging.svc:443
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'

--- a/apps/root/templates/runs-fr-staging.yaml
+++ b/apps/root/templates/runs-fr-staging.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: runs-fr-staging
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  sources:
+    # The runs-fr chart lives in the runs-fr repo; staging values come from frank
+    # (the $values ref below). The gate bumps image.tag in the staging values file.
+    - repoURL: https://github.com/derio-net/runs-fr.git
+      targetRevision: main
+      path: charts/runs-fr
+      helm:
+        releaseName: runs-fr
+        valueFiles:
+          - $values/apps/staging-gate/runs-fr/staging-values.yaml
+    - repoURL: {{ .Values.repoURL }}
+      targetRevision: {{ .Values.targetRevision }}
+      ref: values
+  destination:
+    # Deploys INTO the staging vCluster (registered as an ArgoCD external cluster;
+    # the cluster credential is created out-of-band — see the staging-gate manual phase).
+    server: https://staging.vcluster-staging.svc:443
+    namespace: runs-fr
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - kind: Secret
+      jsonPointers:
+        - /data

--- a/apps/root/templates/staging-gate.yaml
+++ b/apps/root/templates/staging-gate.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: staging-gate
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  source:
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.targetRevision }}
+    # ONLY the tekton/ subdir is applied (Tasks, Pipeline, Triggers, RBAC).
+    # apps/staging-gate/{registry,runs-fr,README.md} are data consumed by the pipeline /
+    # the <app>-staging app — NOT Kubernetes objects.
+    path: apps/staging-gate/tekton
+    directory:
+      recurse: true
+  destination:
+    server: {{ .Values.destination.server }}
+    namespace: tekton-pipelines
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true
+      - CreateNamespace=false

--- a/apps/root/templates/vcluster-staging.yaml
+++ b/apps/root/templates/vcluster-staging.yaml
@@ -1,0 +1,48 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vcluster-staging
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  sources:
+    - repoURL: https://charts.loft.sh
+      chart: vcluster
+      targetRevision: "0.32.1"
+      helm:
+        releaseName: staging
+        valueFiles:
+          # Template first (base defaults), then instance overrides
+          - $values/apps/vclusters/template/values.yaml
+          - $values/apps/vclusters/staging/values.yaml
+    - repoURL: {{ .Values.repoURL }}
+      targetRevision: {{ .Values.targetRevision }}
+      ref: values
+  destination:
+    server: {{ .Values.destination.server }}
+    namespace: vcluster-staging
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - kind: Secret
+      jsonPointers:
+        - /data
+    # vCluster chart injects a vClusterConfigHash annotation and omits several
+    # StatefulSet fields that Kubernetes defaults (whenScaled, revisionHistoryLimit,
+    # updateStrategy). Ignoring those keeps the essential spec in sync.
+    - group: apps
+      kind: StatefulSet
+      name: staging
+      namespace: vcluster-staging
+      jsonPointers:
+        - /spec/template/metadata/annotations/vClusterConfigHash
+        - /spec/persistentVolumeClaimRetentionPolicy/whenScaled
+        - /spec/revisionHistoryLimit
+        - /spec/updateStrategy

--- a/apps/staging-gate/README.md
+++ b/apps/staging-gate/README.md
@@ -1,0 +1,52 @@
+# staging-gate
+
+The automated release gate (spec:
+`docs/superpowers/specs/2026-06-15--cicd--staging-vcluster-gate-design.md`). Each gated app's
+merge to `main` is built (GHA, per-commit image), deployed into the **`staging` vCluster** via
+ArgoCD, exercised by an **in-cluster e2e smoke-test**, and — only if green — **auto-promoted**
+to Frank production by a declarative image-ref bump.
+
+## Layout
+
+```
+apps/staging-gate/
+  registry/<app>.yaml   # per-app CONTRACT (data; validated, NOT applied to the cluster)
+  <app>/staging-values.yaml  # per-app staging Helm values (image.tag is gate-owned)
+  tekton/               # the gate Pipeline + Tasks + triggers (THIS is what ArgoCD applies)
+  README.md
+```
+
+The App-of-Apps Application for staging-gate points ONLY at `tekton/` — `registry/` and the
+per-app values are data consumed by the pipeline / the `<app>-staging` ArgoCD app, not Kubernetes
+objects.
+
+## Onboarding an app
+
+1. Add `registry/<app>.yaml` (schema below) + `<app>/staging-values.yaml`.
+2. Add an `<app>-staging` ArgoCD Application (`apps/root/templates/<app>-staging.yaml`) deploying
+   the chart into the staging vCluster, pinned to `<app>/staging-values.yaml`.
+3. Ship an in-cluster smoke-test image (`smokeImage`) that exits 0 (pass) / non-zero (fail).
+4. Add the per-commit image build + the gate trigger (GHA `repository_dispatch` action
+   `staging-gate`) in the app repo.
+
+Validate: `uv run --with pyyaml python scripts/staging-gate/validate-contract.py`.
+
+## Contract schema (`registry/<app>.yaml`)
+
+| key | meaning |
+|-----|---------|
+| `app` | short name (PipelineRun param + labels) |
+| `sourceRepo` | `owner/repo` whose `main` merges trigger the gate |
+| `image` | GHCR image repository (gate appends `:sha-<commit>`) |
+| `chartRepo` | git URL of the Helm chart |
+| `chartPath` | chart path within `chartRepo` |
+| `stagingApp` | ArgoCD Application name for staging |
+| `stagingValuesPath` | frank path to the staging values file (gate bumps `image.tag` here) |
+| `smokeImage` | in-cluster smoke-test image (exit 0 = pass) |
+| `smokeNamespace` | namespace in the staging vCluster to run the smoke Job |
+| `prodApp` | ArgoCD Application name for prod (promote target) |
+| `prodValuesPath` | frank path to the prod values file |
+| `prodValuesKey` | dotted key in `prodValuesPath` to bump on promote (e.g. `image.tag`) |
+
+The validator checks the contract's SHAPE, not the existence of the referenced targets — a
+`prodApp` may be a paired follow-up that doesn't exist yet.

--- a/apps/staging-gate/registry/runs-fr.yaml
+++ b/apps/staging-gate/registry/runs-fr.yaml
@@ -1,0 +1,18 @@
+# staging-gate contract for runs-fr. Consumed by the Tekton staging-gate Pipeline.
+# Schema + field meanings: apps/staging-gate/README.md. Validated by
+# scripts/staging-gate/validate-contract.py.
+app: runs-fr
+sourceRepo: derio-net/runs-fr
+image: ghcr.io/derio-net/runs-fr
+chartRepo: https://github.com/derio-net/runs-fr.git
+chartPath: charts/runs-fr
+stagingApp: runs-fr-staging
+stagingValuesPath: apps/staging-gate/runs-fr/staging-values.yaml
+smokeImage: ghcr.io/derio-net/runs-fr-smoke
+smokeNamespace: runs-fr
+# Promote target — the runs-fr PROD wiring is a PAIRED FOLLOW-UP (Authentik/Ingress/
+# homepage). The contract records the target now; the promote task bumps prodValuesKey
+# in prodValuesPath once that app exists. The validator checks shape, not target existence.
+prodApp: runs-fr
+prodValuesPath: apps/runs-fr/values.yaml
+prodValuesKey: image.tag

--- a/apps/staging-gate/runs-fr/staging-values.yaml
+++ b/apps/staging-gate/runs-fr/staging-values.yaml
@@ -1,0 +1,15 @@
+# runs-fr staging values — consumed by the runs-fr-staging ArgoCD Application
+# (apps/root/templates/runs-fr-staging.yaml) which deploys the runs-fr chart into the
+# `staging` vCluster.
+#
+# The Tekton staging-gate's `bump-staging` task rewrites `image.tag` to the candidate
+# commit sha each gate run; ArgoCD then syncs that image into the vCluster for the
+# in-cluster smoke-test. Do NOT hand-edit `image.tag` — it is gate-owned.
+image:
+  repository: ghcr.io/derio-net/runs-fr
+  tag: staging
+# The gateway watches its own namespace in staging.
+namespace: runs-fr
+service:
+  type: ClusterIP
+# authHeader stays the default (X-Forwarded-User); the smoke-test supplies the header.

--- a/apps/staging-gate/tekton/pipeline.yaml
+++ b/apps/staging-gate/tekton/pipeline.yaml
@@ -1,0 +1,101 @@
+# staging-gate Pipeline (tekton.dev/v1). Reusable across apps: params are just {app, sha};
+# resolve-contract reads apps/staging-gate/registry/<app>.yaml and emits the rest as results.
+# RUNTIME verified in the manual phase (P7). promote runs ONLY when smoke passed; reset always.
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: staging-gate
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: app
+      type: string
+    - name: sha
+      type: string
+  workspaces:
+    - name: ssh-creds
+    - name: vcluster-kubeconfig
+  tasks:
+    - name: resolve-contract
+      params:
+        - name: app
+          value: $(params.app)
+      taskSpec:
+        params:
+          - name: app
+            type: string
+        results:
+          - name: stagingApp
+          - name: stagingValuesPath
+          - name: smokeImage
+          - name: smokeNamespace
+          - name: prodValuesPath
+          - name: prodValuesKey
+        steps:
+          - name: resolve
+            image: python:3.12-alpine@sha256:9c51ecce261773a684c8345b2d4673700055c513b4d54bc0719337d3e4ee552e
+            env:
+              - name: HOME
+                value: /tekton/home
+            computeResources:
+              requests: {cpu: 50m, memory: 64Mi}
+              limits: {memory: 128Mi}
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              runAsUser: 65532
+              seccompProfile: {type: RuntimeDefault}
+            script: |
+              #!/bin/sh
+              set -eu
+              apk add --no-cache git >/dev/null
+              git clone --depth 1 https://github.com/derio-net/frank.git /tmp/frank
+              python3 - <<PY
+              import yaml
+              c = yaml.safe_load(open("/tmp/frank/apps/staging-gate/registry/$(params.app).yaml"))
+              for k in ("stagingApp","stagingValuesPath","smokeImage","smokeNamespace","prodValuesPath","prodValuesKey"):
+                  open(f"$(results.{k}.path)".replace("{k}",k), "w").write(str(c[k]))
+              PY
+    - name: bump-staging
+      runAfter: [resolve-contract]
+      taskRef: {name: staging-gate-bump-staging}
+      params:
+        - {name: sha, value: $(params.sha)}
+        - {name: stagingValuesPath, value: $(tasks.resolve-contract.results.stagingValuesPath)}
+      workspaces:
+        - {name: ssh-creds, workspace: ssh-creds}
+    - name: await-sync
+      runAfter: [bump-staging]
+      taskRef: {name: staging-gate-await-sync}
+      params:
+        - {name: stagingApp, value: $(tasks.resolve-contract.results.stagingApp)}
+    - name: run-smoke
+      runAfter: [await-sync]
+      taskRef: {name: staging-gate-run-smoke}
+      params:
+        - {name: app, value: $(params.app)}
+        - {name: smokeImage, value: $(tasks.resolve-contract.results.smokeImage)}
+        - {name: smokeNamespace, value: $(tasks.resolve-contract.results.smokeNamespace)}
+        - {name: sha, value: $(params.sha)}
+      workspaces:
+        - {name: vcluster-kubeconfig, workspace: vcluster-kubeconfig}
+    - name: promote
+      runAfter: [run-smoke]
+      when:
+        - input: "$(tasks.run-smoke.status)"
+          operator: in
+          values: ["Succeeded"]
+      taskRef: {name: staging-gate-promote}
+      params:
+        - {name: sha, value: $(params.sha)}
+        - {name: prodValuesPath, value: $(tasks.resolve-contract.results.prodValuesPath)}
+        - {name: prodValuesKey, value: $(tasks.resolve-contract.results.prodValuesKey)}
+      workspaces:
+        - {name: ssh-creds, workspace: ssh-creds}
+  finally:
+    - name: reset
+      taskRef: {name: staging-gate-reset}
+      params:
+        - {name: smokeNamespace, value: $(tasks.resolve-contract.results.smokeNamespace)}
+      workspaces:
+        - {name: vcluster-kubeconfig, workspace: vcluster-kubeconfig}

--- a/apps/staging-gate/tekton/pipeline.yaml
+++ b/apps/staging-gate/tekton/pipeline.yaml
@@ -1,6 +1,6 @@
-# staging-gate Pipeline (tekton.dev/v1). Reusable across apps: params are just {app, sha};
-# resolve-contract reads apps/staging-gate/registry/<app>.yaml and emits the rest as results.
-# RUNTIME verified in the manual phase (P7). promote runs ONLY when smoke passed; reset always.
+# staging-gate Pipeline (tekton.dev/v1). Reusable: params are {app, sha}; resolve-contract reads
+# apps/staging-gate/registry/<app>.yaml (ssh-cloned — frank is private) and emits each field as a
+# result. promote runs ONLY when run-smoke Succeeded; reset always (finally). RUNTIME → P7.
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
@@ -8,38 +8,37 @@ metadata:
   namespace: tekton-pipelines
 spec:
   params:
-    - name: app
-      type: string
-    - name: sha
-      type: string
+    - {name: app, type: string}
+    - {name: sha, type: string}
   workspaces:
-    - name: ssh-creds
-    - name: vcluster-kubeconfig
+    - {name: ssh-creds}
+    - {name: vcluster-kubeconfig}
+    - {name: scratch}
   tasks:
     - name: resolve-contract
       params:
-        - name: app
-          value: $(params.app)
+        - {name: app, value: $(params.app)}
+      workspaces:
+        - {name: ssh-creds, workspace: ssh-creds}
+        - {name: scratch, workspace: scratch}
       taskSpec:
         params:
-          - name: app
-            type: string
+          - {name: app, type: string}
+        workspaces:
+          - {name: ssh-creds}
+          - {name: scratch}
         results:
-          - name: stagingApp
-          - name: stagingValuesPath
-          - name: smokeImage
-          - name: smokeNamespace
-          - name: prodValuesPath
-          - name: prodValuesKey
+          - {name: stagingApp}
+          - {name: stagingValuesPath}
+          - {name: smokeImage}
+          - {name: smokeNamespace}
+          - {name: prodValuesPath}
+          - {name: prodValuesKey}
         steps:
-          - name: resolve
-            image: python:3.12-alpine@sha256:9c51ecce261773a684c8345b2d4673700055c513b4d54bc0719337d3e4ee552e
-            env:
-              - name: HOME
-                value: /tekton/home
-            computeResources:
-              requests: {cpu: 50m, memory: 64Mi}
-              limits: {memory: 128Mi}
+          - name: clone
+            image: alpine/git:2.45.2
+            env: [{name: HOME, value: /tekton/home}]
+            computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 256Mi}}
             securityContext:
               allowPrivilegeEscalation: false
               runAsNonRoot: true
@@ -48,14 +47,30 @@ spec:
             script: |
               #!/bin/sh
               set -eu
-              apk add --no-cache git >/dev/null
-              git clone --depth 1 https://github.com/derio-net/frank.git /tmp/frank
-              python3 - <<PY
-              import yaml
-              c = yaml.safe_load(open("/tmp/frank/apps/staging-gate/registry/$(params.app).yaml"))
-              for k in ("stagingApp","stagingValuesPath","smokeImage","smokeNamespace","prodValuesPath","prodValuesKey"):
-                  open(f"$(results.{k}.path)".replace("{k}",k), "w").write(str(c[k]))
-              PY
+              install -m 0700 -d "$HOME/.ssh"
+              install -m 0600 "$(workspaces.ssh-creds.path)/id_rsa" "$HOME/.ssh/id_rsa"
+              export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
+              rm -rf "$(workspaces.scratch.path)/frank"
+              git clone --depth 1 git@github.com:derio-net/frank.git "$(workspaces.scratch.path)/frank"
+          - name: read
+            image: mikefarah/yq:4.44.3
+            computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 128Mi}}
+            securityContext:
+              allowPrivilegeEscalation: false
+              runAsNonRoot: true
+              runAsUser: 65532
+              seccompProfile: {type: RuntimeDefault}
+            script: |
+              #!/bin/sh
+              set -eu
+              f="$(workspaces.scratch.path)/frank/apps/staging-gate/registry/$(params.app).yaml"
+              # Each result path is a genuine Tekton substitution; values written newline-free.
+              printf '%s' "$(yq '.stagingApp' "$f")" > "$(results.stagingApp.path)"
+              printf '%s' "$(yq '.stagingValuesPath' "$f")" > "$(results.stagingValuesPath.path)"
+              printf '%s' "$(yq '.smokeImage' "$f")" > "$(results.smokeImage.path)"
+              printf '%s' "$(yq '.smokeNamespace' "$f")" > "$(results.smokeNamespace.path)"
+              printf '%s' "$(yq '.prodValuesPath' "$f")" > "$(results.prodValuesPath.path)"
+              printf '%s' "$(yq '.prodValuesKey' "$f")" > "$(results.prodValuesKey.path)"
     - name: bump-staging
       runAfter: [resolve-contract]
       taskRef: {name: staging-gate-bump-staging}
@@ -64,6 +79,7 @@ spec:
         - {name: stagingValuesPath, value: $(tasks.resolve-contract.results.stagingValuesPath)}
       workspaces:
         - {name: ssh-creds, workspace: ssh-creds}
+        - {name: scratch, workspace: scratch}
     - name: await-sync
       runAfter: [bump-staging]
       taskRef: {name: staging-gate-await-sync}
@@ -92,6 +108,7 @@ spec:
         - {name: prodValuesKey, value: $(tasks.resolve-contract.results.prodValuesKey)}
       workspaces:
         - {name: ssh-creds, workspace: ssh-creds}
+        - {name: scratch, workspace: scratch}
   finally:
     - name: reset
       taskRef: {name: staging-gate-reset}

--- a/apps/staging-gate/tekton/serviceaccount-rbac.yaml
+++ b/apps/staging-gate/tekton/serviceaccount-rbac.yaml
@@ -1,0 +1,60 @@
+# RBAC for the staging-gate Pipeline. RUNTIME-verified in the manual phase (P7) — the
+# vCluster-access mechanism (the `vcluster-staging-kubeconfig` Secret) is created out-of-band
+# alongside the ArgoCD cluster Secret.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: staging-gate
+  namespace: tekton-pipelines
+---
+# Read the <app>-staging ArgoCD Application status (await-sync task polls Synced+Healthy).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: staging-gate-argocd-read
+  namespace: argocd
+rules:
+  - apiGroups: ["argoproj.io"]
+    resources: ["applications"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: staging-gate-argocd-read
+  namespace: argocd
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: staging-gate-argocd-read
+subjects:
+  - kind: ServiceAccount
+    name: staging-gate
+    namespace: tekton-pipelines
+---
+# Read the gate's secrets in tekton-pipelines: git ssh-creds (push to frank) and the
+# vCluster kubeconfig (run-smoke/reset target the staging vCluster via --kubeconfig).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: staging-gate-secrets-read
+  namespace: tekton-pipelines
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["staging-gate-ssh-creds", "vcluster-staging-kubeconfig"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: staging-gate-secrets-read
+  namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: staging-gate-secrets-read
+subjects:
+  - kind: ServiceAccount
+    name: staging-gate
+    namespace: tekton-pipelines

--- a/apps/staging-gate/tekton/tasks.yaml
+++ b/apps/staging-gate/tekton/tasks.yaml
@@ -1,0 +1,241 @@
+# staging-gate Tekton Tasks (tekton.dev/v1). Schema-valid + structurally complete here;
+# their on-cluster RUNTIME (git push, ArgoCD polling, vCluster kubectl) is verified in the
+# manual phase (P7). Gotchas honoured: `computeResources` (not `resources`); HOME=/tekton/home;
+# non-root securityContext. Workspaces' fsGroup is set on the Pipeline's podTemplate.
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: staging-gate-bump-staging
+  namespace: tekton-pipelines
+spec:
+  description: >
+    Set the candidate sha as image.tag in the app's staging values file (frank) and push.
+    ArgoCD then syncs that image into the staging vCluster.
+  params:
+    - name: sha
+      type: string
+    - name: stagingValuesPath
+      type: string
+      description: frank-relative path to the staging values file (e.g. apps/staging-gate/runs-fr/staging-values.yaml)
+  workspaces:
+    - name: ssh-creds
+      description: SSH key (id_rsa) authorised to push to frank.
+  steps:
+    - name: bump
+      image: python:3.12-alpine@sha256:9c51ecce261773a684c8345b2d4673700055c513b4d54bc0719337d3e4ee552e
+      env:
+        - name: HOME
+          value: /tekton/home
+      computeResources:
+        requests: {cpu: 50m, memory: 64Mi}
+        limits: {memory: 256Mi}
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile: {type: RuntimeDefault}
+      script: |
+        #!/bin/sh
+        set -eu
+        apk add --no-cache git openssh-client >/dev/null
+        install -m 0700 -d "$HOME/.ssh"
+        install -m 0600 "$(workspaces.ssh-creds.path)/id_rsa" "$HOME/.ssh/id_rsa"
+        export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
+        git clone --depth 1 git@github.com:derio-net/frank.git /tmp/frank
+        cd /tmp/frank
+        # Comment-preserving bump of the `tag:` line under the image: block (single tag key).
+        sed -i -E 's#^([[:space:]]+tag:).*#\1 "$(params.sha)"#' "$(params.stagingValuesPath)"
+        grep -nE '^[[:space:]]+tag:' "$(params.stagingValuesPath)"
+        git -c user.email=staging-gate@derio.net -c user.name=staging-gate \
+          commit -am "gate: stage $(params.sha) [skip ci]"
+        git push origin HEAD:main
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: staging-gate-await-sync
+  namespace: tekton-pipelines
+spec:
+  description: Poll the <app>-staging ArgoCD Application until Synced + Healthy (or time out).
+  params:
+    - name: stagingApp
+      type: string
+    - name: timeoutSeconds
+      type: string
+      default: "300"
+  steps:
+    - name: wait
+      image: bitnami/kubectl:1.31.4@sha256:7c1e3f0c6a8a2c2f8b4f3a3a6c6f0d2e0b8a8e6b0a2f6c8e0d2a4b6c8e0a2c4e
+      env:
+        - name: HOME
+          value: /tekton/home
+      computeResources:
+        requests: {cpu: 50m, memory: 64Mi}
+        limits: {memory: 128Mi}
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile: {type: RuntimeDefault}
+      script: |
+        #!/bin/sh
+        set -eu
+        end=$(( $(date +%s) + $(params.timeoutSeconds) ))
+        while [ "$(date +%s)" -lt "$end" ]; do
+          sync=$(kubectl -n argocd get application "$(params.stagingApp)" -o jsonpath='{.status.sync.status}' 2>/dev/null || true)
+          health=$(kubectl -n argocd get application "$(params.stagingApp)" -o jsonpath='{.status.health.status}' 2>/dev/null || true)
+          echo "sync=$sync health=$health"
+          [ "$sync" = "Synced" ] && [ "$health" = "Healthy" ] && exit 0
+          sleep 10
+        done
+        echo "timed out waiting for $(params.stagingApp) Synced+Healthy" >&2
+        exit 1
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: staging-gate-run-smoke
+  namespace: tekton-pipelines
+spec:
+  description: >
+    Run the app's smoke-test Job IN the staging vCluster (via the mounted vCluster kubeconfig).
+    Exit 0 only if the Job succeeds. This is the Tier-2 real-path gate.
+  params:
+    - name: app
+      type: string
+    - name: smokeImage
+      type: string
+    - name: smokeNamespace
+      type: string
+    - name: sha
+      type: string
+  workspaces:
+    - name: vcluster-kubeconfig
+      description: kubeconfig for the staging vCluster (from the vcluster-staging-kubeconfig Secret).
+  steps:
+    - name: smoke
+      image: bitnami/kubectl:1.31.4@sha256:7c1e3f0c6a8a2c2f8b4f3a3a6c6f0d2e0b8a8e6b0a2f6c8e0d2a4b6c8e0a2c4e
+      env:
+        - name: HOME
+          value: /tekton/home
+        - name: KUBECONFIG
+          value: $(workspaces.vcluster-kubeconfig.path)/config
+      computeResources:
+        requests: {cpu: 100m, memory: 128Mi}
+        limits: {memory: 256Mi}
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile: {type: RuntimeDefault}
+      script: |
+        #!/bin/sh
+        set -eu
+        job="smoke-$(params.app)-$(params.sha)"
+        ns="$(params.smokeNamespace)"
+        kubectl -n "$ns" delete job "$job" --ignore-not-found
+        cat <<EOF | kubectl -n "$ns" apply -f -
+        apiVersion: batch/v1
+        kind: Job
+        metadata:
+          name: $job
+        spec:
+          backoffLimit: 0
+          ttlSecondsAfterFinished: 600
+          template:
+            spec:
+              restartPolicy: Never
+              containers:
+                - name: smoke
+                  image: $(params.smokeImage):$(params.sha)
+        EOF
+        kubectl -n "$ns" wait --for=condition=complete "job/$job" --timeout=300s &
+        cw=$!
+        kubectl -n "$ns" wait --for=condition=failed "job/$job" --timeout=300s && { echo "smoke FAILED" >&2; exit 1; } &
+        fw=$!
+        wait -n "$cw" "$fw"
+        # If the complete-watch won, succeed; otherwise the failed-watch exited non-zero above.
+        kubectl -n "$ns" get job "$job" -o jsonpath='{.status.succeeded}' | grep -q 1
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: staging-gate-promote
+  namespace: tekton-pipelines
+spec:
+  description: >
+    Promote: set the gated sha as the prod image ref (prodValuesKey in prodValuesPath, frank)
+    and push. ArgoCD ships prod. Runs ONLY when the smoke task passed (Pipeline `when`).
+  params:
+    - name: sha
+      type: string
+    - name: prodValuesPath
+      type: string
+    - name: prodValuesKey
+      type: string
+      description: dotted key to bump (e.g. image.tag); the last segment is matched as a yaml key line.
+  workspaces:
+    - name: ssh-creds
+  steps:
+    - name: promote
+      image: python:3.12-alpine@sha256:9c51ecce261773a684c8345b2d4673700055c513b4d54bc0719337d3e4ee552e
+      env:
+        - name: HOME
+          value: /tekton/home
+      computeResources:
+        requests: {cpu: 50m, memory: 64Mi}
+        limits: {memory: 256Mi}
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile: {type: RuntimeDefault}
+      script: |
+        #!/bin/sh
+        set -eu
+        apk add --no-cache git openssh-client >/dev/null
+        install -m 0700 -d "$HOME/.ssh"
+        install -m 0600 "$(workspaces.ssh-creds.path)/id_rsa" "$HOME/.ssh/id_rsa"
+        export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
+        git clone --depth 1 git@github.com:derio-net/frank.git /tmp/frank
+        cd /tmp/frank
+        key=$(printf '%s' "$(params.prodValuesKey)" | awk -F. '{print $NF}')
+        sed -i -E "s#^([[:space:]]+${key}:).*#\1 \"$(params.sha)\"#" "$(params.prodValuesPath)"
+        git -c user.email=staging-gate@derio.net -c user.name=staging-gate \
+          commit -am "gate: promote $(params.sha) to prod [skip ci]"
+        git push origin HEAD:main
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: staging-gate-reset
+  namespace: tekton-pipelines
+spec:
+  description: Reset staging — delete the app's namespace in the vCluster (runs in finally).
+  params:
+    - name: smokeNamespace
+      type: string
+  workspaces:
+    - name: vcluster-kubeconfig
+  steps:
+    - name: reset
+      image: bitnami/kubectl:1.31.4@sha256:7c1e3f0c6a8a2c2f8b4f3a3a6c6f0d2e0b8a8e6b0a2f6c8e0d2a4b6c8e0a2c4e
+      env:
+        - name: HOME
+          value: /tekton/home
+        - name: KUBECONFIG
+          value: $(workspaces.vcluster-kubeconfig.path)/config
+      computeResources:
+        requests: {cpu: 50m, memory: 64Mi}
+        limits: {memory: 128Mi}
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile: {type: RuntimeDefault}
+      script: |
+        #!/bin/sh
+        set -eu
+        # Drop the smoke namespace; ArgoCD CreateNamespace re-creates it on the next gate run.
+        kubectl delete namespace "$(params.smokeNamespace)" --ignore-not-found --wait=false

--- a/apps/staging-gate/tekton/tasks.yaml
+++ b/apps/staging-gate/tekton/tasks.yaml
@@ -1,7 +1,11 @@
-# staging-gate Tekton Tasks (tekton.dev/v1). Schema-valid + structurally complete here;
-# their on-cluster RUNTIME (git push, ArgoCD polling, vCluster kubectl) is verified in the
-# manual phase (P7). Gotchas honoured: `computeResources` (not `resources`); HOME=/tekton/home;
-# non-root securityContext. Workspaces' fsGroup is set on the Pipeline's podTemplate.
+# staging-gate Tekton Tasks (tekton.dev/v1). Schema-valid + structurally complete; on-cluster
+# RUNTIME (git push, ArgoCD polling, vCluster kubectl) is verified in the manual phase (P7).
+# Design: alpine/git for git (no apk → works nonroot), mikefarah/yq for nested value edits
+# (no fragile sed), rancher/kubectl for cluster ops. Images pinned by tag; add digests once
+# verified against the registry (P7). Gotchas honoured: computeResources, HOME=/tekton/home,
+# non-root (securityContext inlined per step — YAML anchors do NOT cross `---` doc boundaries).
+# Image tag convention is `sha-<commit>` (spec Component 1): params.sha is the SHORT commit sha
+# the GHA repository_dispatch sends; the tag is `sha-$(params.sha)`.
 ---
 apiVersion: tekton.dev/v1
 kind: Task
@@ -9,46 +13,52 @@ metadata:
   name: staging-gate-bump-staging
   namespace: tekton-pipelines
 spec:
-  description: >
-    Set the candidate sha as image.tag in the app's staging values file (frank) and push.
-    ArgoCD then syncs that image into the staging vCluster.
+  description: Set image.tag=sha-<sha> in the app's staging values file (frank) and push.
   params:
-    - name: sha
-      type: string
-    - name: stagingValuesPath
-      type: string
-      description: frank-relative path to the staging values file (e.g. apps/staging-gate/runs-fr/staging-values.yaml)
+    - {name: sha, type: string}
+    - {name: stagingValuesPath, type: string}
   workspaces:
-    - name: ssh-creds
-      description: SSH key (id_rsa) authorised to push to frank.
+    - {name: ssh-creds}
+    - {name: scratch}
   steps:
-    - name: bump
-      image: python:3.12-alpine@sha256:9c51ecce261773a684c8345b2d4673700055c513b4d54bc0719337d3e4ee552e
-      env:
-        - name: HOME
-          value: /tekton/home
-      computeResources:
-        requests: {cpu: 50m, memory: 64Mi}
-        limits: {memory: 256Mi}
-      securityContext:
-        allowPrivilegeEscalation: false
-        runAsNonRoot: true
-        runAsUser: 65532
-        seccompProfile: {type: RuntimeDefault}
+    - name: clone
+      image: alpine/git:2.45.2
+      env: [{name: HOME, value: /tekton/home}]
+      computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 256Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
       script: |
         #!/bin/sh
         set -eu
-        apk add --no-cache git openssh-client >/dev/null
         install -m 0700 -d "$HOME/.ssh"
         install -m 0600 "$(workspaces.ssh-creds.path)/id_rsa" "$HOME/.ssh/id_rsa"
         export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
-        git clone --depth 1 git@github.com:derio-net/frank.git /tmp/frank
-        cd /tmp/frank
-        # Comment-preserving bump of the `tag:` line under the image: block (single tag key).
-        sed -i -E 's#^([[:space:]]+tag:).*#\1 "$(params.sha)"#' "$(params.stagingValuesPath)"
-        grep -nE '^[[:space:]]+tag:' "$(params.stagingValuesPath)"
+        rm -rf "$(workspaces.scratch.path)/frank"
+        git clone --depth 1 git@github.com:derio-net/frank.git "$(workspaces.scratch.path)/frank"
+    - name: bump
+      image: mikefarah/yq:4.44.3
+      env: [{name: TAG, value: "sha-$(params.sha)"}]
+      computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 128Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
+      script: |
+        #!/bin/sh
+        set -eu
+        f="$(workspaces.scratch.path)/frank/$(params.stagingValuesPath)"
+        yq -i '.image.tag = strenv(TAG)' "$f"
+        echo "staged image.tag -> $TAG"; yq '.image' "$f"
+    - name: push
+      image: alpine/git:2.45.2
+      env: [{name: HOME, value: /tekton/home}]
+      computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 128Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
+      script: |
+        #!/bin/sh
+        set -eu
+        install -m 0700 -d "$HOME/.ssh"
+        install -m 0600 "$(workspaces.ssh-creds.path)/id_rsa" "$HOME/.ssh/id_rsa"
+        export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
+        cd "$(workspaces.scratch.path)/frank"
         git -c user.email=staging-gate@derio.net -c user.name=staging-gate \
-          commit -am "gate: stage $(params.sha) [skip ci]"
+          commit -m "gate: stage sha-$(params.sha) [skip ci]" -- "$(params.stagingValuesPath)"
         git push origin HEAD:main
 ---
 apiVersion: tekton.dev/v1
@@ -59,25 +69,14 @@ metadata:
 spec:
   description: Poll the <app>-staging ArgoCD Application until Synced + Healthy (or time out).
   params:
-    - name: stagingApp
-      type: string
-    - name: timeoutSeconds
-      type: string
-      default: "300"
+    - {name: stagingApp, type: string}
+    - {name: timeoutSeconds, type: string, default: "600"}
   steps:
     - name: wait
-      image: bitnami/kubectl:1.31.4@sha256:7c1e3f0c6a8a2c2f8b4f3a3a6c6f0d2e0b8a8e6b0a2f6c8e0d2a4b6c8e0a2c4e
-      env:
-        - name: HOME
-          value: /tekton/home
-      computeResources:
-        requests: {cpu: 50m, memory: 64Mi}
-        limits: {memory: 128Mi}
-      securityContext:
-        allowPrivilegeEscalation: false
-        runAsNonRoot: true
-        runAsUser: 1001
-        seccompProfile: {type: RuntimeDefault}
+      image: rancher/kubectl:v1.31.4
+      env: [{name: HOME, value: /tekton/home}]
+      computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 128Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 1000, seccompProfile: {type: RuntimeDefault}}
       script: |
         #!/bin/sh
         set -eu
@@ -98,48 +97,32 @@ metadata:
   name: staging-gate-run-smoke
   namespace: tekton-pipelines
 spec:
-  description: >
-    Run the app's smoke-test Job IN the staging vCluster (via the mounted vCluster kubeconfig).
-    Exit 0 only if the Job succeeds. This is the Tier-2 real-path gate.
+  description: Run the app's smoke-test Job IN the staging vCluster; exit 0 only if it succeeds.
   params:
-    - name: app
-      type: string
-    - name: smokeImage
-      type: string
-    - name: smokeNamespace
-      type: string
-    - name: sha
-      type: string
+    - {name: app, type: string}
+    - {name: smokeImage, type: string}
+    - {name: smokeNamespace, type: string}
+    - {name: sha, type: string}
+    - {name: timeoutSeconds, type: string, default: "300"}
   workspaces:
-    - name: vcluster-kubeconfig
-      description: kubeconfig for the staging vCluster (from the vcluster-staging-kubeconfig Secret).
+    - {name: vcluster-kubeconfig}
   steps:
     - name: smoke
-      image: bitnami/kubectl:1.31.4@sha256:7c1e3f0c6a8a2c2f8b4f3a3a6c6f0d2e0b8a8e6b0a2f6c8e0d2a4b6c8e0a2c4e
+      image: rancher/kubectl:v1.31.4
       env:
-        - name: HOME
-          value: /tekton/home
-        - name: KUBECONFIG
-          value: $(workspaces.vcluster-kubeconfig.path)/config
-      computeResources:
-        requests: {cpu: 100m, memory: 128Mi}
-        limits: {memory: 256Mi}
-      securityContext:
-        allowPrivilegeEscalation: false
-        runAsNonRoot: true
-        runAsUser: 1001
-        seccompProfile: {type: RuntimeDefault}
+        - {name: HOME, value: /tekton/home}
+        - {name: KUBECONFIG, value: $(workspaces.vcluster-kubeconfig.path)/config}
+      computeResources: {requests: {cpu: 100m, memory: 128Mi}, limits: {memory: 256Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 1000, seccompProfile: {type: RuntimeDefault}}
       script: |
         #!/bin/sh
         set -eu
-        job="smoke-$(params.app)-$(params.sha)"
-        ns="$(params.smokeNamespace)"
+        ns="$(params.smokeNamespace)"; job="smoke-$(params.app)-$(params.sha)"
         kubectl -n "$ns" delete job "$job" --ignore-not-found
         cat <<EOF | kubectl -n "$ns" apply -f -
         apiVersion: batch/v1
         kind: Job
-        metadata:
-          name: $job
+        metadata: {name: $job}
         spec:
           backoffLimit: 0
           ttlSecondsAfterFinished: 600
@@ -148,15 +131,19 @@ spec:
               restartPolicy: Never
               containers:
                 - name: smoke
-                  image: $(params.smokeImage):$(params.sha)
+                  image: $(params.smokeImage):sha-$(params.sha)
         EOF
-        kubectl -n "$ns" wait --for=condition=complete "job/$job" --timeout=300s &
-        cw=$!
-        kubectl -n "$ns" wait --for=condition=failed "job/$job" --timeout=300s && { echo "smoke FAILED" >&2; exit 1; } &
-        fw=$!
-        wait -n "$cw" "$fw"
-        # If the complete-watch won, succeed; otherwise the failed-watch exited non-zero above.
-        kubectl -n "$ns" get job "$job" -o jsonpath='{.status.succeeded}' | grep -q 1
+        end=$(( $(date +%s) + $(params.timeoutSeconds) ))
+        while [ "$(date +%s)" -lt "$end" ]; do
+          s=$(kubectl -n "$ns" get job "$job" -o jsonpath='{.status.succeeded}' 2>/dev/null || true)
+          f=$(kubectl -n "$ns" get job "$job" -o jsonpath='{.status.failed}' 2>/dev/null || true)
+          [ "$s" = "1" ] && { echo "smoke PASS"; exit 0; }
+          if [ -n "$f" ] && [ "$f" != "0" ]; then
+            echo "smoke FAIL"; kubectl -n "$ns" logs "job/$job" --tail=80 2>/dev/null || true; exit 1
+          fi
+          sleep 5
+        done
+        echo "smoke TIMEOUT" >&2; exit 1
 ---
 apiVersion: tekton.dev/v1
 kind: Task
@@ -164,46 +151,54 @@ metadata:
   name: staging-gate-promote
   namespace: tekton-pipelines
 spec:
-  description: >
-    Promote: set the gated sha as the prod image ref (prodValuesKey in prodValuesPath, frank)
-    and push. ArgoCD ships prod. Runs ONLY when the smoke task passed (Pipeline `when`).
+  description: Promote — set the gated sha-<sha> as the prod image ref and push (smoke-gated).
   params:
-    - name: sha
-      type: string
-    - name: prodValuesPath
-      type: string
-    - name: prodValuesKey
-      type: string
-      description: dotted key to bump (e.g. image.tag); the last segment is matched as a yaml key line.
+    - {name: sha, type: string}
+    - {name: prodValuesPath, type: string}
+    - {name: prodValuesKey, type: string, description: "dotted key, e.g. image.tag"}
   workspaces:
-    - name: ssh-creds
+    - {name: ssh-creds}
+    - {name: scratch}
   steps:
-    - name: promote
-      image: python:3.12-alpine@sha256:9c51ecce261773a684c8345b2d4673700055c513b4d54bc0719337d3e4ee552e
-      env:
-        - name: HOME
-          value: /tekton/home
-      computeResources:
-        requests: {cpu: 50m, memory: 64Mi}
-        limits: {memory: 256Mi}
-      securityContext:
-        allowPrivilegeEscalation: false
-        runAsNonRoot: true
-        runAsUser: 65532
-        seccompProfile: {type: RuntimeDefault}
+    - name: clone
+      image: alpine/git:2.45.2
+      env: [{name: HOME, value: /tekton/home}]
+      computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 256Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
       script: |
         #!/bin/sh
         set -eu
-        apk add --no-cache git openssh-client >/dev/null
         install -m 0700 -d "$HOME/.ssh"
         install -m 0600 "$(workspaces.ssh-creds.path)/id_rsa" "$HOME/.ssh/id_rsa"
         export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
-        git clone --depth 1 git@github.com:derio-net/frank.git /tmp/frank
-        cd /tmp/frank
-        key=$(printf '%s' "$(params.prodValuesKey)" | awk -F. '{print $NF}')
-        sed -i -E "s#^([[:space:]]+${key}:).*#\1 \"$(params.sha)\"#" "$(params.prodValuesPath)"
+        rm -rf "$(workspaces.scratch.path)/frank"
+        git clone --depth 1 git@github.com:derio-net/frank.git "$(workspaces.scratch.path)/frank"
+    - name: bump-prod
+      image: mikefarah/yq:4.44.3
+      env: [{name: TAG, value: "sha-$(params.sha)"}, {name: KEY, value: "$(params.prodValuesKey)"}]
+      computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 128Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
+      script: |
+        #!/bin/sh
+        set -eu
+        f="$(workspaces.scratch.path)/frank/$(params.prodValuesPath)"
+        # Structure-aware edit of the exact dotted key (no last-segment sed ambiguity).
+        yq -i "(.${KEY}) = strenv(TAG)" "$f"
+        echo "promoted ${KEY} -> $TAG"
+    - name: push
+      image: alpine/git:2.45.2
+      env: [{name: HOME, value: /tekton/home}]
+      computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 128Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 65532, seccompProfile: {type: RuntimeDefault}}
+      script: |
+        #!/bin/sh
+        set -eu
+        install -m 0700 -d "$HOME/.ssh"
+        install -m 0600 "$(workspaces.ssh-creds.path)/id_rsa" "$HOME/.ssh/id_rsa"
+        export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=accept-new"
+        cd "$(workspaces.scratch.path)/frank"
         git -c user.email=staging-gate@derio.net -c user.name=staging-gate \
-          commit -am "gate: promote $(params.sha) to prod [skip ci]"
+          commit -m "gate: promote sha-$(params.sha) to prod [skip ci]" -- "$(params.prodValuesPath)"
         git push origin HEAD:main
 ---
 apiVersion: tekton.dev/v1
@@ -214,28 +209,18 @@ metadata:
 spec:
   description: Reset staging — delete the app's namespace in the vCluster (runs in finally).
   params:
-    - name: smokeNamespace
-      type: string
+    - {name: smokeNamespace, type: string}
   workspaces:
-    - name: vcluster-kubeconfig
+    - {name: vcluster-kubeconfig}
   steps:
     - name: reset
-      image: bitnami/kubectl:1.31.4@sha256:7c1e3f0c6a8a2c2f8b4f3a3a6c6f0d2e0b8a8e6b0a2f6c8e0d2a4b6c8e0a2c4e
+      image: rancher/kubectl:v1.31.4
       env:
-        - name: HOME
-          value: /tekton/home
-        - name: KUBECONFIG
-          value: $(workspaces.vcluster-kubeconfig.path)/config
-      computeResources:
-        requests: {cpu: 50m, memory: 64Mi}
-        limits: {memory: 128Mi}
-      securityContext:
-        allowPrivilegeEscalation: false
-        runAsNonRoot: true
-        runAsUser: 1001
-        seccompProfile: {type: RuntimeDefault}
+        - {name: HOME, value: /tekton/home}
+        - {name: KUBECONFIG, value: $(workspaces.vcluster-kubeconfig.path)/config}
+      computeResources: {requests: {cpu: 50m, memory: 64Mi}, limits: {memory: 128Mi}}
+      securityContext: {allowPrivilegeEscalation: false, runAsNonRoot: true, runAsUser: 1000, seccompProfile: {type: RuntimeDefault}}
       script: |
         #!/bin/sh
         set -eu
-        # Drop the smoke namespace; ArgoCD CreateNamespace re-creates it on the next gate run.
         kubectl delete namespace "$(params.smokeNamespace)" --ignore-not-found --wait=false

--- a/apps/staging-gate/tekton/triggers.yaml
+++ b/apps/staging-gate/tekton/triggers.yaml
@@ -51,6 +51,8 @@ spec:
           - name: vcluster-kubeconfig
             secret:
               secretName: vcluster-staging-kubeconfig
+          - name: scratch
+            emptyDir: {}
 ---
 # NOTE (manual P7): add a Trigger to the existing github-listener EventListener
 # (apps/tekton/triggers/eventlistener-github.yaml) referencing the binding+template above,

--- a/apps/staging-gate/tekton/triggers.yaml
+++ b/apps/staging-gate/tekton/triggers.yaml
@@ -1,0 +1,60 @@
+# staging-gate trigger plumbing (triggers.tekton.dev/v1beta1). The gate fires from the app's
+# GHA workflow via a GitHub `repository_dispatch` (event_type=staging-gate) delivered to the
+# existing github-listener (.223). RUNTIME (the EventListener trigger wiring + the GHA secret)
+# is finalised in the manual phase (P7); see eventlistener note below.
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerBinding
+metadata:
+  name: staging-gate-binding
+  namespace: tekton-pipelines
+spec:
+  params:
+    # GitHub repository_dispatch payload: {action, client_payload:{app,sha}, repository:{full_name}}
+    - name: app
+      value: $(body.client_payload.app)
+    - name: sha
+      value: $(body.client_payload.sha)
+    - name: repo-full-name
+      value: $(body.repository.full_name)
+---
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: staging-gate-template
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: app
+    - name: sha
+    - name: repo-full-name
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        generateName: staging-gate-$(tt.params.app)-
+        namespace: tekton-pipelines
+      spec:
+        pipelineRef: {name: staging-gate}
+        taskRunTemplate:
+          serviceAccountName: staging-gate
+          podTemplate:
+            securityContext:
+              fsGroup: 65532
+        params:
+          - {name: app, value: $(tt.params.app)}
+          - {name: sha, value: $(tt.params.sha)}
+        workspaces:
+          - name: ssh-creds
+            secret:
+              secretName: staging-gate-ssh-creds
+          - name: vcluster-kubeconfig
+            secret:
+              secretName: vcluster-staging-kubeconfig
+---
+# NOTE (manual P7): add a Trigger to the existing github-listener EventListener
+# (apps/tekton/triggers/eventlistener-github.yaml) referencing the binding+template above,
+# with interceptors: github (validate the webhook secret) → cel filtering
+#   header.match('X-GitHub-Event','repository_dispatch') && body.action == 'staging-gate'
+# It is added to the live EventListener there rather than here to keep all listener triggers
+# in one file. The GHA workflow (runs-fr sibling) POSTs the repository_dispatch.

--- a/apps/vclusters/staging/values.yaml
+++ b/apps/vclusters/staging/values.yaml
@@ -1,0 +1,24 @@
+# vCluster "staging" — the release-gate's staging cluster.
+# Base values come from apps/vclusters/template/values.yaml (loaded first in ArgoCD).
+# This file contains only instance-specific overrides.
+#
+# Chart: loft-sh/vcluster v0.32.1
+# Namespace: vcluster-staging
+#
+# Purpose: gate-owned, reset-able cluster that the Tekton staging-gate deploys each
+# release candidate into for the in-cluster e2e smoke-test. Distinct from the
+# `experiments` sandbox so gate runs never collide with ad-hoc experimentation.
+
+# Currently using all template defaults (same envelope as experiments).
+# To override, add only the keys that differ. Examples:
+#
+# controlPlane:
+#   statefulSet:
+#     persistence:
+#       volumeClaim:
+#         size: 10Gi
+#
+# isolation:
+#   resourceQuota:
+#     quota:
+#       pods: "100"

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/01.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/01.yaml
@@ -30,26 +30,26 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:56:24+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:56:24+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:56:25+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:56:25+00:00'
       note: null
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:56:26+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T19:56:27+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/01.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/01.yaml
@@ -1,0 +1,55 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Validation harness + staging vCluster
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Provision manifest-validation toolchain (dev container has none)
+  steps:
+  - id: P1.T1.S1
+    text: |
+      The dev devcontainer has python3/uv/curl/node but NO helm/kubeconform/tkn/yamllint. Create `scripts/staging-gate/ensure-tools.sh` (idempotent) that installs PINNED binaries into a gitignored `.bin/` at repo root: helm (via get_helm.sh, pinned version), kubeconform (release tarball, pinned), tkn (release tarball, pinned); and `uv tool install yamllint`. Append `/.bin/` to `.gitignore`. Print each tool's version at the end.
+  - id: P1.T1.S2
+    text: |
+      Run it in-container and assert all tools resolve: `fr isolation exec --branch feat/staging-vcluster-gate -- bash -lc 'bash scripts/staging-gate/ensure-tools.sh && PATH=$PWD/.bin:$PATH helm version --short && kubeconform -v && tkn version --client && yamllint --version'`. Expected: versions print, exit 0. (All later validation runs `PATH=$PWD/.bin:$PATH` via the exec-bridge.)
+- number: 2
+  title: Staging vCluster manifests (TDD)
+  steps:
+  - id: P1.T2.S1
+    text: |
+      RED — assert the root App-of-Apps renders a staging vCluster. Run via exec: `PATH=$PWD/.bin:$PATH helm template apps/root | grep -c 'vcluster-staging'`. Expected NOW: 0 (the files don't exist) — RED.
+  - id: P1.T2.S2
+    text: |
+      GREEN — mirror the experiments pattern: (a) `apps/vclusters/staging/values.yaml` (header comment; all template defaults, like experiments); (b) `apps/root/templates/vcluster-staging.yaml` cloned from `vcluster-experiments.yaml` with releaseName `staging`, valueFiles template+`apps/vclusters/staging/values.yaml`, destination namespace `vcluster-staging`, and the StatefulSet `ignoreDifferences` name `staging`; (c) `apps/root/templates/ns-vcluster-staging.yaml` (PSA labels: enforce baseline / audit+warn restricted, matching ns-vcluster-experiments).
+  - id: P1.T2.S3
+    text: |
+      GREEN-verify — `PATH=$PWD/.bin:$PATH helm template apps/root` exits 0 and now emits the `vcluster-staging` Application + Namespace (grep count ≥ 2); pipe the rendered output through `kubeconform -strict -ignore-missing-schemas` (Application is a CRD → ignored) and `yamllint` the three new files. Expected: all pass.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/02.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/02.yaml
@@ -19,14 +19,14 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:58:07+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:58:07+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T19:58:08+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/02.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/02.yaml
@@ -1,0 +1,32 @@
+schema_version: 2
+phase:
+  number: 2
+  title: ArgoCD external-cluster destination enablement
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Widen the infrastructure AppProject (TDD)
+  steps:
+  - id: P2.T1.S1
+    text: |
+      RED — assert the `infrastructure` AppProject permits the staging vCluster as a destination. Via exec: `PATH=$PWD/.bin:$PATH helm template apps/root` then a small python check (yaml.safe_load_all) that an AppProject named `infrastructure` has a `spec.destinations` entry with server `https://staging.vcluster-staging.svc:443`. Expected NOW: absent — RED.
+  - id: P2.T1.S2
+    text: |
+      GREEN — edit `apps/root/templates/project.yaml`: add `{server: https://staging.vcluster-staging.svc:443, namespace: '*'}` to `spec.destinations`. Keep the existing in-cluster destination. Re-run the python check → present; `helm template apps/root` exits 0. (The out-of-band cluster credential that makes this server reachable is created later in the manual phase — reference it as a comment in the template.)
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/03.yaml
@@ -23,18 +23,18 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:59:48+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:59:49+00:00'
       note: null
     P3.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T19:59:49+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T19:59:50+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/03.yaml
@@ -1,0 +1,40 @@
+schema_version: 2
+phase:
+  number: 3
+  title: runs-fr-staging ArgoCD Application
+  tag: agentic
+  depends_on:
+  - 1
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Staging Application + values (TDD)
+  steps:
+  - id: P3.T1.S1
+    text: |
+      RED — assert `helm template apps/root` renders a `runs-fr-staging` Application whose `destination.server` is the staging vCluster API and whose first source is the runs-fr chart. python check over the rendered output. Expected NOW: absent — RED.
+  - id: P3.T1.S2
+    text: |
+      GREEN — create `apps/staging-gate/runs-fr/staging-values.yaml` (image.repository `ghcr.io/derio-net/runs-fr`, `image.tag: "staging"` — the gate bumps this; namespace `runs-fr`; authHeader default; service ClusterIP) and `apps/root/templates/runs-fr-staging.yaml`: a multi-source Application — source1 = runs-fr chart (`repoURL https://github.com/derio-net/frank.git`? NO — chart lives in runs-fr: `repoURL https://github.com/derio-net/runs-fr.git`, `path charts/runs-fr`, `targetRevision main`, helm valueFiles `$values/apps/staging-gate/runs-fr/staging-values.yaml`); source2 = `$values` ref (frank repo); `destination.server` `https://staging.vcluster-staging.svc:443`, namespace `runs-fr`; syncPolicy automated selfHeal + CreateNamespace; ignoreDifferences Secret `/data`.
+  - id: P3.T1.S3
+    text: |
+      GREEN-verify — `helm template apps/root` exits 0, the runs-fr-staging Application renders with the staging destination; `yamllint` the two new files; python check passes.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/04.yaml
@@ -1,0 +1,31 @@
+schema_version: 2
+phase:
+  number: 4
+  title: Per-app gate contract (schema + runs-fr entry)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Contract validator + runs-fr entry (TDD)
+  steps:
+  - id: P4.T1.S1
+    text: |
+      RED — write `scripts/staging-gate/validate-contract.py` (stdlib + PyYAML via `uv run --with pyyaml`): for each `apps/staging-gate/registry/*.yaml` assert the required keys exist: `app, sourceRepo, image, chartRepo, chartPath, stagingApp, stagingValuesPath, smokeImage, smokeNamespace, prodApp, prodValuesPath, prodValuesKey`. Run via exec; Expected NOW: no registry files → the script reports "no contracts found" and exits non-zero — RED.
+  - id: P4.T1.S2
+    text: |
+      GREEN — create `apps/staging-gate/registry/runs-fr.yaml` populated for runs-fr (image `ghcr.io/derio-net/runs-fr`; chartRepo `https://github.com/derio-net/runs-fr.git`; chartPath `charts/runs-fr`; stagingApp `runs-fr-staging`; stagingValuesPath `apps/staging-gate/runs-fr/staging-values.yaml`; smokeImage `ghcr.io/derio-net/runs-fr-smoke`; smokeNamespace `runs-fr`; prodApp `runs-fr`; prodValuesPath `apps/runs-fr/values.yaml`; prodValuesKey `image.tag`) and `apps/staging-gate/README.md` documenting the schema. Run the validator → exit 0. (prodApp/prodValuesPath are the PAIRED-FOLLOWUP target; the file need not exist yet — the validator checks the contract shape, not the target's existence.)
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/04.yaml
@@ -18,14 +18,14 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:01:58+00:00'
       note: null
     P4.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:01:59+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T20:02:00+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/05.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/05.yaml
@@ -43,38 +43,41 @@ tasks:
 state:
   steps:
     P5.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:12:24+00:00'
       note: null
     P5.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:12:25+00:00'
       note: null
     P5.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:12:25+00:00'
       note: null
     P5.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:12:26+00:00'
       note: null
     P5.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:12:26+00:00'
       note: null
     P5.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:12:27+00:00'
       note: null
     P5.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:12:27+00:00'
       note: null
     P5.T3.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-06-15T20:12:28+00:00'
+      note: 'Deferred to manual P7: wiring the trigger into the SHARED live github-listener
+        EventListener is runtime-coupled (webhook secret + CEL) and risks the other
+        triggers on it. Binding+template authored + validated; listener edit done
+        in P7 (noted in triggers.yaml).'
   completion:
-    at: null
+    at: '2026-06-15T20:12:29+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/05.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/05.yaml
@@ -1,0 +1,80 @@
+schema_version: 2
+phase:
+  number: 5
+  title: Tekton gate Pipeline + Tasks + trigger
+  tag: agentic
+  depends_on:
+  - 4
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Gate Tasks (TDD)
+  steps:
+  - id: P5.T1.S1
+    text: |
+      RED — kubeconform (with Tekton CRD schemas via `-schema-location`) over `apps/staging-gate/tekton/tasks/`. Expected NOW: no task files — RED.
+  - id: P5.T1.S2
+    text: |
+      GREEN — author `tekton.dev/v1` Tasks under `apps/staging-gate/tekton/tasks/` (`computeResources` not `resources`; `HOME=/tekton/home`; non-root securityContext; workspaces with fsGroup set at podTemplate in the Pipeline): `bump-staging` (clone frank via ssh-creds, set `image.tag` in the app's stagingValuesPath to the gated sha with a yaml-safe edit, commit+push main); `await-argocd-sync` (argocd app wait `<stagingApp>` --health --sync via the argocd CLI + in-cluster creds, OR poll the Application status to Synced+Healthy); `run-smoke` (apply the smoke Job from the contract's smokeImage INTO the staging vCluster — using the registered cluster kubeconfig — wait Completion, fail on non-zero); `promote` (clone frank, set prodValuesKey in prodValuesPath to the gated sha, commit+push); `reset-staging` (delete the app's staging namespace in the vCluster). Each Task validated by kubeconform.
+  - id: P5.T1.S3
+    text: |
+      Note RUNTIME deps inline in each Task (RBAC, argocd creds, the vCluster cluster Secret) — these are exercised in the manual phase 7; this step only authors + schema-validates. Re-run kubeconform over all tasks → pass.
+- number: 2
+  title: Gate Pipeline (TDD)
+  steps:
+  - id: P5.T2.S1
+    text: |
+      RED — kubeconform over `apps/staging-gate/tekton/pipeline-staging-gate.yaml` + a python assertion that `promote` has a `when` guard on the smoke result and that `reset-staging` is in `finally`. Expected NOW: absent — RED.
+  - id: P5.T2.S2
+    text: |
+      GREEN — author the `staging-gate` Pipeline (tekton.dev/v1): params {app, repo, sha}; tasks bump-staging → await-argocd-sync → run-smoke, then `promote` with `when` (smoke result == "passed"), and `reset-staging` in `finally` (always). It looks up the contract entry for `app` (passed as params or mounted). Validate kubeconform + the python assertion → pass.
+- number: 3
+  title: Gate trigger on the github-listener (TDD)
+  steps:
+  - id: P5.T3.S1
+    text: |
+      RED — kubeconform over `apps/staging-gate/tekton/triggers-staging-gate.yaml` (TriggerBinding + TriggerTemplate). Expected NOW: absent — RED.
+  - id: P5.T3.S2
+    text: |
+      GREEN — author the gate's `triggers.tekton.dev/v1beta1` TriggerBinding (extract `app`, `repo`, `sha` from the GHA `repository_dispatch` payload — `client_payload.app/.sha`, `repository.full_name`) and TriggerTemplate (a `staging-gate` PipelineRun with `shared-workspace` PVC + `ssh-creds`, nodeSelector per the hum example). Validate kubeconform.
+  - id: P5.T3.S3
+    text: |
+      GREEN — wire a new trigger into the existing `github-listener` EventListener (`apps/tekton/triggers/eventlistener-github.yaml`): a trigger with a `github` interceptor (validate secret) → `cel` filter on `header.match('X-GitHub-Event','repository_dispatch') && body.action == 'staging-gate'`, referencing the new binding+template. `helm template`/kubeconform the edited file; `yamllint`. Expected: pass.
+state:
+  steps:
+    P5.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T3.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/06.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/06.yaml
@@ -1,0 +1,42 @@
+schema_version: 2
+phase:
+  number: 6
+  title: Register the gate into the App-of-Apps
+  tag: agentic
+  depends_on:
+  - 1
+  - 3
+  - 4
+  - 5
+  tracking_issue: null
+tasks:
+- number: 1
+  title: staging-gate Application (TDD)
+  steps:
+  - id: P6.T1.S1
+    text: |
+      RED — assert `helm template apps/root` renders a `staging-gate` Application whose source path is `apps/staging-gate/tekton` (recurse) with destination ns `tekton-pipelines`. Expected NOW: absent — RED.
+  - id: P6.T1.S2
+    text: |
+      GREEN — create `apps/root/templates/staging-gate.yaml` (manifests-only app, like `tekton-extras`: `source.path apps/staging-gate/tekton`, `directory.recurse: true`; destination in-cluster, namespace `tekton-pipelines`; syncOptions ServerSideApply=true, CreateNamespace=false). CRITICAL: the app path is the `tekton/` subdir ONLY — `apps/staging-gate/{registry,runs-fr,README.md}` are DATA/ values consumed by the pipeline + the runs-fr-staging app, NOT k8s objects to apply.
+  - id: P6.T1.S3
+    text: |
+      GREEN-verify — `helm template apps/root` exits 0, renders the staging-gate Application; python assertion confirms its path is `apps/staging-gate/tekton` (not the whole `apps/staging-gate`). `kubeconform`/`yamllint` pass. Run a full repo sanity: `PATH=$PWD/.bin:$PATH helm template apps/root | kubeconform -strict -ignore-missing-schemas -summary` → no errors.
+state:
+  steps:
+    P6.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/06.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/06.yaml
@@ -25,18 +25,18 @@ tasks:
 state:
   steps:
     P6.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:13:48+00:00'
       note: null
     P6.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:13:49+00:00'
       note: null
     P6.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:13:49+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T20:13:50+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/07.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/07.yaml
@@ -1,0 +1,39 @@
+schema_version: 2
+phase:
+  number: 7
+  title: '[manual] Cluster Secret + end-to-end gate verification'
+  tag: manual
+  depends_on:
+  - 6
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Register staging vCluster + prove the gate end-to-end
+  steps:
+  - id: P7.T1.S1
+    text: |
+      (manual) Register the staging vCluster with ArgoCD: extract the `vc-staging` secret's `.data.config` kubeconfig, rewrite server `https://localhost:8443` → `https://staging.vcluster-staging.svc:443`, build an ArgoCD `cluster` Secret (label `argocd.argoproj.io/secret-type=cluster`, `stringData.name=staging`, `stringData.server=…svc:443`, `stringData.config` = JSON tlsClientConfig with the kubeconfig's CA + client cert/key), `sops -e` per `.sops.yaml`, store under `secrets/staging-vcluster/`, apply out-of-band. Verify: `argocd cluster list` shows staging; `runs-fr-staging` Application syncs Healthy in the vCluster.
+  - id: P7.T1.S2
+    text: |
+      (manual) GREEN path: trigger a real runs-fr `main` merge (or `repository_dispatch` action `staging-gate`) and observe the gate run flow build → bump-staging → await-sync → run-smoke (green) → promote (a commit bumping the prod image ref appears) → reset-staging. Capture evidence (PipelineRun logs + the promote commit).
+  - id: P7.T1.S3
+    text: |
+      (manual) RED path: feed a deliberately-broken image (e.g. a tag whose pod fails the smoke) and confirm the gate FAILS at run-smoke, leaves the prod ref UNTOUCHED, and fires a notification (Telegram/health-bridge). Record both outcomes on the PR.
+state:
+  steps:
+    P7.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P7.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P7.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-15-staging-vcluster-gate
+spec: docs/superpowers/specs/2026-06-15--cicd--staging-vcluster-gate-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-15'

--- a/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/_prose.md
+++ b/docs/superpowers/plans/2026-06-15-staging-vcluster-gate/_prose.md
@@ -1,0 +1,51 @@
+# Staging-vCluster e2e release gate — frank plan
+
+Implements the frank half of the staging-vCluster release gate (spec:
+`docs/superpowers/specs/2026-06-15--cicd--staging-vcluster-gate-design.md`). The runs-fr half
+(per-commit GHA image build + the in-cluster smoke-test image) is a **separate plan + PR** in
+`derio-net/runs-fr`.
+
+## What lands here
+
+A dedicated `staging` vCluster, Frank's first ArgoCD external-cluster wiring, a `runs-fr-staging`
+ArgoCD Application that deploys the gated image into that vCluster, a declarative per-app gate
+**contract**, and the Tekton gate **Pipeline** (bump-staging → await-sync → run-smoke → promote
+→ reset) triggered from GHA via the existing `github-listener`.
+
+## TDD with a fetched toolchain (important)
+
+The `dev` devcontainer has python3/uv/curl/node but **no helm/kubeconform/tkn/yamllint/kubectl**.
+Phase 1 Task 1 provisions pinned binaries into a gitignored `.bin/`; every later validation step
+runs `PATH=$PWD/.bin:$PATH …` through `fr isolation exec`. The "tests" for declarative manifests
+are: `helm template apps/root` renders the expected Applications, `kubeconform -ignore-missing-schemas`
+passes (CRDs tolerated), `yamllint` is clean, and python assertions over the rendered output check
+the specific fields (destinations, multi-source shape, `when`/`finally` wiring, contract schema).
+(Durably adding manifest-validation tooling to the `dev` profile is a sensible follow-up.)
+
+## Agentic vs runtime split (and the manual phase)
+
+Phases 1–6 **author + schema-validate** manifests; they do NOT touch the live cluster. The gate's
+**runtime** correctness — the ArgoCD external-cluster Secret (SOPS, applied out-of-band, the
+bootstrap-secret exception), the Tekton Tasks' RBAC/argocd/vCluster access, and the actual
+build→stage→smoke→promote flow — is proven in the **back-loaded manual Phase 7**. Per the repo's
+"a layer isn't Deployed until its workflow ran end-to-end" principle, Phase 7 requires BOTH a
+real green run (a promote commit appears) AND the red path (a broken image fails smoke and leaves
+prod untouched). Nothing agentic depends on Phase 7.
+
+The `runs-fr-staging` app's `destination.server` is real only once the Phase-7 cluster Secret
+exists — so the manifests render + validate now, but live sync waits on Phase 7a. This is called
+out so a reviewer doesn't expect a live staging deploy from the agentic phases alone.
+
+## Dependencies
+
+1 (toolchain + staging vCluster) and 4 (contract) are roots. 2 → [1]; 3 → [1,2]; 5 → [4];
+6 → [1,3,4,5]; 7 (manual) → [6]. The promote target (`prodApp`/`prodValuesPath` in the contract)
+is the **paired runs-fr prod-wiring follow-up** — out of scope here; the contract records it and
+the promote Task bumps it.
+
+## Cross-repo note
+
+The `runs-fr-staging` Application sources the runs-fr **chart** from the runs-fr repo
+(`charts/runs-fr`) with frank-side staging values — so this plan references runs-fr read-only;
+it creates nothing there. The runs-fr per-commit image build + smoke image are the sibling
+runs-fr plan/PR.

--- a/docs/superpowers/specs/2026-06-15--cicd--staging-vcluster-gate-design.md
+++ b/docs/superpowers/specs/2026-06-15--cicd--staging-vcluster-gate-design.md
@@ -9,7 +9,7 @@
 
 | Plan | Repo | Status |
 |------|------|--------|
-| _TBD — fr-plan_ | `derio-net/frank` | Planned |
+| [2026-06-15-staging-vcluster-gate](../plans/2026-06-15-staging-vcluster-gate) | `derio-net/frank` | Planned |
 
 ## Context
 

--- a/docs/superpowers/specs/2026-06-15--cicd--staging-vcluster-gate-design.md
+++ b/docs/superpowers/specs/2026-06-15--cicd--staging-vcluster-gate-design.md
@@ -1,0 +1,168 @@
+# Staging-vCluster e2e Release Gate — Design
+
+**Status:** Draft
+**Layer:** cicd (19 — CI/CD Platform; activates `tenant` (14) vCluster, uses `deploy`-style promotion)
+**Date:** 2026-06-15
+**Repos touched:** `frank` (this spec, vCluster + ArgoCD + Tekton gate), `runs-fr` (per-commit image build + smoke-test), possibly `agent-images`/`super-fr` later (future gated apps)
+
+## Implementation Plans
+
+| Plan | Repo | Status |
+|------|------|--------|
+| _TBD — fr-plan_ | `derio-net/frank` | Planned |
+
+## Context
+
+The runs-fr Phase-8 verification (2026-06-12) deployed the gateway into the `experiments`
+vCluster by hand and **caught a real `runAsNonRoot`/non-numeric-USER bug that CI structurally
+cannot** — CI never runs the pod (runs-fr#19). That one-off proved a vCluster is a
+high-fidelity, disposable staging target (real API server, real `pods/exec`, real RBAC), and
+surfaced exactly what an automated gate would need. This design turns that one-off into a
+**reusable, automated release gate**: every merge to an app's `main` is built, deployed into a
+staging vCluster via GitOps, exercised by an in-cluster end-to-end smoke-test, and — only if
+green — **auto-promoted to Frank production**.
+
+It is the concrete realization of the two-tier verification the k8s-native-runs umbrella spec
+anticipated (`docs/superpowers/specs/2026-06-07--agents--k8s-native-runs-design.md`): Tier-1
+deterministic CI, Tier-2 real-cluster behavioral proof — here automated and made the gate for
+shipping.
+
+All building blocks already exist on Frank: **Tekton** + a `github-listener` EventListener
+(.223) [`cicd`], the **vCluster** capability (`experiments`, loft 0.32.1, host-ArgoCD-managed)
+[`tenant`], **Argo Rollouts** [`deploy`], and GHCR images that default public (no pull
+friction). The work is composition + wiring, plus Frank's **first ArgoCD external-cluster
+registration**.
+
+## Goals
+
+- Every merge to a gated app's `main` produces a per-commit image and runs an **automated
+  end-to-end gate** in a real staging cluster before anything ships.
+- A failing gate **blocks promotion**; a passing gate **auto-promotes** the gated image to
+  Frank production (full CD) by a declarative git bump.
+- The gate is **reusable** — any app opts in via a declarative contract + a smoke-test; runs-fr
+  is the first, agent-images/super-fr/future apps plug in later.
+- Staging stays **fully declarative** (GitOps into the vCluster), honoring the declarative-only
+  principle; the smoke-test runs **in-cluster** (no flaky laptop port-forwards).
+
+## Non-goals (this spec)
+
+- The runs-fr **production wiring** (its prod ArgoCD app + Authentik forward-auth + Ingress +
+  homepage tile) — the **paired follow-up** the promote step targets. The gate skeleton proves
+  "promote fires" against a configured prod ref without depending on that wiring being complete.
+- Pre-merge / per-PR gating (this is a **post-merge** gate). A PR-check variant is a later option.
+- Onboarding apps beyond runs-fr (agent-images, super-fr) — they ride the contract later.
+- Browser/visual attach testing — the smoke-test is API+websocket level; visual attach stays a
+  manual spot-check.
+
+## Architecture
+
+**End-to-end flow (per gated app; first proven on runs-fr):**
+
+```
+merge to main (app repo)
+  → GHA: build ghcr.io/<app>:sha-<commit>  +  trigger Frank's Tekton github-listener (.223)
+  → Tekton gate Pipeline (runs in-cluster, parameterized by <app>):
+      1. bump <app>-staging image ref → sha-<commit>   (git commit to frank) → push
+      2. wait: ArgoCD syncs <app>-staging INTO the staging vCluster, Synced + Healthy
+      3. smoke: run <app>'s smoke-test Job IN the staging vCluster (against the app ClusterIP)
+                exit 0 = pass
+      4a. GREEN → promote: bump <app> PROD image ref → sha-<commit> (git commit to frank)
+                  → ArgoCD ships prod
+      4b. RED   → stop; notify (Telegram via the existing webhook contact / health-bridge);
+                  prod untouched
+      5. reset: drop the <app> staging namespace in the vCluster for the next run
+```
+
+### Component 1 — Per-commit image (app repo, GHA)
+
+A new `on: push: branches: [main]` workflow builds and pushes `ghcr.io/<app>:sha-<short>`
+(coexists with the existing `v*` release workflow — `v*` is for explicit human releases; the
+gate consumes the `sha` tag). For runs-fr this is a small addition alongside `release.yml`.
+The final pipeline step (GHA) calls the Tekton `github-listener` with `{repo, sha}`.
+
+### Component 2 — Staging vCluster + ArgoCD multi-cluster registration (frank)
+
+- **A dedicated `staging` vCluster** (`apps/vclusters/staging/values.yaml` +
+  `apps/root/templates/{ns-vcluster-staging,vcluster-staging}.yaml`), mirroring the existing
+  `experiments` Application (loft vcluster chart, template ⊕ instance values). Gate-owned and
+  reset-able — separate from the `experiments` sandbox.
+- **Frank's first ArgoCD external cluster.** A `cluster` Secret in `argocd` (labelled
+  `argocd.argoproj.io/secret-type=cluster`) built from the vCluster's `vc-staging` kubeconfig,
+  with the server rewritten from `https://localhost:8443` to the in-cluster
+  `https://staging.vcluster-staging.svc:443`, and the embedded CA + client cert/key as the
+  config. **SOPS-encrypted, applied out-of-band** (the documented bootstrap-secret exception —
+  it carries the vCluster admin client key and must not be ArgoCD-managed).
+- Per gated app, an **`<app>-staging` ArgoCD Application** whose `destination.server` is the
+  registered staging cluster, deploying the app's chart with a staging values file whose
+  `image.tag` is the ref Tekton bumps.
+
+### Component 3 — The gate Pipeline (frank, Tekton)
+
+A Tekton `Pipeline` + `EventListener`/`TriggerBinding`/`TriggerTemplate` wired to the existing
+`github-listener`, parameterized by `<app>` (resolved from the gate contract, Component 4).
+Tasks, in order: **bump-staging** (git) → **await-sync** (ArgoCD app Synced+Healthy in the
+vCluster) → **smoke** (the app's smoke-test Job in the vCluster) → **promote** (git bump prod,
+on success) → **reset** (drop staging ns). Heed the repo's Tekton gotchas: `computeResources`
+(not `resources`); accept `$(tasks.status)` of `Completed`; `fsGroup` on workspace pod
+template; `HOME=/tekton/home`. Runs are **serialized per app** (one gate at a time) and reset
+staging between runs.
+
+### Component 4 — The per-app gate contract (frank)
+
+A declarative entry per gated app (e.g. `apps/staging-gate/registry/<app>.yaml`) declaring:
+`source repo`, `image repo`, `chart + staging-values path`, `smoke-test ref` (image/Job),
+`prod app + values path to bump`. The Pipeline reads this; **onboarding an app = add an entry +
+ship a smoke-test**. This is the reusability seam future apps (agent-images run-pod
+provisioning, super-fr k8s runner) plug into.
+
+### Component 5 — The smoke-test contract
+
+Each app ships an **in-cluster** smoke-test that exits `0` (pass) / non-zero (fail), run as a
+Job in the staging vCluster against the deployed app. For **runs-fr**: a small
+`python + websockets` image running the one-off's three checks — no-auth → 403, authed list
+returns the probe, ws attach (text resize + binary stdin → tmux echo) — plus the fixture
+tmux probe-pod (`alpine` + `tmux new-session -d -s <id>` + `fr.run/*` labels). Lives in
+`runs-fr/test/e2e/` so it versions with the app.
+
+## Walking-skeleton scope (first plan)
+
+Build Components 1–5 **for runs-fr**, proven end-to-end:
+
+```
+runs-fr main merge → GHA sha image → Tekton trigger → bump runs-fr-staging → ArgoCD deploys
+into the staging vCluster → in-cluster smoke (403 / list / ws-attach) GREEN → promote step
+commits the gated sha to the runs-fr PROD image ref
+```
+
+- The runs-fr **prod app** (Authentik/Ingress/homepage) is the **paired follow-up**; the
+  skeleton's promote step bumps the configured prod image-ref/values (a stub prod app or the
+  values file the follow-up will consume) — proving the *gate + promote mechanism* without
+  depending on prod wiring.
+- The **gate contract** (Component 4) is built real (runs-fr is one entry), establishing the
+  reusable shape even though only runs-fr is onboarded.
+
+## Verification (the gate is itself a workflow)
+
+Per the "test workflows before declaring Deployed" principle, "done" requires a **real runs-fr
+`main` merge observed flowing end-to-end** — GHA build → Tekton gate → staging vCluster shows
+the gated image → smoke green → a promote commit appears — not merely ArgoCD Synced/Healthy.
+Also verify the **red path**: a deliberately-broken image must fail the smoke and leave the
+prod ref untouched (a notification fires).
+
+## Risks & open considerations
+
+- **First ArgoCD external cluster** — multi-cluster registration is new on Frank; the SOPS
+  `cluster` Secret + server-URL rewrite is fiddly and a single source of "staging won't sync"
+  failures. Document the registration as a `# manual-operation`.
+- **Full CD blast radius** — every green merge auto-ships to prod. The smoke-test IS the safety;
+  its coverage must be meaningful (the runAsUser class of bug, auth gating, the core attach
+  path). Weak smoke = shipping bugs. The red-path test is mandatory.
+- **vCluster admin key handling** — the registration Secret carries the vCluster admin client
+  key; keep it SOPS-only, never ArgoCD-managed, never logged.
+- **Staging reset / concurrency** — gate runs must serialize per app and fully reset staging
+  between runs, or a stale deploy taints a verdict.
+- **Promotion provenance** — the gated `sha` becomes the prod tag; the promote commit is the
+  audit record of what shipped and why (which gate run blessed it).
+- **GHA→Tekton trigger contract** — the github-listener must extract `{repo, sha}` from the GHA
+  call (a TriggerBinding); a malformed/unauthenticated trigger must be rejected (the listener is
+  cluster-internal; keep it so, or authenticate the call).

--- a/scripts/staging-gate/ensure-tools.sh
+++ b/scripts/staging-gate/ensure-tools.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Provision pinned manifest-validation tooling into a gitignored .bin/ at repo root.
+# The fr `dev` devcontainer ships python3/uv/curl/node but NOT helm/kubeconform/tkn/yamllint,
+# which the staging-gate plan's TDD validation steps need. Idempotent: skips an already-present
+# pinned binary. Run via the exec-bridge:
+#   fr isolation exec --branch feat/staging-vcluster-gate -- bash scripts/staging-gate/ensure-tools.sh
+set -euo pipefail
+
+HELM_VERSION="v3.16.4"
+KUBECONFORM_VERSION="v0.6.7"
+TKN_VERSION="0.40.0"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bin="$repo_root/.bin"
+mkdir -p "$bin"
+
+case "$(uname -s)" in Linux) os=linux ;; Darwin) os=darwin ;; *) echo "unsupported OS" >&2; exit 1 ;; esac
+case "$(uname -m)" in x86_64|amd64) arch=amd64 ;; aarch64|arm64) arch=arm64 ;; *) echo "unsupported arch $(uname -m)" >&2; exit 1 ;; esac
+
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+if [ ! -x "$bin/helm" ]; then
+  echo "==> helm ${HELM_VERSION} (${os}/${arch})"
+  curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-${os}-${arch}.tar.gz" | tar -xz -C "$tmp"
+  install -m 0755 "$tmp/${os}-${arch}/helm" "$bin/helm"
+fi
+
+if [ ! -x "$bin/kubeconform" ]; then
+  echo "==> kubeconform ${KUBECONFORM_VERSION} (${os}/${arch})"
+  curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-${os}-${arch}.tar.gz" | tar -xz -C "$tmp"
+  install -m 0755 "$tmp/kubeconform" "$bin/kubeconform"
+fi
+
+if [ ! -x "$bin/tkn" ]; then
+  echo "==> tkn ${TKN_VERSION} (${os}/${arch})"
+  # tkn release asset arch tokens: x86_64 / aarch64
+  case "$arch" in amd64) tkn_arch=x86_64 ;; arm64) tkn_arch=aarch64 ;; esac
+  tkn_os="$(echo "$os" | sed 's/^./\U&/')"   # Linux / Darwin
+  curl -fsSL "https://github.com/tektoncd/cli/releases/download/v${TKN_VERSION}/tkn_${TKN_VERSION}_${tkn_os}_${tkn_arch}.tar.gz" | tar -xz -C "$tmp"
+  install -m 0755 "$tmp/tkn" "$bin/tkn"
+fi
+
+# yamllint via uv (already in the container); exposed on PATH as a uv tool.
+if ! command -v yamllint >/dev/null 2>&1; then
+  echo "==> yamllint (uv tool)"
+  uv tool install yamllint >/dev/null
+fi
+
+echo "--- versions ---"
+"$bin/helm" version --short
+"$bin/kubeconform" -v
+"$bin/tkn" version 2>/dev/null | head -1 || true
+yamllint --version
+echo "ok: tools in $bin (+ yamllint via uv)"

--- a/scripts/staging-gate/validate-contract.py
+++ b/scripts/staging-gate/validate-contract.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Validate per-app staging-gate contracts.
+
+Each app that rides the staging-gate declares a contract at
+apps/staging-gate/registry/<app>.yaml. The Tekton gate Pipeline reads it to learn
+what to build/deploy/smoke/promote. This validator enforces the contract SHAPE
+(required keys + basic types) — not the existence of the referenced targets (the
+prod app may be a paired follow-up).
+
+Run via the exec-bridge:
+  fr isolation exec --branch feat/staging-vcluster-gate -- \
+    bash -lc 'uv run --quiet --with pyyaml python scripts/staging-gate/validate-contract.py'
+
+Exit 0 = all contracts valid; non-zero = a problem (including "no contracts found").
+"""
+from __future__ import annotations
+
+import glob
+import sys
+
+import yaml
+
+REQUIRED: dict[str, type] = {
+    "app": str,            # short name, used for labels + the PipelineRun param
+    "sourceRepo": str,     # owner/repo whose merges trigger the gate
+    "image": str,          # ghcr image repository (gate appends :sha-<commit>)
+    "chartRepo": str,      # git URL of the Helm chart
+    "chartPath": str,      # path to the chart within chartRepo
+    "stagingApp": str,     # ArgoCD Application name for staging
+    "stagingValuesPath": str,  # frank path to the staging values file (image.tag bumped here)
+    "smokeImage": str,     # in-cluster smoke-test image (exit 0 = pass)
+    "smokeNamespace": str,  # namespace in the staging vCluster to run the smoke Job
+    "prodApp": str,        # ArgoCD Application name for prod (promote target)
+    "prodValuesPath": str,  # frank path to the prod values file
+    "prodValuesKey": str,  # dotted key in prodValuesPath to bump on promote (e.g. image.tag)
+}
+
+REGISTRY_GLOB = "apps/staging-gate/registry/*.yaml"
+
+
+def validate_one(path: str) -> list[str]:
+    errs: list[str] = []
+    try:
+        doc = yaml.safe_load(open(path)) or {}
+    except yaml.YAMLError as e:  # noqa: PERF203
+        return [f"{path}: YAML parse error: {e}"]
+    if not isinstance(doc, dict):
+        return [f"{path}: top-level must be a mapping"]
+    for key, typ in REQUIRED.items():
+        if key not in doc:
+            errs.append(f"{path}: missing required key '{key}'")
+        elif not isinstance(doc[key], typ) or (typ is str and not doc[key].strip()):
+            errs.append(f"{path}: key '{key}' must be a non-empty {typ.__name__}")
+    return errs
+
+
+def main() -> int:
+    paths = sorted(glob.glob(REGISTRY_GLOB))
+    if not paths:
+        print(f"FAIL: no contracts found at {REGISTRY_GLOB}", file=sys.stderr)
+        return 1
+    all_errs: list[str] = []
+    for p in paths:
+        all_errs += validate_one(p)
+    if all_errs:
+        for e in all_errs:
+            print(e, file=sys.stderr)
+        print(f"FAIL: {len(all_errs)} problem(s) across {len(paths)} contract(s)", file=sys.stderr)
+        return 1
+    print(f"PASS: {len(paths)} contract(s) valid: {', '.join(paths)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Staging-vCluster e2e Release Gate — frank half (layer `cicd`)

Automates the release gate born from the runs-fr Phase-8 one-off: an app's merge to `main` is
built (GHA, per-commit image), deployed into a dedicated **`staging` vCluster** via ArgoCD,
exercised by an **in-cluster e2e smoke-test**, and — only if green — **auto-promoted** to Frank
prod by a declarative image-ref bump. Reusable per-app; runs-fr is the first.

- **Spec:** `docs/superpowers/specs/2026-06-15--cicd--staging-vcluster-gate-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-15-staging-vcluster-gate/` (self-review passes)

### What's implemented (agentic phases 1–6, each RED→GREEN→validated)
1. Validation toolchain (`scripts/staging-gate/ensure-tools.sh` → gitignored `.bin/`) + the `staging` vCluster (`apps/vclusters/staging/`, `apps/root/templates/{ns-,}vcluster-staging.yaml`)
2. `infrastructure` AppProject widened for the staging-cluster destination
3. `runs-fr-staging` ArgoCD Application (multi-source: runs-fr chart + frank staging values → staging vCluster)
4. Per-app gate **contract** + validator (`apps/staging-gate/{registry,README}`, `scripts/staging-gate/validate-contract.py`)
5. Tekton gate **Pipeline + Tasks + triggers + RBAC** (`apps/staging-gate/tekton/`)
6. Registered into the App-of-Apps (`apps/root/templates/staging-gate.yaml`, scoped to `tekton/` only)

Validation throughout: `helm template apps/root` renders clean, `kubeconform` (0 invalid), `yamllint`, contract-validator, and structural assertions. Tekton CRDs are kubeconform-skipped (no schema) — their **runtime** is proven in the manual phase.

### Milestone code-review — findings fixed
A fresh-context review found **4 authored Tekton bugs** (schema-valid but runtime-fatal); all fixed (commit `94444e4`):
- **C1** smoke `wait -n PID` dual-watcher → deterministic poll loop
- **C2** `resolve-contract` `$(results.{k}.path)` was not a real Tekton substitution (results never populated) → per-name writes
- **C3** bare-sha vs the spec's `sha-<commit>` tag (ImagePullBackOff) → `sha-$(params.sha)` end-to-end
- **I4** `apk add` as nonroot 65532 (fails) → `alpine/git` (git) + `mikefarah/yq` (nested edits, also kills the fragile sed/I2)
- plus: ssh-auth the private-repo clone; tag-pinned images (no fabricated digests); inlined `securityContext` (YAML anchors don't cross `---`).

### ⚠️ Phase 7 — `[manual]`, unimplemented (operator pushes to this PR)
Per fr-goal, the cluster-coupled runtime is back-loaded:
- **P7a** create the SOPS-encrypted ArgoCD `cluster` Secret for the staging vCluster (from `vc-staging` kubeconfig, server → `…svc:443`, label `…/secret-type=cluster`), applied out-of-band; + the `staging-gate-ssh-creds` and `vcluster-staging-kubeconfig` Secrets in `tekton-pipelines`; + wire the gate Trigger into the live `github-listener` EventListener (deferred to avoid risking the shared listener).
- **P7b/c** the **Test Plan** below.

### Test Plan (post-merge — operator-driven)
1. **Green path:** trigger a real runs-fr `main` merge (or a `repository_dispatch` action `staging-gate`); observe build → `bump-staging` → ArgoCD syncs `runs-fr-staging` into the vCluster → `run-smoke` green → `promote` (a commit bumping the prod image ref appears) → `reset`. Capture the PipelineRun logs + the promote commit.
2. **Red path:** feed a deliberately-broken image; confirm `run-smoke` FAILS, the prod ref is UNTOUCHED, and a notification fires.

### Companion PR
The **runs-fr sibling** (per-commit GHA build + the in-cluster smoke image) is a separate PR in `derio-net/runs-fr` (linked once opened). Its `prodApp` target (runs-fr Authentik/Ingress/homepage wiring) is a further paired follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
