### PR TITLE
docs(obs): plans — agentic alert-helper + n8n agent-session migration (Parts B+C)

### DIFF
--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/01.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/01.yaml
@@ -1,0 +1,67 @@
+schema_version: 2
+phase:
+  number: 1
+  title: frank-facts CLI — port facts.py/surge.py to stdlib (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Rewrite tests off respx (stdlib urllib)
+  steps:
+  - id: P1.T1.S1
+    text: |
+      New app dir `apps/alert-agent/frank-facts/`. Copy `apps/ai-alert-helper/src/
+      ai_alert_helper/{facts.py,surge.py}` in as the starting point. Copy the existing tests
+      `apps/ai-alert-helper/src/tests/{test_facts.py,test_surge.py}` to
+      `apps/alert-agent/frank-facts/tests/`. Establish a green baseline against the original
+      (httpx + respx) code: `cd apps/alert-agent/frank-facts && uv run --with httpx --with
+      respx --with pytest pytest tests/ -q`. Expected: PASS (baseline before the stdlib port).
+  - id: P1.T1.S2
+    text: |
+      Rewrite the tests to NOT use respx/httpx — drive the HTTP boundary with a stdlib
+      `unittest.mock` patch of `urllib.request.urlopen` (a small fake returning canned
+      JSON/bytes per URL). Keep every assertion (surge tiers, edge_filter, digest/alert fact
+      shapes, GoatCounter parsing). Run `uv run --with pytest pytest tests/ -q`. Expected:
+      FAIL (RED — facts.py still imports httpx / calls httpx.Client).
+- number: 2
+  title: Port facts.py + surge.py to stdlib urllib
+  steps:
+  - id: P1.T2.S1
+    text: |
+      Replace httpx in `facts.py` with `urllib.request`/`urllib.parse` (GET with query params,
+      POST LogsQL form bodies, JSON parse). Preserve every public function signature
+      (`build_for_digest`, `build_for_surge`, `build_for_alert`, `surge_visitor_pageviews`,
+      `scan_pattern_counts`, `top_attacker_ips`, `top_scanned_paths`, `crowdsec_activity`,
+      `edge_filter`). `surge.py compute()` is pure logic over facts — leave its shape. Run
+      `uv run --with pytest pytest tests/ -q`. Expected: GREEN.
+  - id: P1.T2.S2
+    text: |
+      Add a thin CLI `apps/alert-agent/frank-facts/frank-facts` (argparse): subcommands
+      `surge-compute` (prints surge.compute() JSON — the gate), `digest`, `surge`, `alert`
+      (reads alert JSON on stdin), + granular `top-attacker-ips` / `top-scanned-paths` /
+      `crowdsec` / `scan-patterns`. Each prints JSON to stdout. stdlib-only (runs on the
+      image's python3). Add a `test_cli.py` asserting `surge-compute` emits the gate verdict.
+      Run the suite. Expected: GREEN.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/02.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/02.yaml
@@ -1,0 +1,44 @@
+schema_version: 2
+phase:
+  number: 2
+  title: telegram-bridge — single-consumer + deterministic fallback (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Failing tests for allowlist + fallback + single-consumer
+  steps:
+  - id: P2.T1.S1
+    text: |
+      `apps/alert-agent/telegram-bridge/` (stdlib python). Write `tests/test_bridge.py` first
+      (mock urlopen for getUpdates/sendMessage): (a) an allowlisted chat message → one
+      /session/send call + one sendMessage reply; (b) a non-allowlisted chat → dropped (WARN,
+      no /session/send); (c) outbound helper posts a given narrative to the configured chat;
+      (d) the cron/webhook path: when /session/send returns `{"status":"timeout","payload":
+      null}`, the caller posts the deterministic `frank-facts` render instead (fallback).
+      Run `uv run --with pytest pytest -q`. Expected: FAIL (RED — bridge not written).
+- number: 2
+  title: Implement the bridge
+  steps:
+  - id: P2.T2.S1
+    text: |
+      Implement `telegram-bridge` (stdlib): long-poll getUpdates with an allowlist
+      (TELEGRAM_CHAT_ID allowlist), route allowlisted messages → POST localhost
+      /session/send → post the payload reply via sendMessage; expose a `send(text)` used by
+      the cron/webhook handlers; single process = single getUpdates consumer (document the
+      replicas:1/Recreate requirement in a header comment). Run the suite. Expected: GREEN.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/03.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/03.yaml
@@ -1,0 +1,42 @@
+schema_version: 2
+phase:
+  number: 3
+  title: surge-gate + digest orchestration (TDD)
+  tag: agentic
+  depends_on:
+  - 1
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Gate logic test-first
+  steps:
+  - id: P3.T1.S1
+    text: |
+      `apps/alert-agent/handlers/` — `test_orchestration.py` first: (a) surge-gate runs
+      `frank-facts surge-compute`; on a NON-escalating verdict the agent is NOT woken (no
+      /session/send); (b) on an escalating tier past cooldown, the agent IS woken once and the
+      narrative delivered; (c) the same tier within `SURGE_COOLDOWN_HOURS` is suppressed
+      (edge-trigger + cooldown, mirroring the old surge semantics); (d) digest always wakes
+      once/run and delivers (with the timeout→deterministic-render fallback from P2). Run.
+      Expected: FAIL (RED).
+  - id: P3.T1.S2
+    text: |
+      Implement `surge-gate` + `digest` handler scripts: call frank-facts, apply the
+      edge-trigger+cooldown gate (in-memory state is fine — single replica, like the old
+      design), POST the trigger prompt to /session/send on escalation, deliver via the bridge
+      with fallback. Run. Expected: GREEN.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/04.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/04.yaml
@@ -1,0 +1,36 @@
+schema_version: 2
+phase:
+  number: 4
+  title: grafana-webhook receiver (TDD)
+  tag: agentic
+  depends_on:
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Receiver test-first then implement
+  steps:
+  - id: P4.T1.S1
+    text: |
+      `apps/alert-agent/handlers/` — `test_webhook.py` first: a POSTed Grafana alert webhook
+      → builds the alert fact sheet (`frank-facts alert`), POSTs a triage prompt to
+      /session/send, delivers the narrative via the bridge; a malformed body → 400, no
+      delivery; `/healthz` → 200 (used by the cutover receiver-health check). RED.
+  - id: P4.T1.S2
+    text: |
+      Implement the receiver (stdlib http.server, like agent-session serve). Run. Expected:
+      GREEN. Keep summary/runbook free of `<>&` (Telegram HTML-400 gotcha) in any default text.
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/05.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/05.yaml
@@ -1,0 +1,54 @@
+schema_version: 2
+phase:
+  number: 5
+  title: alert-agent Deployment + ArgoCD app
+  tag: agentic
+  depends_on:
+  - 1
+  - 2
+  - 3
+  - 4
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Manifests (consumes Plan A image; HTTP-only, no RBAC)
+  steps:
+  - id: P5.T1.S1
+    text: |
+      `apps/alert-agent/manifests/`: Deployment on `ghcr.io/derio-net/multi-agent-shell:<Plan-A
+      tag>` (CROSS-REPO: pin the new tag once Plan A's image is built), `replicas:1`,
+      `strategy:Recreate`, PVC for `~/.claude` + agent-session turn state, env
+      `AGENT_SESSION_SERVE=1`, **default ServiceAccount, NO Role/ClusterRole** (HTTP-only
+      posture). Mount frank-facts CLI + bridge + handlers (ConfigMaps, like fetch-text). LB or
+      ClusterIP for the grafana-webhook receiver.
+  - id: P5.T1.S2
+    text: |
+      ESO ExternalSecret(s) for `FRANK_C2_TELEGRAM_BOT_TOKEN`/`_CHAT_ID` + the GoatCounter
+      stats token (mirror `apps/ai-alert-helper`'s secret keys). supercronic crontab ConfigMap:
+      surge-gate `*/15`, digest daily. A `SKILL.md`/SOUL ConfigMap teaching the agent its job,
+      the frank-facts tool catalog, the HTTP-only/read-only boundary, and the output-payload
+      contract.
+  - id: P5.T1.S3
+    text: |
+      `apps/root/templates/alert-agent.yaml` (+ `ns-alert-agent.yaml`) Application CR
+      (ServerSideApply=true, prune:true so hash-suffixed ConfigMaps roll the pod, selfHeal).
+      Validate: `kustomize build apps/alert-agent/manifests >/dev/null && echo OK` (or yq
+      parse each). Expected: valid YAML.
+state:
+  steps:
+    P5.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/06.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/06.yaml
@@ -1,0 +1,41 @@
+schema_version: 2
+phase:
+  number: 6
+  title: Cutover — re-point Grafana, retire old app (ORDER MATTERS)
+  tag: agentic
+  depends_on:
+  - 5
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Re-point then retire (old app removed LAST)
+  steps:
+  - id: P6.T1.S1
+    text: |
+      In `apps/grafana-alerting/manifests/contact-points-cm.yaml`, re-point the "AI Helper
+      Webhook" (uid `ai-alert-helper-webhook`) url from
+      `http://ai-alert-helper.ai-alert-helper-system.svc.cluster.local:8080/alert` to the new
+      alert-agent receiver Service. (Deploy-time: the cutover verifies the receiver answers
+      /healthz BEFORE this flip — see the spec Cutover order; that verification is operator-run
+      post-deploy.)
+  - id: P6.T1.S2
+    text: |
+      ONLY in the same change after the re-point: remove `apps/ai-alert-helper/`,
+      `apps/root/templates/ai-alert-helper.yaml`, `apps/root/templates/ns-ai-alert-helper.yaml`.
+      Update `agents/rules/frank-gotchas.md` (obs-digest section) + `docs/runbooks/frank-gotchas/
+      obs-digest.md` + the inference/operating posts to point at alert-agent. The namespace
+      delete + old-Service removal are the LAST steps (operator confirms the flip serves first).
+state:
+  steps:
+    P6.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/07.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/07.yaml
@@ -1,0 +1,39 @@
+schema_version: 2
+phase:
+  number: 7
+  title: Post-Deploy Checklist
+  tag: agentic
+  depends_on:
+  - 6
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Checklist (replacement of a deployed app)
+  steps:
+  - id: P7.T1.S1
+    text: |
+      Step 1 expose — the grafana-webhook receiver is internal (Grafana→receiver in-cluster);
+      no public ingress / homepage tile unless you want an ops endpoint. Record decision.
+      Steps 2-3 blog — update the existing inference/obs operating post (no new post; this is a
+      re-platforming of an existing capability). Step 4 `/update-readme` if Service Access
+      changed (new alert-agent Service; old ai-alert-helper removed). Record outcomes.
+  - id: P7.T1.S2
+    text: |
+      Step 5 `/sync-runbook` — Phase 8 has a `# manual-operation` (claude login); sync it.
+      Step 6 set the plan `**Status:**` to Deployed once agentic phases merge + ArgoCD-syncs
+      (the manual claude-login + the four-trigger end-to-end verification are post-merge,
+      operator-driven — note as the remaining gate).
+state:
+  steps:
+    P7.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P7.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/08.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/08.yaml
@@ -1,0 +1,52 @@
+schema_version: 2
+phase:
+  number: 8
+  title: '[manual] claude login on the alert-agent shell'
+  tag: manual
+  depends_on:
+  - 5
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Operator-only subscription auth (PVC-resident)
+  steps:
+  - id: P8.T1.S1
+    text: |
+      # manual-operation
+      id: obs-alert-agent-claude-login
+      layer: obs
+      app: alert-agent
+      plan: 2026-06-15--obs--agentic-alert-helper
+      when: post-merge, after the Deployment is Running; before the four-trigger verification
+      why_manual: the multi-agent-shell agent uses an Anthropic subscription; first `claude
+        login` is interactive and its credential persists on the PVC (cannot be committed)
+      commands: |
+        # attach to the persistent session and authenticate (mirrors n8n MO-4):
+        kubectl exec -n alert-agent deploy/alert-agent -it -- tmux attach -t <default-session>
+        #   then run:  claude   ->  /login   (complete the OAuth flow)
+        # verify the session can complete a turn:
+        kubectl exec -n alert-agent deploy/alert-agent -- \
+          /usr/local/bin/agent-session send '{"session_id":"smoke","agent":"claude","message":"reply OK as JSON {\"ok\":true}"}'
+      verify: |
+        # the send returns status:ok with a payload (not timeout); a manual /digest POST then
+        # posts to Telegram. Confirm all four triggers deliver end-to-end (digest, a synthetic
+        # surge escalation, a test Grafana alert, an inbound allowlisted DM).
+      status: pending
+  - id: P8.T1.S2
+    text: |
+      Operator implements this phase and pushes to the same PR (`fr plan edit --complete-phase
+      8 --note`). NEVER agent-implemented. Nothing agentic depends on this phase.
+state:
+  steps:
+    P8.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P8.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-15--obs--agentic-alert-helper
+spec: docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-15'

--- a/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/_prose.md
+++ b/docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/_prose.md
@@ -1,0 +1,49 @@
+# Agentic Alert-Helper (frank — Plan B)
+
+**Status:** Planned
+**Spec:** `docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md` (Part B + Cutover)
+**Layer:** obs (replaces the retired `apps/ai-alert-helper`)
+
+## Why
+
+The old `ai-alert-helper` calls LiteLLM→Ollama to write its narrative, so it dies when local
+inference dies (a circular dependency the GPU-timeshare exposed), and a single fixed LLM shot can't
+investigate. This rebuilds it as an autonomous agent on the `multi-agent-shell` image — brain =
+cloud `claude` (no local-inference dependency), able to investigate, conversational over Telegram —
+keeping the tested `facts.py`/`surge.py` plumbing as deterministic tools.
+
+## Depends on (cross-repo)
+
+Consumes the `multi-agent-shell` image tag produced by **Plan A** (agent-images
+`2026-06-15-agent-session-extract` — the baked `agent-session` + `AGENT_SESSION_SERVE`). `fr`
+`depends_on` is within-plan only, so this gate lives here in prose: do not pin/deploy P5 before
+Plan A's tag exists.
+
+## Phase map
+
+1. **frank-facts CLI** — port `facts.py`/`surge.py` to **stdlib urllib** (so it runs as a bare
+   mounted script on the image's python3, like `fetch-text`), tests rewritten off `respx`.
+2. **telegram-bridge** — single-consumer getUpdates poller ↔ `/session/send` + the deterministic
+   outbound sender; allowlist; **timeout→deterministic-`frank-facts`-render fallback**.
+3. **surge-gate + digest** — the deterministic gate wakes the (paid) agent only on a real surge
+   (edge-trigger + cooldown) and once/day for the digest.
+4. **grafana-webhook receiver** — alert → triage prompt → narrate; `/healthz` for the cutover check.
+5. **alert-agent Deployment** — `multi-agent-shell` image, `AGENT_SESSION_SERVE=1`, PVC,
+   **default SA / no RBAC (HTTP-only)**, ESO secrets, supercronic crontab, SKILL/SOUL.
+6. **Cutover** — re-point the Grafana "AI Helper Webhook"; retire `apps/ai-alert-helper` **last**
+   (after the new receiver is verified serving — see the spec's ordered Cutover).
+7. **Post-Deploy Checklist.**
+8. **[manual] `claude login`** — back-loaded; the agent's subscription auth (PVC-resident). Nothing
+   agentic depends on it.
+
+## Boundary
+
+HTTP-only, read-only: VictoriaLogs/VictoriaMetrics/Grafana-alert-API/GoatCounter. **No kube
+credential** (matches the old posture; cluster-API agentic investigation is Sympozium's deferred
+slice). Named residual: exfil-via-narration to the allowlisted operator chat (accepted).
+
+## Post-merge verification (operator-driven, needs `claude login`)
+
+All four triggers deliver to Telegram and the agent demonstrably investigates: the daily digest, a
+synthetic surge escalation, a test Grafana alert, an inbound allowlisted DM. Not Deployed until
+observed.

--- a/docs/superpowers/plans/2026-06-15--obs--n8n-session-migrate/01.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--n8n-session-migrate/01.yaml
@@ -1,0 +1,69 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Migrate n8n-01 sidecar onto the baked agent-session driver (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Update the sidecar wiring test first (RED)
+  steps:
+  - id: P1.T1.S1
+    text: |
+      Establish a green baseline of the existing wiring test:
+      `uv run --with pyyaml --with pytest pytest scripts/tests/test_n8n_agent_sidecar.py -q`.
+      Expected: PASS against the CURRENT (ConfigMap-driver) wiring.
+  - id: P1.T1.S2
+    text: |
+      Rewrite `scripts/tests/test_n8n_agent_sidecar.py` to assert the POST-migration wiring of
+      `apps/n8n-01/manifests/deployment.yaml`'s `multi-agent-shell` sidecar:
+      (a) the image tag is the new Plan A `multi-agent-shell` tag;
+      (b) env `AGENT_SESSION_SERVE=1` is set on the sidecar;
+      (c) `AGENT_SIDECAR_URL=http://localhost:8765` is UNCHANGED;
+      (d) NO `volumeMount` at `/opt/stoa-bin` or `/opt/stoa-bootstrap`, and the matching
+          `volumes` are gone;
+      (e) NO `lifecycle.postStart` on the sidecar (the baked s6 longrun replaces it);
+      (f) the `agent-session-driver` + `agent-session-bootstrap` ConfigMap manifests no longer
+          exist under `apps/n8n-01/manifests/`.
+      Run the test. Expected: FAIL (RED — current wiring still mounts the ConfigMaps + postStart).
+- number: 2
+  title: Apply the migration (GREEN)
+  steps:
+  - id: P1.T2.S1
+    text: |
+      Edit `apps/n8n-01/manifests/deployment.yaml`: bump the `multi-agent-shell` sidecar image
+      to the Plan A tag (CROSS-REPO — pin once Plan A's image is built); add env
+      `AGENT_SESSION_SERVE=1`; REMOVE the `/opt/stoa-bin` + `/opt/stoa-bootstrap` volumeMounts,
+      their `volumes`, and the `lifecycle.postStart` block. Leave `AGENT_SIDECAR_URL` as-is.
+  - id: P1.T2.S2
+    text: |
+      Delete `apps/n8n-01/manifests/agent-session-driver.yaml` +
+      `apps/n8n-01/manifests/agent-session-bootstrap.yaml` and remove their refs from the n8n
+      kustomization. Run `uv run --with pyyaml --with pytest pytest
+      scripts/tests/test_n8n_agent_sidecar.py -q`. Expected: GREEN. Also re-run the driver test
+      (`scripts/tests/test_agent_session_driver.py`) — it now sources the driver from the baked
+      image, not the deleted n8n ConfigMap; confirm it was moved/re-pointed by Plan A (if it
+      still references the n8n path, the test belongs to Plan A — note and skip here).
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--n8n-session-migrate/02.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--n8n-session-migrate/02.yaml
@@ -1,0 +1,38 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Post-Deploy verification (content-factory drives)
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Checklist + status
+  steps:
+  - id: P2.T1.S1
+    text: |
+      Steps 1-4 (expose/blog/README) — N/A (internal infra migration; no user-facing change).
+      Step 5 `/sync-runbook` — no `# manual-operation` blocks in this plan (the baked s6 service
+      auto-starts; n8n's `claude login` was its own MO-4, unaffected). Record N/A.
+  - id: P2.T1.S2
+    text: |
+      Step 6: set `**Status:**` to Deployed once merged + ArgoCD-synced. Post-merge,
+      operator-driven verification (the remaining gate): content-factory's n8n session still
+      drives a script-gen turn end-to-end through the BAKED driver (POST localhost:8765
+      /session/send returns a payload; a content-factory run completes). A layer is not
+      Deployed until this is observed.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15--obs--n8n-session-migrate/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-15--obs--n8n-session-migrate/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-15--obs--n8n-session-migrate
+spec: docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-15'

--- a/docs/superpowers/plans/2026-06-15--obs--n8n-session-migrate/_prose.md
+++ b/docs/superpowers/plans/2026-06-15--obs--n8n-session-migrate/_prose.md
@@ -1,0 +1,35 @@
+# n8n agent-session migration (frank — Plan C)
+
+**Status:** Planned
+**Spec:** `docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md` (Part C)
+**Layer:** obs
+
+## Why
+
+n8n-01 currently bolts the persistent-agent driver on via two ConfigMaps
+(`agent-session-driver`, `agent-session-bootstrap`) mounted at `/opt/stoa-bin` + `/opt/stoa-bootstrap`
+with a `lifecycle.postStart` bootstrap. Plan A bakes that `agent-session` interface into the
+`multi-agent-shell` image. This migrates n8n onto the baked version — proving the extraction against
+its **original** client and removing the duplicate. Split from the alert-agent plan deliberately:
+n8n is a **live content-factory prod path**, so it gets its own review/rollback blast radius.
+
+## Depends on (cross-repo)
+
+Consumes the `multi-agent-shell` image tag from **Plan A**. `fr` `depends_on` is within-plan only,
+so this gate is prose: don't bump n8n's image before Plan A's tag exists. Until then n8n stays on its
+current pinned SHA with its ConfigMap driver — there is no broken window.
+
+## What changes (beyond "drop two ConfigMaps")
+
+The container spec changes too: remove the `/opt/stoa-bin` + `/opt/stoa-bootstrap` `volumeMounts` +
+`volumes` AND the `lifecycle.postStart` hook (a postStart pointing at a deleted ConfigMap, or a
+dangling mount, crashloops the sidecar). `AGENT_SIDECAR_URL=http://localhost:8765` is unchanged
+(the driver's default port); set `AGENT_SESSION_SERVE=1` so the baked s6 longrun serves.
+
+## Phase map
+
+1. **Migrate the sidecar (TDD)** — rewrite `test_n8n_agent_sidecar.py` to assert the post-migration
+   wiring (new image, `AGENT_SESSION_SERVE=1`, no `/opt/stoa-*` mounts, no postStart, ConfigMaps
+   gone) RED; apply the deployment edits + delete the ConfigMaps GREEN.
+2. **Post-Deploy verification** — content-factory's session drives a turn end-to-end through the
+   baked driver after the swap (operator-driven; the remaining gate before Deployed).

--- a/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
+++ b/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
@@ -10,6 +10,9 @@
 
 | Plan | Target repo | Slug | Status |
 |------|-------------|------|--------|
+| 2026-06-15-agent-session-extract (Part A, **gating**) | `derio-net/agent-images` | `2026-06-15-agent-session-extract` | — |
+| 2026-06-15--obs--agentic-alert-helper (Part B) | `derio-net/frank` | `2026-06-15--obs--agentic-alert-helper` | — |
+| 2026-06-15--obs--n8n-session-migrate (Part C) | `derio-net/frank` | `2026-06-15--obs--n8n-session-migrate` | — |
 
 > Multi-repo, **three plans**. The **agent-images** plan (Part A — bake the `agent-session`
 > interface into the `multi-agent-shell` image) **gates** two **frank** plans that both consume the

--- a/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
+++ b/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
@@ -1,0 +1,216 @@
+# Agentic Alert-Helper + Extracted Persistent-Agent Interface
+
+**Layers:** obs (frank — replaces the retired `apps/ai-alert-helper`) + agent-images (the reusable interface)
+**Status:** Draft
+**Date:** 2026-06-15
+**Repos:** `derio-net/frank`, `derio-net/agent-images` (multi-repo)
+**Supersedes:** `apps/ai-alert-helper/` (ns `ai-alert-helper-system`) — retired in this work.
+
+## Implementation Plans
+
+| Plan | Target repo | Slug | Status |
+|------|-------------|------|--------|
+
+> Multi-repo. The **agent-images** plan (bake the `agent-session` interface into the
+> `multi-agent-shell` image) **gates** the **frank** plan (alert-agent + n8n migration consume the
+> image-built-in driver). Sequence: agent-images merges → image builds → frank bumps the image SHA.
+
+## Problem
+
+The old `ai-alert-helper` (FastAPI app + two CronJobs, ns `ai-alert-helper-system`) builds a fixed
+fact sheet (GoatCounter / VictoriaLogs / Caddy / Falco / CrowdSec) and makes **one** LiteLLM
+chat-completion call to write a Telegram narrative. Two structural flaws:
+
+1. **Circular dependency.** Its LLM call goes LiteLLM → Ollama. When local inference dies (the
+   GPU-timeshare hands gpu-1 to ComfyUI — the steady state for now), it 500s. The tool meant to
+   report "inference is down" dies *with* inference.
+2. **No agency.** One fixed fact sheet + one LLM shot can't investigate, follow a thread, or answer
+   a follow-up.
+
+Separately, the mechanism for **driving a persistent agent session** (the n8n `agent-session`
+driver, frank #540) is currently a ConfigMap copy-pasted inside `apps/n8n-01/`. This alert-agent is
+the **second** consumer and a **third** is planned — the pattern wants extraction before it drifts.
+
+## Goal
+
+1. Rebuild the alert-helper as an **autonomous agent** on the `multi-agent-shell` image: resilient
+   to local-inference outages (brain = cloud `claude`, not LiteLLM/Ollama), able to **investigate**,
+   and **conversational** (DM the bot, it investigates and replies) — keeping the old deterministic
+   data plumbing (`facts.py`/`surge.py`) as tools, with bounded cloud spend via deterministic gating.
+2. **Extract the persistent-agent interface** (`agent-session`) into the `multi-agent-shell` image
+   as a reusable, versioned contract every consumer shares; migrate n8n onto it.
+
+---
+
+## Part A — Reusable `agent-session` interface (agent-images)
+
+Move the `agent-session` driver + bootstrap **out of n8n's ConfigMap and into the image**, beside
+the existing `/usr/local/lib/multi-agent-shell/notify-telegram.sh`.
+
+- **Location:** `multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session` (Python),
+  symlinked to `/usr/local/bin/agent-session` (mirrors the existing `…-reconcile` symlink).
+- **Contract (stable, documented in the image README):**
+  - `agent-session serve` — HTTP on `127.0.0.1:${AGENT_SESSION_PORT:-8765}`, `POST /session/send
+    {session_id, agent, message, timeout_s?} → {session_id, agent, status, turn, payload}`,
+    `GET /healthz`. Drives the **running** session (never `-p`): bracketed-paste submit + per-turn
+    nonce-file read (the file appearing + parsing = completion). Locked atomic turn counter.
+  - `agent-session send '<json>'` — same core as a CLI (debug/manual).
+- **Configurable agent** (the operator decision): `ensure_session` dispatches on the `agent` field
+  via a small per-agent launch profile. `claude` (default) → `claude --permission-mode auto`
+  (fully wired + verified). `antigravity` (`agy`) / `codex` → their own launch + auto-approve flags
+  (config-selectable; verifying each is a follow-up). The profile table lives in the image so every
+  consumer inherits new agents on image bump.
+- **Bootstrap becomes a baked s6 service** (improvement over n8n's postStart hook, which has no
+  ordering guarantee with the ENTRYPOINT): an s6-overlay service starts the `serve` restart-loop +
+  pre-trusts the workspace, **gated on `AGENT_SESSION_SERVE=1`** (default off — a plain interactive
+  shell is unaffected; consumers opt in).
+- **Genericize naming:** `STOA_*` env → `AGENT_SESSION_*` (`_TURN_DIR`, `_OUT_DIR`, `_PORT`,
+  `_POLL_S`, `_SETTLE_S`, `_SESSION_NAME`). The interface is generic infra, not stoa-specific (and
+  shouldn't carry a private codename). Keep `STOA_*` as **deprecated aliases** (read if the new var
+  is unset) for one cycle so a consumer mid-migration never breaks.
+- **Tests:** port `scripts/tests/test_agent_session_driver.py` (mock tmux: paste + file-write flow,
+  turn counter, timeout, per-agent dispatch) into the image's `tests/`.
+- **Output:** a new `multi-agent-shell` image tag carrying the baked `agent-session`.
+
+This is the **gating deliverable** — frank consumes the new tag.
+
+---
+
+## Part B — alert-agent (frank, layer obs)
+
+```
+┌─ alert-agent  (Deployment, replicas:1, strategy:Recreate) ──────────────────────────┐
+│  image: ghcr.io/derio-net/multi-agent-shell:<new tag>  (cloud claude, PVC login —   │
+│                                                          NO LiteLLM/Ollama/GPU)      │
+│  AGENT_SESSION_SERVE=1  → baked agent-session serve (localhost POST /session/send)   │
+│  persistent agent session (tmux), configurable agent (default claude)               │
+│  telegram-bridge   long-poll getUpdates (allowlist) ↔ /session/send; SOLE bot-token │
+│                    owner (single consumer) + deterministic OUTBOUND sender           │
+│  supercronic crontab   surge */15 (deterministic gate) · digest daily               │
+│  grafana-webhook   HTTP receiver (re-pointed "AI Helper Webhook") → triage prompt   │
+│  agent TOOLS (HTTP-only, read-only): frank-facts CLI · LogsQL/PromQL curl ·          │
+│                                      Grafana alert API · GoatCounter · fetch-text    │
+└─────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Why resilient:** `multi-agent-shell` runs `claude` on an Anthropic subscription (PVC login state,
+first `claude login` is a manual op). Zero dependency on LiteLLM/Ollama/GPU — it can narrate a
+local-inference outage *because* its brain isn't local inference.
+
+### The four triggers (all deterministically gated)
+
+The **paid cloud agent wakes only on a real event** — cron runs cheap deterministic checks; the
+agent runs on escalation / the daily digest / an alert / an inbound question. Edge-triggered +
+cooldown (preserving `SURGE_ABS_FLOOR` / `SURGE_VISITOR_FLOOR` / `SURGE_COOLDOWN_HOURS`).
+
+| Trigger | Mechanism | Gate |
+|---------|-----------|------|
+| **Daily digest** | supercronic cron (daily) | once/day |
+| **Traffic surge** | cron */15 → `frank-facts surge-compute` | agent woken ONLY when the deterministic surge math escalates (edge + cooldown) |
+| **Grafana alert triage** | `grafana-webhook` (re-pointed contact point) | per firing alert (Grafana gates) |
+| **Inbound ask-the-cluster** | `telegram-bridge` getUpdates | per allowlisted DM |
+
+**Delivery is orchestration-owned (deterministic), not agent-owned.** Cron/webhook handlers
+`POST /session/send`, get the `payload`, and hand it to `telegram-bridge` to send — the daily
+digest is *guaranteed* to post even if the agent is terse. The agent returns a structured payload;
+it never owns the bot token.
+
+### Components
+
+1. **alert-agent Deployment** — `multi-agent-shell` image, `replicas:1`, `strategy:Recreate`
+   (single Telegram consumer + single tmux session), PVC for `~/.claude` login + agent-session turn
+   state, `AGENT_SESSION_SERVE=1`. **Default ServiceAccount, no RBAC** (see boundary below).
+2. **telegram-bridge** — single process owning the bot token: long-poll getUpdates, drop
+   non-allowlisted chats (WARN), route allowlisted messages → `/session/send` → reply; the
+   deterministic outbound sender for cron/webhook narratives. `replicas:1` + `Recreate` mandatory
+   (one getUpdates consumer per token — the old analyst gotcha).
+3. **frank-facts CLI** — `facts.py`/`surge.py` repackaged as a mounted script (like `fetch-text`):
+   `surge-compute` (the gate), `digest`, `surge`, `alert`, + granular `top-attacker-ips` /
+   `top-scanned-paths` / `crowdsec` / `scan-patterns` for ad-hoc investigation. Pure deterministic
+   HTTP data access; no LLM, no kube.
+4. **grafana-webhook receiver** — re-point `apps/grafana-alerting/manifests/contact-points-cm.yaml`
+   "AI Helper Webhook" from `ai-alert-helper.ai-alert-helper-system.svc:8080/alert` to this.
+5. **agent guidance** — a `SKILL.md`/SOUL: the job, the tool catalog, the HTTP-only/read-only
+   boundary, the output-payload contract.
+
+### Read-only boundary (HTTP-only — match the old posture, do NOT widen the attack surface)
+
+The agent now consumes **untrusted input** (arbitrary Telegram DMs, raw log lines) and feeds it to
+an LLM that can run tools — a prompt-injection surface. And its job is to narrate to Telegram, so
+any read primitive is also an exfil primitive. Therefore:
+
+- **No Kubernetes credential.** Default ServiceAccount, **no Role/ClusterRole** — exactly the old
+  helper's posture (it never had a kube token). Investigation is purely over **read-only HTTP data
+  planes**: VictoriaLogs (LogsQL, query-only), VictoriaMetrics (PromQL), the Grafana alert API,
+  GoatCounter (stats-scoped token).
+- **Cluster-API agentic investigation is explicitly out of scope and out of slice.** That capability
+  (`kubectl get`/`describe` driven by an agent) was always intended to be **Sympozium's** charter
+  (currently inactive) — a different, more carefully-scoped slice of the cluster. The alert-agent
+  does not annex it. (Documented-and-deferred, not silently dropped.)
+- Read-only safety = no kube credential + stats-scoped GoatCounter token + query-only log/metric APIs.
+
+### Boundaries vs Grafana alerting + health-bridge
+
+Grafana = detection. health-bridge = tile/bug lifecycle. **alert-agent = human-facing narration /
+investigation / digest.** It consumes Grafana alerts (the re-pointed webhook) to *explain* them; it
+does not manage tiles or issues. No overlap.
+
+### Cutover (clean replace)
+
+1. Stand up the alert-agent (manifests + ArgoCD app on the new image), `claude login` (manual op).
+2. Re-point the Grafana "AI Helper Webhook" contact point.
+3. Move GoatCounter + Telegram secret refs to the new app's ESO.
+4. Verify all four triggers end-to-end.
+5. Remove `apps/ai-alert-helper/` + its root Application; delete `ai-alert-helper-system`; update
+   the obs-digest gotchas + operating post.
+
+---
+
+## Part C — n8n migration (frank)
+
+n8n-01 currently bolts the driver on via the `agent-session-driver` / `agent-session-bootstrap`
+ConfigMaps. Migrate it onto the image-baked `agent-session`:
+
+- Bump `apps/n8n-01` multi-agent-shell sidecar image to the new tag.
+- Set `AGENT_SESSION_SERVE=1` on the sidecar (the baked s6 service replaces the postStart bootstrap).
+- Remove the `agent-session-driver` + `agent-session-bootstrap` ConfigMaps and their mounts/hook.
+- Keep n8n's `AGENT_SIDECAR_URL=http://localhost:8765` (unchanged contract) and `STOA_SESSION_NAME`
+  (honored via the deprecated alias) — verify content-factory's session still drives end-to-end.
+
+This proves the extraction against its original client and removes the duplicate.
+
+---
+
+## Multi-repo sequencing
+
+1. **agent-images plan** merges first → CI builds the new `multi-agent-shell` image tag.
+   (agent-images CI builds on push:main; validate a branch via `gh workflow run build.yaml --ref`.)
+2. **frank plan** bumps the image SHA in both `apps/n8n-01` (Part C) and the new `apps/alert-agent`
+   (Part B), then proceeds. Front-load nothing in frank that needs the baked driver before the
+   agent-images tag exists.
+
+## Secrets / manual operations
+
+- **`claude login`** in the alert-agent shell (PVC-resident; like n8n's MO-4): subscription auth,
+  first login is manual (operator attaches via tmux/ssh). `# manual-operation`.
+- Telegram bot token + chat id (`FRANK_C2_TELEGRAM_BOT_TOKEN` / `_CHAT_ID`) + GoatCounter stats
+  token via ESO from Infisical (existing keys).
+
+## Non-goals (v1)
+
+- **Kubernetes / cluster-API access for the agent** — HTTP-only; cluster-API agentic investigation
+  is Sympozium's slice (deferred).
+- **Shared memory across agents/restarts** — operator is adding it at the image level; out of scope.
+  v1 = one persistent session with within-lifetime continuity; context resets on pod restart.
+- **Write-actions** — read-only investigation only.
+- **antigravity / codex verification** — config-selectable; claude is the wired+verified default.
+
+## Testing
+
+- **agent-images:** ported driver tests (mock tmux: paste + file-write, turn counter, timeout,
+  per-agent dispatch); CI smoke that `agent-session --help` / `serve` bind works in the image.
+- **frank (deterministic, no LLM):** `frank-facts` unit tests (port existing `facts.py`/`surge.py`
+  tests), surge gate escalate/cooldown, telegram-bridge allowlist + single-consumer invariant.
+- **End-to-end (post-deploy, operator-driven — needs `claude login`):** all four alert-agent
+  triggers deliver to Telegram and the agent demonstrably investigates (cites a tool it ran); n8n's
+  content-factory session still drives after migration. A layer is not Deployed until observed.

--- a/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
+++ b/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
@@ -11,9 +11,12 @@
 | Plan | Target repo | Slug | Status |
 |------|-------------|------|--------|
 
-> Multi-repo. The **agent-images** plan (bake the `agent-session` interface into the
-> `multi-agent-shell` image) **gates** the **frank** plan (alert-agent + n8n migration consume the
-> image-built-in driver). Sequence: agent-images merges → image builds → frank bumps the image SHA.
+> Multi-repo, **three plans**. The **agent-images** plan (Part A — bake the `agent-session`
+> interface into the `multi-agent-shell` image) **gates** two **frank** plans that both consume the
+> new image but are **independent of each other**: the **alert-agent** plan (Part B, greenfield) and
+> the **n8n-migration** plan (Part C). Splitting Part C off keeps a live content-factory prod-path
+> migration out of the greenfield build's review/rollback blast radius (they share no dependency).
+> Sequence: agent-images merges → image builds → each frank plan bumps the image SHA independently.
 
 ## Problem
 
@@ -65,7 +68,10 @@ the existing `/usr/local/lib/multi-agent-shell/notify-telegram.sh`.
   runs `agent-session serve` **directly** — s6 supervises restarts, so the n8n bootstrap's
   `while true … sleep 2` loop (needed only inside a tmux pane) is dropped. It also pre-trusts the
   workspace, **gated on `AGENT_SESSION_SERVE=1`** (default off — a plain interactive shell is
-  unaffected; consumers opt in).
+  unaffected; consumers opt in). Follow the image's existing **sshd** s6 precedent exactly
+  (`#!/command/with-contenv bash` shebang, a `finish` script, and the Dockerfile
+  `chmod +x /etc/services.d/*/run` line) — the image is s6-overlay v3 using the v2-compat
+  `/etc/services.d/<svc>/run` convention; mirror it rather than inventing an s6-rc layout.
 - **Genericize naming:** rename to `AGENT_SESSION_*` with the REAL source vars (verified against the
   driver + tests): `AGENT_SESSION_TURN_DIR ← STOA_TURN_DIR`, `_OUT_DIR ← STOA_OUT_DIR`,
   `_PORT ← STOA_SESSION_PORT`, `_POLL_S ← STOA_POLL_S`, `_SETTLE_S ← STOA_SETTLE_S`,
@@ -73,11 +79,15 @@ the existing `/usr/local/lib/multi-agent-shell/notify-telegram.sh`.
   generic infra, not stoa-specific (and shouldn't carry a private codename). Keep each `STOA_*` as a
   **deprecated alias** (read if the new var is unset) for one cycle so a consumer mid-migration never
   breaks.
-- **Tests:** port the existing tmux-mock tests from `scripts/tests/test_agent_session_driver.py`
-  (paste + file-write flow, turn counter, timeout, HTTP serve) into the image's `tests/`, **adding**
-  new per-agent-dispatch tests for the launch-profile table (none exist today — the driver hardcodes
+- **Tests:** port the existing tmux-mock tests from frank `scripts/tests/test_agent_session_driver.py`
+  (paste + file-write flow, turn counter, timeout, HTTP serve) into the image, **adding** new
+  per-agent-dispatch tests for the launch-profile table (none exist today — the driver hardcodes
   claude). Re-point the test's driver-source fixture from the n8n ConfigMap path
   (`apps/n8n-01/manifests/agent-session-driver.yaml`) to the baked image file.
+  **Test-infra reality:** `multi-agent-shell/tests/` is **bats-only** today, but the repo already has
+  pytest (`pyproject.toml` + `kali/tests/test_*.py`; the `dev` profile runs "pytest locally"). So add
+  a `multi-agent-shell/tests/test_agent_session.py` modeled on the existing `kali/tests/` pytest
+  setup and wire it into the image's CI — extend the existing pytest facility, don't stand one up.
 - **Output:** a new `multi-agent-shell` image tag carrying the baked `agent-session`.
 
 This is the **gating deliverable** — frank consumes the new tag.
@@ -175,25 +185,34 @@ Grafana = detection. health-bridge = tile/bug lifecycle. **alert-agent = human-f
 investigation / digest.** It consumes Grafana alerts (the re-pointed webhook) to *explain* them; it
 does not manage tiles or issues. No overlap.
 
-### Cutover (clean replace)
+### Cutover (clean replace — ORDER MATTERS, no dropped alerts)
 
 1. Stand up the alert-agent (manifests + ArgoCD app on the new image), `claude login` (manual op).
-2. Re-point the Grafana "AI Helper Webhook" contact point.
-3. Move GoatCounter + Telegram secret refs to the new app's ESO.
-4. Verify all four triggers end-to-end.
-5. Remove `apps/ai-alert-helper/` + its root Application; delete `ai-alert-helper-system`; update
-   the obs-digest gotchas + operating post.
+2. Move GoatCounter + Telegram secret refs to the new app's ESO.
+3. **Verify the `grafana-webhook` receiver answers** (a `/healthz` or test POST) — BEFORE touching the
+   contact point. A fired alert between the flip and a reachable receiver is a dropped triage.
+4. Re-point the Grafana "AI Helper Webhook" contact point to the new receiver (only after step 3).
+5. Verify all four triggers end-to-end.
+6. **LAST, only after the flip is verified serving:** remove `apps/ai-alert-helper/` + its root
+   Application (`apps/root/templates/ai-alert-helper.yaml`, `ns-ai-alert-helper.yaml`); delete the
+   `ai-alert-helper-system` namespace; update the obs-digest gotchas + operating post. (The old
+   Service stays alive through the flip so nothing is in-flight-dropped.)
 
 ---
 
-## Part C — n8n migration (frank)
+## Part C — n8n migration (frank — SEPARATE plan)
 
+A standalone frank plan (not bundled with the alert-agent — see the Implementation Plans note).
 n8n-01 currently bolts the driver on via the `agent-session-driver` / `agent-session-bootstrap`
 ConfigMaps. Migrate it onto the image-baked `agent-session`:
 
 - Bump `apps/n8n-01` multi-agent-shell sidecar image to the new tag.
 - Set `AGENT_SESSION_SERVE=1` on the sidecar (the baked s6 service replaces the postStart bootstrap).
-- Remove the `agent-session-driver` + `agent-session-bootstrap` ConfigMaps and their mounts/hook.
+- Remove BOTH ConfigMaps **and the container-spec wiring they require**: the `volumeMounts` at
+  `/opt/stoa-bin` (driver) and `/opt/stoa-bootstrap` (bootstrap), the matching `volumes`, **and the
+  `lifecycle.postStart` hook** that runs `session-bootstrap.sh`. Leaving a postStart pointing at a
+  deleted ConfigMap, or a dangling mount, crashloops the sidecar — so this touches the Deployment's
+  container spec, not just the two ConfigMaps.
 - n8n's only session config is `AGENT_SIDECAR_URL=http://localhost:8765` (the driver's default port)
   — **unchanged**. n8n sets none of the `STOA_*` vars itself (it relied on driver/bootstrap
   defaults), so the migration is config-clean; the deprecated aliases are belt-and-suspenders, not
@@ -206,19 +225,22 @@ This proves the extraction against its original client and removes the duplicate
 
 ## Multi-repo sequencing
 
-0. **fr-enablement (agent-images) — already done.** agent-images is fr-enabled: it has
-   `docs/superpowers/{specs,plans}`, an existing v2 plan with `vk_version`, and a
-   `.devcontainer/dev/` profile (`fr-profiles.yaml` default `dev`). So the agent-session plan is
-   authored + dispatched exactly like a frank plan — **no `fr-init` needed**. (An earlier review
-   flagged a missing profile; verified false against the live checkout.)
+0. **fr-enablement (agent-images) — already done (verified twice, direct).** agent-images is
+   fr-enabled: `.devcontainer/fr-profiles.yaml` defines profile `dev` (default), `.devcontainer/dev/
+   devcontainer.json` exists, and `docs/superpowers/plans/2026-06-01-agent-shells-batch/` is a real
+   v2 plan (`01/02/03.yaml` + `_meta.yaml` `schema_version:2`, `vk_version`). So the agent-session
+   plan is authored + dispatched exactly like a frank plan — **no `fr-init` needed**. (TWO reviews
+   claimed a missing profile / "empty placeholder dirs"; both refuted by direct `ls`/`cat` of the
+   live checkout — do not re-dispute without re-running those reads.)
 1. **agent-images plan** merges first → CI builds the new `multi-agent-shell` image tag.
    (agent-images CI builds on `push:main`, paths-ignore `docs/**`; validate a branch via
    `gh workflow run build.yaml --ref <branch>` — **confirm in the plan that the dispatch build
    publishes a BRANCH-tagged image** to consume, not a main tag, since the whole gate depends on it.)
-2. **frank plan** bumps the image SHA in both `apps/n8n-01` (Part C) and the new `apps/alert-agent`
-   (Part B), then proceeds. n8n stays on its current pinned SHA (with its existing ConfigMap driver)
-   until Part C explicitly bumps it — so there is no window where n8n is broken. Front-load nothing in
-   frank that needs the baked driver before the agent-images tag exists.
+2. **Two frank plans** then consume the new tag independently: the **alert-agent** plan creates
+   `apps/alert-agent` on it (Part B); the **n8n-migration** plan bumps `apps/n8n-01` to it (Part C).
+   n8n stays on its current pinned SHA (with its existing ConfigMap driver) until the n8n-migration
+   plan explicitly bumps it — so there is no window where n8n is broken. Front-load nothing in either
+   frank plan that needs the baked driver before the agent-images tag exists.
 
 ## Secrets / manual operations
 

--- a/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
+++ b/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
@@ -61,15 +61,23 @@ the existing `/usr/local/lib/multi-agent-shell/notify-telegram.sh`.
   (config-selectable; verifying each is a follow-up). The profile table lives in the image so every
   consumer inherits new agents on image bump.
 - **Bootstrap becomes a baked s6 service** (improvement over n8n's postStart hook, which has no
-  ordering guarantee with the ENTRYPOINT): an s6-overlay service starts the `serve` restart-loop +
-  pre-trusts the workspace, **gated on `AGENT_SESSION_SERVE=1`** (default off — a plain interactive
-  shell is unaffected; consumers opt in).
-- **Genericize naming:** `STOA_*` env → `AGENT_SESSION_*` (`_TURN_DIR`, `_OUT_DIR`, `_PORT`,
-  `_POLL_S`, `_SETTLE_S`, `_SESSION_NAME`). The interface is generic infra, not stoa-specific (and
-  shouldn't carry a private codename). Keep `STOA_*` as **deprecated aliases** (read if the new var
-  is unset) for one cycle so a consumer mid-migration never breaks.
-- **Tests:** port `scripts/tests/test_agent_session_driver.py` (mock tmux: paste + file-write flow,
-  turn counter, timeout, per-agent dispatch) into the image's `tests/`.
+  ordering guarantee with the ENTRYPOINT): an s6-overlay **longrun** (`/etc/services.d/<svc>/run`)
+  runs `agent-session serve` **directly** — s6 supervises restarts, so the n8n bootstrap's
+  `while true … sleep 2` loop (needed only inside a tmux pane) is dropped. It also pre-trusts the
+  workspace, **gated on `AGENT_SESSION_SERVE=1`** (default off — a plain interactive shell is
+  unaffected; consumers opt in).
+- **Genericize naming:** rename to `AGENT_SESSION_*` with the REAL source vars (verified against the
+  driver + tests): `AGENT_SESSION_TURN_DIR ← STOA_TURN_DIR`, `_OUT_DIR ← STOA_OUT_DIR`,
+  `_PORT ← STOA_SESSION_PORT`, `_POLL_S ← STOA_POLL_S`, `_SETTLE_S ← STOA_SETTLE_S`,
+  `_NAME ← STOA_SESSION_NAME` (the last lives in the bootstrap, not the driver). The interface is
+  generic infra, not stoa-specific (and shouldn't carry a private codename). Keep each `STOA_*` as a
+  **deprecated alias** (read if the new var is unset) for one cycle so a consumer mid-migration never
+  breaks.
+- **Tests:** port the existing tmux-mock tests from `scripts/tests/test_agent_session_driver.py`
+  (paste + file-write flow, turn counter, timeout, HTTP serve) into the image's `tests/`, **adding**
+  new per-agent-dispatch tests for the launch-profile table (none exist today — the driver hardcodes
+  claude). Re-point the test's driver-source fixture from the n8n ConfigMap path
+  (`apps/n8n-01/manifests/agent-session-driver.yaml`) to the baked image file.
 - **Output:** a new `multi-agent-shell` image tag carrying the baked `agent-session`.
 
 This is the **gating deliverable** — frank consumes the new tag.
@@ -113,7 +121,9 @@ cooldown (preserving `SURGE_ABS_FLOOR` / `SURGE_VISITOR_FLOOR` / `SURGE_COOLDOWN
 **Delivery is orchestration-owned (deterministic), not agent-owned.** Cron/webhook handlers
 `POST /session/send`, get the `payload`, and hand it to `telegram-bridge` to send — the daily
 digest is *guaranteed* to post even if the agent is terse. The agent returns a structured payload;
-it never owns the bot token.
+it never owns the bot token. **Fallback:** if `/session/send` returns `status:timeout` or an empty
+payload (the driver's nonce-file never appeared), the handler posts the deterministic `frank-facts`
+render instead — so a stuck or unauthenticated agent never *silences* the digest.
 
 ### Components
 
@@ -124,12 +134,17 @@ it never owns the bot token.
    non-allowlisted chats (WARN), route allowlisted messages → `/session/send` → reply; the
    deterministic outbound sender for cron/webhook narratives. `replicas:1` + `Recreate` mandatory
    (one getUpdates consumer per token — the old analyst gotcha).
-3. **frank-facts CLI** — `facts.py`/`surge.py` repackaged as a mounted script (like `fetch-text`):
-   `surge-compute` (the gate), `digest`, `surge`, `alert`, + granular `top-attacker-ips` /
-   `top-scanned-paths` / `crowdsec` / `scan-patterns` for ad-hoc investigation. Pure deterministic
-   HTTP data access; no LLM, no kube.
+3. **frank-facts CLI** — `facts.py`/`surge.py` repackaged: `surge-compute` (the gate), `digest`,
+   `surge`, `alert`, + granular `top-attacker-ips` / `top-scanned-paths` / `crowdsec` /
+   `scan-patterns` for ad-hoc investigation. Pure deterministic HTTP data access; no LLM, no kube.
+   **Dependency decision (settle in the plan):** `facts.py` imports `httpx` + needs Python ≥3.12, so
+   it is NOT a drop-in bare-ConfigMap script like `fetch-text` (which is stdlib `urllib` precisely so
+   it runs on the image's `python3`). Either (a) port `facts.py` to stdlib `urllib.request` — then
+   `tests/test_facts.py` (currently `respx`-based) is rewritten too — or (b) ship it against a baked
+   httpx / venv. Recommend (a) for parity with the fetch-text precedent and zero image change.
 4. **grafana-webhook receiver** — re-point `apps/grafana-alerting/manifests/contact-points-cm.yaml`
-   "AI Helper Webhook" from `ai-alert-helper.ai-alert-helper-system.svc:8080/alert` to this.
+   "AI Helper Webhook" (uid `ai-alert-helper-webhook`) from
+   `http://ai-alert-helper.ai-alert-helper-system.svc.cluster.local:8080/alert` to this.
 5. **agent guidance** — a `SKILL.md`/SOUL: the job, the tool catalog, the HTTP-only/read-only
    boundary, the output-payload contract.
 
@@ -148,6 +163,11 @@ any read primitive is also an exfil primitive. Therefore:
   (currently inactive) — a different, more carefully-scoped slice of the cluster. The alert-agent
   does not annex it. (Documented-and-deferred, not silently dropped.)
 - Read-only safety = no kube credential + stats-scoped GoatCounter token + query-only log/metric APIs.
+- **Named residual — exfil-via-narration.** No-kube bounds the *kube* blast radius, but a successful
+  prompt injection can still reflect read-plane data (logs/metrics) into the *outbound narrative* —
+  the allowlist gates who can DM the bot, not what the bot says back. Accepted because outbound goes
+  only to the allowlisted operator chat, and the read planes carry no secrets beyond observability
+  data the operator already sees. (If outbound ever fans out beyond the operator, revisit.)
 
 ### Boundaries vs Grafana alerting + health-bridge
 
@@ -174,8 +194,11 @@ ConfigMaps. Migrate it onto the image-baked `agent-session`:
 - Bump `apps/n8n-01` multi-agent-shell sidecar image to the new tag.
 - Set `AGENT_SESSION_SERVE=1` on the sidecar (the baked s6 service replaces the postStart bootstrap).
 - Remove the `agent-session-driver` + `agent-session-bootstrap` ConfigMaps and their mounts/hook.
-- Keep n8n's `AGENT_SIDECAR_URL=http://localhost:8765` (unchanged contract) and `STOA_SESSION_NAME`
-  (honored via the deprecated alias) — verify content-factory's session still drives end-to-end.
+- n8n's only session config is `AGENT_SIDECAR_URL=http://localhost:8765` (the driver's default port)
+  — **unchanged**. n8n sets none of the `STOA_*` vars itself (it relied on driver/bootstrap
+  defaults), so the migration is config-clean; the deprecated aliases are belt-and-suspenders, not
+  load-bearing for n8n. Verify content-factory's session still drives end-to-end after the swap.
+  (Alias coverage is proven by the ported unit tests, not by n8n's live behaviour.)
 
 This proves the extraction against its original client and removes the duplicate.
 
@@ -183,11 +206,19 @@ This proves the extraction against its original client and removes the duplicate
 
 ## Multi-repo sequencing
 
+0. **fr-enablement pre-step (agent-images).** agent-images has a `docs/superpowers/` tree but **no
+   `.devcontainer/` profile**, so fr-isolation/fr-brainstorming hard-stop there. Before the
+   agent-session plan, either run `fr-init` to scaffold a devcontainer profile for agent-images, or
+   execute Part A as a plain (non-fr) PR with the shared spec as the source of truth. Decide at
+   planning; it does not change the design.
 1. **agent-images plan** merges first → CI builds the new `multi-agent-shell` image tag.
-   (agent-images CI builds on push:main; validate a branch via `gh workflow run build.yaml --ref`.)
+   (agent-images CI builds on `push:main`, paths-ignore `docs/**`; validate a branch via
+   `gh workflow run build.yaml --ref <branch>` — **confirm in the plan that the dispatch build
+   publishes a BRANCH-tagged image** to consume, not a main tag, since the whole gate depends on it.)
 2. **frank plan** bumps the image SHA in both `apps/n8n-01` (Part C) and the new `apps/alert-agent`
-   (Part B), then proceeds. Front-load nothing in frank that needs the baked driver before the
-   agent-images tag exists.
+   (Part B), then proceeds. n8n stays on its current pinned SHA (with its existing ConfigMap driver)
+   until Part C explicitly bumps it — so there is no window where n8n is broken. Front-load nothing in
+   frank that needs the baked driver before the agent-images tag exists.
 
 ## Secrets / manual operations
 
@@ -207,10 +238,12 @@ This proves the extraction against its original client and removes the duplicate
 
 ## Testing
 
-- **agent-images:** ported driver tests (mock tmux: paste + file-write, turn counter, timeout,
-  per-agent dispatch); CI smoke that `agent-session --help` / `serve` bind works in the image.
-- **frank (deterministic, no LLM):** `frank-facts` unit tests (port existing `facts.py`/`surge.py`
-  tests), surge gate escalate/cooldown, telegram-bridge allowlist + single-consumer invariant.
+- **agent-images:** ported tmux-mock driver tests (paste + file-write, turn counter, timeout) **plus
+  new per-agent-dispatch tests** (none exist today); CI smoke that `agent-session serve` binds in the
+  image.
+- **frank (deterministic, no LLM):** `frank-facts` unit tests (port `facts.py`/`surge.py` tests —
+  rewritten off `respx` if I-1 chooses the stdlib `urllib` port), surge gate escalate/cooldown,
+  telegram-bridge allowlist + single-consumer invariant + the timeout→deterministic-render fallback.
 - **End-to-end (post-deploy, operator-driven — needs `claude login`):** all four alert-agent
   triggers deliver to Telegram and the agent demonstrably investigates (cites a tool it ran); n8n's
   content-factory session still drives after migration. A layer is not Deployed until observed.

--- a/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
+++ b/docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
@@ -206,11 +206,11 @@ This proves the extraction against its original client and removes the duplicate
 
 ## Multi-repo sequencing
 
-0. **fr-enablement pre-step (agent-images).** agent-images has a `docs/superpowers/` tree but **no
-   `.devcontainer/` profile**, so fr-isolation/fr-brainstorming hard-stop there. Before the
-   agent-session plan, either run `fr-init` to scaffold a devcontainer profile for agent-images, or
-   execute Part A as a plain (non-fr) PR with the shared spec as the source of truth. Decide at
-   planning; it does not change the design.
+0. **fr-enablement (agent-images) — already done.** agent-images is fr-enabled: it has
+   `docs/superpowers/{specs,plans}`, an existing v2 plan with `vk_version`, and a
+   `.devcontainer/dev/` profile (`fr-profiles.yaml` default `dev`). So the agent-session plan is
+   authored + dispatched exactly like a frank plan — **no `fr-init` needed**. (An earlier review
+   flagged a missing profile; verified false against the live checkout.)
 1. **agent-images plan** merges first → CI builds the new `multi-agent-shell` image tag.
    (agent-images CI builds on `push:main`, paths-ignore `docs/**`; validate a branch via
    `gh workflow run build.yaml --ref <branch>` — **confirm in the plan that the dispatch build


### PR DESCRIPTION
## Planning docs — agentic alert-helper (Parts B + C)

Spec + two of the three plans for replacing the retired `ai-alert-helper` with an autonomous agent on the `multi-agent-shell` image, and migrating n8n onto the extracted `agent-session` interface. **Docs only — no code/manifests yet;** execution is dispatched per-plan after merge.

- **Spec:** `docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md` (brainstormed + two adversarial review rounds, all findings applied/refuted).
- **Plan B — `2026-06-15--obs--agentic-alert-helper`** (8 phases): greenfield alert-agent — frank-facts CLI (stdlib port), telegram-bridge (single-consumer + deterministic fallback), surge-gate + digest, grafana-webhook, Deployment (HTTP-only, **no kube RBAC**), cutover, back-loaded `claude login`.
- **Plan C — `2026-06-15--obs--n8n-session-migrate`** (2 phases): migrate n8n-01 onto the baked driver (own plan — live content-factory prod path).

**Multi-repo:** both consume the image tag from the gating **Plan A** (`derio-net/agent-images`, separate PR). Sequence: A merges → image builds → B/C dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
