### PR TITLE
docs(edge): decommission raspi-vlan10-D/E → gondor argonath

### DIFF
--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -609,6 +609,7 @@ operations:
   plan: docs/superpowers/plans/2026-03-21--edge--subnet-router-autoapproval.md
   when: After Headscale ConfigMap deploy
   why_manual: Raspberry Pis are standalone devices outside the cluster; OS and Tailscale config is imperative
+  decommissioned: "2026-07-11 — Pi retired and its Headscale node deleted. The exit-node + subnet-router role moved to the gondor Proxmox VM argonath-w (192.168.10.31). See derio-homelab/proxmox-cluster: infra/tailscale.ts, config/roles/tailscale, docs/runbooks/05-tailscale-exit-node-cutover.md."
   commands:
   - sudo sysctl -w net.ipv4.ip_forward=1
   - echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/99-ip-forward.conf
@@ -616,13 +617,14 @@ operations:
   verify:
   - 'cat /proc/sys/net/ipv4/ip_forward  # Should return 1'
   - 'tailscale status  # Should show connected with tag:subnet-router'
-  status: done
+  status: decommissioned
 - id: edge-configure-raspi-e
   layer: edge
   app: headscale
   plan: docs/superpowers/plans/2026-03-21--edge--subnet-router-autoapproval.md
   when: After Headscale ConfigMap deploy
   why_manual: Raspberry Pis are standalone devices outside the cluster; OS and Tailscale config is imperative
+  decommissioned: "2026-07-11 — Pi retired and its Headscale node deleted. The exit-node + subnet-router role moved to the gondor Proxmox VM argonath-e (192.168.10.32). See derio-homelab/proxmox-cluster: infra/tailscale.ts, config/roles/tailscale, docs/runbooks/05-tailscale-exit-node-cutover.md."
   commands:
   - sudo sysctl -w net.ipv4.ip_forward=1
   - echo 'net.ipv4.ip_forward = 1' | sudo tee /etc/sysctl.d/99-ip-forward.conf
@@ -630,7 +632,7 @@ operations:
   verify:
   - 'cat /proc/sys/net/ipv4/ip_forward  # Should return 1'
   - 'tailscale status  # Should show connected with tag:subnet-router'
-  status: done
+  status: decommissioned
 - id: edge-hop-argocd-bootstrap
   layer: edge
   app: argocd (hop)


### PR DESCRIPTION
Retire the two Raspberry Pi Headscale subnet-router/exit nodes, whose role moved to the gondor Proxmox VMs `argonath-w`/`argonath-e` (derio-homelab/proxmox-cluster, PRs #19/#21).

**Scope (per operator): ops note + pointer only** — the dated blog narratives (building/operating/edge-observability) are left as historical records.

- `docs/runbooks/manual-operations.yaml`: both `edge-configure-raspi-{d,e}` marked `status: decommissioned` with a `decommissioned:` note pointing at the gondor argonath VMs + cutover runbook.

**Already done out-of-band (2026-07-11):** Pis powered off; their Headscale node entries deleted; argonath verified serving as subnet-router + exit (one Primary, one standby).

Validator: `scripts/validate-agent-config.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)