### PR TITLE
chore(paperclip): bump to v2026.626.0

### DIFF
--- a/apps/paperclip/manifests/deployment.yaml
+++ b/apps/paperclip/manifests/deployment.yaml
@@ -94,17 +94,17 @@ spec:
       containers:
         - name: paperclip
           # Upstream public image. Pinned by digest-equivalent sha tag.
-          # sha-911a1e8 == git tag v2026.529.0 (released 2026-05-29).
-          # v2026.529.0 adds inline document annotations with revision-aware
-          # threads, company skills CLI + catalog management, user-scoped
-          # sidebar visibility for projects/agents, first-admin claim flow
-          # for fresh self-hosted deployments, and live Claude model discovery
-          # (auto-refreshes Anthropic catalog from the UI). Tag scheme is
-          # upstream's: only `latest` (master HEAD), `canary`, and `sha-<short>`
-          # are published — no semver image tags. We pin to the sha for
-          # traceability: v2026.529.0 → commit 911a1e8b0d24205acd5006e837a5c5e8c4bfb447.
-          # Bumped from sha-60efa38 (v2026.525.0, 2026-05-25).
-          image: ghcr.io/paperclipai/paperclip:sha-911a1e8
+          # sha-4c6c0c6 == git tag v2026.626.0 (released 2026-06-26).
+          # v2026.626.0 adds task watchdogs, ask work mode, built-in Hermes
+          # adapter (local + remote gateway), workspace file downloads,
+          # sandbox runtime status in threads, routine date variables,
+          # per-company JWT signing key isolation, Skills Store, and
+          # self-hostable K8s sandbox execution. Tag scheme is upstream's:
+          # only `latest` (master HEAD), `canary`, and `sha-<short>` are
+          # published — no semver image tags. We pin to the sha for
+          # traceability: v2026.626.0 → commit 4c6c0c6ad048838dda4a67e1aca43aa37a6fcf0d.
+          # Bumped from sha-911a1e8 (v2026.529.0, 2026-05-29).
+          image: ghcr.io/paperclipai/paperclip:sha-4c6c0c6
           ports:
             - name: http
               containerPort: 3100


### PR DESCRIPTION
Bumps the Paperclip image from `sha-911a1e8` (v2026.529.0, 2026-05-29) to `sha-4c6c0c6` (v2026.626.0, 2026-06-26). Spans **3 upstream releases**.

---

### v2026.609.0 (2026-06-09)

- **Company Artifacts** — Files, media, and documents agents produce are now first-class: a company-scoped Artifacts page indexes every work product across issues and runs, with upload and rich video playback.
- **Collapsible sidebar rail** — Primary navigation can collapse to a persisted rail with hover/focus peek, giving contextual pages more horizontal room.
- **Rich issue attachments with video** — Issues now accept video attachments with inline playback and standalone PWA browser controls.
- **Checkbox confirmation interactions** — Issue-thread interactions can ask the board or user to confirm options via a structured checkbox payload, with consistent validation across API, CLI, plugin helpers, and UI.
- **Information Architecture refresh (experimental)** — Opt-in visual refresh of project and agent surfaces; instance settings now live under company settings.
- **Automated PR quality and security gates** — `commitperclip` runs automated quality and security gates on incoming PRs (linked issue, test coverage, clean lockfile, dedup-search), with low-trust review containment.

### v2026.618.0 (2026-06-18)

- **Skills Store** — Browse, install, and manage agent skills from a dedicated in-app store; skills are now a first-class installable unit with install counts and a company-scoped catalog.
- **Self-hostable sandbox execution** — A self-hostable Kubernetes sandbox provider plugin lands alongside server-side K8s execution integration, hardened agent-runtime images, and a new Novita sandbox provider.
- **Per-company multi-tenant isolation** — Each company now gets its own JWT signing keys; cloud tenants are strictly company-scoped, and plugin tables carry a `company_id` foreign key.
- **Workspace file viewer and artifact links** — Inspect files agents produced directly from the issue thread via a built-in workspace file viewer and artifact links.
- **Env-driven gateway routing for local adapters** — `codex`, `pi`, `opencode`, and `gemini` local adapters can now route through custom providers and gateways via environment configuration.

### v2026.626.0 (2026-06-26)

- **Hermes, now built in (local & remote gateway)** — Hermes is a first-class adapter: hire `hermes_local` agents that run on your own machine, or `hermes_gateway` agents running Hermes remotely through a gateway — no manual plugin install required. *(Note: our deployment already wires hermes via the PVC/initContainer; the built-in adapter may interact with or shadow the existing setup — verify.)*
- **Task watchdogs** — A first-class watchdog control plane lets you attach automated checks to a task and have Paperclip watch it for you, surfacing state, outcomes, and outstanding work in the issue thread.
- **Ask work mode** — Issues can now run in an "ask" work mode for Q&A tasks.
- **Sandbox runtime status, live in threads** — Ephemeral sandbox runtimes report status directly in issue threads; Daytona sandbox leases are reused across runs.
- **Workspace file downloads & external object references** — Download agent-produced files straight from the workspace; reference external objects across issue surfaces.
- **Routine date variables** — Routines gain date variable controls for parameterizing recurring prompts on the run date.
- **Per-company JWT signing keys** — Security foundation for shared/cloud deployments (landed in v2026.618.0, hardened here).

---

## Pre-deploy checklist

- [ ] Snapshot the `paperclip-data` PVC (`data-paperclip-db-postgresql-0`) before merging — apply a `snapshots.longhorn.io` CR with `spec.createSnapshot: true` and `spec.volume: <pvc-uuid>`
- [ ] Check for new DB migrations across v2026.609.0 → v2026.626.0 in `packages/db/src/migrations/*.sql` on the upstream repo (diff the `sha-911a1e8...sha-4c6c0c6` range); flag any `CREATE EXTENSION` (must pre-create) or unguarded `DROP CONSTRAINT`/`ALTER`
- [ ] Confirm any new env vars called out in upstream Upgrade Guides are added to `apps/paperclip/manifests/configmap.yaml`
- [ ] Assess the built-in Hermes adapter landing (v2026.626.0 #8543): verify it does not conflict with the existing `hermes-init` initContainer and `/paperclip/agent-bin/.hermes` PVC setup; the built-in may shadow or duplicate the manual install
- [ ] Confirm imagePullSecret is still NOT needed (upstream package is public)

Generated by the monthly upstream-watcher routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F6RZ7t9X3qFYBvMk5Cnuw4)_