### PR TITLE
fix(net): re-front auth.frank.derio.net on in-cluster Traefik (frank-omni Pi dead)

### DIFF
--- a/apps/traefik/manifests/ingressroutes.yaml
+++ b/apps/traefik/manifests/ingressroutes.yaml
@@ -91,6 +91,39 @@ spec:
     domains:
       - main: "*.cluster.derio.net"
 ---
+# Incident 2026-06-20: the frank-omni Pi (192.168.55.10) that fronted
+# auth.frank.derio.net died (hardware; replacement ETA ~5 days). The Authentik
+# pod is alive and already served at auth.cluster.derio.net — but every consumer
+# hard-codes the legacy auth.frank.derio.net name: the kube-apiserver OIDC issuer
+# (patches/phase13-auth/oidc-apiserver.yaml — unchangeable while Omni is down),
+# AUTHENTIK_HOST, Grafana/ArgoCD OAuth, and the forward-auth browser redirect.
+# Re-front that name on the surviving in-cluster Traefik so all of them heal with
+# zero consumer edits. Pair with a DNS flip: auth.frank.derio.net A -> 192.168.55.220.
+# TEMPORARY — revert when the replacement host restores the original edge, or fold
+# into the frank.derio.net retirement (docs/superpowers/specs/2026-06-01--net--*).
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: authentik-frank
+  namespace: traefik-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`auth.frank.derio.net`)
+      kind: Rule
+      middlewares:
+        - name: ip-allowlist
+        - name: security-headers
+      services:
+        - name: authentik-server
+          namespace: authentik
+          port: 80
+  tls:
+    certResolver: cloudflare
+    domains:
+      - main: "auth.frank.derio.net"
+---
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:


### PR DESCRIPTION
Incident hotfix — the **frank-omni Pi 5** (`192.168.55.10`) that fronted both `omni.` and `auth.frank.derio.net` died (hardware; replacement ETA ~5 days).

## Why this works
The Authentik **pod is alive** and already served at `auth.cluster.derio.net` (verified HTTP 200 via Traefik `192.168.55.220`). Only the legacy hostname `auth.frank.derio.net` is dead — and every consumer hard-codes it:
- kube-apiserver OIDC issuer (`patches/phase13-auth/oidc-apiserver.yaml`) — **cannot be changed while Omni is down**, so the name must be restored, not replaced
- `AUTHENTIK_HOST`, Grafana / ArgoCD OAuth endpoints
- the forward-auth **browser redirect** (the server-side check already uses `authentik-server.authentik.svc.cluster.local`, so it never broke)

Re-fronting the name on the surviving in-cluster Traefik heals all of them with **zero consumer edits**.

## Change
One new `IngressRoute` (`authentik-frank`) → `authentik-server`, cert via the existing Cloudflare DNS-01 resolver (`derio.net` zone covers it). Deployed via **ArgoCD** — the only surviving apply path (kubectl/talosctl route through the dead Omni proxy).

## Operator steps after merge
1. ArgoCD syncs the route; Traefik issues the `auth.frank.derio.net` cert (~1–2 min, DNS-01).
2. **DNS flip:** `auth.frank.derio.net` A record `192.168.55.10` → `192.168.55.220`.
3. Verify SSO (Grafana/ArgoCD login, the 12 forward-auth services); tier-B alerts self-clear.

**TEMPORARY** — revert when the replacement host restores the original edge, or fold into the `frank.derio.net` retirement (`docs/superpowers/specs/2026-06-01--net--frank-derio-net-retire-design.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)