### PR TITLE
fix(gpu): persist ComfyUI output + user dirs (PVCs)

### DIFF
--- a/apps/comfyui/manifests/deployment.yaml
+++ b/apps/comfyui/manifests/deployment.yaml
@@ -65,6 +65,14 @@ spec:
               mountPath: /app/models
             - name: custom-nodes
               mountPath: /app/custom_nodes
+            # Persist generated assets + saved workflows/settings. /app/output and
+            # /app/user are ephemeral by default, so a pod recreate (image bump or
+            # GPU-time-share scale 0->1) wipes renders and UI workflows. PVC-back
+            # them so they survive restarts.
+            - name: output
+              mountPath: /app/output
+            - name: user
+              mountPath: /app/user
           startupProbe:
             httpGet:
               path: /
@@ -93,3 +101,9 @@ spec:
         - name: custom-nodes
           persistentVolumeClaim:
             claimName: comfyui-custom-nodes
+        - name: output
+          persistentVolumeClaim:
+            claimName: comfyui-output
+        - name: user
+          persistentVolumeClaim:
+            claimName: comfyui-user

--- a/apps/comfyui/manifests/pvc-output.yaml
+++ b/apps/comfyui/manifests/pvc-output.yaml
@@ -1,0 +1,16 @@
+# Persistent storage for ComfyUI generated assets (/app/output).
+# Ephemeral by default — a pod recreate (image bump or GPU-time-share scale
+# 0->1) wipes renders. 50Gi holds many LTX-2.3 / Wan video test outputs;
+# Longhorn online expansion (allowVolumeExpansion=true).
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-output
+  namespace: comfyui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 50Gi

--- a/apps/comfyui/manifests/pvc-user.yaml
+++ b/apps/comfyui/manifests/pvc-user.yaml
@@ -1,0 +1,15 @@
+# Persistent storage for ComfyUI user state (/app/user): saved workflows,
+# settings, and the workflow browser. Ephemeral by default — a pod recreate
+# wipes saved workflows. Small (workflows are JSON); 2Gi is generous.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: comfyui-user
+  namespace: comfyui
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi

--- a/docs/runbooks/frank-gotchas/gpu-1.md
+++ b/docs/runbooks/frank-gotchas/gpu-1.md
@@ -65,6 +65,14 @@ the PVC and restart so the entrypoint re-seeds the patched copy —
 `kubectl -n comfyui exec deploy/comfyui -- rm -rf /app/custom_nodes/<NodeName>`
 then `kubectl -n comfyui rollout restart deploy/comfyui`.
 
+**Persistence (which dirs survive a restart).** Only `/app/models`
+(`comfyui-models`), `/app/custom_nodes` (`comfyui-custom-nodes`), `/app/output`
+(`comfyui-output`) and `/app/user` (`comfyui-user`) are PVC-backed. `output`
+(generated assets) and `user` (saved workflows/settings) were added later — they
+were ephemeral originally, so a pod recreate (image bump or GPU-time-share scale
+0→1) silently wiped renders and saved workflows (cost an early set of stoa-agent
+test assets). Anything ComfyUI writes elsewhere in `/app` is still ephemeral.
+
 ## Intel GPU Resource Driver (separate from gpu-1)
 
 Uses a vendored chart with K8s 1.35 DRA patches. Lives in `patches/phase05-mini-config/` for the iGPUs on the mini-* nodes — distinct from gpu-1's NVIDIA stack.


### PR DESCRIPTION
## Summary

ComfyUI persisted `/app/models` and `/app/custom_nodes` but **not** `/app/output`
(generated assets) or `/app/user` (saved workflows + settings) — those lived in
the pod's ephemeral container layer. So a pod recreate — an image bump, or every
GPU-time-share scale `0→1` (Ollama↔ComfyUI), or a node reboot — silently wiped
all renders and saved workflows. This is what discarded the earlier stoa-agent
test assets.

## Change (manifest-only, no image rebuild)

- New PVCs: `comfyui-output` (50Gi) → `/app/output`, `comfyui-user` (2Gi) → `/app/user`.
- Mount both in the comfyui Deployment.
- Documented in `docs/runbooks/frank-gotchas/gpu-1.md` (which dirs survive a restart).

## Deploy / verify

Directory-sourced app (no kustomization) → ArgoCD picks up the new PVC manifests
automatically. `strategy: Recreate` + RWO Longhorn PVCs on gpu-1 (where ComfyUI
is pinned). On sync: PVCs bind, the pod recreates with the two new mounts; fresh
empty volumes (ComfyUI repopulates `user/default` on boot). Verify:
`kubectl -n comfyui exec deploy/comfyui -- sh -c 'mount | grep -E "/app/output|/app/user"'`.

> Note: existing ephemeral content is wiped one final time by this recreate (nothing
> of value present now); everything written afterward persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)