### PR TITLE
alert-agent Telegram UX — slash commands + ack/answer reactions

### DIFF
--- a/apps/alert-agent/manifests/deployment.yaml
+++ b/apps/alert-agent/manifests/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       containers:
         # --- main: the persistent agent session + the surge/digest cron --------
         - name: agent
-          image: ghcr.io/derio-net/multi-agent-shell:56c652ede9414152ec12b068f271b160937b52cf
+          image: ghcr.io/derio-net/multi-agent-shell:c946a672aa5dc16b24fc65273c8cdc3da17bb854
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: ["ALL"] }
@@ -65,7 +65,7 @@ spec:
             limits: { memory: 3Gi }
         # --- sidecar: inbound Telegram (single getUpdates consumer) ------------
         - name: telegram-bridge
-          image: ghcr.io/derio-net/multi-agent-shell:56c652ede9414152ec12b068f271b160937b52cf
+          image: ghcr.io/derio-net/multi-agent-shell:c946a672aa5dc16b24fc65273c8cdc3da17bb854
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: ["ALL"] }
@@ -85,7 +85,7 @@ spec:
             limits: { memory: 96Mi }
         # --- sidecar: grafana-webhook receiver (the re-pointed contact point) --
         - name: grafana-webhook
-          image: ghcr.io/derio-net/multi-agent-shell:56c652ede9414152ec12b068f271b160937b52cf
+          image: ghcr.io/derio-net/multi-agent-shell:c946a672aa5dc16b24fc65273c8cdc3da17bb854
           securityContext:
             allowPrivilegeEscalation: false
             capabilities: { drop: ["ALL"] }

--- a/apps/alert-agent/telegram-bridge/tests/test_bridge.py
+++ b/apps/alert-agent/telegram-bridge/tests/test_bridge.py
@@ -30,6 +30,11 @@ def _sent(rec, method):
     return [p for (u, p) in rec.calls if u.endswith(method)]
 
 
+def _reactions(rec):
+    """Emoji set on each setMessageReaction call, in call order."""
+    return [p["reaction"][0]["emoji"] for (u, p) in rec.calls if u.endswith("/setMessageReaction")]
+
+
 def test_allowlisted_message_drives_agent_and_replies(calls):
     calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "inference is on gpu-1"}}
     drove = bridge.process_update({"message": {"chat": {"id": 100}, "text": "why is X firing?"}})
@@ -137,3 +142,45 @@ def test_freetext_still_drives_agent(calls):
     bridge.process_update({"message": {"chat": {"id": 100}, "text": "why is X firing?"}})
     sent = _sent(calls, "/session/send")
     assert len(sent) == 1 and sent[0]["message"] == "why is X firing?"
+
+
+# --- Thread C: ack/answer reactions -------------------------------------------
+
+def test_tg_react_posts_reaction(calls):
+    bridge.tg_react("100", 7, "⚡")
+    sent = _sent(calls, "/setMessageReaction")
+    assert len(sent) == 1
+    assert sent[0]["chat_id"] == "100" and sent[0]["message_id"] == 7
+    assert sent[0]["reaction"] == [{"type": "emoji", "emoji": "⚡"}]
+
+
+def test_tg_react_swallows_failure(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("api down")
+    monkeypatch.setattr(bridge, "_http_post_json", boom)
+    monkeypatch.setattr(bridge, "BOT_TOKEN", "T")
+    bridge.tg_react("100", 7, "⚡")   # best-effort: must NOT raise
+
+
+def test_reaction_ack_then_thumbsup(calls):
+    calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "ok"}}
+    bridge.process_update({"message": {"message_id": 42, "chat": {"id": 100}, "text": "hi"}})
+    assert _reactions(calls) == ["⚡", "👍"]
+
+
+def test_reaction_ack_then_thinking(calls):
+    calls.canned["/session/send"] = {"status": "timeout", "payload": None}
+    bridge.process_update({"message": {"message_id": 42, "chat": {"id": 100}, "text": "hi"}})
+    assert _reactions(calls) == ["⚡", "🤔"]   # fallback → thinking-face, not thumbs-up
+
+
+def test_reaction_on_slash_prompt(calls):
+    calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "d"}}
+    bridge.process_update({"message": {"message_id": 9, "chat": {"id": 100}, "text": "/digest"}})
+    assert _reactions(calls) == ["⚡", "👍"]
+
+
+def test_reaction_on_static_help(calls):
+    # /help never touches the agent but still gets receipt → done reactions.
+    bridge.process_update({"message": {"message_id": 3, "chat": {"id": 100}, "text": "/help"}})
+    assert _reactions(calls) == ["⚡", "👍"]

--- a/apps/alert-agent/telegram-bridge/tests/test_bridge.py
+++ b/apps/alert-agent/telegram-bridge/tests/test_bridge.py
@@ -67,3 +67,73 @@ def test_deliver_uses_agent_payload_when_present(calls):
     resp = {"status": "ok", "payload": {"text": "agent narrative"}}
     bridge.deliver(resp, fallback_text="fallback")
     assert _sent(calls, "/sendMessage")[0]["text"] == "agent narrative"
+
+
+# --- Thread B: slash commands (expand_command + COMMANDS registry) -------------
+
+CATALOG = ["/help", "/digest", "/surge", "/edge-traffic", "/security", "/status"]
+
+
+def test_commands_registry_shape():
+    # COMMANDS is the single source of truth for setMyCommands AND routing: a
+    # dict keyed by the six /-prefixed commands, each with a menu description.
+    assert set(bridge.COMMANDS) == set(CATALOG)
+    for spec in bridge.COMMANDS.values():
+        assert spec["desc"]  # non-empty menu text
+
+
+def test_expand_command_help_is_static_and_lists_catalog():
+    kind, payload = bridge.expand_command("/help")
+    assert kind == "static"
+    for cmd in CATALOG:
+        assert cmd in payload   # the help body names every command
+
+
+def test_expand_command_prompt_carries_defaults_suffix():
+    kind, payload = bridge.expand_command("/digest")
+    assert kind == "prompt"
+    assert "frank-facts" in payload
+    assert "sensible defaults" in payload   # Defaults-&-proceed, encoded once
+
+
+def test_expand_command_appends_operator_args():
+    kind, payload = bridge.expand_command("/edge-traffic hop-1")
+    assert kind == "prompt"
+    assert "hop-1" in payload   # operator-typed trailing args reach the agent
+
+
+def test_expand_command_unknown():
+    kind, payload = bridge.expand_command("/foo")
+    assert kind == "unknown"
+    assert payload == "Unknown command — try /help"
+
+
+def test_slash_help_no_agent(calls):
+    drove = bridge.process_update({"message": {"chat": {"id": 100}, "text": "/help"}})
+    assert drove is True
+    assert _sent(calls, "/session/send") == []          # static — agent NOT driven
+    replies = _sent(calls, "/sendMessage")
+    assert len(replies) == 1 and "/digest" in replies[0]["text"]
+
+
+def test_slash_prompt_drives_agent(calls):
+    calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "digest narrative"}}
+    bridge.process_update({"message": {"chat": {"id": 100}, "text": "/digest"}})
+    sent = _sent(calls, "/session/send")
+    assert len(sent) == 1
+    assert "frank-facts" in sent[0]["message"] and "sensible defaults" in sent[0]["message"]
+    assert _sent(calls, "/sendMessage")[0]["text"] == "digest narrative"
+
+
+def test_slash_unknown_replies_directly(calls):
+    bridge.process_update({"message": {"chat": {"id": 100}, "text": "/nope"}})
+    assert _sent(calls, "/session/send") == []          # unknown — agent NOT driven
+    assert _sent(calls, "/sendMessage")[0]["text"] == "Unknown command — try /help"
+
+
+def test_freetext_still_drives_agent(calls):
+    # No leading slash → the unchanged free-text Q&A path forwards verbatim.
+    calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "free answer"}}
+    bridge.process_update({"message": {"chat": {"id": 100}, "text": "why is X firing?"}})
+    sent = _sent(calls, "/session/send")
+    assert len(sent) == 1 and sent[0]["message"] == "why is X firing?"

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -48,7 +48,10 @@ def tg_react(chat_id, message_id, emoji: str) -> None:
     """Set a single emoji reaction on a message — best-effort feedback (⚡ on
     receipt, 👍/🤔 on completion). A reaction failure must NEVER block or delay
     the reply, so any error is swallowed with a WARN. setMessageReaction REPLACES
-    the reaction set, so ⚡ → 👍/🤔 reads as 'working → done'."""
+    the reaction set, so ⚡ → 👍/🤔 reads as 'working → done'.
+
+    NOTE: `emoji` MUST be from Telegram's fixed reaction allowlist (⚡ 👍 🤔 are);
+    an off-list emoji 400s and — by design — fails silently here."""
     try:
         _tg("setMessageReaction", {"chat_id": chat_id, "message_id": message_id,
                                    "reaction": [{"type": "emoji", "emoji": emoji}]})
@@ -118,13 +121,14 @@ def expand_command(text: str):
     kind 'prompt'  → payload is the agent instruction (template + operator args + defaults).
     kind 'unknown' → payload is the not-found reply.
     """
-    word, _, rest = text.strip().partition(" ")
+    parts = text.strip().split(None, 1)   # split on any whitespace run, not just " "
+    word = parts[0] if parts else ""
     spec = COMMANDS.get(word)
     if spec is None:
         return "unknown", "Unknown command — try /help"
     if spec["kind"] == "static":
         return "static", _help_text()
-    args = rest.strip()
+    args = parts[1].strip() if len(parts) > 1 else ""
     instruction = spec["template"] + ((" " + args) if args else "") + _DEFAULTS_SUFFIX
     return "prompt", instruction
 

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -44,6 +44,18 @@ def is_allowed(chat_id) -> bool:
     return str(chat_id) in ALLOWED_CHATS
 
 
+def tg_react(chat_id, message_id, emoji: str) -> None:
+    """Set a single emoji reaction on a message — best-effort feedback (⚡ on
+    receipt, 👍/🤔 on completion). A reaction failure must NEVER block or delay
+    the reply, so any error is swallowed with a WARN. setMessageReaction REPLACES
+    the reaction set, so ⚡ → 👍/🤔 reads as 'working → done'."""
+    try:
+        _tg("setMessageReaction", {"chat_id": chat_id, "message_id": message_id,
+                                   "reaction": [{"type": "emoji", "emoji": emoji}]})
+    except Exception as exc:  # noqa: BLE001
+        print(f"WARN telegram-bridge: setMessageReaction failed: {exc}", file=sys.stderr)
+
+
 # --- Slash commands ------------------------------------------------------------
 # COMMANDS is the SINGLE source of truth for both the Telegram menu (setMyCommands)
 # and routing. A command is never argument-parsed: a templated command becomes one
@@ -161,6 +173,7 @@ def process_update(update: dict) -> bool:
     are dropped with a WARN (the gate working, not the bot broken)."""
     msg = update.get("message") or update.get("edited_message") or {}
     chat_id = (msg.get("chat") or {}).get("id")
+    message_id = msg.get("message_id")
     text = (msg.get("text") or "").strip()
     if chat_id is None or not text:
         return False
@@ -168,6 +181,12 @@ def process_update(update: dict) -> bool:
         print(f"WARN telegram-bridge: dropped message from non-allowlisted chat {chat_id}",
               file=sys.stderr)
         return False
+
+    def react(emoji):
+        if message_id is not None:
+            tg_react(str(chat_id), message_id, emoji)
+
+    react("⚡")   # receipt — fired BEFORE the (possibly slow) turn so feedback is instant
     # Slash command? Static/unknown are answered by the bridge directly (so /help
     # works even when the agent is cold); a prompt command expands to an agent
     # instruction. No leading slash → the unchanged free-text Q&A path.
@@ -175,6 +194,7 @@ def process_update(update: dict) -> bool:
         kind, payload = expand_command(text)
         if kind in ("static", "unknown"):
             tg_send(payload, str(chat_id))
+            react("👍")
             return True
         message = payload
     else:
@@ -182,8 +202,10 @@ def process_update(update: dict) -> bool:
     # Shorter timeout for an interactive DM than the cron 300s — a stuck turn
     # must not freeze the single getUpdates consumer for 5 minutes.
     resp = session_send(message, session_id=f"{SESSION_ID}-tg-{chat_id}", timeout_s=120)
-    reply = render_payload(resp) or "(the agent did not return a reply — it may be busy or unauthenticated)"
-    tg_send(reply, str(chat_id))
+    rendered = render_payload(resp)
+    tg_send(rendered or "(the agent did not return a reply — it may be busy or unauthenticated)",
+            str(chat_id))
+    react("👍" if rendered is not None else "🤔")   # 🤔 = only the deterministic fallback was posted
     return True
 
 

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -44,6 +44,79 @@ def is_allowed(chat_id) -> bool:
     return str(chat_id) in ALLOWED_CHATS
 
 
+# --- Slash commands ------------------------------------------------------------
+# COMMANDS is the SINGLE source of truth for both the Telegram menu (setMyCommands)
+# and routing. A command is never argument-parsed: a templated command becomes one
+# English instruction for the agent (which has the frank-facts CLI as a shell tool),
+# carrying a "use sensible defaults" suffix — so the argless-from-menu trap (Telegram
+# sends a menu command bare) simply has no positional arg to be missing.
+_DEFAULTS_SUFFIX = (
+    " Use sensible defaults and answer now; if a parameter is truly needed, pick the "
+    "obvious default and state which you used."
+)
+
+COMMANDS = {
+    "/help": {"desc": "List the available commands", "kind": "static"},
+    "/digest": {
+        "desc": "On-demand daily digest",
+        "kind": "prompt",
+        "template": "Run the daily digest (`frank-facts digest`) and summarize for the operator.",
+    },
+    "/surge": {
+        "desc": "Current traffic-surge status",
+        "kind": "prompt",
+        "template": "Report current surge status (`frank-facts surge`).",
+    },
+    "/edge-traffic": {
+        "desc": "Hop edge traffic summary",
+        "kind": "prompt",
+        "template": (
+            "Summarize Hop edge traffic — top scanned paths and attacker IPs "
+            "(`frank-facts top-scanned-paths`, `top-attacker-ips`), last 24h by default."
+        ),
+    },
+    "/security": {
+        "desc": "Security picture (CrowdSec/Falco/scans)",
+        "kind": "prompt",
+        "template": (
+            "Summarize the security picture — CrowdSec decisions and scan patterns "
+            "(`frank-facts crowdsec`, `scan-patterns`) plus any notable Falco events."
+        ),
+    },
+    "/status": {
+        "desc": "Cluster + alert-agent health snapshot",
+        "kind": "prompt",
+        "template": (
+            "Give a short cluster + alert-agent health snapshot from the HTTP probes you "
+            "can reach (Derio Ops / blackbox)."
+        ),
+    },
+}
+
+
+def _help_text() -> str:
+    lines = ["Commands:"] + [f"{cmd} — {spec['desc']}" for cmd, spec in COMMANDS.items()]
+    return "\n".join(lines)
+
+
+def expand_command(text: str):
+    """Map a leading-slash message to (kind, payload).
+
+    kind 'static'  → payload is text the bridge replies with directly (no agent).
+    kind 'prompt'  → payload is the agent instruction (template + operator args + defaults).
+    kind 'unknown' → payload is the not-found reply.
+    """
+    word, _, rest = text.strip().partition(" ")
+    spec = COMMANDS.get(word)
+    if spec is None:
+        return "unknown", "Unknown command — try /help"
+    if spec["kind"] == "static":
+        return "static", _help_text()
+    args = rest.strip()
+    instruction = spec["template"] + ((" " + args) if args else "") + _DEFAULTS_SUFFIX
+    return "prompt", instruction
+
+
 def session_send(message: str, session_id: str | None = None, timeout_s: float = 300) -> dict:
     """Drive the persistent agent session. Returns the agent-session response
     {session_id, agent, status, turn, payload}; status 'timeout' → payload None."""
@@ -95,16 +168,38 @@ def process_update(update: dict) -> bool:
         print(f"WARN telegram-bridge: dropped message from non-allowlisted chat {chat_id}",
               file=sys.stderr)
         return False
+    # Slash command? Static/unknown are answered by the bridge directly (so /help
+    # works even when the agent is cold); a prompt command expands to an agent
+    # instruction. No leading slash → the unchanged free-text Q&A path.
+    if text.startswith("/"):
+        kind, payload = expand_command(text)
+        if kind in ("static", "unknown"):
+            tg_send(payload, str(chat_id))
+            return True
+        message = payload
+    else:
+        message = text
     # Shorter timeout for an interactive DM than the cron 300s — a stuck turn
     # must not freeze the single getUpdates consumer for 5 minutes.
-    resp = session_send(text, session_id=f"{SESSION_ID}-tg-{chat_id}", timeout_s=120)
+    resp = session_send(message, session_id=f"{SESSION_ID}-tg-{chat_id}", timeout_s=120)
     reply = render_payload(resp) or "(the agent did not return a reply — it may be busy or unauthenticated)"
     tg_send(reply, str(chat_id))
     return True
 
 
+def set_my_commands() -> None:
+    """Register the Telegram command menu from COMMANDS (best-effort — a failure
+    logs a WARN and the bridge runs anyway; the menu is a nicety, not a dependency)."""
+    try:
+        cmds = [{"command": c.lstrip("/"), "description": s["desc"]} for c, s in COMMANDS.items()]
+        _tg("setMyCommands", {"commands": cmds})
+    except Exception as exc:  # noqa: BLE001
+        print(f"WARN telegram-bridge: setMyCommands failed: {exc}", file=sys.stderr)
+
+
 def poll_loop(poll_timeout: int = 30) -> None:  # pragma: no cover - network loop
     """Long-poll getUpdates forever (single consumer per bot token)."""
+    set_my_commands()
     offset = 0
     while True:
         try:

--- a/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/01.yaml
+++ b/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/01.yaml
@@ -1,0 +1,97 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Thread B — Telegram slash commands (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED — tests for COMMANDS registry + expand_command
+  steps:
+  - id: P1.T1.S1
+    text: |
+      In `apps/alert-agent/telegram-bridge/tests/test_bridge.py` add tests for a new pure
+      `bridge.expand_command(text) -> (kind, payload)`. Cover all four kinds:
+        * `expand_command("/help")` → `("static", help_text)` where `help_text` mentions
+          every catalog command (`/digest`, `/surge`, `/edge-traffic`, `/security`,
+          `/status`, `/help`).
+        * `expand_command("/digest")` → `("prompt", s)` where `s` contains `frank-facts`
+          AND the Defaults-&-proceed suffix substring `"sensible defaults"`.
+        * `expand_command("/edge-traffic hop-1")` → `("prompt", s)` where `s` ends with /
+          contains the operator-typed arg `"hop-1"` (args appended to the template).
+        * `expand_command("/foo")` → `("unknown", "Unknown command — try /help")`.
+      Also assert the registry shape: `bridge.COMMANDS` is a dict whose keys are the six
+      `/`-prefixed commands and whose values carry a menu description string (the
+      `setMyCommands` source). Run `cd apps/alert-agent/telegram-bridge && uv run --with
+      pytest pytest tests/ -q`. Expected: FAIL (RED — `expand_command`/`COMMANDS` undefined).
+- number: 2
+  title: GREEN — COMMANDS registry + expand_command
+  steps:
+  - id: P1.T2.S1
+    text: |
+      Add to `tg_bridge/bridge.py` a `COMMANDS` dict — the single source of truth for both
+      the Telegram menu and routing. Each entry: `{"desc": <menu text>, "kind":
+      "static"|"prompt", "template": <str for prompt kind>}`. Catalog (templates map to
+      `frank-facts` subcommands the agent has as a shell tool):
+        /help         static
+        /digest       "Run the daily digest (`frank-facts digest`) and summarize for the operator."
+        /surge        "Report current surge status (`frank-facts surge`)."
+        /edge-traffic "Summarize Hop edge traffic — top scanned paths and attacker IPs (`frank-facts top-scanned-paths`, `top-attacker-ips`), last 24h by default."
+        /security     "Summarize the security picture — CrowdSec decisions and scan patterns (`frank-facts crowdsec`, `scan-patterns`) plus any notable Falco events."
+        /status       "Give a short cluster + alert-agent health snapshot from the HTTP probes you can reach (Derio Ops / blackbox)."
+      Implement `_help_text()` (renders the command list from `COMMANDS`) and
+      `expand_command(text)`: split first whitespace token as the command word + remainder
+      as operator args; `/help` → `("static", _help_text())`; known template → `("prompt",
+      template + (" " + args if args) + " Use sensible defaults and answer now; if a
+      parameter is truly needed, pick the obvious default and state which you used.")`;
+      unknown → `("unknown", "Unknown command — try /help")`. The Defaults-&-proceed suffix
+      lives in exactly one place. Run the suite. Expected: GREEN.
+- number: 3
+  title: Route slash commands in process_update (TDD)
+  steps:
+  - id: P1.T3.S1
+    text: |
+      RED — add routing tests to `test_bridge.py` using the existing `calls` fixture:
+        * `test_slash_help_no_agent`: `process_update({"message":{"chat":{"id":100},
+          "text":"/help"}})` → `_sent(calls,"/session/send") == []` (agent NOT driven) and
+          one `/sendMessage` whose text contains `/digest` (the help body).
+        * `test_slash_prompt_drives_agent`: `text:"/digest"` → exactly one `/session/send`
+          whose payload `message` contains `frank-facts` and `sensible defaults`; one reply.
+        * `test_slash_unknown_replies_directly`: `text:"/nope"` → no `/session/send`; one
+          `/sendMessage` text == `"Unknown command — try /help"`.
+        * `test_freetext_still_drives_agent`: the existing free-text assertion still holds
+          (no leading `/` → verbatim `/session/send`).
+      Run the suite. Expected: FAIL (RED — process_update doesn't branch on `/`).
+  - id: P1.T3.S2
+    text: |
+      GREEN — in `process_update`, after the allowlist gate, if `text.startswith("/")`
+      dispatch via `expand_command`: `static`/`unknown` → `tg_send(payload, str(chat_id))`
+      and return True WITHOUT calling `session_send`; `prompt` → `session_send(payload, …)`
+      then reply (reuse the existing render_payload+fallback line). No leading `/` → the
+      unchanged free-text path. Add `set_my_commands()` (best-effort: POST `setMyCommands`
+      with `[{"command": k.lstrip("/"), "description": v["desc"]} for k,v in COMMANDS]`,
+      wrapped try/except → WARN on failure) and call it once at `poll_loop` entry
+      (`poll_loop` stays `# pragma: no cover`). Run the suite. Expected: GREEN.
+state:
+  steps:
+    P1.T1.S1:
+      state: x
+      ticked_at: '2026-06-16T21:05:02+00:00'
+      note: null
+    P1.T2.S1:
+      state: x
+      ticked_at: '2026-06-16T21:05:04+00:00'
+      note: null
+    P1.T3.S1:
+      state: x
+      ticked_at: '2026-06-16T21:05:06+00:00'
+      note: null
+    P1.T3.S2:
+      state: x
+      ticked_at: '2026-06-16T21:05:07+00:00'
+      note: null
+  completion:
+    at: '2026-06-16T21:05:09+00:00'
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/02.yaml
+++ b/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/02.yaml
@@ -1,0 +1,69 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Thread C — ack/answer reactions (TDD)
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED+GREEN — tg_react best-effort helper
+  steps:
+  - id: P2.T1.S1
+    text: |
+      RED — add tests: `test_tg_react_posts_reaction` asserts `bridge.tg_react("100", 7,
+      "⚡")` makes one `/setMessageReaction` call with `chat_id=="100"`, `message_id==7`,
+      and `reaction==[{"type":"emoji","emoji":"⚡"}]`. `test_tg_react_swallows_failure`:
+      monkeypatch `_http_post_json` to raise, assert `tg_react(...)` returns without raising
+      (best-effort). Run the suite. Expected: FAIL (RED — `tg_react` undefined).
+  - id: P2.T1.S2
+    text: |
+      GREEN — add `tg_react(chat_id, message_id, emoji)` to `bridge.py`: calls `_tg(
+      "setMessageReaction", {"chat_id": chat_id, "message_id": message_id, "reaction":
+      [{"type":"emoji","emoji": emoji}]})` inside try/except → on exception print a WARN to
+      stderr and return (never propagate). Run the suite. Expected: GREEN.
+- number: 2
+  title: Wire ⚡-on-receipt / 👍|🤔-on-answer into process_update (TDD)
+  steps:
+  - id: P2.T2.S1
+    text: |
+      RED — reaction-ordering tests (the `calls` fixture records order):
+        * `test_reaction_ack_then_thumbsup`: free-text + `/session/send` ok payload →
+          `/setMessageReaction` calls in order emoji `⚡` then `👍`, message_id threaded from
+          the update (`{"message":{"message_id":42,"chat":{"id":100},"text":"hi"}}`).
+        * `test_reaction_ack_then_thinking`: `/session/send` returns `{"status":"timeout",
+          "payload":None}` → reactions `⚡` then `🤔` (fallback path).
+        * `test_reaction_on_slash_prompt`: `text:"/digest"`, ok payload → `⚡` then `👍`.
+      Run the suite. Expected: FAIL (RED — no reactions emitted).
+  - id: P2.T2.S2
+    text: |
+      GREEN — thread `message_id = msg.get("message_id")` through `process_update`. After
+      the allowlist gate (and only when `message_id` is present) call `tg_react(chat_id,
+      message_id, "⚡")` BEFORE any `session_send`. After producing the reply, pick the
+      terminal reaction: `render_payload(resp) is not None` → `"👍"`, else `"🤔"`; for the
+      static/unknown slash replies (which always "succeed") use `"👍"`. Emit the terminal
+      `tg_react` after `tg_send`. All reaction calls are best-effort (tg_react already
+      swallows). Run the suite — all reaction + routing + legacy tests GREEN.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/02.yaml
+++ b/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/02.yaml
@@ -48,22 +48,22 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-16T21:07:49+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-16T21:07:55+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-16T21:08:01+00:00'
       note: null
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-16T21:08:07+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-16T21:08:14+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/03.yaml
+++ b/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/03.yaml
@@ -39,9 +39,10 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-16T22:04:10+00:00'
+      note: bumped multi-agent-shell 56c652e->c946a672 (=#129 merge commit, cold-start
+        fix verified in tag tree)
     P3.T2.S1:
       state: ' '
       ticked_at: null

--- a/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/03.yaml
+++ b/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/03.yaml
@@ -1,0 +1,52 @@
+schema_version: 2
+phase:
+  number: 3
+  title: '[manual] Image SHA bump + post-merge Test Plan'
+  tag: manual
+  depends_on:
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Bump multi-agent-shell image SHA (operator-gated — agent-images merges first)
+  steps:
+  - id: P3.T1.S1
+    text: |
+      BACK-LOADED / MANUAL — do NOT implement during the agentic run; ships unimplemented
+      in the PR. The new image tag does not exist until the agent-images Thread A PR
+      (`2026-06-16-agent-session-coldstart`) merges and CI builds a fresh
+      `ghcr.io/derio-net/multi-agent-shell` tag. Once the operator reports that tag, bump
+      every `multi-agent-shell:<sha>` occurrence in
+      `apps/alert-agent/manifests/deployment.yaml` (currently
+      `56c652ede9414152ec12b068f271b160937b52cf`) to the new SHA and push to THIS PR's
+      branch. ArgoCD rolls the pod (3-container deployment) onto the fixed driver. Record
+      via `fr plan edit --complete-phase 3 --note "<old>…<new>"`.
+- number: 2
+  title: Post-merge Test Plan (operator-driven verification)
+  steps:
+  - id: P3.T2.S1
+    text: |
+      MANUAL / post-merge (both PRs merged, ArgoCD rolled the new image). Operator-driven:
+        1. Cold-start answered — `kubectl -n alert-agent rollout restart deploy/alert-agent`
+           (cold session); from Telegram send a free-text DM ("what's the cluster status?").
+           Expect ⚡ within ~1s, a real agent answer within seconds, reaction flips to 👍 —
+           NOT the "(the agent did not return a reply…)" fallback.
+        2. Argless slash — tap `/edge-traffic` from the Telegram menu (sent bare). Expect
+           ⚡ → a defaults-based edge summary stating the default window used → 👍.
+        3. Static `/help` — tap `/help`. Expect an immediate bridge-rendered command list
+           (no agent latency), ⚡→👍.
+        4. Fallback reaction (optional) — if any turn times out, terminal reaction is 🤔.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-16--obs--alert-agent-telegram-ux
+spec: docs/superpowers/specs/2026-06-16--obs--alert-agent-telegram-ux-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-16'

--- a/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/_prose.md
+++ b/docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux/_prose.md
@@ -1,0 +1,38 @@
+# Alert-Agent Telegram UX (frank portion)
+
+Extends the live agentic alert-agent (PR #563). Two bridge threads + one back-loaded
+cross-repo join. The agent-session **driver** cold-start fix (Thread A) is a separate
+agent-images plan (`2026-06-16-agent-session-coldstart`) that gates only the live smoke test.
+
+## Why these threads
+
+The bridge currently forwards every allowlisted DM verbatim to the agent — no command layer, no
+receipt feedback. Two gaps surface in real use:
+
+- **Slash commands need to survive the argless-from-menu trap.** Telegram's command menu sends a
+  command the instant it's tapped, so a parameterized command always arrives bare. We dissolve the
+  trap instead of handling it: a slash command is a *prompt template* expanded into one English
+  instruction for the agent (which already has `frank-facts`), carrying a "use sensible defaults"
+  suffix. There is no positional arg to be missing. `/help` is the one command rendered by the
+  bridge itself — it must work when the agent is cold.
+- **No ack/answer feedback.** ⚡ on receipt (before the blocking turn) + 👍 on a real answer / 🤔 on
+  the deterministic fallback, via `setMessageReaction`. Best-effort — a reaction failure never
+  blocks the reply.
+
+## Design boundaries
+
+- All changes are pure functions over the existing `_http_post_json` seam, unit-tested the same way
+  as the current 5 bridge tests. `poll_loop` (the network loop) stays `# pragma: no cover`; the
+  only new code there is the best-effort `set_my_commands()` call.
+- Poll loop stays **synchronous** (single getUpdates consumer per bot token). ⚡ fires before the
+  blocking `session_send`, so receipt feedback is instant; per-update threading is deferred (YAGNI,
+  single operator).
+- The bridge code ships via a hash-suffixed `configMapGenerator` (kustomization at the app root), so
+  an edit rolls the pod automatically once merged.
+
+## Cross-repo sequencing
+
+agent-images Thread A merges → CI builds a new `multi-agent-shell` tag → Phase 3 bumps
+`deployment.yaml` to that SHA on this PR (the join) → operator merges → post-merge Test Plan proves
+a cold DM is answered with the ⚡/👍 reactions. Phase 3 is manual/back-loaded: the tag doesn't exist
+until agent-images merges, so the agentic run ships Phases 1–2 and leaves Phase 3 for the operator.

--- a/docs/superpowers/specs/2026-06-16--obs--alert-agent-telegram-ux-design.md
+++ b/docs/superpowers/specs/2026-06-16--obs--alert-agent-telegram-ux-design.md
@@ -1,0 +1,199 @@
+# Alert-Agent Telegram UX + Agent-Session Driver Reliability
+
+**Layers:** obs (frank — extends `apps/alert-agent`) + agent-images (the `agent-session` driver)
+**Status:** Draft
+**Date:** 2026-06-16
+**Repos:** `derio-net/frank`, `derio-net/agent-images` (multi-repo)
+**Extends:** `2026-06-15--obs--agentic-alert-helper-design.md` (the agentic alert-agent this builds on)
+
+## Implementation Plans
+
+| Plan | Target repo | Slug | Status |
+|------|-------------|------|--------|
+| agent-session-coldstart (Thread A, **gating**) | `derio-net/agent-images` | `2026-06-16-agent-session-coldstart` | — |
+| 2026-06-16--obs--alert-agent-telegram-ux (Threads B+C) | `derio-net/frank` | `2026-06-16--obs--alert-agent-telegram-ux` | — |
+
+> Multi-repo, **two plans**. The **agent-images** plan (Thread A — make the baked `agent-session`
+> driver survive a cold session) **gates** the **frank** plan only for the live end-to-end smoke
+> test: the bridge changes (Threads B+C) are independently valuable and independently unit-tested,
+> but the post-merge "cold DM gets answered" proof needs the fixed driver image deployed.
+> Sequence: agent-images merges → CI builds a new `multi-agent-shell` tag → the frank PR bumps the
+> image SHA in `apps/alert-agent/manifests/deployment.yaml` (the cross-repo join) → operator merges
+> → smoke test.
+
+## Problem
+
+The agentic alert-agent (PR #563, live) works end-to-end on a **warm** agent session — a synthetic
+Grafana alert was triaged and delivered to Telegram. But three UX/reliability gaps remain, surfaced
+when the operator tried real Telegram interaction:
+
+1. **Cold-start race — inbound DMs go unanswered.** The baked `agent-session` driver
+   (`multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session`) creates a tmux session
+   with `tmux new-session -d … 'claude --permission-mode auto'` and **returns immediately**. `send()`
+   then pastes the message and presses Enter after a fixed `SETTLE_S=0.5s`. On a **cold** pane
+   (claude still booting its TUI, ~5–8s) the Enter lands before the REPL accepts input → dropped →
+   the turn times out → the bridge posts its "(the agent did not return a reply…)" fallback. The
+   operator's `/edge-traffic` and `/help` both hit this. Turn 2+ on a warm pane works perfectly.
+   Bumping `SETTLE_S` is a band-aid; the structural fix is a readiness gate. A *second* swallowed-Enter
+   source: the first-ever `--permission-mode auto` entry shows a one-time interstitial warning that
+   eats an Enter — the same class of bug `pretrust()` already fixes for the folder-trust dialog.
+
+2. **Slash commands and the argless-from-menu trap.** The old `ai-alert-helper` exposed Telegram
+   commands (`/edge-traffic`, `/help`, …) that needed positional arguments. Telegram's bot command
+   **menu sends a command immediately when tapped** — no chance to append an argument — so a
+   parameterized command always arrived bare and failed. The bridge currently has *no* command
+   layer at all: every allowlisted DM is forwarded verbatim to `/session/send`.
+
+3. **No receipt/answer feedback.** A DM that triggers a multi-second (or timing-out) turn gives the
+   operator no signal that the message was even received. The single getUpdates consumer blocks in
+   `process_update` for the whole turn, so the chat looks dead until the reply (or fallback) lands.
+
+## Thread A — Driver cold-start reliability (`agent-images`)
+
+All three changes are in the single `agent-session` driver file. Stdlib-only, as the rest of it.
+
+**A1. Readiness gate in `ensure_session`.** After `tmux new-session`, poll `tmux capture-pane -p -t
+<session_id>` until the claude REPL input prompt is rendered and accepting input, then return. A
+hard timeout (`AGENT_SESSION_READY_TIMEOUT_S`, default ~30s) caps the wait → on timeout, log to
+stderr and proceed best-effort (never hang a request forever). Covers **every** session id —
+including the lazily-created per-chat DM sessions (`alert-agent-tg-<chat>`) and the
+`alert-agent-ops` handler session — which is why a boot-time pre-warm of one session would not be
+enough. The readiness marker is a stable substring of the claude prompt box; the **exact marker is
+verified live against the running pod** during implementation (`tmux capture-pane` on a real cold
+boot), with a permissive fallback (pane non-empty AND unchanged across two consecutive polls) so a
+marker drift across claude versions degrades to a stability heuristic rather than a hard fail.
+
+**A2. Seed the auto-mode-entry flag in `pretrust()`.** Alongside `hasTrustDialogAccepted=True`, set
+the first-run auto-mode-entry warning flag so the interstitial never appears to eat the first Enter.
+The **exact `~/.claude.json` key is verified live** against the running pod's file during
+implementation (candidate: `hasSeenAutoModeEntryWarning`) — `pretrust()` writes it idempotently the
+same way it writes the trust flag, tolerant of an absent/corrupt file.
+
+**A3. Verified submit in `submit()`.** After the post-paste Enter, re-capture the pane; if the
+pasted message text is still sitting in the input box (not submitted), press Enter once more. A
+belt-and-suspenders that makes submission self-healing even if the A1 readiness marker is wrong on a
+future claude version. Single retry only — no unbounded loop.
+
+**Test (Thread A):** unit tests with a tmux mock (mirroring the existing extract plan's driver
+tests): readiness gate polls then returns once the mocked pane reports ready; `pretrust()` writes
+both flags; verified-submit retries Enter exactly once when the mocked pane still shows the message,
+and not at all when it cleared. The true proof is the post-merge live smoke test (below).
+
+## Thread B — Slash commands (`frank` bridge)
+
+A new command layer in `apps/alert-agent/telegram-bridge/tg_bridge/bridge.py`. No argument parsing —
+commands are **prompt templates** expanded into one English instruction for the agent, which already
+has the `frank-facts` CLI as a shell tool. The argless trap is *dissolved*, not handled: there is no
+positional argument to be missing.
+
+**`COMMANDS` registry** — single source of truth for both `setMyCommands` (the Telegram menu) and
+routing. Each entry: a short menu description + either a **static** handler or a **prompt template**.
+
+| Command | Kind | Behaviour |
+|---------|------|-----------|
+| `/help` | static | Bridge renders the command list directly from the registry — never touches the agent (works when the agent is cold/unauthenticated). |
+| `/digest` | template | "Run the daily digest (`frank-facts digest`) and summarize for the operator." |
+| `/surge` | template | "Report current surge status (`frank-facts surge`)." |
+| `/edge-traffic` | template | "Summarize Hop edge traffic — top scanned paths and attacker IPs (`frank-facts top-scanned-paths`, `top-attacker-ips`), last 24h by default." |
+| `/security` | template | "Summarize the security picture — CrowdSec decisions and scan patterns (`frank-facts crowdsec`, `scan-patterns`), plus any notable Falco events." |
+| `/status` | template | "Give a short cluster + alert-agent health snapshot from the HTTP probes you can reach (Derio Ops / blackbox)." |
+
+**`expand_command(text) -> (kind, payload)`** — pure function: strips the leading `/`, splits the
+command word from any trailing free-text the operator *did* type. Returns:
+- `("static", help_text)` for `/help`;
+- `("prompt", template + appended-args + "Use sensible defaults and answer now; if a parameter is
+  truly needed, pick the obvious default and state which you used.")` for a templated command (the
+  **Defaults & proceed** philosophy, encoded once in the suffix);
+- `("unknown", "Unknown command — try /help")` for an unrecognized `/foo`.
+
+**`setMyCommands` on startup** — best-effort; a failure logs a WARN and the bridge runs anyway (the
+menu is a nicety, not a dependency). Called once at `poll_loop` entry.
+
+**`process_update` routing** — a leading `/` dispatches through `expand_command`: static → reply
+directly (no `session_send`); prompt → `session_send` with the expanded instruction; unknown →
+reply directly. **No leading `/` → unchanged free-text Q&A path** (forward verbatim to the agent).
+
+## Thread C — Ack/answer reactions (`frank` bridge)
+
+`setMessageReaction` on the operator's own message gives instant, in-place feedback.
+
+- **On receipt** (before `session_send`, inside `process_update` once the message is allowlisted): set
+  ⚡ via `setMessageReaction(chat_id, message_id, [{type:"emoji", emoji:"⚡"}])`.
+- **On completion**: set 👍 for a real agent answer; **🤔** when only the deterministic fallback was
+  posted (agent timed out / returned no payload). Reactions **replace** (⚡ → 👍/🤔), so the final
+  glyph tells the operator whether the brain actually answered.
+- **Best-effort, never blocking.** A new `tg_react(chat_id, message_id, emoji)` helper wraps
+  `setMessageReaction` in try/except — a reaction API failure logs a WARN and is swallowed so it can
+  never delay or suppress the reply. Static-command replies (`/help`, unknown) get ⚡→👍 too (they
+  always "succeed"). ⚡ and 👍/🤔 are all in Telegram's allowed free-reaction set.
+
+`process_update` gains the `message_id` (already present in the update) and threads it through.
+`render_payload(resp) is not None` is the existing success/fallback discriminator — reuse it to pick
+👍 vs 🤔.
+
+## Cross-cutting — keep the poll loop synchronous (YAGNI)
+
+The single getUpdates consumer (required: one consumer per bot token) stays **synchronous**. The ⚡
+reaction fires *before* the blocking `session_send`, so the operator gets instant receipt feedback
+even while a turn runs. Thread A collapses warm-turn latency to a few seconds, so the historical
+~120s block largely evaporates. Per-update worker threads (with per-session locks to stop two DMs to
+the same chat interleaving pastes into one tmux session) are **deferred** until a real multi-operator
+need exists — a single-operator ops bot does not justify the concurrency surface.
+
+## Multi-repo sequencing
+
+0. **agent-images is fr-enabled** (verified in the parent work — `.devcontainer/dev` + v2 plans).
+1. **agent-images plan (Thread A) merges first** → CI builds a new `multi-agent-shell` image tag.
+   (agent-images CI builds on `push:main`, `paths-ignore: docs/**`; a branch is validated via
+   `gh workflow run build.yaml --ref <branch>`.)
+2. **frank plan (Threads B+C)** implements the bridge changes (independently unit-tested, no image
+   dependency) and **bumps `apps/alert-agent/manifests/deployment.yaml`** to the new image SHA — the
+   cross-repo join. The SHA only exists after step 1 merges + builds, so the bump is the **last**
+   frank step (back-loaded): the operator reports the agent-images tag, the bump lands on the same
+   frank PR, then the operator merges.
+3. The bridge changes do **not** require the new image to *function* (the bridge talks to the driver
+   over HTTP; A's behaviour change is internal to the driver). The new image is required only for
+   the live cold-start smoke test to pass.
+
+`depends_on` reaches only within a plan — this cross-repo ordering lives here in the spec and in PR
+sequencing, not in either plan's `depends_on`.
+
+## Test Plan (post-merge, operator-driven)
+
+The deliverable is a deployed bot; the real proof needs the operator's Telegram client and a cold
+pod. After **both** PRs merge and ArgoCD rolls the new `multi-agent-shell` image:
+
+1. **Cold-start answered.** Restart the alert-agent pod (`kubectl -n alert-agent rollout restart
+   deploy/alert-agent`) so the agent session is cold. From Telegram, send a free-text DM (e.g.
+   "what's the cluster status?"). **Expect:** ⚡ appears on the message within ~1s, then a real agent
+   answer within seconds and the reaction flips to 👍 — not the "(the agent did not return a reply…)"
+   fallback.
+2. **Slash command, argless.** Tap `/edge-traffic` from the Telegram command menu (sends it bare).
+   **Expect:** ⚡ → a defaults-based edge-traffic summary that states the default window it used →
+   👍.
+3. **Static `/help`.** Tap `/help`. **Expect:** an immediate command list rendered by the bridge
+   (no agent latency), ⚡→👍.
+4. **Fallback reaction.** (Optional, hard to force) If a turn ever times out, confirm the terminal
+   reaction is 🤔, not 👍.
+
+## Named gaps
+
+- **Readiness marker fragility.** The exact claude prompt substring can change across versions; A1's
+  stability-heuristic fallback (non-empty + unchanged across two polls) is the mitigation, but a
+  future claude TUI redesign may need the marker re-verified. Documented as a gotcha.
+- **Auto-mode flag name.** `hasSeenAutoModeEntryWarning` is the candidate; the live `~/.claude.json`
+  is the source of truth, verified at implementation. If claude renames it, A3's verified-submit
+  still catches the swallowed Enter (defense in depth).
+- **Reaction permission.** In a private DM the bot can always react; no group-permission edge here.
+
+## Counter-arguments considered
+
+- **"Just pre-warm one session at boot."** Rejected: the bridge uses a *per-chat* session id and the
+  handlers use `alert-agent-ops`, so there are multiple lazily-created sessions — only a readiness
+  gate in `ensure_session` covers them all. Pre-warm is at best a latency nicety on one id.
+- **"Parse command arguments properly (inline keyboard)."** Rejected (operator chose Defaults &
+  proceed): an LLM brain with the `frank-facts` CLI makes argument parsing redundant and adds
+  stateful pending-command tracking to a deliberately stateless bridge.
+- **"Thread the poll loop for responsiveness."** Deferred: ⚡-before-block already gives receipt
+  feedback, and Thread A removes the latency that made blocking painful; threading adds per-session
+  locking for no single-operator benefit.


### PR DESCRIPTION
📦 Repo: derio-net/frank
📋 Plan: docs/superpowers/plans/2026-06-16--obs--alert-agent-telegram-ux
📐 Spec: docs/superpowers/specs/2026-06-16--obs--alert-agent-telegram-ux-design.md

**Goal (from plan):** Make the agentic alert-agent's Telegram interface usable — slash commands that survive the argless-from-menu trap, and ⚡/👍 ack-answer reactions — building on the live alert-agent (#563).

## Summary

Two bridge threads in `apps/alert-agent/telegram-bridge/` (TDD, 20 tests):

- **Thread B — slash commands.** A `COMMANDS` registry (single source of truth for both the `setMyCommands` menu and routing) + a pure `expand_command(text)→(kind,payload)`. Catalog: `/help` (static, bridge-rendered so it works even when the agent is cold), `/digest /surge /edge-traffic /security /status` (prompt templates mapping to `frank-facts` subcommands). Philosophy **Defaults & proceed**: a templated command becomes one English instruction for the agent with a "use sensible defaults, answer now, state which default you used" suffix — so Telegram's argless-from-menu behaviour (a tapped menu command is sent bare) has no positional arg to be missing. `process_update` routes a leading `/`; no-slash stays the unchanged free-text Q&A path.
- **Thread C — reactions.** `tg_react` (best-effort `setMessageReaction`, failures swallowed + WARN, never blocks the reply). `process_update` sets ⚡ on receipt **before** the (possibly slow) turn, then 👍 on a real agent answer / 🤔 on the deterministic fallback (reactions replace → ⚡→👍/🤔 reads "working→done"). The synchronous single-consumer loop is kept (one getUpdates consumer per bot token); ⚡-before-block gives instant receipt feedback; per-update threading deferred (YAGNI, single operator).

## Code review

Fresh-eyes review: **Ready to merge — Yes**, no Critical/Important findings. Minor items:
- **#1 whitespace-robust command split** — adopted `text.split(None, 1)` over `partition(" ")`. ✅ fixed.
- **#3 emoji-allowlist note** — documented the Telegram reaction-emoji allowlist constraint near `tg_react`. ✅ fixed.
- **#2 length guard** — left as-is (trusted single operator; the agent session, not Telegram's 4096-char limit, is the consumer). *Reasoning recorded.*
- **#4 `react()` closure recheck** — reviewer-confirmed non-issue. *Not changed.*

## Cross-repo dependency (merge order)

**Phase 3 is a deliberately-unimplemented `[manual]` back-loaded phase**: the image-SHA bump in `apps/alert-agent/manifests/deployment.yaml`. It depends on the **agent-images** companion PR (`feat/agent-session-coldstart`, the driver cold-start fix) merging first and CI building a new `multi-agent-shell` tag.

**Merge order:** agent-images PR → CI builds tag → push the SHA bump to this branch → merge this PR.

→ **Operator pushes the image-SHA bump to this PR after the agent-images tag exists.**

## Test Plan (post-merge, operator-driven)

After both PRs merge and ArgoCD rolls the new image:
1. **Cold-start answered** — `kubectl -n alert-agent rollout restart deploy/alert-agent` (cold session); send a free-text DM. Expect ⚡ within ~1s, a real agent answer within seconds, reaction → 👍 (not the fallback).
2. **Argless slash** — tap `/edge-traffic` from the menu (sent bare). Expect ⚡ → a defaults-based edge summary stating the default window used → 👍.
3. **Static `/help`** — tap `/help`. Expect an immediate bridge-rendered command list, ⚡→👍.
4. **Fallback reaction** (optional) — if a turn times out, terminal reaction is 🤔.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
