### PR TITLE
fix(cicd): align tekton persisted defaults

### DIFF
--- a/apps/root/templates/stoa-live-mirror-sync.yaml
+++ b/apps/root/templates/stoa-live-mirror-sync.yaml
@@ -41,6 +41,8 @@ spec:
       namespace: tekton-pipelines
       jqPathExpressions:
         - '.spec.results[]?.type | select(. == "string")'
+      jsonPointers:
+        - /spec/steps/0/computeResources
     - group: triggers.tekton.dev
       kind: EventListener
       namespace: tekton-pipelines

--- a/apps/tekton/pipelines/content-factory-ci.yaml
+++ b/apps/tekton/pipelines/content-factory-ci.yaml
@@ -123,7 +123,7 @@ spec:
   finally:
     - name: github-status-success
       when: [{input: $(tasks.status), operator: in, values: ["Succeeded", "Completed"]}]
-      taskRef: {name: github-status}
+      taskRef: {kind: Task, name: github-status}
       params:
         - {name: repo-full-name, value: $(params.github-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -132,7 +132,7 @@ spec:
         - {name: context,        value: "tekton/ci"}
     - name: github-status-failure
       when: [{input: $(tasks.status), operator: notin, values: ["Succeeded", "Completed"]}]
-      taskRef: {name: github-status}
+      taskRef: {kind: Task, name: github-status}
       params:
         - {name: repo-full-name, value: $(params.github-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -143,7 +143,7 @@ spec:
     - name: gitea-status-success
       when: [{input: $(tasks.status), operator: in, values: ["Succeeded", "Completed"]}]
       onError: continue
-      taskRef: {name: gitea-status}
+      taskRef: {kind: Task, name: gitea-status}
       params:
         - {name: repo-full-name, value: $(params.gitea-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -153,7 +153,7 @@ spec:
     - name: gitea-status-failure
       when: [{input: $(tasks.status), operator: notin, values: ["Succeeded", "Completed"]}]
       onError: continue
-      taskRef: {name: gitea-status}
+      taskRef: {kind: Task, name: gitea-status}
       params:
         - {name: repo-full-name, value: $(params.gitea-repo)}
         - {name: revision,       value: $(params.sha)}

--- a/apps/tekton/pipelines/gitea-ci.yaml
+++ b/apps/tekton/pipelines/gitea-ci.yaml
@@ -30,6 +30,7 @@ spec:
   tasks:
     - name: clone
       taskRef:
+        kind: Task
         name: git-clone
       params:
         - name: url
@@ -42,6 +43,7 @@ spec:
     - name: test
       runAfter: ["clone"]
       taskRef:
+        kind: Task
         name: run-tests
       params:
         - name: test-command
@@ -56,6 +58,7 @@ spec:
           operator: notin
           values: [""]
       taskRef:
+        kind: Task
         name: build-push
       params:
         - name: image
@@ -74,6 +77,7 @@ spec:
           operator: notin
           values: [""]
       taskRef:
+        kind: Task
         name: cosign-sign
       params:
         - name: image
@@ -87,6 +91,7 @@ spec:
           operator: in
           values: ["Succeeded", "Completed"]
       taskRef:
+        kind: Task
         name: gitea-status
       params:
         - name: repo-full-name
@@ -103,6 +108,7 @@ spec:
           operator: notin
           values: ["Succeeded", "Completed"]
       taskRef:
+        kind: Task
         name: gitea-status
       params:
         - name: repo-full-name

--- a/apps/tekton/pipelines/hum-ci.yaml
+++ b/apps/tekton/pipelines/hum-ci.yaml
@@ -200,7 +200,7 @@ spec:
         - input: $(tasks.status)
           operator: in
           values: ["Succeeded", "Completed"]
-      taskRef: {name: github-status}
+      taskRef: {kind: Task, name: github-status}
       params:
         - {name: repo-full-name, value: $(params.github-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -213,7 +213,7 @@ spec:
         - input: $(tasks.status)
           operator: notin
           values: ["Succeeded", "Completed"]
-      taskRef: {name: github-status}
+      taskRef: {kind: Task, name: github-status}
       params:
         - {name: repo-full-name, value: $(params.github-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -231,7 +231,7 @@ spec:
           operator: in
           values: ["Succeeded", "Completed"]
       onError: continue
-      taskRef: {name: gitea-status}
+      taskRef: {kind: Task, name: gitea-status}
       params:
         - {name: repo-full-name, value: $(params.gitea-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -244,7 +244,7 @@ spec:
           operator: notin
           values: ["Succeeded", "Completed"]
       onError: continue
-      taskRef: {name: gitea-status}
+      taskRef: {kind: Task, name: gitea-status}
       params:
         - {name: repo-full-name, value: $(params.gitea-repo)}
         - {name: revision,       value: $(params.sha)}

--- a/apps/tekton/pipelines/stoa-blog-ci.yaml
+++ b/apps/tekton/pipelines/stoa-blog-ci.yaml
@@ -117,7 +117,7 @@ spec:
   finally:
     - name: github-status-success
       when: [{input: $(tasks.status), operator: in, values: ["Succeeded", "Completed"]}]
-      taskRef: {name: github-status}
+      taskRef: {kind: Task, name: github-status}
       params:
         - {name: repo-full-name, value: $(params.github-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -126,7 +126,7 @@ spec:
         - {name: context,        value: "tekton/ci"}
     - name: github-status-failure
       when: [{input: $(tasks.status), operator: notin, values: ["Succeeded", "Completed"]}]
-      taskRef: {name: github-status}
+      taskRef: {kind: Task, name: github-status}
       params:
         - {name: repo-full-name, value: $(params.github-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -137,7 +137,7 @@ spec:
     - name: gitea-status-success
       when: [{input: $(tasks.status), operator: in, values: ["Succeeded", "Completed"]}]
       onError: continue
-      taskRef: {name: gitea-status}
+      taskRef: {kind: Task, name: gitea-status}
       params:
         - {name: repo-full-name, value: $(params.gitea-repo)}
         - {name: revision,       value: $(params.sha)}
@@ -147,7 +147,7 @@ spec:
     - name: gitea-status-failure
       when: [{input: $(tasks.status), operator: notin, values: ["Succeeded", "Completed"]}]
       onError: continue
-      taskRef: {name: gitea-status}
+      taskRef: {kind: Task, name: gitea-status}
       params:
         - {name: repo-full-name, value: $(params.gitea-repo)}
         - {name: revision,       value: $(params.sha)}

--- a/apps/tekton/tasks/cosign-sign.yaml
+++ b/apps/tekton/tasks/cosign-sign.yaml
@@ -27,7 +27,6 @@ spec:
           memory: 512Mi
       env:
         - name: COSIGN_PASSWORD
-          value: ""
         - name: DOCKER_CONFIG
           value: /docker
       command: ["cosign"]


### PR DESCRIPTION
## Summary
- add Tekton's persisted `taskRef.kind: Task` defaults to CI Pipeline manifests
- remove the empty `COSIGN_PASSWORD` value that the Tekton API prunes from `cosign-sign`
- add a simple jsonPointer ignore for the external Stoa task's defaulted empty `computeResources`

## Evidence
After #614 merged, drift narrowed to source-vs-live Tekton defaults:
- `cosign-sign`: live prunes empty `env[].value`
- CI Pipelines: live persists `taskRef.kind: Task`
- external Stoa Task: live persists empty `steps[0].computeResources`

## Verification
- `helm lint apps/root`
- changed Tekton manifests parse with `kubectl create --dry-run=client --validate=false`
- `scripts/validate-agent-config.sh`
- `scripts/validate-plans.sh` (minimal checks; super-fr validator unavailable)

## After merge
Sync root, hard-refresh `tekton-extras` and `stoa-live-mirror-sync`, then verify no OutOfSync resources remain before closing isolation.