### PR TITLE
ci(bump): pin agent-images per-image by GHCR tag existence

### DIFF
--- a/.github/workflows/agent-images-bump.yml
+++ b/.github/workflows/agent-images-bump.yml
@@ -48,7 +48,9 @@ jobs:
           echo "Resolved: OLD_AI_SHA=$OLD_AI_SHA AI_SHA=$AI_SHA VKR_SHA=$VKR_SHA"
 
       - name: Update manifests
+        id: bump
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AI_SHA: ${{ steps.shas.outputs.ai_sha }}
           VKR_SHA: ${{ steps.shas.outputs.vkr_sha }}
         run: |
@@ -63,11 +65,45 @@ jobs:
           # `{ grep || true; }` so a listed-but-unpinned image (e.g. infra-shell)
           # — grep exit 1 — doesn't trip `bash -eo pipefail`; `xargs -r` no-ops on
           # empty input.
+          #
+          # PER-IMAGE EXISTENCE GATE: agent-images can now bump frank even when a
+          # flaky leg (e.g. secure-agent-kali on a Kali-rolling t64 break) did NOT
+          # publish at this SHA — its build leg is soft and dispatch-frank no
+          # longer waits on the kali smoke (see agent-images build.yaml). A blind
+          # pin would then point an app at a non-existent ghcr tag →
+          # ImagePullBackOff. So only pin an image whose
+          # ghcr.io/derio-net/<img>:<AI_SHA> tag actually exists. tag_exists:
+          #   0 = present            → pin
+          #   1 = definitively absent→ skip + warn, leave the old pin (recorded in
+          #                            the `skipped` output for the Verify step)
+          #   2 = could not verify (GHCR API error) → FAIL-OPEN, pin anyway (the
+          #       pre-existing behaviour) rather than stall the whole bump on a
+          #       transient API glitch.
           AGENT_IMAGES="secure-agent-kali vk-local paperclip-shell ruflo-server ruflo-shell multi-agent-shell hermes-agent-shell infra-shell"
+
+          tag_exists() {
+            local img="$1" sha="$2" out
+            if ! out=$(gh api --paginate "/orgs/derio-net/packages/container/${img}/versions" \
+                         --jq '.[].metadata.container.tags[]' 2>/dev/null); then
+              return 2
+            fi
+            printf '%s\n' "$out" | grep -qx "$sha"
+          }
+
+          SKIPPED=""
           for img in $AGENT_IMAGES; do
+            r=0; tag_exists "$img" "$AI_SHA" || r=$?
+            if [ "$r" -eq 1 ]; then
+              echo "::warning::${img} has no ghcr tag ${AI_SHA} — leaving its pin unchanged (per-image existence skip)"
+              SKIPPED="${SKIPPED:+$SKIPPED }${img}"
+              continue
+            fi
+            [ "$r" -eq 2 ] && echo "::warning::could not verify ${img}@${AI_SHA} in GHCR (API error) — pinning anyway (fail-open)"
             { grep -rlZ "ghcr.io/derio-net/$img:[a-f0-9]" apps/ 2>/dev/null || true; } \
               | xargs -0 -r sed -i "s|ghcr.io/derio-net/$img:[a-f0-9]\+|ghcr.io/derio-net/$img:$AI_SHA|g"
           done
+          echo "skipped=$SKIPPED" >> "$GITHUB_OUTPUT"
+          [ -n "$SKIPPED" ] && echo "Left un-bumped (not published at ${AI_SHA}): $SKIPPED"
 
           # vk-remote rides a DIFFERENT build (separate repo) → its own SHA.
           if [ -n "$VKR_SHA" ]; then
@@ -80,6 +116,7 @@ jobs:
       - name: Verify coverage
         env:
           AI_SHA: ${{ steps.shas.outputs.ai_sha }}
+          SKIPPED: ${{ steps.bump.outputs.skipped }}
         run: |
           # Guard against a NEW app pinning an agent-image the AGENT_IMAGES list
           # above does not cover (the silent-skip bug that stranded alert-agent /
@@ -87,15 +124,29 @@ jobs:
           # ghcr.io/derio-net/* pin in apps/ must equal AI_SHA — any other value
           # is an uncovered agent-image. vk-remote uses a short tag (not 40-hex)
           # so it is out of scope; `blog` is built by frank, not agent-images.
+          #
+          # Images intentionally left un-bumped this run by the per-image
+          # existence gate above (no ghcr tag at AI_SHA — e.g. a flaky kali that
+          # didn't publish) are ALLOWED to remain at their prior SHA; exclude them
+          # so a skipped image doesn't fail the very bump the gate was built to let
+          # through. This is NOT a coverage hole: an uncovered image (missing from
+          # AGENT_IMAGES) is never in SKIPPED, so it still trips the error below.
           stale=$(grep -rEo "ghcr.io/derio-net/[a-z0-9-]+:[a-f0-9]{40}" apps/ \
                     | grep -vE ":${AI_SHA}\$" \
                     | grep -vE "derio-net/blog:" || true)
+          for img in $SKIPPED; do
+            stale=$(printf '%s\n' "$stale" | grep -vE "derio-net/${img}:" || true)
+          done
           if [ -n "$stale" ]; then
-            echo "::error::agent-image pin(s) not bumped to ${AI_SHA} — add the image name to AGENT_IMAGES in .github/workflows/agent-images-bump.yml:"
+            echo "::error::agent-image pin(s) not bumped to ${AI_SHA} — add the image name to AGENT_IMAGES in .github/workflows/agent-images-bump.yml (or it genuinely failed to publish and isn't in the skip list):"
             printf '%s\n' "$stale" | sort -u
             exit 1
           fi
-          echo "coverage OK: all agent-image pins in apps/ are at ${AI_SHA}"
+          if [ -n "$SKIPPED" ]; then
+            echo "coverage OK: pins at ${AI_SHA}; intentionally left un-bumped (not published at this SHA): $SKIPPED"
+          else
+            echo "coverage OK: all agent-image pins in apps/ are at ${AI_SHA}"
+          fi
 
       - name: Open PR
         env:


### PR DESCRIPTION
## Why
The `agent-images-bumped` handler **blindly sed-pins every image** in `AGENT_IMAGES` to the incoming `$AI_SHA`, and its Verify-coverage step *fails* unless all pins equal `$AI_SHA`. That was safe only because `dispatch-frank` fired **exclusively when every agent-image (incl. `secure-agent-kali`) built + smoke-passed** at that SHA, guaranteeing all tags exist.

The companion agent-images PR (decouple the bump from the flaky kali leg) breaks that guarantee: a bump can now arrive at a SHA where `secure-agent-kali` did **not** publish. A blind pin would then point `secure-agent-pod` at a non-existent `secure-agent-kali:<sha>` → **ImagePullBackOff**.

## What
Pin per-image, gated on GHCR tag existence:
- `tag_exists(img, sha)` → **0** present (pin) · **1** definitively absent (skip + warn, leave prior pin, record in the `skipped` step output) · **2** GHCR API error (**fail-open** — pin anyway, the pre-existing behaviour, so a transient glitch never stalls the whole bump).
- `Verify coverage` excludes `skipped` images from the stale check. An **uncovered** image (missing from `AGENT_IMAGES`) is never in `skipped`, so it still trips the error — the coverage guard (`scripts/tests/test_agent_images_bump_coverage.py`) is intact.

Net: frank advances every image that actually published at the SHA and leaves the rest at their last-good pin. Future-proof for **any** image missing for any reason, not just kali.

## Design note
Alternative considered: have agent-images pass the built-image set via `client_payload` and consume it here. Rejected in favour of the handler querying GHCR directly — self-contained in frank, and robust to any publish gap regardless of cause. `$AI_SHA` stays regex-validated (`^[a-f0-9]{7,40}$`) upstream and is used via `env:`, so no injection surface.

## Validation
**Best-effort, unverified on CI** (cluster/CI down for maintenance; docker pruned). Locally: YAML parses, `bash -n` clean on both run blocks, and the coverage-test logic replicated green (no MISSING; only literal ghcr name in the workflow is still `vk-remote`; `AGENT_IMAGES` unchanged). No related open issue found.

Draft — do not merge during the maintenance window. **Merge before/with the agent-images decouple PR** so the decoupling is safe.