### PR TITLE
feat(gpu): ComfyUI v0.24 bump + LTX-2.3 dev model hydration (content-factory#70)

### DIFF
--- a/.github/workflows/build-comfyui.yml
+++ b/.github/workflows/build-comfyui.yml
@@ -10,7 +10,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/comfyui
-  COMFYUI_REF: "v0.9.2"
+  COMFYUI_REF: "v0.24.0"
   MANAGER_REF: "4.0.5"
   PYTORCH_VERSION: "2.10.0"
   TORCHVISION_VERSION: "0.25.0"
@@ -22,7 +22,10 @@ env:
   #        libtorchaudio -> audio nodes + WanVideoWrapper + FishSpeech failed to load).
   # rev 3: patch ComfyUI-LTXVideo's kornia `pad` import (kornia 0.8.3 dropped it);
   #        pre-create FishSpeech's site-packages .pth as comfyui-owned.
-  STOA_NODES: "3"
+  # rev 4: bump ComfyUI core v0.9.2 -> v0.24.0 (v0.23.0 fixed two LTX audio-video
+  #        correctness bugs; v0.24.x adds NVFP4 weight-loading for the LTX-2.3
+  #        dev NVFP4 checkpoint). Custom-node SHAs unchanged.
+  STOA_NODES: "4"
   LTXVIDEO_REF: "229437c6b65796d6a7a63ae34be2bd5ba31fa543"
   GGUF_REF: "6ea2651e7df66d7585f6ffee804b20e92fb38b8a"
   WANVIDEO_REF: "088128b224242e110d3906c6750e9a3a348a659b"

--- a/apps/comfyui/docker/Dockerfile
+++ b/apps/comfyui/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM nvidia/cuda:12.8.0-devel-ubuntu22.04
 
 # Version pins — passed as build args from CI, with defaults for local builds
-ARG COMFYUI_REF=v0.9.2
+ARG COMFYUI_REF=v0.24.0
 ARG MANAGER_REF=4.0.5
 ARG PYTORCH_VERSION=2.10.0
 ARG TORCHVISION_VERSION=0.25.0

--- a/apps/comfyui/manifests/deployment.yaml
+++ b/apps/comfyui/manifests/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: comfyui
-          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa3
+          image: ghcr.io/derio-net/comfyui:comfyui-v0.24.0-pt2.10.0-cu128-stoa4
           # Overrides the image CMD to add VRAM/offload flags for the 16GB
           # RTX 5070 Ti. The stoa runner drives one clip at a time, so models
           # load serially: reserve a little VRAM for the OS and don't cache

--- a/apps/comfyui/manifests/job-model-download.yaml
+++ b/apps/comfyui/manifests/job-model-download.yaml
@@ -42,7 +42,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: download
-          image: ghcr.io/derio-net/comfyui:comfyui-v0.9.2-pt2.10.0-cu128-stoa3
+          image: ghcr.io/derio-net/comfyui:comfyui-v0.24.0-pt2.10.0-cu128-stoa4
           env:
             # Optional: lifts the anonymous-download throttle + reaches gated
             # weights. Absent Secret -> empty -> anonymous download still works.

--- a/apps/comfyui/manifests/job-model-download.yaml
+++ b/apps/comfyui/manifests/job-model-download.yaml
@@ -9,9 +9,11 @@
 # download -n comfyui && kubectl apply -f` (or let ArgoCD recreate on change).
 # Re-runs are no-ops for artefacts already present.
 #
-# NOTE: LTX-2's text-encoder wiring (Gemma-3 base + embeddings connector) is the
-# best-known set for the ComfyUI LTX-2 nodes; confirm against the live nodes at
-# activation (MO-2) and adjust if a node expects a different format.
+# LTX-2.3 native audio: the on-box `ltx-2.3-22b-distilled-fp8.safetensors` baked
+# a 2048-dim audio connector and is the wrong lineage for the Gemma-3-12B encoder
+# (needs 3840-dim) — it is rm -f'd below and replaced by the "dev" checkpoint set:
+# dev-fp8 + dev-nvfp4 (Blackwell-native) checkpoints + the distilled-1.1 LoRA
+# (the audio path is dev checkpoint + LoRA, not the single-file distilled).
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -75,9 +77,19 @@ spec:
               download "text_encoders/t5xxl_fp8_e4m3fn_scaled.safetensors" \
                 "$HF/comfyanonymous/flux_text_encoders/resolve/main/t5xxl_fp8_e4m3fn_scaled.safetensors"
 
-              # ── LTX-2 (NVFP8 fp8 + GGUF Q3_K_S) + Gemma-3 encoder + VAEs ──
-              download "checkpoints/ltx-2.3-22b-distilled-fp8.safetensors" \
-                "$HF/Lightricks/LTX-2.3-fp8/resolve/main/ltx-2.3-22b-distilled-fp8.safetensors"
+              # ── LTX-2.3 "dev" set (Gemma-3-paired native audio) + GGUF + VAEs ──
+              # The Gemma-3-12B encoder needs the 3840-dim "dev" checkpoint; the
+              # old single-file `distilled-fp8` baked a 2048-dim audio connector
+              # (wrong lineage) and is removed here. Native audio uses the dev
+              # checkpoint + the distilled-1.1 LoRA. NVFP4 is Blackwell-native for
+              # the RTX 5070 Ti (lower VRAM than fp8); needs ComfyUI >= v0.24.
+              rm -f /app/models/checkpoints/ltx-2.3-22b-distilled-fp8.safetensors
+              download "checkpoints/ltx-2.3-22b-dev-fp8.safetensors" \
+                "$HF/Lightricks/LTX-2.3-fp8/resolve/main/ltx-2.3-22b-dev-fp8.safetensors"
+              download "checkpoints/ltx-2.3-22b-dev-nvfp4.safetensors" \
+                "$HF/Lightricks/LTX-2.3-nvfp4/resolve/main/ltx-2.3-22b-dev-nvfp4.safetensors"
+              download "loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors" \
+                "$HF/Comfy-Org/ltx-2.3/resolve/main/split_files/loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors"
               download "unet/LTX-2.3-22B-distilled-1.1-Q3_K_S.gguf" \
                 "$HF/QuantStack/LTX-2.3-GGUF/resolve/main/LTX-2.3-distilled-1.1/LTX-2.3-22B-distilled-1.1-Q3_K_S.gguf"
               download "text_encoders/gemma-3-12b-it-Q4_K_S.gguf" \

--- a/apps/comfyui/manifests/pvc.yaml
+++ b/apps/comfyui/manifests/pvc.yaml
@@ -1,8 +1,10 @@
 # Persistent storage for ComfyUI models (checkpoints, GGUF, VAEs, text encoders).
-# 200Gi holds the stoa video stack: LTX-Video 0.9.8 + LTX-2 (NVFP8 ~29.5GB +
-# GGUF Q3_K_S ~14GB) + Wan 2.2 (2x ~15GB MoE experts) + text encoders + Kokoro/
-# Fish TTS (~110GB of weights) plus headroom for outputs/cache. Longhorn online
-# expansion (allowVolumeExpansion=true); never shrink (k8s rejects it).
+# 200Gi holds the stoa video stack: LTX-Video 0.9.8 + LTX-2.3 "dev" set (fp8
+# ~29GB + nvfp4 ~21.7GB checkpoints + distilled-1.1 LoRA; the wrong-lineage
+# distilled-fp8 ~29.5GB was removed) + GGUF Q3_K_S ~14GB + Wan 2.2 (2x ~15GB MoE
+# experts) + text encoders + Kokoro/Fish TTS (~130GB of weights) plus headroom
+# for outputs/cache. Longhorn online expansion (allowVolumeExpansion=true);
+# never shrink (k8s rejects it).
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/01.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/01.yaml
@@ -1,0 +1,77 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Image bump — ComfyUI core v0.9.2 → v0.24.0
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Bump COMFYUI_REF + STOA_NODES and re-pin the image tag
+  steps:
+  - id: P1.T1.S1
+    text: |
+      **Write tag-consistency assertion (RED).** Throwaway check that the
+      new image tag is consistent across all three files and the old tag is
+      gone. Must FAIL before edits.
+
+      ```bash
+      cd "$WT"   # isolation worktree root
+      OLD=comfyui-v0.9.2-pt2.10.0-cu128-stoa3
+      NEW=comfyui-v0.24.0-pt2.10.0-cu128-stoa4
+      ! grep -rq "$OLD" apps/comfyui/ \
+        && grep -q 'COMFYUI_REF=v0.24.0' apps/comfyui/docker/Dockerfile \
+        && grep -q 'COMFYUI_REF: "v0.24.0"' .github/workflows/build-comfyui.yml \
+        && grep -q 'STOA_NODES: "4"' .github/workflows/build-comfyui.yml \
+        && [ "$(grep -rl "$NEW" apps/comfyui/manifests | wc -l)" = "2" ]
+      ```
+      Expected NOW: non-zero exit (RED — old tag still present).
+  - id: P1.T1.S2
+    text: |
+      **Bump Dockerfile ARG.** In `apps/comfyui/docker/Dockerfile`:
+      `ARG COMFYUI_REF=v0.9.2` → `ARG COMFYUI_REF=v0.24.0`.
+  - id: P1.T1.S3
+    text: |
+      **Bump workflow COMFYUI_REF + STOA_NODES.** In
+      `.github/workflows/build-comfyui.yml`:
+      - `COMFYUI_REF: "v0.9.2"` → `"v0.24.0"`
+      - `STOA_NODES: "3"` → `"4"`
+      - Add a `# rev 4:` comment above STOA_NODES documenting the core bump
+        (v0.9.2→v0.24.0, LTX-2.3 a/v fixes + NVFP4 load support).
+  - id: P1.T1.S4
+    text: |
+      **Re-pin image tag (×2).** Replace
+      `comfyui-v0.9.2-pt2.10.0-cu128-stoa3` →
+      `comfyui-v0.24.0-pt2.10.0-cu128-stoa4` in both
+      `apps/comfyui/manifests/deployment.yaml` and
+      `apps/comfyui/manifests/job-model-download.yaml`.
+  - id: P1.T1.S5
+    text: |
+      **Run assertion (GREEN) + commit.** Re-run the S1 check — expect exit
+      0. Then `git commit` (feat(gpu): bump ComfyUI core to v0.24.0).
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S5:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/01.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/01.yaml
@@ -52,26 +52,26 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:59:25+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:59:27+00:00'
       note: null
     P1.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:59:28+00:00'
       note: null
     P1.T1.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:59:30+00:00'
       note: null
     P1.T1.S5:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T20:59:31+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T20:59:33+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/02.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/02.yaml
@@ -1,0 +1,78 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Hydration Job — LTX-2.3 dev model set
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Rewrite the LTX-2 download block + remove the wrong checkpoint
+  steps:
+  - id: P2.T1.S1
+    text: |
+      **Write model-inventory assertion (RED).** Check over
+      `apps/comfyui/manifests/job-model-download.yaml`: three new artefacts
+      referenced, old distilled-fp8 download line gone, `rm -f` present.
+
+      ```bash
+      J=apps/comfyui/manifests/job-model-download.yaml
+      grep -q 'checkpoints/ltx-2.3-22b-dev-fp8.safetensors' "$J" \
+        && grep -q 'checkpoints/ltx-2.3-22b-dev-nvfp4.safetensors' "$J" \
+        && grep -q 'loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors' "$J" \
+        && grep -q 'rm -f .*ltx-2.3-22b-distilled-fp8.safetensors' "$J" \
+        && ! grep -q 'download "checkpoints/ltx-2.3-22b-distilled-fp8.safetensors"' "$J"
+      ```
+      Expected NOW: non-zero (RED).
+  - id: P2.T1.S2
+    text: |
+      **Edit the hydration Job download block.** In the LTX-2 section of
+      the Job command:
+      - Add `rm -f /app/models/checkpoints/ltx-2.3-22b-distilled-fp8.safetensors`
+        before the download() calls (idempotent cleanup of the wrong file).
+      - Remove the `download "checkpoints/ltx-2.3-22b-distilled-fp8.safetensors" …` line.
+      - Add three download() calls (verified URLs, 2026-06-15):
+        - `checkpoints/ltx-2.3-22b-dev-fp8.safetensors`
+          ← `$HF/Lightricks/LTX-2.3-fp8/resolve/main/ltx-2.3-22b-dev-fp8.safetensors`
+        - `checkpoints/ltx-2.3-22b-dev-nvfp4.safetensors`
+          ← `$HF/Lightricks/LTX-2.3-nvfp4/resolve/main/ltx-2.3-22b-dev-nvfp4.safetensors`
+        - `loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors`
+          ← `$HF/Comfy-Org/ltx-2.3/resolve/main/split_files/loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors`
+      - Update the header comment block (model inventory + 2026-06-15 note;
+        NVFP4 is Blackwell-native for the RTX 5070 Ti).
+  - id: P2.T1.S3
+    text: |
+      **Refresh pvc.yaml capacity comment.** Update
+      `apps/comfyui/manifests/pvc.yaml` comment to reflect the dev
+      checkpoints (fp8 ~29GB + NVFP4 ~21.7GB) replacing the removed
+      distilled-fp8. No size change (stays 200Gi).
+  - id: P2.T1.S4
+    text: |
+      **Run assertion + yamllint + URL check (GREEN) + commit.** Re-run the
+      S1 check (exit 0); `yamllint apps/comfyui/manifests/job-model-download.yaml`;
+      verify the three HF URLs resolve (302) via
+      `curl -sI -o /dev/null -w '%{http_code}'`. Then `git commit`
+      (feat(gpu): hydrate LTX-2.3 dev model set).
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/02.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/02.yaml
@@ -57,22 +57,22 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:02:22+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:02:23+00:00'
       note: null
     P2.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:02:25+00:00'
       note: null
     P2.T1.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:02:26+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T21:02:28+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/03.yaml
@@ -29,14 +29,14 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:24:21+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:24:22+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T21:24:24+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/03.yaml
@@ -1,0 +1,42 @@
+schema_version: 2
+phase:
+  number: 3
+  title: CI build validation (branch)
+  tag: agentic
+  depends_on:
+  - 1
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Validate the v0.24.0 image builds on the feature branch
+  steps:
+  - id: P3.T1.S1
+    text: |
+      **Trigger the build on the branch.** Push the branch, then dispatch
+      (workflow runs on push:main docker/** OR workflow_dispatch; dispatch
+      validates the branch without merging):
+      ```bash
+      gh workflow run build-comfyui.yml --ref feat/stoa-comfyui-models-70
+      ```
+  - id: P3.T1.S2
+    text: |
+      **Watch the run to completion.** `gh run watch <id>` (or poll
+      `gh run list --workflow=build-comfyui.yml`). Expected: build succeeds,
+      pushes `comfyui-v0.24.0-pt2.10.0-cu128-stoa4` to GHCR. A FAILURE means
+      the core jump broke a custom node → bump that node ref (fast-follow)
+      and re-run. Record the run URL in the PR body.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/04.yaml
@@ -1,0 +1,36 @@
+schema_version: 2
+phase:
+  number: 4
+  title: '[manual] Cluster re-hydration + render verification'
+  tag: agentic
+  depends_on:
+  - 1
+  - 2
+  - 3
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Operator-driven post-merge Test Plan
+  steps:
+  - id: P4.T1.S1
+    text: |
+      **MANUAL — operator-driven, post-merge.** Touches live gpu-1, ~50GB
+      HF downloads, the stoa runner. The agent does NOT run this; it ships
+      unimplemented for the operator, who pushes evidence to the PR.
+
+      Per the spec `## Test Plan`:
+      1. CI build green (validated on branch in Phase 3; re-runs on merge, cache-hit).
+      2. ArgoCD syncs the deployment image pin (replicas:0 by design — GPU time-share).
+      3. `kubectl delete job comfyui-stoa-model-download -n comfyui` + re-apply; watch logs (new models in, old distilled-fp8 removed).
+      4. GPU switcher (192.168.55.214:8080) → ComfyUI up; `GET /object_info` lists dev-fp8 + dev-nvfp4 checkpoints + distilled LoRA.
+      5. Small LTX-2.3 audio+video render via the stoa runner completes (G2 proof).
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-15-gpu-comfyui-ltx23-dev
+spec: docs/superpowers/specs/2026-06-15-gpu-comfyui-ltx23-dev-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-15'

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/_prose.md
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/_prose.md
@@ -1,0 +1,55 @@
+# ComfyUI v0.24 bump + LTX-2.3 "dev" model hydration (gpu-1)
+
+Frank-side implementation of the stoa pipeline's native-audio unblock
+(content-factory#70). The on-box `ltx-2.3-22b-distilled-fp8` checkpoint is the
+wrong lineage — its baked audio connector is 2048-dim while the installed
+Gemma-3-12B encoder needs 3840-dim — so native LTX-2 audio fails. The fix is to
+hydrate the current Gemma-paired **LTX-2.3 "dev"** checkpoint set and move the
+ComfyUI core off the stale January `v0.9.2`.
+
+> **OPSEC.** Public frank repo. The pipeline is the "stoa pipeline"/"stoa
+> runner" everywhere — never the private codename, in any commit, comment, or
+> manifest.
+
+## Scope (operator-approved, Blackwell-optimal)
+
+fp8 dev checkpoint **+** distilled-1.1 LoRA **+** NVFP4 dev checkpoint **+**
+ComfyUI core bump `v0.9.2 → v0.24.0`, **and** removal of the wrong-lineage
+on-box `distilled-fp8` checkpoint. NVFP4 weight loading needs the v0.24.x core;
+the RTX 5070 Ti is Blackwell → native NVFP4 matmul, lower VRAM than fp8.
+
+## Phases
+
+1. **Image bump** — `COMFYUI_REF v0.9.2→v0.24.0` (Dockerfile + workflow),
+   `STOA_NODES 3→4` with a rev comment, and re-pin the derived tag
+   `comfyui-v0.24.0-pt2.10.0-cu128-stoa4` in `deployment.yaml` +
+   `job-model-download.yaml`. The tag is composed from these vars, so all three
+   tag occurrences must move together or the deploy serves a stale image.
+2. **Hydration Job** — rewrite the LTX-2 download block: drop the distilled-fp8
+   line, add an idempotent `rm -f` of the old file, add fp8-dev + NVFP4-dev
+   checkpoints + the distilled LoRA. Refresh the pvc.yaml capacity comment.
+3. **CI build validation** — dispatch `build-comfyui.yml` on the branch to prove
+   the 5-month / 15-minor core jump compiles before merge. A failure means a
+   pinned custom node broke → bump that one node ref as a fast-follow.
+4. **[manual] Cluster verification** — back-loaded, operator-driven post-merge:
+   ArgoCD sync, Job delete+re-apply re-hydration, GPU-switcher bring-up,
+   `/object_info` check, and a small LTX-2.3 audio+video render (the real G2
+   proof). Ships unimplemented; the operator pushes evidence to the PR.
+
+## Key facts (verified 2026-06-15)
+
+- ComfyUI `v0.24.0` (2026-06-03); `v0.23.0` fixed the LTX a/v bugs.
+- fp8: `Lightricks/LTX-2.3-fp8/…/ltx-2.3-22b-dev-fp8.safetensors`
+- nvfp4: `Lightricks/LTX-2.3-nvfp4/…/ltx-2.3-22b-dev-nvfp4.safetensors`
+- LoRA: `Comfy-Org/ltx-2.3/…/split_files/loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors`
+- PVC `comfyui-models` 200Gi; net ≈ +22GB after removing the old checkpoint.
+- ComfyUI Deployment is `replicas: 0` (gpu-1 GPU time-share); the download Job
+  requests no GPU and runs anytime.
+
+## Risks
+
+- **Core jump may break pinned custom nodes** (LTXVideo/GGUF/Wan/Kokoro/Fish).
+  Caught by Phase 3 (build) + the operator's render (runtime). Nodes are NOT
+  pre-bumped; fix the offender as a fast-follow. The kornia-`pad` Dockerfile
+  patch is keyed to kornia, not ComfyUI core — carries forward unchanged.
+- **Job immutability** → re-hydration is delete+apply (operator, Phase 4).

--- a/docs/superpowers/specs/2026-06-15-gpu-comfyui-ltx23-dev-design.md
+++ b/docs/superpowers/specs/2026-06-15-gpu-comfyui-ltx23-dev-design.md
@@ -1,0 +1,119 @@
+# Design: ComfyUI v0.24 bump + LTX-2.3 "dev" model hydration (gpu-1)
+
+**Status:** ready
+**Layer:** gpu
+**Date:** 2026-06-15
+**Source:** stoa pipeline ticket (content-factory#70) — native-audio gate (G2)
+
+## Goal
+
+Move gpu-1's ComfyUI from the stale `v0.9.2` core to `v0.24.0` and hydrate the
+current, Gemma-3-paired **LTX-2.3 "dev"** checkpoint set into the `comfyui-models`
+PVC, replacing the wrong-lineage on-box `distilled-fp8` checkpoint. This unblocks
+the stoa video pipeline's native-audio gate, which currently fails because the
+on-box checkpoint's baked audio connector is 2048-dim while the installed
+Gemma-3-12B text encoder requires 3840-dim.
+
+The frank-side deliverable is **image + model store** only. The stoa runner graph
+wiring lives in the private content-factory repo and is out of scope here.
+
+> **OPSEC.** This is the public frank repo. Refer to the pipeline only as the
+> "stoa pipeline"/"stoa runner". Do not write the private codename in any frank
+> artifact (spec, plan, commit, manifest comment, blog).
+
+## Operator decisions (batched Q&A, 2026-06-15)
+
+1. **Scope:** Blackwell-optimal — fp8 dev checkpoint **+** distilled-1.1 LoRA
+   **+** NVFP4 dev checkpoint **+** ComfyUI core bump to v0.24.0. (NVFP4 weight
+   loading requires the v0.24.x core; the RTX 5070 Ti is Blackwell → native NVFP4
+   matmul, lower VRAM than fp8.)
+2. **On-box wrong checkpoint:** Remove `ltx-2.3-22b-distilled-fp8.safetensors`
+   (2048-dim connector, unusable for the Gemma audio path; ~29.5 GB reclaimed).
+3. **Test plan:** Full — download + a real LTX-2.3 audio+video render
+   (operator-driven, post-merge).
+
+## Verified facts (HuggingFace + GitHub, 2026-06-15)
+
+- ComfyUI releases: `v0.22.0` (05-20), `v0.23.0` (06-01, **fixed two LTX
+  audio-video correctness bugs**), `v0.24.0` (06-03). Current pin `v0.9.2`
+  (01-15) is ~5 months / 15 minor versions stale. Target = **`v0.24.0`** (latest
+  with a full GitHub release; `v0.24.1` exists as a tag but has no release object).
+- fp8 dev: `https://huggingface.co/Lightricks/LTX-2.3-fp8/resolve/main/ltx-2.3-22b-dev-fp8.safetensors` (~29 GB)
+- NVFP4 dev: `https://huggingface.co/Lightricks/LTX-2.3-nvfp4/resolve/main/ltx-2.3-22b-dev-nvfp4.safetensors` (~21.7 GB)
+- distilled LoRA: `https://huggingface.co/Comfy-Org/ltx-2.3/resolve/main/split_files/loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors`
+- Gemma-3-12B encoder + spatial upscaler: already on-box (from content-factory#69).
+- PVC `comfyui-models` = 200Gi (`allowVolumeExpansion=true`). Net delta:
+  `-29.5` (remove distilled-fp8) `+29 +21.7 +~2` ≈ **+22 GB** → fits comfortably.
+
+## Changes (frank repo only)
+
+All paths under `apps/comfyui/` unless noted.
+
+1. **`docker/Dockerfile`** — `ARG COMFYUI_REF=v0.9.2` → `v0.24.0`.
+2. **`.github/workflows/build-comfyui.yml`** —
+   - `COMFYUI_REF: "v0.9.2"` → `"v0.24.0"`
+   - `STOA_NODES: "3"` → `"4"` + a `# rev 4:` comment documenting the core bump
+     (the rev-log is the image's human-readable change history; the tag is also
+     made unique by the `v0.24.0` change, so this is belt-and-suspenders).
+3. **Re-pin the image tag** `comfyui-v0.9.2-pt2.10.0-cu128-stoa3` →
+   `comfyui-v0.24.0-pt2.10.0-cu128-stoa4` in both:
+   - `manifests/deployment.yaml`
+   - `manifests/job-model-download.yaml`
+4. **`manifests/job-model-download.yaml`** (the hydration Job):
+   - **Remove** the `distilled-fp8` download line.
+   - **Add** a one-line `rm -f` of the old `checkpoints/ltx-2.3-22b-distilled-fp8.safetensors`
+     before the downloads (idempotent; `-f` so a re-run after deletion is a no-op).
+   - **Add** downloads:
+     - `checkpoints/ltx-2.3-22b-dev-fp8.safetensors`
+     - `checkpoints/ltx-2.3-22b-dev-nvfp4.safetensors`
+     - `loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors`
+   - Update the header comment block (model inventory + the 2026-06-15 verification note).
+5. **`manifests/pvc.yaml`** — refresh the capacity-budget comment to reflect the
+   dev checkpoints replacing the distilled one. No size change.
+
+## Risks & mitigations
+
+- **Primary risk — core jump (v0.9.2 → v0.24.0) breaks the pinned custom nodes**
+  (ComfyUI-LTXVideo, GGUF, WanVideoWrapper, Kokoro, FishSpeech) at build or
+  runtime. Mitigation: validate the image build on the feature branch via
+  `gh workflow run build-comfyui.yml --ref feat/stoa-comfyui-models-70`
+  (catches pip/import breakage at build time); the operator's post-merge render
+  catches runtime node-load issues. **Node SHAs are NOT pre-bumped** — bump only
+  the offending node as a fast-follow if the build or render surfaces a break.
+  The Dockerfile's existing kornia-`pad` patch is keyed to kornia, not ComfyUI
+  core, so it carries forward unchanged.
+- **NVFP4 filename drift** — verified present in the repo today; the download is
+  skip-if-present, so a wrong name fails loudly in the Job log (not silently).
+- **Job immutability** — k8s Jobs are immutable and the comfyui ArgoCD app has no
+  `Replace=true`; re-hydration is `kubectl delete job … && kubectl apply -f`
+  (or ArgoCD recreate). This makes re-hydration an operator step (back-loaded).
+
+## Test Plan (post-merge, operator-driven)
+
+1. **CI build** — `comfyui-v0.24.0-pt2.10.0-cu128-stoa4` builds green
+   (validated on the branch pre-merge; re-runs on merge via the docker/** push trigger, cache-hit).
+2. **Deploy** — after merge, ArgoCD syncs `deployment.yaml`, re-pinning the
+   image. The Deployment is `replicas: 0` by design (gpu-1 GPU time-share —
+   ComfyUI and Ollama alternate on the GPU; the Application `ignoreDifferences`
+   on `/spec/replicas`), so no pod starts on sync. Confirm the pin landed:
+   `kubectl -n comfyui get deploy comfyui -o jsonpath='{.spec.template.spec.containers[0].image}'`.
+3. **Re-hydrate** — the download Job requests no GPU (`nodeSelector: gpu-1`), so
+   it runs even while Ollama holds the GPU. `kubectl delete job
+   comfyui-stoa-model-download -n comfyui` then re-apply (or let ArgoCD
+   recreate); watch logs → new checkpoints + LoRA downloaded, old `distilled-fp8`
+   removed. (~50 GB; the Job is immutable, hence the delete+apply.)
+4. **Bring ComfyUI up + /object_info** — switch the GPU to ComfyUI via the GPU
+   switcher (`192.168.55.214:8080` — scales ComfyUI→1, Ollama→0); once the pod is
+   Ready, `GET /object_info` → `CheckpointLoaderSimple.ckpt_name` lists
+   `ltx-2.3-22b-dev-fp8.safetensors` **and** `ltx-2.3-22b-dev-nvfp4.safetensors`;
+   the LoRA loader lists the distilled-1.1 LoRA.
+5. **Render** — a small LTX-2.3 audio+video test render via the stoa runner
+   completes (e.g. 544×960, ~97 frames / 8n+1, 8 distilled steps) — the real G2
+   proof that native audio works.
+
+## Manual phases (back-loaded)
+
+Steps 2–5 of the Test Plan touch the live gpu-1 cluster, ~50 GB of HF downloads,
+and the stoa runner — all operator-driven post-merge. The PR ships the
+Dockerfile / workflow / manifest changes; the operator runs the Test Plan and
+pushes any node-bump fast-follow to the same PR if a break surfaces.

--- a/docs/superpowers/specs/2026-06-15-gpu-comfyui-ltx23-dev-design.md
+++ b/docs/superpowers/specs/2026-06-15-gpu-comfyui-ltx23-dev-design.md
@@ -111,6 +111,12 @@ All paths under `apps/comfyui/` unless noted.
    completes (e.g. 544×960, ~97 frames / 8n+1, 8 distilled steps) — the real G2
    proof that native audio works.
 
+## Implementation Plans
+
+| Plan | Target repo | Slug | Status |
+|------|-------------|------|--------|
+| 2026-06-15-gpu-comfyui-ltx23-dev | `derio-net/frank` | `2026-06-15-gpu-comfyui-ltx23-dev` | — |
+
 ## Manual phases (back-loaded)
 
 Steps 2–5 of the Test Plan touch the live gpu-1 cluster, ~50 GB of HF downloads,


### PR DESCRIPTION
## Summary

Bumps gpu-1's ComfyUI image **core v0.9.2 → v0.24.0** and re-hydrates the
**LTX-2.3 "dev"** model set on the `comfyui-models` PVC, unblocking the stoa
pipeline's native-audio path. The on-box `ltx-2.3-22b-distilled-fp8.safetensors`
is the wrong lineage — its baked audio connector is 2048-dim while the installed
Gemma-3-12B encoder needs 3840-dim — so it is removed and replaced by the dev set:
**dev-fp8 + dev-nvfp4** (Blackwell-native for the RTX 5070 Ti) checkpoints **+ the
distilled-1.1 LoRA**.

Source: stoa pipeline ticket (content-factory#70). Frank-side deliverable is
**image + model store** only; the stoa runner graph wiring lives in the private
content-factory repo and is out of scope here.

- **Spec:** `docs/superpowers/specs/2026-06-15-gpu-comfyui-ltx23-dev-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/`

## Changes (agentic phases 1–3, all complete)

- **Phase 1 — image bump:** `COMFYUI_REF v0.9.2 → v0.24.0` (Dockerfile + workflow),
  `STOA_NODES 3 → 4` with a `# rev 4:` changelog line, and the derived tag
  `comfyui-v0.24.0-pt2.10.0-cu128-stoa4` re-pinned in `deployment.yaml` +
  `job-model-download.yaml`. (v0.23.0 fixed two LTX audio-video bugs; v0.24.x adds
  NVFP4 weight-loading. Custom-node SHAs unchanged.)
- **Phase 2 — hydration Job:** drop the distilled-fp8 download, `rm -f` the old
  file (idempotent), add dev-fp8 + dev-nvfp4 checkpoints + the distilled-1.1 LoRA;
  refresh the PVC capacity comment (no size change — stays 200Gi, net ≈ +22 GB).
- **Phase 3 — CI build validation:** the v0.24.0 image **built green** on this
  branch and pushed to GHCR — proves the 5-month / 15-minor core jump compiles
  with the existing custom-node pins. Run:
  https://github.com/derio-net/frank/actions/runs/27576456251
  (manifest `comfyui-v0.24.0-pt2.10.0-cu128-stoa4@sha256:f4af61…`).

## Verified facts (HuggingFace + GitHub, 2026-06-15)

- ComfyUI `v0.24.0` (2026-06-03); `v0.23.0` fixed the LTX a/v bugs.
- All three model URLs resolve (HTTP 302, no token):
  `Lightricks/LTX-2.3-fp8/…/ltx-2.3-22b-dev-fp8.safetensors`,
  `Lightricks/LTX-2.3-nvfp4/…/ltx-2.3-22b-dev-nvfp4.safetensors`,
  `Comfy-Org/ltx-2.3/…/split_files/loras/ltx_2.3_22b_distilled_1.1_lora_dynamic_fro09_avg_rank_111_bf16.safetensors`.

## Code review

Reviewed clean — **no Critical / Important / Minor blocking findings**. Verified:
the derived tag composes correctly and is pinned identically in all three places
(no stale `v0.9.2` / `stoa3`); the hydration bash is correct (`rm -f` precedes,
no dest conflict, old line gone); OPSEC clean (no private codename anywhere); doc
math consistent. One immaterial nit (PVC comment "~130GB" vs spec "+22 GB"
rounding) — reviewer confirmed no change needed.

## ⚠️ Phase 4 — UNIMPLEMENTED (operator-driven, back-loaded)

The cluster re-hydration + render verification touch the live gpu-1 cluster,
~50 GB of HF downloads, and the stoa runner — operator-only. **This phase ships
deliberately unimplemented; the operator runs the Test Plan post-merge and pushes
any evidence / node-bump fast-follow to this PR.**

### Test Plan (post-merge — operator-driven)

1. **CI build** — `comfyui-v0.24.0-pt2.10.0-cu128-stoa4` builds green (already
   validated on this branch; re-runs on merge via the docker/** push trigger, cache-hit).
2. **Deploy** — after merge, ArgoCD syncs `deployment.yaml`, re-pinning the image.
   The Deployment is `replicas: 0` by design (gpu-1 GPU time-share — ComfyUI/Ollama
   alternate; Application `ignoreDifferences` on `/spec/replicas`), so no pod starts
   on sync. Confirm the pin:
   `kubectl -n comfyui get deploy comfyui -o jsonpath='{.spec.template.spec.containers[0].image}'`.
3. **Re-hydrate** — the Job requests no GPU (`nodeSelector: gpu-1`), so it runs
   even while Ollama holds the GPU. `kubectl delete job comfyui-stoa-model-download
   -n comfyui` then re-apply (or let ArgoCD recreate); watch logs → new checkpoints
   + LoRA downloaded, old `distilled-fp8` removed (~50 GB; Job is immutable, hence
   delete+apply).
4. **Bring up + /object_info** — switch the GPU to ComfyUI via the GPU switcher
   (`192.168.55.214:8080` — scales ComfyUI→1, Ollama→0); once Ready, `GET /object_info`
   → `CheckpointLoaderSimple.ckpt_name` lists `ltx-2.3-22b-dev-fp8.safetensors`
   **and** `ltx-2.3-22b-dev-nvfp4.safetensors`; the LoRA loader lists the
   distilled-1.1 LoRA.
5. **Render** — a small LTX-2.3 audio+video test render via the stoa runner
   completes (e.g. 544×960, ~97 frames / 8n+1, 8 distilled steps) — the real proof
   that native audio works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
