### PR TITLE
fix(obs): alert-agent session reliability — menu ids + threaded turns (+ back-loaded env/bump)

### DIFF
--- a/apps/alert-agent/telegram-bridge/tests/test_bridge.py
+++ b/apps/alert-agent/telegram-bridge/tests/test_bridge.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 import json
 import re
+import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -213,3 +215,71 @@ def test_set_my_commands_sends_only_valid_ids(calls):
     assert ids, "must still register the valid commands"
     assert all(_TG_ID_RE.match(i) for i in ids), f"setMyCommands sent an invalid id: {ids}"
     assert "bad-id" not in ids, "the invalid id must be skipped, not sent"
+
+
+# --- Fix D: threaded turns off the poll loop (per-session lock) -----------------
+
+def _gated_session_send(calls, monkeypatch, on_send):
+    """Wrap the fixture's recording fake so /session/send runs `on_send(payload)`
+    (e.g. block on an Event) before returning the canned response. Other calls
+    (sendMessage / setMessageReaction) pass through to the recorder unchanged."""
+    base = bridge._http_post_json
+    def gated(url, payload, timeout=310):
+        if url.endswith("/session/send"):
+            on_send(payload)
+        return base(url, payload, timeout)
+    monkeypatch.setattr(bridge, "_http_post_json", gated)
+
+
+def _texts(rec):
+    return [p.get("text") for (u, p) in list(rec.calls) if u.endswith("/sendMessage")]
+
+
+def test_slow_turn_does_not_block_static(calls, monkeypatch):
+    # A slow free-text turn (blocks in session_send) must NOT head-of-line-block a
+    # /help dispatched right after — /help is answered inline by the consumer.
+    release = threading.Event()
+    calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "A answer"}}
+    _gated_session_send(calls, monkeypatch, lambda payload: release.wait(5))
+
+    t = bridge.dispatch_update({"message": {"message_id": 1, "chat": {"id": 100}, "text": "slow question"}})
+    bridge.dispatch_update({"message": {"message_id": 2, "chat": {"id": 100}, "text": "/help"}})
+
+    # /help's static reply lands while A is still blocked.
+    assert any("/digest" in (txt or "") for txt in _texts(calls)), "/help must reply, not wait for the turn"
+    assert "A answer" not in _texts(calls), "the blocked turn's reply must not have landed yet"
+
+    release.set()
+    t.join(5)
+    assert "A answer" in _texts(calls), "the turn's reply lands once unblocked"
+
+
+def test_same_session_turns_serialize(calls, monkeypatch):
+    # Two turns for the SAME session_id serialize under a per-session lock — the
+    # second session_send does not start until the first returns.
+    order = []
+    gate = threading.Event()
+    calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "x"}}
+
+    def on_send(payload):
+        order.append("start:" + payload["message"])
+        if payload["message"] == "first":
+            gate.wait(5)
+        order.append("end:" + payload["message"])
+    _gated_session_send(calls, monkeypatch, on_send)
+
+    t1 = bridge.dispatch_update({"message": {"message_id": 1, "chat": {"id": 100}, "text": "first"}})
+    t2 = bridge.dispatch_update({"message": {"message_id": 2, "chat": {"id": 100}, "text": "second"}})
+    time.sleep(0.15)
+    assert "start:second" not in order, "the second same-session turn must wait for the lock"
+    gate.set()
+    t1.join(5); t2.join(5)
+    assert order == ["start:first", "end:first", "start:second", "end:second"]
+
+
+def test_reaction_order_preserved_per_message(calls):
+    # A threaded turn still reacts ⚡ before 👍/🤔 on its own message.
+    calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "ok"}}
+    t = bridge.dispatch_update({"message": {"message_id": 42, "chat": {"id": 100}, "text": "hi"}})
+    t.join(5)
+    assert _reactions(calls) == ["⚡", "👍"]

--- a/apps/alert-agent/telegram-bridge/tests/test_bridge.py
+++ b/apps/alert-agent/telegram-bridge/tests/test_bridge.py
@@ -1,11 +1,14 @@
 """telegram-bridge: allowlist, single-consumer routing, deterministic fallback."""
 from __future__ import annotations
 import json
+import re
 from types import SimpleNamespace
 
 import pytest
 
 from tg_bridge import bridge
+
+_TG_ID_RE = re.compile(r"^[a-z0-9_]{1,32}$")
 
 
 @pytest.fixture
@@ -76,7 +79,7 @@ def test_deliver_uses_agent_payload_when_present(calls):
 
 # --- Thread B: slash commands (expand_command + COMMANDS registry) -------------
 
-CATALOG = ["/help", "/digest", "/surge", "/edge-traffic", "/security", "/status"]
+CATALOG = ["/help", "/digest", "/surge", "/edge_traffic", "/security", "/status"]
 
 
 def test_commands_registry_shape():
@@ -102,7 +105,7 @@ def test_expand_command_prompt_carries_defaults_suffix():
 
 
 def test_expand_command_appends_operator_args():
-    kind, payload = bridge.expand_command("/edge-traffic hop-1")
+    kind, payload = bridge.expand_command("/edge_traffic hop-1")
     assert kind == "prompt"
     assert "hop-1" in payload   # operator-typed trailing args reach the agent
 
@@ -184,3 +187,29 @@ def test_reaction_on_static_help(calls):
     # /help never touches the agent but still gets receipt → done reactions.
     bridge.process_update({"message": {"message_id": 3, "chat": {"id": 100}, "text": "/help"}})
     assert _reactions(calls) == ["⚡", "👍"]
+
+
+# --- Fix A: Telegram menu command ids (the setMyCommands 400) -------------------
+
+def test_command_ids_are_valid_telegram():
+    # Every COMMANDS key (sans leading /) must be a valid Telegram command id —
+    # no hyphens. One invalid id makes setMyCommands 400 and rejects the WHOLE menu.
+    for cmd in bridge.COMMANDS:
+        ident = cmd.lstrip("/")
+        assert _TG_ID_RE.match(ident), f"invalid Telegram command id: {cmd!r}"
+
+
+def test_set_my_commands_sends_only_valid_ids(calls):
+    # An invalid id must be SKIPPED (logged), never sent — so a single bad id can
+    # never reject the whole batch (fail-soft: the menu just lacks that command).
+    bridge.COMMANDS["/bad-id"] = {"desc": "temp invalid", "kind": "static"}
+    try:
+        bridge.set_my_commands()
+    finally:
+        del bridge.COMMANDS["/bad-id"]
+    sent = _sent(calls, "/setMyCommands")
+    assert len(sent) == 1
+    ids = [c["command"] for c in sent[0]["commands"]]
+    assert ids, "must still register the valid commands"
+    assert all(_TG_ID_RE.match(i) for i in ids), f"setMyCommands sent an invalid id: {ids}"
+    assert "bad-id" not in ids, "the invalid id must be skipped, not sent"

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -9,6 +9,7 @@ import json
 import os
 import re
 import sys
+import threading
 import time
 import urllib.request
 
@@ -176,46 +177,107 @@ def deliver(resp: dict, fallback_text: str, chat_id: str | None = None) -> dict:
     return tg_send(text, chat_id)
 
 
-def process_update(update: dict) -> bool:
-    """Handle one getUpdates entry. Allowlisted message → agent → reply.
-    Returns True if it drove the agent, False if dropped. Non-allowlisted chats
-    are dropped with a WARN (the gate working, not the bot broken)."""
+# Per-session_id locks serialize same-session agent turns so two DMs never
+# interleave pastes into one tmux session. A registry lock guards lazy creation.
+# Different sessions and static commands never contend.
+_session_locks: dict[str, threading.Lock] = {}
+_session_locks_registry = threading.Lock()
+
+
+def _session_lock(session_id: str) -> threading.Lock:
+    with _session_locks_registry:
+        lock = _session_locks.get(session_id)
+        if lock is None:
+            lock = threading.Lock()
+            _session_locks[session_id] = lock
+        return lock
+
+
+def _react_fn(chat_id, message_id):
+    def react(emoji):
+        if message_id is not None:
+            tg_react(str(chat_id), message_id, emoji)
+    return react
+
+
+def _prepare(update: dict):
+    """Parse + allowlist one getUpdates entry. Returns (chat_id, message_id, text)
+    or None if the update is empty / from a non-allowlisted chat (dropped, WARNed)."""
     msg = update.get("message") or update.get("edited_message") or {}
     chat_id = (msg.get("chat") or {}).get("id")
     message_id = msg.get("message_id")
     text = (msg.get("text") or "").strip()
     if chat_id is None or not text:
-        return False
+        return None
     if not is_allowed(chat_id):
         print(f"WARN telegram-bridge: dropped message from non-allowlisted chat {chat_id}",
               file=sys.stderr)
-        return False
+        return None
+    return chat_id, message_id, text
 
-    def react(emoji):
-        if message_id is not None:
-            tg_react(str(chat_id), message_id, emoji)
 
+def _receipt_and_route(chat_id, message_id, text):
+    """Fire the ⚡ receipt and answer static/unknown slash commands INLINE (so /help
+    works even when the agent is cold/slow). Returns the agent instruction to run,
+    or None when the update was already fully handled inline."""
+    react = _react_fn(chat_id, message_id)
     react("⚡")   # receipt — fired BEFORE the (possibly slow) turn so feedback is instant
-    # Slash command? Static/unknown are answered by the bridge directly (so /help
-    # works even when the agent is cold); a prompt command expands to an agent
-    # instruction. No leading slash → the unchanged free-text Q&A path.
     if text.startswith("/"):
         kind, payload = expand_command(text)
         if kind in ("static", "unknown"):
             tg_send(payload, str(chat_id))
             react("👍")
-            return True
-        message = payload
-    else:
-        message = text
-    # Shorter timeout for an interactive DM than the cron 300s — a stuck turn
-    # must not freeze the single getUpdates consumer for 5 minutes.
-    resp = session_send(message, session_id=f"{SESSION_ID}-tg-{chat_id}", timeout_s=120)
+            return None
+        return payload
+    return text   # no leading slash → free-text Q&A verbatim
+
+
+def _run_agent_turn(chat_id, message_id, message) -> None:
+    """Drive the agent for one turn under the per-session lock, reply, react 👍/🤔.
+    The lock serializes same-session turns (no interleaved pastes); the wait spans
+    only session_send so a finished turn frees the session immediately."""
+    react = _react_fn(chat_id, message_id)
+    session_id = f"{SESSION_ID}-tg-{chat_id}"
+    with _session_lock(session_id):
+        # Shorter timeout for an interactive DM than the cron 300s — a stuck turn
+        # must not hold the session lock for 5 minutes.
+        resp = session_send(message, session_id=session_id, timeout_s=120)
     rendered = render_payload(resp)
     tg_send(rendered or "(the agent did not return a reply — it may be busy or unauthenticated)",
             str(chat_id))
     react("👍" if rendered is not None else "🤔")   # 🤔 = only the deterministic fallback was posted
+
+
+def process_update(update: dict) -> bool:
+    """Synchronous handler (one update end-to-end) — the inline core and the unit
+    contract. poll_loop uses dispatch_update for non-blocking turns. Returns True
+    if handled (driven or static reply), False if dropped."""
+    prepared = _prepare(update)
+    if prepared is None:
+        return False
+    chat_id, message_id, text = prepared
+    message = _receipt_and_route(chat_id, message_id, text)
+    if message is not None:
+        _run_agent_turn(chat_id, message_id, message)
     return True
+
+
+def dispatch_update(update: dict):
+    """Non-blocking entry the poll loop calls. ⚡ receipt + static/unknown replies
+    are answered INLINE in the single getUpdates consumer; an agent turn runs in a
+    per-session-serialized worker thread so a slow/stuck turn never head-of-line-
+    blocks the consumer (or a static /help). Returns the worker Thread for an agent
+    turn, else None (handled inline / dropped)."""
+    prepared = _prepare(update)
+    if prepared is None:
+        return None
+    chat_id, message_id, text = prepared
+    message = _receipt_and_route(chat_id, message_id, text)
+    if message is None:
+        return None
+    t = threading.Thread(target=_run_agent_turn, args=(chat_id, message_id, message), daemon=True)
+    t.start()
+    return t
 
 
 def set_my_commands() -> None:
@@ -251,6 +313,6 @@ def poll_loop(poll_timeout: int = 30) -> None:  # pragma: no cover - network loo
         for upd in resp.get("result", []):
             offset = max(offset, upd.get("update_id", 0) + 1)
             try:
-                process_update(upd)
+                dispatch_update(upd)   # non-blocking: agent turn threads, consumer keeps reading
             except Exception as exc:  # noqa: BLE001 — one bad update must not kill the loop
                 print(f"WARN telegram-bridge: update handling failed: {exc}", file=sys.stderr)

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -7,9 +7,14 @@ endpoint) the tests patch. Telegram messages are sent as PLAIN TEXT (no parse_mo
 from __future__ import annotations
 import json
 import os
+import re
 import sys
 import time
 import urllib.request
+
+# Telegram's command-id rule: lowercase letters, digits, underscore; 1–32 chars
+# (NO hyphens). One invalid id makes setMyCommands 400 and rejects the WHOLE menu.
+_TG_COMMAND_ID_RE = re.compile(r"^[a-z0-9_]{1,32}$")
 
 BOT_TOKEN = os.environ.get("FRANK_C2_TELEGRAM_BOT_TOKEN", "")
 # Allowlist of chat ids permitted to drive the agent (comma-separated). The
@@ -82,7 +87,7 @@ COMMANDS = {
         "kind": "prompt",
         "template": "Report current surge status (`frank-facts surge`).",
     },
-    "/edge-traffic": {
+    "/edge_traffic": {
         "desc": "Hop edge traffic summary",
         "kind": "prompt",
         "template": (
@@ -217,7 +222,16 @@ def set_my_commands() -> None:
     """Register the Telegram command menu from COMMANDS (best-effort — a failure
     logs a WARN and the bridge runs anyway; the menu is a nicety, not a dependency)."""
     try:
-        cmds = [{"command": c.lstrip("/"), "description": s["desc"]} for c, s in COMMANDS.items()]
+        cmds = []
+        for c, s in COMMANDS.items():
+            ident = c.lstrip("/")
+            if not _TG_COMMAND_ID_RE.match(ident):
+                # Skip (don't send) an invalid id — a single bad one would 400 the
+                # whole menu. Fail-soft: that command is just absent from the menu.
+                print(f"WARN telegram-bridge: skipping invalid command id {c!r} "
+                      f"(not {_TG_COMMAND_ID_RE.pattern})", file=sys.stderr)
+                continue
+            cmds.append({"command": ident, "description": s["desc"]})
         _tg("setMyCommands", {"commands": cmds})
     except Exception as exc:  # noqa: BLE001
         print(f"WARN telegram-bridge: setMyCommands failed: {exc}", file=sys.stderr)

--- a/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/01.yaml
+++ b/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/01.yaml
@@ -1,0 +1,48 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Telegram menu command ids — fix the setMyCommands 400 (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED — tests for valid command ids + filtered registration
+  steps:
+  - id: P1.T1.S1
+    text: |
+      In `apps/alert-agent/telegram-bridge/tests/test_bridge.py` add:
+        * `test_command_ids_are_valid_telegram`: every `bridge.COMMANDS` key with the leading `/`
+          stripped matches `^[a-z0-9_]{1,32}$` (Telegram's rule — no hyphens). This FAILS today on
+          `/edge-traffic`.
+        * `test_set_my_commands_sends_only_valid_ids`: with the `calls` fixture, call
+          `bridge.set_my_commands()`; the `setMyCommands` payload's `commands[].command` are all
+          valid ids; inject a temporary invalid key into a copy and assert it is SKIPPED (not sent),
+          so one bad id can't reject the whole batch.
+      Run `cd apps/alert-agent/telegram-bridge && uv run --with pytest python -m pytest tests/ -q`.
+      Expected: FAIL (RED — `/edge-traffic` hyphen + no filter).
+- number: 2
+  title: GREEN — rename + validity filter
+  steps:
+  - id: P1.T2.S1
+    text: |
+      In `tg_bridge/bridge.py`: rename the `COMMANDS` key `"/edge-traffic"` → `"/edge_traffic"`
+      (routing follows the key; the template text is unchanged). In `set_my_commands()`, build the
+      list only from keys whose stripped id matches `^[a-z0-9_]{1,32}$`, and `print` a WARN to
+      stderr for any skipped key — so a future invalid id degrades to "missing from the menu"
+      instead of a 400 that nukes the whole menu. Run the suite. Expected: GREEN (incl. the
+      existing routing/expand tests — `/edge_traffic` still routes).
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/01.yaml
+++ b/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/01.yaml
@@ -35,14 +35,14 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:51:25+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:51:34+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-17T20:51:41+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/02.yaml
+++ b/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/02.yaml
@@ -1,0 +1,52 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Thread agent turns off the poll loop (TDD)
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED — tests for non-blocking dispatch + per-session serialization
+  steps:
+  - id: P2.T1.S1
+    text: |
+      Add tests driving a new `dispatch_update(update)` (the threaded entry the poll loop will
+      call) over the patched seam:
+        * `test_slow_turn_does_not_block_static`: a free-text DM whose `session_send` blocks on an
+          Event, dispatched on session A; a `/help` dispatched immediately after returns its static
+          reply WITHOUT waiting for A's turn (assert the `/sendMessage` for `/help` lands before A's
+          Event is released).
+        * `test_same_session_turns_serialize`: two turns for the SAME session_id run under a
+          per-session lock — the second `session_send` does not start until the first returns
+          (assert ordering via a shared list).
+        * `test_reaction_order_preserved_per_message`: for a threaded turn, ⚡ precedes 👍/🤔 on that
+          message (reuse `_reactions`).
+      Run the suite. Expected: FAIL (RED — no threaded dispatch / lock).
+- number: 2
+  title: GREEN — worker threads + per-session lock
+  steps:
+  - id: P2.T2.S1
+    text: |
+      In `bridge.py`: keep the single getUpdates consumer, but `poll_loop` hands each update to
+      `dispatch_update`, which runs the turn in a worker thread. Static `/help`/unknown replies are
+      answered inline (no thread). A module-level `dict` of per-`session_id` `threading.Lock`
+      (guarded by a registry lock) serializes same-session turns; ⚡ fires before acquiring/​running,
+      👍/🤔 from the worker after. Keep one getUpdates consumer (replicas:1 unchanged). Run the
+      suite. Expected: GREEN (incl. legacy process_update tests, or refactor them onto
+      dispatch_update). RED-verify by stash.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/02.yaml
+++ b/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/02.yaml
@@ -39,14 +39,14 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:58:47+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:58:53+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-17T20:58:58+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/03.yaml
+++ b/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/03.yaml
@@ -1,0 +1,53 @@
+schema_version: 2
+phase:
+  number: 3
+  title: '[manual] Env on both agent pods + image bump + post-merge double-restart
+    test'
+  tag: manual
+  depends_on:
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: AGENT_TMUX_RESTORE env + multi-agent-shell SHA bump (operator-gated)
+  steps:
+  - id: P3.T1.S1
+    text: |
+      BACK-LOADED / MANUAL — ships unimplemented; the new image tag does not exist until the
+      agent-images plan (`2026-06-17-agent-session-persistence`) merges + CI builds it. Then:
+        1. Add `AGENT_TMUX_RESTORE=off` to the agent container env in
+           `apps/alert-agent/manifests/deployment.yaml` and to the `multi-agent-shell` sidecar in
+           `apps/n8n-01/manifests/deployment.yaml` (driver-managed pods; human shells stay unset).
+        2. Bump `multi-agent-shell:<sha>` in BOTH deployments to the new tag (alert-agent off
+           c946a672; n8n-01 off the stranded 9635df9a — this also unstrands n8n). All multi-agent-
+           shell pins must move (alert-agent has 3 containers).
+      Push to THIS PR's branch; ArgoCD rolls both pods. Record via `fr plan edit --complete-phase 3
+      --note "<old>…<new> + env"`.
+- number: 2
+  title: Post-merge double-cold-restart Test Plan (operator-driven)
+  steps:
+  - id: P3.T2.S1
+    text: |
+      MANUAL / post-merge (both PRs merged, ArgoCD rolled the new image). Operator-driven:
+        1. **Cold restart #1** — `kubectl -n alert-agent rollout restart deploy/alert-agent`. From
+           Telegram: `what's the cluster status?` → ⚡ within ~1s → real answer → 👍 (no fallback).
+           `/help` instant + NOT blocked behind the turn (threading). Command menu populated;
+           `/edge_traffic` works argless.
+        2. **Cold restart #2** — restart again; DM a follow-up referencing the prior turn → the
+           session RESUMES with memory (`--session-id` persistence). `tmux ls` shows only live
+           claude REPLs (no `smoke-*` / dead shells); the chat's
+           `~/.claude/projects/.../<uuid>.jsonl` exists and grew.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-17--obs--alert-agent-session-reliability
+spec: docs/superpowers/specs/2026-06-17--obs--alert-agent-session-reliability-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-17'

--- a/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/_prose.md
+++ b/docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/_prose.md
@@ -1,0 +1,16 @@
+# alert-agent session reliability — frank portion
+
+Bridge UX + the deployment side of the continuum fix, gated by the agent-images persistence plan.
+
+- **A (Phase 1):** the `setMyCommands` 400 — `/edge-traffic`'s hyphen is an invalid Telegram command
+  id and rejects the whole menu. Rename to `/edge_traffic` and filter `set_my_commands` to valid ids
+  so one bad name can never nuke the menu again.
+- **D (Phase 2):** thread agent turns off the single getUpdates consumer with a per-session lock, so a
+  slow/stuck turn no longer head-of-line-blocks static `/help`. One consumer per bot token preserved.
+- **Phase 3 [manual, back-loaded]:** set `AGENT_TMUX_RESTORE=off` on the alert-agent + n8n-01 agent
+  containers and bump both `multi-agent-shell` image SHAs to the new tag (which also unstrands n8n
+  from 9635df9a). The tag only exists after the agent-images plan merges, so this is operator-driven.
+
+Post-merge proof is a double cold-restart: the first proves liveness (no continuum dead-shell reuse) +
+menu + reactions + unblocked /help; the second proves `--session-id` persistence (memory across
+restarts).

--- a/docs/superpowers/specs/2026-06-17--obs--alert-agent-session-reliability-design.md
+++ b/docs/superpowers/specs/2026-06-17--obs--alert-agent-session-reliability-design.md
@@ -1,0 +1,154 @@
+# Alert-Agent Persistent-Session Reliability + Telegram UX Hardening
+
+**Layers:** obs (frank — `apps/alert-agent`, `apps/n8n-01`) + agent-images (the `agent-session` driver + `agent-shell-base` tmux config)
+**Status:** Draft
+**Date:** 2026-06-17
+**Repos:** `derio-net/frank`, `derio-net/agent-images` (multi-repo)
+**Extends:** `2026-06-16--obs--alert-agent-telegram-ux-design.md` (the cold-start fix this supersedes-by-completing) + `2026-06-15--obs--agentic-alert-helper-design.md`
+
+## Implementation Plans
+
+| Plan | Target repo | Slug | Status |
+|------|-------------|------|--------|
+| agent-session-persistence (C+E+continuum, **gating**) | `derio-net/agent-images` | `2026-06-17-agent-session-persistence` | — |
+| 2026-06-17--obs--alert-agent-session-reliability (A+D+env+bump) | `derio-net/frank` | `2026-06-17--obs--alert-agent-session-reliability` | — |
+
+> Multi-repo, two plans. The **agent-images** plan (driver liveness + `--session-id` persistence +
+> the `agent-shell-base` continuum conditional) gates the **frank** plan (bridge menu/threading + the
+> `AGENT_TMUX_RESTORE` env on the two agent pods + the image-SHA bump). Sequence: agent-images merges
+> → CI builds a new `multi-agent-shell` tag → frank bumps the SHA (auto-covered once frank#570 lands).
+
+## Problem — proven live, today
+
+The agentic alert-agent (frank#568 / agent-images#129, live) answers correctly on a **genuinely-fresh
+session** (driving the endpoint: 7s trivial, 30s realistic "cluster status", `status=ok`). But a live
+post-merge Test Plan proved the cold-start fix is **necessary but insufficient**, and surfaced three
+more issues:
+
+1. **tmux-continuum resurrects DEAD sessions** (the real blocker). `agent-shell-base` bakes
+   tmux-resurrect/continuum (`@continuum-restore on`); on every fresh tmux-server start it restores
+   saved sessions **as bash shells, not claude** (proven: `smoke-i1`/`smoke-i2` from a prior debug
+   session reappeared; the operator's `alert-agent-tg-<chat>` came back as a shell). `ensure_session`
+   sees `has-session` ok and **reuses the dead shell** — its readiness gate only runs on session
+   *creation*. The DM is pasted into bash → `syntax error near '('` → 120s timeout → fallback. claude
+   itself is fine (authenticated Max/Sonnet 4.6; the "not logged in" MOTD is a wrong check).
+2. **`setMyCommands` 400** — `/edge-traffic`'s hyphen is an invalid Telegram command id
+   (`[a-z0-9_]{1,32}`); one bad id rejects the **whole** menu, so it never registers.
+3. **Head-of-line blocking** — the single synchronous getUpdates consumer blocks in `process_update`
+   for the entire turn (`timeout_s=120`), so a queued static `/help` waits behind a slow/stuck turn.
+
+And a structural gap: each driver launch starts a **fresh** claude conversation — no memory across
+restarts. The operator wants durable, resumable named sessions.
+
+## Fix A — Telegram menu command ids (frank `telegram-bridge`)
+
+- Rename the `COMMANDS` key `/edge-traffic` → `/edge_traffic` (valid id; routing follows the key).
+- `set_my_commands()` filters to ids matching `^[a-z0-9_]{1,32}$`, skipping (with a WARN) any invalid
+  one — so a single bad id can never reject the whole menu again.
+- Tests: every `COMMANDS` key (sans `/`) is a valid id; `set_my_commands` sends only valid ids (and
+  still sends the rest if one were invalid). RED against the current `/edge-traffic`.
+
+## Fix B — Disable continuum for agent pods (agent-images base + frank deployments)
+
+- **agent-images** `agent-shell-base/etc/agent/tmux-resurrect.conf`: replace the static
+  `set -g @continuum-restore 'on'` with a conditional honoring a new env —
+  `@continuum-restore 'off'` when `AGENT_TMUX_RESTORE=off`, else `'on'` (default preserves human-shell
+  behavior). Implemented with `if-shell '[ "${AGENT_TMUX_RESTORE:-on}" = off ]' …`, placed **before**
+  the `run-shell …/continuum.tmux` so the plugin sees the setting at server start.
+- **frank**: set `AGENT_TMUX_RESTORE=off` on the agent containers of `apps/alert-agent` **and**
+  `apps/n8n-01` (operator: include n8n). Human shells (hermes, secure-agent-pod, paperclip, ruflo)
+  leave it unset → continuum stays on, unchanged.
+- This is defence/cleanliness; **Fix C is the load-bearing guarantee** (a dead session is recreated
+  regardless of how it appeared).
+
+## Fix C — Driver liveness check (agent-images `agent-session`)
+
+`ensure_session` must stop trusting bare `has-session`. New behaviour: if the session is absent,
+create it (as today, with `wait_ready`). If it **exists**, probe readiness quickly — capture the pane;
+if it is **not a live claude REPL** (no `❯` within a short bounded wait — a dead bash shell, a
+continuum-restored pane, or a crashed claude), **kill and recreate** it (then `wait_ready`). A live
+REPL is reused untouched (warm path, no added latency). This generalizes the creation-only gate to
+cover today's continuum bug and any future claude crash.
+
+- TDD against the existing PATH-injected `FAKE_TMUX` harness, extended to model an *existing-but-dead*
+  session (pane shows a shell prompt, no `❯`): assert the driver kills + recreates it, then submits to
+  the fresh REPL; and that a live `❯` session is reused without a kill.
+
+## Fix D — Thread agent turns (frank `telegram-bridge`)
+
+Keep the single getUpdates consumer (one per bot token), but dispatch each agent turn to a **worker
+thread** so the poll loop keeps reading and static commands answer immediately. A **per-`session_id`
+lock** serializes same-session turns (no interleaved pastes into one tmux session); different sessions
+and static `/help`/unknown replies run without waiting. The ⚡ receipt reaction still fires before the
+turn; 👍/🤔 from the worker on completion.
+
+- Tests over the patched seam: a slow turn on session A does not delay a `/help` reply; two concurrent
+  same-session turns serialize (lock held); the reaction order per message is preserved.
+
+## Fix E — Persistent resumable sessions + context management (agent-images `agent-session`)
+
+Verified CLI semantics (claude 2.1.177): `claude --session-id <uuid>` (must be a valid UUID)
+**creates-or-resumes** a conversation, works interactively with `--permission-mode auto`, persists to
+`~/.claude/projects/<proj>/<uuid>.jsonl` (PVC-resident → survives restart). `--resume <id>` on a
+*missing* session opens an interactive picker (would hang headless) — so `--session-id` is the right
+create-or-resume primitive; `/clear` resets context keeping the id.
+
+- **Deterministic id:** the driver derives `uuid = uuidv5(NAMESPACE, session_id)` (stable, valid UUID,
+  no state file) and launches `claude --session-id <uuid> --permission-mode auto`. On pod restart the
+  same `session_id` → same uuid → resumes the persisted conversation (memory across restarts), no
+  reliance on continuum.
+- **Idle reset (12h):** the driver tracks `last_activity` per session (a PVC file beside the turn
+  counter). On a new request, if `now - last_activity > 12h`, send `/clear` first (fresh conversation,
+  **same stable id**) before the message. Otherwise continue.
+- **Proactive compact (>60%):** after a turn, read claude's context-usage indicator and send
+  `/compact` when it exceeds 60%. **Measurement is the risk** — there is no programmatic "% full"
+  signal; the driver parses the indicator from `/context` (or the status line) with the exact target
+  **live-verified on the pod during implementation**, and falls back to claude's own auto-compact
+  (near-limit) if parsing is unreliable. Flagged as a named gap.
+- Persistence requires `~/.claude/projects` on the PVC — confirm the `alert-agent-home` mount covers
+  it (it mounts `/home/agent`, so yes).
+
+## Multi-repo sequencing
+
+1. **agent-images** merges first (C + E + the `agent-shell-base` continuum conditional) → CI builds a
+   new `multi-agent-shell` tag (all shells rebuild; human-shell behaviour unchanged by default).
+2. **frank** implements A + D + the `AGENT_TMUX_RESTORE=off` env on alert-agent + n8n-01, then bumps
+   `apps/alert-agent/manifests/deployment.yaml` (and `apps/n8n-01` for the env) to the new SHA
+   (back-loaded last step; auto-covered by the generalized bumper once frank#570 lands).
+
+`depends_on` is intra-plan only; this cross-repo order lives here + in PR sequencing.
+
+## Test Plan (post-merge, operator-driven) — double cold-restart
+
+After both PRs merge and ArgoCD rolls the new image:
+
+1. **Cold restart #1** — `kubectl -n alert-agent rollout restart deploy/alert-agent` (genuinely cold;
+   no continuum restore). From Telegram: send `what's the cluster status?` → expect ⚡ within ~1s →
+   real answer in seconds → 👍 (no fallback). Tap/type `/help` → instant, **not** blocked behind the
+   turn (threading). Confirm the command **menu is populated** and `/edge_traffic` works argless.
+2. **Cold restart #2** — restart again, then DM a follow-up that references the prior turn → confirm
+   the session **resumed with memory** (persistence via `--session-id`) and still answers. Verify no
+   `smoke-*`/dead sessions reappear (`tmux ls` shows only live claude REPLs).
+3. Spot-check: `tmux capture-pane` on the chat session shows a claude REPL (not a bash shell); the
+   `~/.claude/projects/.../<uuid>.jsonl` for the chat exists and grew across restarts.
+
+## Named gaps
+
+- **60% compaction signal.** No programmatic context-% API; parsing claude's indicator is
+  version-fragile. Mitigation: live-verify the parse target + fall back to claude auto-compact. If the
+  parse is unreliable, the idle-12h `/clear` + auto-compact still bound growth (degraded, not broken).
+- **`--session-id` resume across versions.** Behaviour verified by docs + must be live-verified on
+  2.1.177 before relying on it; the reliability fixes (A–D) do **not** depend on E, so E can degrade to
+  fresh-session-per-launch without breaking the bot.
+- **`AGENT_TMUX_RESTORE` env reaching the tmux server.** The conditional needs the env in the tmux
+  server's startup environment; live-verify the `if-shell` sees it (the driver/s6 env should carry it).
+
+## Counter-arguments considered
+
+- **"Just fix C; skip B."** C alone makes the bot work (dead sessions recreated), but continuum keeps
+  saving/restoring dead shells every 5 min + on shutdown — wasted work and clutter. The operator chose
+  to also disable it (incl. n8n), so B + C together.
+- **"Use `--resume` not `--session-id`."** `--resume` on a missing id opens an interactive picker →
+  hangs a headless driver. `--session-id <uuid>` is the create-or-resume primitive that never hangs.
+- **"Daily-cron `/clear`."** Rejected for the operator's idle-12h + 60%-compact policy — resets tied to
+  actual usage/idleness, not wall-clock, so an active conversation isn't wiped mid-stream.


### PR DESCRIPTION
## Summary

The frank half of the alert-agent persistent-session reliability round. Pairs
with **derio-net/agent-images#130** (the gating driver/continuum changes).

- **Fix A — Telegram menu command ids.** `/edge-traffic`'s hyphen is an invalid
  Telegram command id; one bad id 400s the **whole** `setMyCommands` batch, so the
  menu never registered. Rename the `COMMANDS` key → `/edge_traffic` (routing
  follows the key) and filter `set_my_commands` to `^[a-z0-9_]{1,32}$`, skipping
  (with a WARN) any invalid id — a future bad id degrades to "missing from the
  menu", never a whole-menu 400.
- **Fix D — thread agent turns.** A slow/stuck 120s agent turn used to
  head-of-line-block the single getUpdates consumer, so a queued `/help` waited
  behind it. `poll_loop` now hands each update to `dispatch_update`: the ⚡ receipt
  and static `/help`/unknown replies answer **inline** in the consumer thread; an
  agent turn runs in a per-session-serialized worker thread. A `dict[session_id →
  Lock]` serializes same-session turns (no interleaved pastes into one tmux
  session); single getUpdates consumer preserved (`replicas: 1`).

**Spec:** `docs/superpowers/specs/2026-06-17--obs--alert-agent-session-reliability-design.md`
**Plan:** `docs/superpowers/plans/2026-06-17--obs--alert-agent-session-reliability/` (3 phases, TDD)

## Tests

TDD throughout (the `_http_post_json` seam; RED-verified against HEAD for both
fixes). **25/25 bridge tests pass.**

## Phase 3 — manual, back-loaded (operator pushes to this PR)

The plan's final phase is deliberately **unimplemented** here — it can only run
after agent-images#130 merges and CI builds the new `multi-agent-shell` tag:

1. Set `AGENT_TMUX_RESTORE=off` on the **agent** containers of `apps/alert-agent`
   **and** `apps/n8n-01` (so continuum stops resurrecting dead sessions; Fix C in
   the driver is the load-bearing guarantee, this is defence + cleanliness).
2. Bump both apps' `multi-agent-shell` image SHA to the new tag (also unstrands
   n8n-01 from `9635df9a`). Auto-covered by the generalized bumper (#570) once the
   agent-images merge dispatches.

Push those two changes to this branch, then `fr plan edit … --complete-phase 3 --note`.

## Post-merge Test Plan (operator-driven) — double cold-restart

After both PRs merge and ArgoCD rolls the new image:

1. **Cold restart #1** — `kubectl -n alert-agent rollout restart deploy/alert-agent`
   (genuinely cold; no continuum restore). From Telegram: `what's the cluster
   status?` → ⚡ within ~1s → real answer in seconds → 👍 (no fallback). Tap/type
   `/help` → instant, **not** blocked behind the turn. Confirm the command **menu
   is populated** and `/edge_traffic` works argless.
2. **Cold restart #2** — restart again, DM a follow-up referencing the prior turn →
   confirm the session **resumed with memory** (`--session-id` persistence). Verify
   no `smoke-*`/dead sessions reappear (`tmux ls` shows only live claude REPLs).
3. Spot-check: `tmux capture-pane` on the chat session shows a claude REPL (not a
   bash shell); `~/.claude/projects/.../<uuid>.jsonl` exists and grew across restarts.

## Sequencing

agent-images#130 merges first → CI tags `multi-agent-shell` → Phase 3 here
(env + SHA bump) → merge → post-merge Test Plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
