### PR TITLE
chore(plans): normalize stale plan/spec refs (fr repair)

### DIFF
--- a/docs/superpowers/implemented/plans/2026-06-04--cicd--stoa-live-mirror-sync/_meta.yaml
+++ b/docs/superpowers/implemented/plans/2026-06-04--cicd--stoa-live-mirror-sync/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-06-04--cicd--stoa-live-mirror-sync
-spec: docs/superpowers/specs/2026-06-04--cicd--stoa-live-mirror-sync-trigger-design.md
+spec: 2026-06-04--cicd--stoa-live-mirror-sync-trigger-design.md
 target_repo: derio-net/frank
 vk_version: '>=2.0.0,<3.0.0'
 created: '2026-06-04'

--- a/docs/superpowers/implemented/plans/2026-06-08--obs--nic-link-flap-alert/_meta.yaml
+++ b/docs/superpowers/implemented/plans/2026-06-08--obs--nic-link-flap-alert/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-06-08--obs--nic-link-flap-alert
-spec: docs/superpowers/specs/2026-06-08--obs--nic-link-flap-alert-design.md
+spec: 2026-06-08--obs--nic-link-flap-alert-design.md
 target_repo: derio-net/frank
 fr_version: '>=3.0.0,<4.0.0'
 created: '2026-06-08'

--- a/docs/superpowers/implemented/plans/2026-06-14-stoa-frank-infra/_meta.yaml
+++ b/docs/superpowers/implemented/plans/2026-06-14-stoa-frank-infra/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-06-14-stoa-frank-infra
-spec: docs/superpowers/specs/2026-06-14-stoa-frank-infra-design.md
+spec: 2026-06-14-stoa-frank-infra-design.md
 target_repo: derio-net/frank
 fr_version: '>=3.0.0,<4.0.0'
 created: '2026-06-14'

--- a/docs/superpowers/plans/2026-06-08--obs--health-bridge-blind-state/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-08--obs--health-bridge-blind-state/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-06-08--obs--health-bridge-blind-state
-spec: docs/superpowers/specs/2026-06-08--obs--health-bridge-blind-state-design.md
+spec: 2026-06-08--obs--health-bridge-blind-state-design.md
 target_repo: derio-net/frank
 fr_version: '>=3.0.0,<4.0.0'
 created: '2026-06-08'

--- a/docs/superpowers/plans/2026-06-11-agent-images-bump-context/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-11-agent-images-bump-context/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-06-11-agent-images-bump-context
-spec: docs/superpowers/specs/2026-06-11-agent-images-bump-context-design.md
+spec: 2026-06-11-agent-images-bump-context-design.md
 target_repo: derio-net/frank
 fr_version: '>=3.0.0,<4.0.0'
 created: '2026-06-11'

--- a/docs/superpowers/specs/2026-06-04--cicd--stoa-live-mirror-sync-trigger-design.md
+++ b/docs/superpowers/specs/2026-06-04--cicd--stoa-live-mirror-sync-trigger-design.md
@@ -210,7 +210,7 @@ Deployed:
 
 | Plan | Repo | Scope | Status |
 |------|------|-------|--------|
-| 2026-06-04--cicd--stoa-live-mirror-sync | `derio-net/frank` | `docs/superpowers/plans/2026-06-04--cicd--stoa-live-mirror-sync/` | — |
+| 2026-06-04--cicd--stoa-live-mirror-sync | `derio-net/frank` | `2026-06-04--cicd--stoa-live-mirror-sync` | — |
 
 ## Post-deploy
 


### PR DESCRIPTION
Registry hygiene via `fr repair --yes` — surfaced while archiving the stoa-ltx2 plan (#557).

Rewrites 6 stale references to the v2 bare-filename convention (resolves under `specs/` and `implemented/specs/`):
- 5× `_meta.yaml` `spec:` full-path → bare filename (stoa-live-mirror-sync, nic-link-flap-alert, stoa-frank-infra, health-bridge-blind-state, agent-images-bump-context)
- 1× spec table plan-path cell → bare slug (stoa-live-mirror-sync-trigger spec)

Ref-only normalization — no file moves, no content/logic changes.

**Left untouched** (not auto-fixable, need human judgment): the Frank Papers 12/16 deferred-row annotations (intentional prose) and the `VK Relay Binary` stale row pointing at a non-existent plan dir.

Independent of #557 (which owns the stoa-ltx2 plan/spec move); no file overlap.