### PR TITLE
fix(obs): alert-agent — split GoatCounter secret + optional envFrom (unblock pod)

### DIFF
--- a/apps/alert-agent/manifests/deployment.yaml
+++ b/apps/alert-agent/manifests/deployment.yaml
@@ -49,7 +49,12 @@ spec:
             - { name: SURGE_COOLDOWN_HOURS, value: "6" }
             - { name: SURGE_STATE_PATH, value: "/home/agent/.alert-agent/surge-state.json" }
           envFrom:
-            - secretRef: { name: alert-agent-secrets }   # FRANK_C2_TELEGRAM_* + OBS_GOATCOUNTER_API_TOKEN
+            # optional:true so a missing/lagging Secret never blocks the pod
+            # (the gotcha: a non-optional envFrom secretRef wedges it on a missing
+            # Secret). Telegram is required-but-present; GoatCounter may be absent
+            # until seeded (facts.py is fail-open).
+            - secretRef: { name: alert-agent-secrets, optional: true }       # FRANK_C2_TELEGRAM_*
+            - secretRef: { name: alert-agent-goatcounter, optional: true }   # OBS_GOATCOUNTER_API_TOKEN
           volumeMounts:
             - { name: home, mountPath: /home/agent }
             - { name: pylib-frankfacts, mountPath: /opt/pylib/frank_facts }
@@ -74,7 +79,8 @@ spec:
             - { name: PYTHONPATH, value: "/opt/pylib" }
             - { name: AGENT_SESSION_URL, value: "http://localhost:8765" }   # shared pod netns
           envFrom:
-            - secretRef: { name: alert-agent-secrets }
+            - secretRef: { name: alert-agent-secrets, optional: true }
+            - secretRef: { name: alert-agent-goatcounter, optional: true }
           volumeMounts:
             - { name: pylib-frankfacts, mountPath: /opt/pylib/frank_facts }
             - { name: pylib-bridge, mountPath: /opt/pylib/tg_bridge }
@@ -98,7 +104,8 @@ spec:
             - { name: GRAFANA_WEBHOOK_PORT, value: "8090" }
             - { name: VICTORIALOGS_URL, value: "http://victoria-logs-victoria-logs-single-server.monitoring.svc.cluster.local:9428" }
           envFrom:
-            - secretRef: { name: alert-agent-secrets }
+            - secretRef: { name: alert-agent-secrets, optional: true }
+            - secretRef: { name: alert-agent-goatcounter, optional: true }
           volumeMounts:
             - { name: pylib-frankfacts, mountPath: /opt/pylib/frank_facts }
             - { name: pylib-bridge, mountPath: /opt/pylib/tg_bridge }

--- a/apps/alert-agent/manifests/externalsecret.yaml
+++ b/apps/alert-agent/manifests/externalsecret.yaml
@@ -4,9 +4,9 @@ metadata:
   name: alert-agent-secrets
   namespace: alert-agent
 spec:
-  # Telegram bot token + chat id (the @agent_zero_cc_bot the old helper used) and
-  # the GoatCounter stats-scoped token. Mirrors the old ai-alert-helper-secrets +
-  # the litellm ExternalSecret pattern (ClusterSecretStore infisical).
+  # REQUIRED — Telegram bot token + chat id (the @agent_zero_cc_bot the old helper
+  # used). These keys exist in Infisical (also pulled by argocd-notifications,
+  # grafana-alerting, hermes-agent-shell), so this secret always syncs.
   refreshInterval: 5m
   secretStoreRef:
     name: infisical
@@ -20,5 +20,29 @@ spec:
       remoteRef: { key: FRANK_C2_TELEGRAM_BOT_TOKEN }
     - secretKey: FRANK_C2_TELEGRAM_CHAT_ID
       remoteRef: { key: FRANK_C2_TELEGRAM_CHAT_ID }
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alert-agent-goatcounter
+  namespace: alert-agent
+spec:
+  # OPTIONAL — the GoatCounter stats token. `OBS_GOATCOUNTER_API_TOKEN` was never
+  # seeded into Infisical (the seed was deferred; the value lives as the
+  # `grafana-goatcounter-token` Secret in monitoring). So this ExternalSecret may
+  # stay SecretSyncedError (Infisical 404) until the operator seeds it — see the
+  # manual-op `obs-alert-agent-goatcounter-infisical-seed`. It is in its OWN secret
+  # (not bundled with the Telegram keys) and mounted `optional: true`, so the pod
+  # runs without it; facts.py is fail-open (GoatCounter calls return None → the
+  # surge visitor cross-check + digest pageviews degrade gracefully, nothing crashes).
+  refreshInterval: 5m
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: alert-agent-goatcounter
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
     - secretKey: OBS_GOATCOUNTER_API_TOKEN
       remoteRef: { key: OBS_GOATCOUNTER_API_TOKEN }

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -1801,3 +1801,15 @@ operations:
   verify:
   - "agent-session send returns status:ok with a payload (not timeout); then all four triggers deliver to Telegram (digest, a synthetic surge, a test Grafana alert, an inbound allowlisted DM)"
   status: pending
+- id: obs-alert-agent-goatcounter-infisical-seed
+  layer: obs
+  app: alert-agent
+  plan: docs/superpowers/plans/2026-06-15--obs--agentic-alert-helper/
+  when: anytime — restores GoatCounter facts (digest pageviews + surge visitor cross-check); the agent runs without it (fail-open) until then
+  why_manual: OBS_GOATCOUNTER_API_TOKEN was never seeded into Infisical (the seed was deferred in the hop-blog-edge-monitoring plan); the token value lives only as the grafana-goatcounter-token Secret in the monitoring ns
+  commands:
+  - "# Read the existing token value:\nkubectl get secret grafana-goatcounter-token -n monitoring -o jsonpath='{.data.*}' | base64 -d; echo\n# (Infisical UI, project frank-cluster, env prod, path /) add secret:\n#   OBS_GOATCOUNTER_API_TOKEN = <that value>\n# Then force the ExternalSecret to re-sync:\nkubectl -n alert-agent annotate externalsecret alert-agent-goatcounter force-sync=$(date +%s) --overwrite\n"
+  verify:
+  - "kubectl -n alert-agent get externalsecret alert-agent-goatcounter  # READY=True, SecretSynced"
+  - "kubectl -n alert-agent get secret alert-agent-goatcounter  # exists"
+  status: pending


### PR DESCRIPTION
Live deploy of #563 wedged the pod at `CreateContainerConfigError`: the ExternalSecret 404'd on `OBS_GOATCOUNTER_API_TOKEN` (never seeded into Infisical — the value lives only as `monitoring/grafana-goatcounter-token`), and one bad key fails the whole secret while the non-optional `envFrom` blocks the pod.

**Fix:** split GoatCounter into its own ExternalSecret (can't fail the required Telegram keys, which DO exist in Infisical) + mark all `envFrom` `optional:true` (the documented gotcha). The pod now starts on Telegram alone; `facts.py` is fail-open so GoatCounter facts (digest pageviews + surge visitor cross-check) degrade gracefully. Manual-op `obs-alert-agent-goatcounter-infisical-seed` restores full GoatCounter once the token is seeded into Infisical.

Found by driving the post-merge deploy of #563.

🤖 Generated with [Claude Code](https://claude.com/claude-code)