### PR TITLE
fix(cicd): ignore remaining controller defaults

### DIFF
--- a/apps/root/templates/stoa-live-mirror-sync.yaml
+++ b/apps/root/templates/stoa-live-mirror-sync.yaml
@@ -35,3 +35,17 @@ spec:
       - CreateNamespace=false
       - ServerSideApply=true
       - RespectIgnoreDifferences=true
+  ignoreDifferences:
+    - group: tekton.dev
+      kind: Task
+      namespace: tekton-pipelines
+      jqPathExpressions:
+        - '.spec.results[]?.type | select(. == "string")'
+    - group: triggers.tekton.dev
+      kind: EventListener
+      namespace: tekton-pipelines
+      jqPathExpressions:
+        - '.spec.namespaceSelector | select(. == {})'
+        - '.spec.resources | select(. == {})'
+        - '.spec.triggers[]?.bindings[]?.kind | select(. == "TriggerBinding")'
+        - '.spec.triggers[]?.interceptors[]?.ref.kind | select(. == "ClusterInterceptor")'

--- a/apps/root/templates/tekton-extras.yaml
+++ b/apps/root/templates/tekton-extras.yaml
@@ -39,3 +39,18 @@ spec:
         - '.spec.tasks[]?.taskSpec.spec | select(. == null)'
         - '.spec.tasks[]?.taskSpec.stepTemplate.computeResources | select(. == {})'
         - '.spec.tasks[]?.taskSpec.steps[]?.computeResources | select(. == {})'
+        - '.spec.tasks[]?.taskRef.kind | select(. == "Task")'
+    - group: tekton.dev
+      kind: Task
+      namespace: tekton-pipelines
+      jqPathExpressions:
+        - '.spec.results[]?.type | select(. == "string")'
+    - group: triggers.tekton.dev
+      kind: EventListener
+      namespace: tekton-pipelines
+      jqPathExpressions:
+        - '.spec.namespaceSelector | select(. == {})'
+        - '.spec.resources.kubernetesResource.spec.template.metadata.creationTimestamp | select(. == null)'
+        - '.spec.resources.kubernetesResource.spec.template.spec.containers | select(. == null)'
+        - '.spec.triggers[]?.bindings[]?.kind | select(. == "TriggerBinding")'
+        - '.spec.triggers[]?.interceptors[]?.ref.kind | select(. == "ClusterInterceptor")'

--- a/apps/root/templates/vcluster-experiments.yaml
+++ b/apps/root/templates/vcluster-experiments.yaml
@@ -47,3 +47,17 @@ spec:
         - /spec/persistentVolumeClaimRetentionPolicy/whenScaled
         - /spec/revisionHistoryLimit
         - /spec/updateStrategy
+        - /spec/template/spec/containers/0/imagePullPolicy
+        - /spec/template/spec/containers/0/terminationMessagePath
+        - /spec/template/spec/containers/0/terminationMessagePolicy
+        - /spec/template/spec/dnsPolicy
+        - /spec/template/spec/initContainers/0/terminationMessagePath
+        - /spec/template/spec/initContainers/0/terminationMessagePolicy
+        - /spec/template/spec/restartPolicy
+        - /spec/template/spec/schedulerName
+        - /spec/template/spec/serviceAccount
+        - /spec/template/spec/volumes/4/secret/defaultMode
+        - /spec/volumeClaimTemplates/0/apiVersion
+        - /spec/volumeClaimTemplates/0/kind
+        - /spec/volumeClaimTemplates/0/spec/volumeMode
+        - /spec/volumeClaimTemplates/0/status


### PR DESCRIPTION
## Summary
- ignore Tekton-defaulted task result types, taskRef kinds, and EventListener defaults
- add the same scoped Task/EventListener defaults to the external stoa-live-mirror-sync app
- ignore remaining Kubernetes/vCluster StatefulSet defaults that keep the vCluster app OutOfSync

## Evidence
After #613 merged, Sympozium and Longhorn became clean, but these residual resources still reported OutOfSync:
- tekton-extras: Pipeline, Task, and EventListener defaults plus old TriggerTemplates requiring prune
- stoa-live-mirror-sync: Task and EventListener defaults
- vcluster-experiments: StatefulSet runtime/defaulted fields

Representative direct diffs showed fields like:
- Task result `type: string`
- Pipeline `taskRef.kind: Task`
- EventListener `namespaceSelector: {}`, binding/interceptor kinds, and generated resource defaults
- StatefulSet pod policy/imagePull/termination defaults

## Verification
- `helm lint apps/root`
- `scripts/validate-agent-config.sh`
- `scripts/validate-plans.sh` (minimal checks; super-fr validator unavailable)

## Follow-up after merge
Sync root, delete the three stale TriggerTemplates from tekton-pipelines, hard-refresh affected apps, and verify all apps are Synced/Healthy before closing isolation.