### PR TITLE
fix(net): drop forward-auth from self-authing legacy .frank routes (404 fix)

### DIFF
--- a/apps/traefik/manifests/ingressroutes.yaml
+++ b/apps/traefik/manifests/ingressroutes.yaml
@@ -550,10 +550,13 @@ spec:
   routes:
     - match: Host(`grafana.frank.derio.net`)
       kind: Rule
+      # No forward-auth: Grafana self-auths via its own Authentik OAuth
+      # (generic_oauth). The forward-auth proxy providers are *.cluster-scoped,
+      # so Authentik 404s on the .frank host (incident 2026-06-20). LAN-only
+      # via ip-allowlist; SSO gate restored when the .frank edge returns.
       middlewares:
         - name: ip-allowlist
         - name: security-headers
-        - name: authentik-forwardauth
       services:
         - name: victoria-metrics-grafana
           namespace: monitoring
@@ -645,10 +648,12 @@ spec:
   routes:
     - match: Host(`infisical.frank.derio.net`)
       kind: Rule
+      # No forward-auth: Infisical has its own login. .cluster-scoped proxy
+      # providers 404 on the .frank host (incident 2026-06-20). LAN-only via
+      # ip-allowlist; SSO gate restored when the .frank edge returns.
       middlewares:
         - name: ip-allowlist
         - name: security-headers
-        - name: authentik-forwardauth
       services:
         - name: infisical-infisical-standalone-infisical
           namespace: infisical
@@ -669,10 +674,12 @@ spec:
   routes:
     - match: Host(`paperclip.frank.derio.net`)
       kind: Rule
+      # No forward-auth: Paperclip self-auths (better-auth session). .cluster-scoped
+      # proxy providers 404 on the .frank host (incident 2026-06-20). LAN-only via
+      # ip-allowlist; SSO gate restored when the .frank edge returns.
       middlewares:
         - name: ip-allowlist
         - name: security-headers
-        - name: authentik-forwardauth
       services:
         - name: paperclip-lb
           namespace: paperclip-system
@@ -716,10 +723,12 @@ spec:
   routes:
     - match: Host(`n8n-01.frank.derio.net`)
       kind: Rule
+      # No forward-auth: n8n has its own owner-account login. .cluster-scoped
+      # proxy providers 404 on the .frank host (incident 2026-06-20). LAN-only via
+      # ip-allowlist; SSO gate restored when the .frank edge returns.
       middlewares:
         - name: ip-allowlist
         - name: security-headers
-        - name: authentik-forwardauth
       services:
         - name: n8n-01
           namespace: n8n-01


### PR DESCRIPTION
Follow-up to #591. After it deployed, 4 of the 8 legacy `.frank` routes returned **404 from Authentik** (`x-powered-by: authentik` on the 404 body), while `argocd`/`sympozium` returned 200 and `longhorn`/`hubble` correctly 302-redirected to login.

## Root cause
#591 mirrored each `.cluster` route's middlewares, including `authentik-forwardauth`. But Authentik's proxy providers are registered with `external_host: *.cluster.derio.net`, so the forward-auth check **has no application matching the `.frank` host → 404**. `longhorn`/`hubble` work only because their providers happen to carry legacy `.frank` redirect URIs. Adding `.frank` to the other providers would need an Authentik blueprint change **plus** the manual outpost-assignment ORM step — which requires `kubectl exec`, unavailable while Omni is down.

## Fix
The four 404 services all have **their own application login**, so they never needed the forward-auth gate that the auth-less `longhorn`/`hubble` UIs require:

| Service | Native auth | Action |
|---|---|---|
| `grafana.frank` | Authentik OAuth (`generic_oauth`) | drop forward-auth |
| `infisical.frank` | Infisical login | drop forward-auth |
| `paperclip.frank` | better-auth session | drop forward-auth |
| `n8n-01.frank` | n8n owner account | drop forward-auth |

They fall back to native login, still behind the **LAN-only `ip-allowlist`**. `longhorn`/`hubble` keep their (working) forward-auth.

## Tradeoff
This drops the *SSO gate* for these four on their `.frank` host for the outage window — they rely on app-native login + LAN-only access instead. Restored when the replacement edge returns (or when forward-auth `.frank` support is added to the providers).

## After merge
ArgoCD syncs (~3 min) → `grafana.frank.derio.net` loads its own login → "Sign in with Authentik" completes the OAuth round-trip (also verifies the in-cluster pod→token path). Then Grafana is reachable to silence the residual `omni.frank` alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)