### PR TITLE
chore(obs): alert-agent agent container memory 3Gi -> 8Gi (native claude auto-updater headroom)

### DIFF
--- a/apps/alert-agent/manifests/deployment.yaml
+++ b/apps/alert-agent/manifests/deployment.yaml
@@ -72,8 +72,12 @@ spec:
           resources:
             requests: { cpu: 50m, memory: 256Mi }
             # claude TUI + tmux: one shared "alert-agent-ops" session for surge/
-            # digest/grafana + one per inbound chat. Headroom for ~2-3 live sessions.
-            limits: { memory: 3Gi }
+            # digest/grafana + one per inbound chat. 8Gi (not 3Gi) so the NATIVE
+            # claude build's background auto-updater — which buffers the ~245MB
+            # download ~17x in anon memory, peaking ~4.2-4.5GiB — fits without a
+            # group-OOM (frank-gotchas/agent-shells.md; hermes was raised 4->8 for
+            # the same reason). Request stays low; this only permits the spike.
+            limits: { memory: 8Gi }
         # --- sidecar: inbound Telegram (single getUpdates consumer) ------------
         - name: telegram-bridge
           image: ghcr.io/derio-net/multi-agent-shell:df0eaba0b92cdc1c119d739397c8e8744bdcd731


### PR DESCRIPTION
Raises `apps/alert-agent` **agent** container `limits.memory` from **3Gi → 8Gi**.

The native claude build is the intended runtime (npm is bootstrap-only; the native installer self-updates in a writable PVC location, since harnesses evolve faster than image rebuilds). Its background auto-updater buffers the ~245 MB download ~17× in anon memory, peaking ~4.2–4.5 GiB (Bun HTTP client — see `docs/runbooks/frank-gotchas/agent-shells.md`). At 3 Gi that **group-OOMs the agent container mid-session** (`claude install` exits 137 / SIGKILL).

8 Gi lets the update fit — the same fix applied to hermes-agent-shell (4→8); n8n-01's `multi-agent-shell` sidecar is already 8 Gi. It's a **limit, not a request** (request stays 256 Mi), so it only permits the transient spike — no reservation change; mini-2 has the headroom.

Pairs with the manual memory-safe native-claude install on the running pod (the curl-the-binary recipe, avoiding `claude install`'s OOM). Follow-up: have the multi-agent-shell image's first-boot bootstrap do that memory-safe install itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)