### PR TITLE
fix(obs): alert-agent ExternalSecrets — explicit remoteRef defaults (clear OutOfSync)

### DIFF
--- a/apps/alert-agent/manifests/externalsecret.yaml
+++ b/apps/alert-agent/manifests/externalsecret.yaml
@@ -16,10 +16,22 @@ spec:
     creationPolicy: Owner
     deletionPolicy: Retain
   data:
+    # Set the remoteRef defaults EXPLICITLY (conversionStrategy/decodingStrategy/
+    # metadataPolicy) — the CRD defaults them on the live object, so omitting them
+    # leaves ArgoCD perpetually OutOfSync on a git-vs-live diff (matches the working
+    # litellm ExternalSecret pattern).
     - secretKey: FRANK_C2_TELEGRAM_BOT_TOKEN
-      remoteRef: { key: FRANK_C2_TELEGRAM_BOT_TOKEN }
+      remoteRef:
+        key: FRANK_C2_TELEGRAM_BOT_TOKEN
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
     - secretKey: FRANK_C2_TELEGRAM_CHAT_ID
-      remoteRef: { key: FRANK_C2_TELEGRAM_CHAT_ID }
+      remoteRef:
+        key: FRANK_C2_TELEGRAM_CHAT_ID
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -45,4 +57,8 @@ spec:
     deletionPolicy: Retain
   data:
     - secretKey: OBS_GOATCOUNTER_API_TOKEN
-      remoteRef: { key: OBS_GOATCOUNTER_API_TOKEN }
+      remoteRef:
+        key: OBS_GOATCOUNTER_API_TOKEN
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None


### PR DESCRIPTION
The alert-agent ExternalSecrets show perpetually **OutOfSync** (Healthy, working) because the CRD defaults `conversionStrategy`/`decodingStrategy`/`metadataPolicy` on the live object, but the compact `remoteRef: { key: ... }` omits them → ArgoCD diffs git-vs-live forever. Set the three defaults explicitly on every remoteRef, matching the already-Synced litellm ExternalSecret pattern. Found driving the post-merge deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)