### PR TITLE
chore(gpu): ComfyUI LTX-2.3 close-out + imagePullPolicy IfNotPresent

### DIFF
--- a/apps/comfyui/manifests/deployment.yaml
+++ b/apps/comfyui/manifests/deployment.yaml
@@ -34,6 +34,11 @@ spec:
       containers:
         - name: comfyui
           image: ghcr.io/derio-net/comfyui:comfyui-v0.24.0-pt2.10.0-cu128-stoa5
+          # IfNotPresent (not Always): the tag is unique per image rev
+          # (…-stoaN), so a genuinely-new image still pulls, while restarts /
+          # GPU-time-share switches reuse the node cache instead of re-pulling
+          # ~20GB over gpu-1's slow NIC every time.
+          imagePullPolicy: IfNotPresent
           # Overrides the image CMD to add VRAM/offload flags for the 16GB
           # RTX 5070 Ti. The stoa runner drives one clip at a time, so models
           # load serially: reserve a little VRAM for the OS and don't cache

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/04.yaml
@@ -27,10 +27,14 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-16T21:08:27+00:00'
       note: null
   completion:
-    at: null
-    note: null
+    at: '2026-06-16T21:08:34+00:00'
+    note: 'Cluster verification done end-to-end (deploy stoa5, re-hydrate dev-fp8+nvfp4+LoRA,
+      old checkpoint removed, /object_info lists LTXAVTextEncoderLoader + dev checkpoints
+      + LoRA). Two fast-follows: #562 (LTXVideo seed version-gate, kornia regression)
+      + #566 (persist output/user PVCs). G2 audio+video render DEFERRED to content-factory
+      runner graph (P8) per operator.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/_prose.md
+++ b/docs/superpowers/plans/2026-06-15-gpu-comfyui-ltx23-dev/_prose.md
@@ -64,3 +64,16 @@ already-seeded PVC (a stale unpatched copy shadowed it). Fixed as a fast-follow
 (`fix/comfyui-node-reseed-versiongate`): version-gate the entrypoint seed
 (`.seed-version` marker, `STOA_NODES 4→5`) so an image-rev bump re-seeds baked
 nodes. See `docs/runbooks/frank-gotchas/gpu-1.md` (ComfyUI custom-node PVC seed).
+
+Second deviation: the redeploys also exposed that `/app/output` (renders) and
+`/app/user` (saved workflows) were **ephemeral** — a pod recreate (image bump /
+GPU-time-share scale 0→1) wiped them (cost an early set of stoa-agent test
+assets). Fixed in `fix/comfyui-persist-output-user` (PR #566): added
+`comfyui-output` (50Gi) + `comfyui-user` (2Gi) PVCs + mounts; manifest-only.
+
+**G2 status:** frank's deliverable is Deployed and verified end-to-end via
+`/object_info` (v0.24.0 + dev-fp8/dev-nvfp4 checkpoints + distilled LoRA +
+`LTXAVTextEncoderLoader` and the native-audio node set all load). The actual
+audio+video render is **deferred** — the content-factory runner's real LTX-2.3
+graph (the P8 "live phase"; `build_prompt` is still a placeholder) isn't built
+yet, which is out of this frank ticket's scope.

--- a/docs/superpowers/specs/2026-06-15-gpu-comfyui-ltx23-dev-design.md
+++ b/docs/superpowers/specs/2026-06-15-gpu-comfyui-ltx23-dev-design.md
@@ -115,7 +115,7 @@ All paths under `apps/comfyui/` unless noted.
 
 | Plan | Target repo | Slug | Status |
 |------|-------------|------|--------|
-| 2026-06-15-gpu-comfyui-ltx23-dev | `derio-net/frank` | `2026-06-15-gpu-comfyui-ltx23-dev` | — |
+| 2026-06-15-gpu-comfyui-ltx23-dev | `derio-net/frank` | `2026-06-15-gpu-comfyui-ltx23-dev` | Deployed (G2 render deferred to content-factory) |
 
 ## Manual phases (back-loaded)
 


### PR DESCRIPTION
Finalizes the ComfyUI LTX-2.3 deployment.

**Docs/plan close-out:** records Phase-4 completion + the two fast-follows (#562 LTXVideo seed version-gate, #566 output/user persistence) and marks the plan Deployed. The G2 audio+video render is deferred to the content-factory runner's LTX-2.3 graph (P8 "live phase", currently a placeholder `build_prompt`) — out of this frank ticket's scope. Frank side is verified end-to-end via `/object_info`.

**imagePullPolicy Always → IfNotPresent:** `Always` re-pulled the full ~20GB image on every pod recreate (image bump / GPU-time-share scale 0→1), which crawls on gpu-1's slow NIC — the cause of every slow rollout this session. The tag is unique per rev (…-stoaN), so IfNotPresent still pulls genuinely-new images but reuses the node cache on restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)