### PR TITLE
chore(obs): AGENT_TMUX_RESTORE=off on alert-agent + n8n-01 (session-reliability Phase 3)

### DIFF
--- a/apps/alert-agent/manifests/deployment.yaml
+++ b/apps/alert-agent/manifests/deployment.yaml
@@ -40,6 +40,12 @@ spec:
             - { name: ssh, containerPort: 2222 }
           env:
             - { name: AGENT_SESSION_SERVE, value: "1" }            # bake the serve endpoint
+            # Disable tmux-continuum auto-restore: the driver owns sessions, so
+            # continuum must never resurrect a DEAD bash shell that ensure_session
+            # would reuse (the DM-into-bash failure). Honored by agent-shell-base's
+            # tmux-resurrect.conf if-shell (Fix B). Fix C is the load-bearing guard;
+            # this is defence + cleanliness (stops the 5-min save/restore churn).
+            - { name: AGENT_TMUX_RESTORE, value: "off" }
             - { name: AGENT_SESSION_URL, value: "http://localhost:8765" }
             - { name: PYTHONPATH, value: "/opt/pylib" }
             - { name: VICTORIALOGS_URL, value: "http://victoria-logs-victoria-logs-single-server.monitoring.svc.cluster.local:9428" }

--- a/apps/n8n-01/manifests/deployment.yaml
+++ b/apps/n8n-01/manifests/deployment.yaml
@@ -120,6 +120,10 @@ spec:
           env:
             - name: HOME
               value: /home/agent
+            # Disable tmux-continuum auto-restore (Fix B / agent-shell-base): the
+            # driver owns sessions; continuum must not resurrect dead bash shells.
+            - name: AGENT_TMUX_RESTORE
+              value: "off"
           resources:
             requests:
               cpu: "1000m"


### PR DESCRIPTION
Completes Phase 3 of the alert-agent session-reliability round (the env half; the image-SHA bump to `31c8a03` already landed via the auto-bumper in #572).

Sets `AGENT_TMUX_RESTORE=off` on the driver-managed agent containers of `apps/alert-agent` (the `agent` container) and `apps/n8n-01` (the `multi-agent-shell` sidecar). agent-images **Fix B** (the `tmux-resurrect.conf` `if-shell` honoring this env) is in the deployed image, so it takes effect on the next roll: tmux-continuum no longer auto-restores dead bash-shell sessions that `ensure_session` would reuse.

**Fix C (driver liveness probe) is the load-bearing guarantee** — a dead session is recreated regardless; this is defence + cleanliness (stops the 5-min save/restore churn). Human shells (hermes, secure-agent-pod, paperclip, ruflo) leave it unset → continuum stays on, unchanged.

Pairs with the OOM/MOTD re-land **derio-net/agent-images#131** (the two fixes orphaned by #130's squash-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)