### PR TITLE
fix(obs): raise alert-agent DM timeout 120s→600s + steer faster answers

### DIFF
--- a/apps/alert-agent/manifests/files/SKILL.md
+++ b/apps/alert-agent/manifests/files/SKILL.md
@@ -33,3 +33,12 @@ Telegram HTML sender 400s on them), no markdown tables, a few short lines.
 **Boundary:** you investigate and narrate. You do NOT mutate the cluster (no kubectl,
 no restarts, no acks) — cluster-API actions are out of scope (that is Sympozium's slice).
 Ground every claim in a fact you pulled; if you can't determine something, say so.
+
+## Answering inbound DMs — be fast and focused
+
+The operator is waiting in a live chat. **Lead with `frank-facts`** (pre-computed,
+instant) and only the **one or two** most relevant probes/queries; answer in a few
+short lines. Do NOT exhaustively sweep every endpoint or fire many sequential
+queries unless the operator explicitly asks for a full audit — a focused answer in
+well under a minute beats a 5-minute one. If a deeper dive is warranted, say what
+you'd check next and let the operator ask.

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -27,6 +27,13 @@ ALLOWED_CHATS = set(_CHATS)
 SESSION_URL = os.environ.get("AGENT_SESSION_URL", "http://localhost:8765")
 SESSION_AGENT = os.environ.get("AGENT_SESSION_AGENT", "claude")
 SESSION_ID = os.environ.get("AGENT_SESSION_ID", "alert-agent")
+# How long to wait for an interactive DM turn. The old 120s cut off legitimate
+# answers — a thorough probe-based "cluster status" investigation runs ~5 min. The
+# 120s was a pre-threading guard against freezing the single getUpdates consumer;
+# Fix D moved turns to per-session worker threads, so a slow turn no longer blocks
+# the consumer or static /help — only a second DM to the SAME chat waits. So allow
+# DM turns to run long enough to actually finish.
+DM_TIMEOUT_S = float(os.environ.get("DM_TIMEOUT_S", "600"))
 
 
 def _http_post_json(url: str, payload: dict, timeout: float = 310) -> dict:
@@ -239,9 +246,9 @@ def _run_agent_turn(chat_id, message_id, message) -> None:
     react = _react_fn(chat_id, message_id)
     session_id = f"{SESSION_ID}-tg-{chat_id}"
     with _session_lock(session_id):
-        # Shorter timeout for an interactive DM than the cron 300s — a stuck turn
-        # must not hold the session lock for 5 minutes.
-        resp = session_send(message, session_id=session_id, timeout_s=120)
+        # Long enough for a thorough turn to finish (DM_TIMEOUT_S). Safe under
+        # threading: a slow turn holds only THIS session's lock, not the consumer.
+        resp = session_send(message, session_id=session_id, timeout_s=DM_TIMEOUT_S)
     rendered = render_payload(resp)
     tg_send(rendered or "(the agent did not return a reply — it may be busy or unauthenticated)",
             str(chat_id))


### PR DESCRIPTION
**The agent was already answering free-text DMs correctly — it just couldn't deliver in time.**

Captured live: claude produced a proper probe-based cluster-status snapshot (UP/DOWN per `probe_success`, the CrowdSec-LAPI flap — **no kubectl**, so the CLAUDE.md context fix landed), but it **"Churned for 4m 47s"**. The DM timeout was **120 s**, so the driver gave up at 2 min and posted the fallback while the good answer sat undelivered in the pane.

That 120 s was a pre-threading guard so a slow turn wouldn't freeze the single getUpdates consumer. **Fix D made turns per-session worker threads**, so a slow turn no longer blocks the consumer or static `/help` — only a second DM to the *same* chat waits on the lock. So:

- **`DM_TIMEOUT_S` → 600 s** (env-overridable) — thorough turns finish and get delivered.
- **SKILL.md nudge**: answer DMs fast + focused — lead with `frank-facts` (pre-computed/instant) + 1-2 relevant probes, a few short lines; don't exhaustively sweep every endpoint unless asked. A sub-minute focused answer beats a 5-minute sweep for a live chat.

25 bridge tests pass. This is the last functional blocker — with it, free-text DMs both *answer correctly* (CLAUDE.md) and *get delivered* (timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)