### PR TITLE
fix(cicd): quiet cluster drift and restore tekton gc

### DIFF
--- a/apps/longhorn/manifests/backup-target-default.yaml
+++ b/apps/longhorn/manifests/backup-target-default.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   backupTargetURL: "s3://frank-longhorn-backups@auto/"
   credentialSecret: "longhorn-r2-secret"
-  pollInterval: "5m"
+  pollInterval: "5m0s"

--- a/apps/root/templates/longhorn-extras.yaml
+++ b/apps/root/templates/longhorn-extras.yaml
@@ -26,3 +26,10 @@ spec:
       namespace: longhorn-system
       jsonPointers:
         - /data
+    # Longhorn writes this timestamp every backup-target sync request.
+    - group: longhorn.io
+      kind: BackupTarget
+      name: default
+      namespace: longhorn-system
+      jsonPointers:
+        - /spec/syncRequestedAt

--- a/apps/root/templates/sympozium-extras.yaml
+++ b/apps/root/templates/sympozium-extras.yaml
@@ -25,3 +25,11 @@ spec:
     - kind: Service
       jsonPointers:
         - /spec/selector
+    # Sympozium reconciles disabled PersonaPacks and normalizes these fields
+    # while leaving status.phase=Inactive. Keep ArgoCD from self-healing forever.
+    - group: sympozium.ai
+      kind: PersonaPack
+      namespace: sympozium-system
+      jsonPointers:
+        - /spec/enabled
+        - /spec/authRefs

--- a/apps/root/templates/tekton-extras.yaml
+++ b/apps/root/templates/tekton-extras.yaml
@@ -28,3 +28,14 @@ spec:
     - kind: Secret
       jsonPointers:
         - /data
+    # Tekton defaults embedded taskSpecs with empty metadata/spec and empty
+    # computeResources maps. Ignore only those empty defaults, not real step
+    # images, scripts, params, or non-empty resource requests/limits.
+    - group: tekton.dev
+      kind: Pipeline
+      namespace: tekton-pipelines
+      jqPathExpressions:
+        - '.spec.tasks[]?.taskSpec.metadata | select(. == {})'
+        - '.spec.tasks[]?.taskSpec.spec | select(. == null)'
+        - '.spec.tasks[]?.taskSpec.stepTemplate.computeResources | select(. == {})'
+        - '.spec.tasks[]?.taskSpec.steps[]?.computeResources | select(. == {})'

--- a/apps/root/templates/vcluster-experiments.yaml
+++ b/apps/root/templates/vcluster-experiments.yaml
@@ -34,16 +34,16 @@ spec:
     - kind: Secret
       jsonPointers:
         - /data
-    # vCluster chart injects a vClusterConfigHash annotation and omits
-    # several StatefulSet fields that Kubernetes defaults (whenScaled,
-    # revisionHistoryLimit, updateStrategy). Ignoring those keeps the
-    # essential spec in sync without fighting defaulted fields.
+    # vCluster and Kubernetes inject runtime/defaulted StatefulSet fields.
+    # Ignore only those fields so chart-owned spec still reconciles normally.
     - group: apps
       kind: StatefulSet
       name: experiments
       namespace: vcluster-experiments
       jsonPointers:
         - /spec/template/metadata/annotations/vClusterConfigHash
+        - /spec/template/metadata/annotations/kubectl.kubernetes.io~1restartedAt
+        - /spec/persistentVolumeClaimRetentionPolicy/whenDeleted
         - /spec/persistentVolumeClaimRetentionPolicy/whenScaled
         - /spec/revisionHistoryLimit
         - /spec/updateStrategy

--- a/apps/tekton/manifests/pipelinerun-ttl-gc.yaml
+++ b/apps/tekton/manifests/pipelinerun-ttl-gc.yaml
@@ -61,7 +61,7 @@ spec:
             kubernetes.io/hostname: pc-1
           containers:
             - name: gc
-              image: bitnami/kubectl:1.35.3
+              image: bitnamilegacy/kubectl:1.33.4
               securityContext:
                 allowPrivilegeEscalation: false
                 runAsNonRoot: true

--- a/docs/superpowers/debugging/2026-07-06-cluster-status-drift.md
+++ b/docs/superpowers/debugging/2026-07-06-cluster-status-drift.md
@@ -1,0 +1,73 @@
+# 2026-07-06 cluster status drift
+
+## Symptom & reproduction
+
+`kubectl get nodes` showed all seven Frank nodes `Ready`, but the status check had three noisy classes of issues:
+
+- ArgoCD applications repeatedly reported `OutOfSync` while `Healthy`: `longhorn-extras`, `stoa-live-mirror-sync`, `sympozium-extras`, `tekton-extras`, and `vcluster-experiments`.
+- `tekton-pipelines` had old failed task pods and one long-lived `pipelinerun-ttl-gc-29646990-m2dhv` pod stuck in image pull.
+- Recent events showed ArgoCD repeatedly self-healing partial sync drift.
+
+Reproduction commands used during diagnosis:
+
+```bash
+kubectl get applications -n argocd -o 'custom-columns=NAME:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status'
+kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded
+kubectl -n tekton-pipelines get pod pipelinerun-ttl-gc-29646990-m2dhv -o json
+```
+
+## Evidence
+
+Live ArgoCD resource status identified these drift resources:
+
+```text
+longhorn-extras BackupTarget longhorn-system/default OutOfSync
+sympozium-extras PersonaPack sympozium-system/developer-team OutOfSync
+sympozium-extras PersonaPack sympozium-system/devops-essentials OutOfSync
+tekton-extras Pipeline/Task/EventListener resources OutOfSync
+tekton-extras old TriggerTemplates requiresPruning=true
+vcluster-experiments StatefulSet vcluster-experiments/experiments OutOfSync
+```
+
+The stuck GC pod was owned by `Job/pipelinerun-ttl-gc-29646990` and used:
+
+```text
+bitnami/kubectl:1.35.3
+```
+
+The container runtime reported that `docker.io/bitnami/kubectl:1.35.3` was not found.
+
+Longhorn live `BackupTarget/default` contained controller-written fields not present in Git:
+
+```yaml
+spec:
+  pollInterval: 5m0s
+  syncRequestedAt: "2026-07-06T13:19:44Z"
+```
+
+Sympozium live disabled PersonaPacks remained `status.phase: Inactive`, but the controller normalized away `spec.enabled` and `spec.authRefs`, causing ArgoCD to keep trying to restore them.
+
+vCluster live `StatefulSet/experiments` contained runtime/defaulted fields such as `kubectl.kubernetes.io/restartedAt` and `persistentVolumeClaimRetentionPolicy.whenDeleted` that were not ignored.
+
+Tekton live embedded `taskSpec`s had defaulted empty fields such as `metadata: {}`, `spec: null`, and empty `computeResources: {}` maps.
+
+## Root cause
+
+The cluster was healthy, but ArgoCD was noisy because several controllers normalize their CRs after apply, and the Application ignore rules did not cover those controller-owned/defaulted fields. The pending Tekton pod existed because the daily PipelineRun TTL GC CronJob pinned a removed image tag, `bitnami/kubectl:1.35.3`.
+
+## Fix
+
+- Changed the PipelineRun TTL GC CronJob image to `bitnamilegacy/kubectl:1.33.4`, preserving bash, GNU date, and kubectl behavior while using the post-Bitnami-migration namespace.
+- Canonicalized Longhorn `pollInterval` to `5m0s` and ignored controller-written `/spec/syncRequestedAt` for `BackupTarget/default`.
+- Ignored Sympozium controller-normalized `PersonaPack` fields `/spec/enabled` and `/spec/authRefs`.
+- Extended vCluster StatefulSet ignores to runtime/defaulted `restartedAt` and `whenDeleted` fields.
+- Added narrow Tekton Pipeline `jqPathExpressions` for defaulted empty embedded `taskSpec` fields.
+
+The live old failed Tekton pods and old failed GC job are historical objects. The repo fix prevents new GC jobs from failing; deleting historical pods/jobs is a one-time cluster cleanup rather than declarative source repair.
+
+## Rejected hypotheses
+
+- Node or kubelet failure: rejected because all seven Kubernetes nodes were `Ready`, Talos health passed etcd/apid/kubelet/boot/disk/memory checks, and no Deployment/StatefulSet/DaemonSet was under-ready.
+- Pending storage or LoadBalancer exhaustion: rejected because PVCs and LoadBalancer services had no pending rows.
+- Missing Sympozium CRD fields: rejected because the live CRD schema includes `enabled` and `authRefs`; the fields are controller-normalized, not API-pruned.
+- Repo source for the stuck image outside this repository: rejected after finding `apps/tekton/manifests/pipelinerun-ttl-gc.yaml` pins the exact failing image.

--- a/docs/superpowers/implemented/plans/2026-03-29--cicd--platform/_prose.md
+++ b/docs/superpowers/implemented/plans/2026-03-29--cicd--platform/_prose.md
@@ -186,7 +186,7 @@
 
 Tekton doesn't TTL PipelineRuns natively. Their task pods stay around for log inspection (good for the first hour) but accumulate over weeks. Aside from being clutter, they triggered a false-positive Layer 25 alert on 2026-05-13 (see the corresponding deviation note in `2026-04-16--platform--derio-ops-pass3-grafana-wiring/_prose.md` of the same date for context).
 
-New CronJob `pipelinerun-ttl-gc` in the `tekton-pipelines` namespace, daily at 04:30 UTC, deletes PipelineRuns whose `status.completionTime` is older than 7 days. ServiceAccount + Role limit blast radius to local-namespace `tekton.dev/pipelineruns: get/list/delete` only. Bash + kubectl image (`bitnami/kubectl:1.35.3`), no jq/python deps, lexical ISO-8601 comparison. Ad-hoc invocation:
+New CronJob `pipelinerun-ttl-gc` in the `tekton-pipelines` namespace, daily at 04:30 UTC, deletes PipelineRuns whose `status.completionTime` is older than 7 days. ServiceAccount + Role limit blast radius to local-namespace `tekton.dev/pipelineruns: get/list/delete` only. Bash + kubectl image (`bitnamilegacy/kubectl:1.33.4`), no jq/python deps, lexical ISO-8601 comparison. Ad-hoc invocation:
 
 ```bash
 kubectl create job -n tekton-pipelines --from=cronjob/pipelinerun-ttl-gc pipelinerun-ttl-gc-manual-$(date +%s)


### PR DESCRIPTION
## Summary
- replace the removed PipelineRun TTL GC image with verified `bitnamilegacy/kubectl:1.33.4`
- add narrow ArgoCD ignore rules for controller/defaulted drift in Longhorn, Sympozium, Tekton, and vCluster
- record the investigation in `docs/superpowers/debugging/2026-07-06-cluster-status-drift.md`

## Root cause
Frank was healthy at the node/workload level, but ArgoCD was repeatedly self-healing controller-normalized fields. The pending Tekton GC pod was caused by `bitnami/kubectl:1.35.3` no longer existing on Docker Hub.

## Verification
- `helm lint apps/root`
- `scripts/validate-agent-config.sh`
- `scripts/validate-plans.sh` (minimal checks; super-fr validator unavailable)
- disposable pod smoke test: `bitnamilegacy/kubectl:1.33.4` runs bash, GNU date, and kubectl client under restricted PodSecurity

## Live cleanup performed
- deleted stale June 14 failed hum-ci PipelineRuns and their pods
- deleted stale June 13 live-mirror TaskRun and pod
- deleted failed PipelineRun TTL GC Jobs that were stuck on the removed image

Remaining non-running pods after cleanup are the two July 4 `live-mirror-sync` failures, left intact for recent log retention.