### PR TITLE
test(obs): fix stale cert-canary route pin (gpu_timeshare route)

### DIFF
--- a/scripts/tests/test_cert_expiry_canary.py
+++ b/scripts/tests/test_cert_expiry_canary.py
@@ -135,10 +135,14 @@ def test_canary_mute_route_is_second():
 def test_existing_routes_preserved_in_order():
     # pin the total so a stray route inserted between the canary pair and the
     # tail can't hide in the [2:] slice
-    assert len(_routes()) == 6
+    assert len(_routes()) == 7
     tail = _routes()[2:]
     expected = [
         ("AI Helper Webhook", ['grafana_folder="blog-edge"'], False),
+        # GPU-timeshare feature-health: early continue:false to Health Bridge only
+        # (degraded tile, no Telegram) — must precede the severity routes so a
+        # gpu_timeshare alert never pages. See frank-gotchas "gpu_timeshare".
+        ("Health Bridge Webhook", ['gpu_timeshare="true"'], False),
         ("Telegram - Willikins", ["severity=critical"], True),
         ("Telegram - Willikins", ["severity=warning"], True),
         ("Health Bridge Webhook", ['grafana_folder="feature-health"'], False),


### PR DESCRIPTION
## Summary

`scripts/tests/test_cert_expiry_canary.py::test_existing_routes_preserved_in_order` fails on `main` (`assert 7 == 6`). Found incidentally during the CrowdSec post-merge verification (#583/#584).

**Cause:** the test pins the notification-policy route list. A legitimate route — `Health Bridge Webhook` matching `gpu_timeshare="true"` (`continue: false`, placed ahead of the severity routes so a GPU-timeshare alert reaches the degraded-tile webhook and never pages Telegram; see `frank-gotchas` "gpu_timeshare") — was added later without bumping the test's pinned count.

**Fix:** bump the pin to 7 and add the `gpu_timeshare` route to the expected tail in its correct position. **Test-only, no behavior change.**

## Verification

`uv run --with pytest --with pyyaml python -m pytest scripts/tests/test_cert_expiry_canary.py -q` → **12/12 pass** (was 11 pass / 1 fail).

> Note: no general CI runs `scripts/tests/` (only `agent-images-bump.yml` runs its own test), which is why this drift went unnoticed. Wiring `scripts/tests/` into CI is a worthwhile separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)