### PR TITLE
feat(repo): wire /blog-craft:blog-post overview auto-append + fix blog workflows

### DIFF
--- a/agents/rules/repo-workflows.md
+++ b/agents/rules/repo-workflows.md
@@ -6,7 +6,7 @@ Every layer follows this sequence:
 2. **Plan** — `/fr-plan` to produce a phase-structured implementation plan. The layer code is chosen at this step (see `docs/layers.yaml` for the registry). Plan behavior is driven by `docs/superpowers/plan-config.yaml`
 3. **Execute** — fr-plan offers three execution paths: VK dispatch, subagent-driven, or inline execution
 4. **Deploy** — Implement the ArgoCD app (values, Application CR, manifests)
-5. **Blog** — Use the `/blog-craft:blog-post` skill to write the Hugo post. After creating the post, update `blog/content/docs/building/00-overview/index.md` (Series Index + Capability Map) and add the new roadmap layer to `blog/data/roadmap.yaml` (the roadmap is data-driven now — not the old `cluster-roadmap.html` shortcode)
+5. **Blog** — Use `/blog-craft:blog-post <series> <NN> <slug> "<title>"`. It scaffolds the page bundle, generates the cover, **auto-appends to the building overview's Series Index + Capability Map** (via the `<!-- /blog-post auto-appends … -->` markers in `blog/content/docs/building/00-overview/index.md`), and runs `/blog-craft:media` for any media markers. Then **add the new layer to `blog/data/roadmap.yaml`** (data-driven roadmap; not the old `cluster-roadmap.html` shortcode). Note: the **operating** series index lives in the same combined `building/00-overview` (there is no `operating/00-overview`), so operating-series posts are **not** auto-appended — update that index by hand until it's split out
 6. **Update README** — Run `/update-readme` to sync Technology Stack, Repository Structure, Service Access, and Current Status in `README.md`
 7. **Sync runbook** — Run `/sync-runbook` if the layer plan contains any `# manual-operation` blocks
 8. **Review** — Verify deployment health and blog accuracy. Update the plan's `**Status:**` to `Deployed` (cluster workload) or `Complete` (repo/meta work)
@@ -18,7 +18,7 @@ When a deployed layer needs a bugfix or unplanned extension:
 1. **Diagnose** — `/systematic-debugging` to identify root cause. Document findings in the existing layer plan as a new "Deviation" entry
 2. **Fix** — Implement the fix in the original layer's ArgoCD app/manifests (not a new app)
 3. **Update plan** — Add deviation notes inline at the affected task + append to the Deployment Deviations section
-4. **Update blog** — Retroactively update the layer's building/ post (add gotcha or correction) and operating/ post (add new operational commands). Do NOT create a new post unless the fix is substantial enough to warrant its own narrative (e.g., the GPU Talos validation fix)
+4. **Update blog** — Retroactively edit the layer's building/ post (add gotcha or correction) and operating/ post (add new operational commands) directly — extending an existing post is a normal markdown edit, not a `/blog-craft:blog-post` run. If you add new `<!-- MEDIA: … -->` markers, run `/blog-craft:media` to fill them. Do NOT create a new post unless the fix is substantial enough to warrant its own narrative (e.g., the GPU Talos validation fix)
 5. **Update gotchas** — If the fix reveals a non-obvious pattern, add a one-liner to `agents/rules/frank-gotchas.md` (or `hop-gotchas.md`) and the full prose / recovery commands to the matching per-topic file under `docs/runbooks/frank-gotchas/<topic>.md` (see that dir's `README.md` for the topic→file map). Hot file is part of the required agent load order; per-topic files are not (read on demand).
 
 Use the layer code in commit messages: `fix(gpu): <description>` or `feat(edge): <description>`.

--- a/blog/content/docs/building/00-overview/index.md
+++ b/blog/content/docs/building/00-overview/index.md
@@ -73,6 +73,7 @@ This post is a **living document**: it gets updated as new technologies and capa
 | gpu-1 | AI Compute (C) | Worker | i9, 128GB RAM, RTX 5070, 2x4TB SSD |
 | pc-1 | Edge (D) | Worker | Legacy desktop, 64GB SSD + 3x HDD |
 | raspi-1/2 | Edge (D) | Worker | Raspberry Pi 4, 32GB SD |
+<!-- /blog-post auto-appends rows here. -->
 
 ## Series Index
 
@@ -111,6 +112,7 @@ This post is a **living document**: it gets updated as new technologies and capa
 33. [Hermes Agent Shell — A BYOK Pod That Ignored Its Own Keys]({{< relref "/docs/building/33-hermes-shell" >}})
 
 - Virtual Machines with KubeVirt _(planned)_
+<!-- /blog-post auto-appends entries here as posts are created. -->
 
 ## Operating on Frank — Series Index
 


### PR DESCRIPTION
Post-cutover follow-up for writing/extending blog posts.

## Problem
The cutover retired frank's inline `blog-post` skill for `/blog-craft:blog-post`, but the helper auto-appends to the series overview at two **marker comments** my overview didn't have (the old skill used a different anchor). They're invisible HTML comments and the overview is content (preserved as-is), so this passed render-identity and every gate — it would only surface on the **next** post write: the scaffold succeeds but the Series-Index / Capability-Map update silently no-ops.

## Fix
- **`building/00-overview`**: added the INDEX marker (end of the building Series Index) + the MAP marker (end of the Capability Map). Proven with the real `insert-before-marker.py` — a building post now auto-appends to both.
- **`repo-workflows.md`**: 
  - Standard step 5 now describes the real flow: `/blog-craft:blog-post` scaffolds + generates the cover + auto-appends the overview + runs `/blog-craft:media`; then add the layer to `data/roadmap.yaml`.
  - Fix/extension step 4: extending an existing post is a plain markdown edit (+ `/blog-craft:media` for new markers), not a `blog-post` run.

## Known gap (flagged, not fixed here)
**Operating-series posts** point at a missing `operating/00-overview`. frank's operating index lives in the *combined* `building/00-overview`, which blog-craft's per-series helper can't reach — so operating index/map updates stay manual. Two ways to close it later, operator's call:
1. **Split** `operating/00-overview` out of the combined overview (matches blog-craft's per-series model; adds an operating landing page), or
2. teach blog-craft a **combined-overview** mode (a `series[].overview` path override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)