### PR TITLE
fix(obs): load alert-agent instructions as CLAUDE.md (free-text DMs fumble without context)

### DIFF
--- a/apps/alert-agent/manifests/deployment.yaml
+++ b/apps/alert-agent/manifests/deployment.yaml
@@ -68,12 +68,16 @@ spec:
             - { name: pylib-handlers, mountPath: /opt/pylib/handlers }
             - { name: bin, mountPath: /opt/alert-agent-bin }
             - { name: crontab, mountPath: /home/agent/.crontab, subPath: .crontab }
-            # Mount the agent instructions as CLAUDE.md (NOT SKILL.md): claude
-            # auto-loads ./CLAUDE.md / ~/.claude/CLAUDE.md from its cwd, but never a
-            # file named SKILL.md. The driver launches claude with cwd /home/agent
-            # (WORKDIR), so this is loaded into context — without it, a free-text DM
-            # has no tools/boundary and reaches for kubectl (which doesn't exist
-            # here), burning the timeout. (ConfigMap key stays SKILL.md.)
+            # Load the agent instructions as the harness context file(s) — NOT
+            # SKILL.md, which no harness auto-loads. claude reads CLAUDE.md ONLY
+            # (never AGENTS.md natively); codex/opencode/antigravity read AGENTS.md
+            # (the cross-tool standard). Mount the same ConfigMap content under both
+            # so whichever harness the driver launches picks it up. The driver runs
+            # claude with cwd /home/agent (WORKDIR), so ./CLAUDE.md auto-loads —
+            # without it a free-text DM has no tools/boundary and reaches for kubectl
+            # (absent here), burning the timeout. (The multi-agent-shell image also
+            # fans AGENTS.md out to GEMINI.md / .github/copilot-instructions.md.)
+            - { name: skill, mountPath: /home/agent/AGENTS.md, subPath: SKILL.md }
             - { name: skill, mountPath: /home/agent/CLAUDE.md, subPath: SKILL.md }
           resources:
             requests: { cpu: 50m, memory: 256Mi }

--- a/apps/alert-agent/manifests/deployment.yaml
+++ b/apps/alert-agent/manifests/deployment.yaml
@@ -68,7 +68,13 @@ spec:
             - { name: pylib-handlers, mountPath: /opt/pylib/handlers }
             - { name: bin, mountPath: /opt/alert-agent-bin }
             - { name: crontab, mountPath: /home/agent/.crontab, subPath: .crontab }
-            - { name: skill, mountPath: /home/agent/SKILL.md, subPath: SKILL.md }
+            # Mount the agent instructions as CLAUDE.md (NOT SKILL.md): claude
+            # auto-loads ./CLAUDE.md / ~/.claude/CLAUDE.md from its cwd, but never a
+            # file named SKILL.md. The driver launches claude with cwd /home/agent
+            # (WORKDIR), so this is loaded into context — without it, a free-text DM
+            # has no tools/boundary and reaches for kubectl (which doesn't exist
+            # here), burning the timeout. (ConfigMap key stays SKILL.md.)
+            - { name: skill, mountPath: /home/agent/CLAUDE.md, subPath: SKILL.md }
           resources:
             requests: { cpu: 50m, memory: 256Mi }
             # claude TUI + tmux: one shared "alert-agent-ops" session for surge/


### PR DESCRIPTION
**Root cause of "the agent did not return a reply" on free-text DMs.**

The agent's instructions — persona, tools (`frank-facts`, VictoriaLogs/Grafana/GoatCounter HTTP endpoints) and the **"HTTP-only, NO kubernetes credential, no kubectl"** boundary — were mounted at `/home/agent/SKILL.md`. But claude Code auto-loads `CLAUDE.md`/`AGENTS.md` from cwd; it **never loads a file named `SKILL.md`**. So the instructions never entered claude's context. On a free-text DM ("what's the cluster status?") claude had no idea it's HTTP-only, reached for `kubectl` (→ `command not found`), and exhausted the 120 s timeout fumbling → fallback.

Confirmed live: the session is a healthy authed REPL running `Bash(kubectl … --all-namespaces)` → `kubectl: command not found`, "Effecting… 1m 20s". Slash commands (`/digest`, `/status`) work because their templates are self-contained.

**Fix:** mount the same ConfigMap content at `/home/agent/CLAUDE.md` (the driver launches claude with cwd `/home/agent` via WORKDIR, so it auto-loads). One-line `mountPath` change; ConfigMap key stays `SKILL.md`.

After deploy, the Recreate roll gives a fresh session that loads the instructions; the persisted conversation resumes (`--resume`) with CLAUDE.md in context, so claude uses `frank-facts`/the probes instead of kubectl. This is very likely the *original* "DMs not answered" bug that the infra fixes (continuum/cold-start/auth/OOM) were stacked on top of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)