### PR TITLE
fix(gpu): apply gpu-1 pcie_aspm=off via KernelArgs resource (not ConfigPatch)

### DIFF
--- a/patches/phase04-gpu/403-gpu1-pcie-aspm.yaml
+++ b/patches/phase04-gpu/403-gpu1-pcie-aspm.yaml
@@ -1,42 +1,50 @@
 ## Disable PCIe ASPM on gpu-1 to stop the onboard Realtek r8169 (enp3s0) NIC
-## link-flap. The 2.5GbE NIC flaps (link up/down every few seconds, stripping
+## link-flap. The 2.5GbE NIC flaps (link up/down every minute or two, stripping
 ## the node IP off Cilium's direct-routing device → datapath collapse → all
 ## gpu-1 pod traffic drops) — a classic r8169 PCIe Active State Power Management
 ## instability. A cable reseat on 2026-06-08 only downgraded a continuous storm
-## to intermittent flapping (recurred 2026-06-08 13:18/13:30/13:49/20:45); this
-## is the durable fix that survives reboots, unlike a reseat. Detected by the
-## layer-1-nic-link-flap Grafana alert (frank#510/#513).
+## to intermittent flapping; pcie_aspm=off is the durable fix that survives
+## reboots. Detected by the layer-1-nic-link-flap Grafana alert (frank#510/#513).
 ##
-## Full incident + monitoring gap: docs/runbooks/frank-gotchas/networking.md
+## ── MECHANISM (this is the load-bearing correction) ───────────────────────────
+## Frank is an Omni-managed cluster whose machines boot a UKI (grubUseUKICmdline:
+## true). On a UKI machine the kernel cmdline is baked into the signed image, so
+## kernel args MUST go through Omni's SCHEMATIC, which Omni recomputes from the
+## KernelArgs.omni.sidero.dev resource (the kernel-arg analogue of the
+## ExtensionsConfigurations used by 402). Changing it triggers an Omni-driven
+## image rebuild + reboot — declarative, Omni-managed, no break-glass, no taint.
 ##
-## ⚠ MANUAL / DISRUPTIVE: changing install.extraKernelArgs reboots gpu-1 — the
-## ONLY GPU node (ollama / litellm / comfyui) and host of hard-pinned agent pods
-## (hermes-agent-shell, secure-agent-pod). Apply in a maintenance window; the
-## pods come back when gpu-1 rejoins. If pcie_aspm=off does NOT hold the link,
-## escalate to: switch-end cable + different switch port, then cap the link to
-## 1G (enp3s0 ethtool / 2.5G negotiation), then NIC replacement (one chassis
-## port only — no host-side failover).
+## The PREVIOUS revision of this file used a ConfigPatches resource with
+## machine.install.extraKernelArgs. That is the WRONG mechanism here: it does not
+## change the schematic ID, so Omni reported configuptodate:true and never
+## reinstalled — the arg was INERT from PR #515 (2026-06-09) until corrected here.
+## (Also: a plain reboot can't apply it — UKI cmdline is fixed until the installer
+## reruns; and `talosctl upgrade` is refused by Omni's API proxy for every role,
+## so the only direct-talosctl path is break-glass, which taints the cluster.)
 ##
-## Apply:
+## ⚠ DISRUPTIVE: reboots gpu-1 — the ONLY GPU node (ollama / litellm / comfyui)
+## and host of single-replica workloads (infisical) + the agent pods
+## (hermes-agent-shell, secure-agent-pod, n8n, paperclip). Longhorn volumes stay
+## up (replicas on other nodes). Pods come back when gpu-1 rejoins (~3-5 min).
+## If pcie_aspm=off does NOT hold the link, escalate to: switch-end cable +
+## different switch port, then cap the link to 1G (enp3s0 ethtool / 2.5G
+## negotiation), then NIC replacement (one chassis port only — no host failover).
+##
+## Apply (Omni rebuilds the schematic and reboots gpu-1 with its own authority):
+##   omnictl delete configpatch 403-gpu1-pcie-aspm   # remove the old inert resource, if present
 ##   omnictl apply -f patches/phase04-gpu/403-gpu1-pcie-aspm.yaml
-##   # Omni reconciles the machine config; gpu-1 reboots to pick up the boot arg.
 ## Verify:
-##   talosctl -n 192.168.55.31 read /proc/cmdline | grep -o 'pcie_aspm=off'
+##   talosctl -n 192.168.55.31 read /proc/cmdline | tr ' ' '\n' | grep pcie_aspm=off
+##   omnictl get kernelargsstatus 03ff0210-04e0-05b0-ab06-300700080009
 ##   # then watch the flap counter go quiet over the next day:
 ##   #   increase(node_network_carrier_changes_total{instance="192.168.55.31:9100",device="enp3s0"}[30m])
-##   # If /proc/cmdline lacks the arg after the reboot, force a bootloader
-##   # rewrite with a same-version upgrade:
-##   #   talosctl -n 192.168.55.31 upgrade --image <current-schematic-image>
 metadata:
     namespace: default
-    type: ConfigPatches.omni.sidero.dev
-    id: 403-gpu1-pcie-aspm
+    type: KernelArgs.omni.sidero.dev
+    id: 03ff0210-04e0-05b0-ab06-300700080009
     labels:
         omni.sidero.dev/cluster: frank
         omni.sidero.dev/cluster-machine: 03ff0210-04e0-05b0-ab06-300700080009
 spec:
-    data: |
-        machine:
-            install:
-                extraKernelArgs:
-                    - pcie_aspm=off
+    args:
+        - pcie_aspm=off


### PR DESCRIPTION
## Problem

The chronic gpu-1 `enp3s0` (Realtek r8169) NIC link-flap — which collapses the node's Cilium datapath and drives a recurring Grafana/Telegram alert storm (`layer-1-nic-link-flap`, frank-ops#1 + cascading Layer 5/8 alerts) — had a "durable fix" merged in #515 (2026-06-09) that **never actually applied**.

Root cause: `403` declared `pcie_aspm=off` via a **`ConfigPatches`** resource using `machine.install.extraKernelArgs`. On this Omni-managed cluster the machines boot a **UKI** (`grubUseUKICmdline: true`), so the kernel cmdline is baked into the signed image and kernel args must flow through the machine **schematic**. `machine.install.extraKernelArgs` does **not** change the schematic id, so Omni reported `configuptodate: true` and never recomputed the install image or reinstalled gpu-1. The arg sat inert for months.

## Fix

Replace the `ConfigPatches` resource with a **`KernelArgs.omni.sidero.dev`** resource — the kernel-arg analogue of the `ExtensionsConfigurations` already used by `402-gpu1-nvidia-extensions`. Omni folds the arg into gpu-1's schematic, recomputes the install image, and performs an **Omni-managed image rebuild + reboot** with its own authority (declarative, no break-glass, no taint).

## Verification

- ✅ `pcie_aspm=off` is now live in gpu-1's `/proc/cmdline` (confirmed via `talosctl dmesg`).
- ⏳ NIC-flap suppression is being confirmed over the day via `frank-ops#1`. Early signal is strong (only 2 transitional flaps since the reboot, none since; alert no longer re-firing).

## Notes

- A separate operational issue surfaced during deployment: the on-prem Omni control-plane runtime had **silently wedged** since a power outage (cold boot → stale clock → NTP jump → deadlock), accepting desired-state writes but reconciling nothing. Resolved out-of-band by restarting the `omni` container. A durable time-sync-gate fix for the Omni host is tracked separately (not in this repo — the `omni/` dir here is a copy).
- Blog/gotcha writeups are **deferred** until the flap-suppression confirmation lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)