### PR TITLE
fix(hermes-agent-shell): wire dashboard basic-auth (unblocks the gateway)

### DIFF
--- a/apps/hermes-agent-shell/manifests/deployment.yaml
+++ b/apps/hermes-agent-shell/manifests/deployment.yaml
@@ -104,6 +104,32 @@ spec:
             # UNVERIFIED against migrated state and must be reconfirmed in Phase 3.
             - name: HERMES_DASHBOARD
               value: "1"
+            # Dashboard basic-auth. HERMES_DASHBOARD=1 makes the v0.18.2 dashboard
+            # HARD-REFUSE to bind (9119) without an auth provider, and that refusal
+            # loops and blocks the gateway API (8642) from binding at all, so the
+            # whole `hermes` container CrashLoops. These three env supply the auth
+            # (username/password + a session-signing secret) the dashboard needs.
+            # Sourced from a SOPS-bootstrapped Secret applied out-of-band (like the
+            # ssh-keys Secret — NOT ArgoCD-managed; see secrets/hermes-agent-shell/
+            # README.md). The migrate deployment used these same three keys from
+            # hermes-agent-shell-migrate-dashboard-auth; prod uses the stable name.
+            # NOT optional: the dashboard genuinely needs them to bind, so the pod
+            # must not start until the Secret exists (apply it before merging this).
+            - name: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-shell-dashboard-auth
+                  key: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+            - name: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-shell-dashboard-auth
+                  key: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+            - name: HERMES_DASHBOARD_BASIC_AUTH_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-shell-dashboard-auth
+                  key: HERMES_DASHBOARD_BASIC_AUTH_SECRET
             # Image-blessed ownership remap: the official image's internal `hermes`
             # user is UID/GID 10000. Setting these makes the s6 boot (running as
             # root) remap that user to 1000 and chown /opt/data, so shared-PVC

--- a/secrets/hermes-agent-shell/dashboard-auth.yaml
+++ b/secrets/hermes-agent-shell/dashboard-auth.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: hermes-agent-shell-dashboard-auth
+    namespace: hermes-agent-shell
+type: Opaque
+stringData:
+    HERMES_DASHBOARD_BASIC_AUTH_USERNAME: ENC[AES256_GCM,data:0WTzJH0045A=,iv:npe2XuxJTSqSL5HsbwwWbNrBVg4j4egkPfNElAGAKHI=,tag:2HdNNoAZvelpNWMVs1Wm1w==,type:str]
+    HERMES_DASHBOARD_BASIC_AUTH_PASSWORD: ENC[AES256_GCM,data:ladpOaqqhbcAw/78X0I+v0gETNWm1av0gdt2pV0Tue8=,iv:+LClSgxw+90WRPoMKQvUYORdNVMmGxq0dSABCngBAug=,tag:76lsAy6/IaDIGiwecKDCGw==,type:str]
+    HERMES_DASHBOARD_BASIC_AUTH_SECRET: ENC[AES256_GCM,data:SCx96j+a5pgeTUuDIcXwwmSaTyCAUWhw+MmaP2mhrb0hdK1/xjuRwRZA/QKYb6lyYemaeIShpUE9K1LKJJ4C7A==,iv:sL/6DgIJ6m5vhtyts5zdCkDoa0m+V+iTyPalMstpgkA=,tag:Vwwj7GiMW02OeNtU4nEGTQ==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA1a29HMEFwcUtRMjllYkow
+            WEg0blRwc1Y1Wi9ZUFhiUVNKVmNMQnE1bGprCm50R3FxSjhZS01CbDdLSlVFL2ds
+            UXRvM01KUmNkSVAwVmJrTVhOVlFJSXcKLS0tIEtJTlZ0NHVnK0lTSytWclhkVkpB
+            RVh0Y21zQTcrczlaRCtncGFsNVVDNjgKpfFaddU67yGxZ9yaL7Mh6+W61MHdvGEM
+            DjvXpUFs++QlSRghvwH7UsknhlAUSh5Fir9MfEj/BkYCZqbx2zdenA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ufxvcn4us3cue5dglwn4uk8ctjfpuaw6dqlwu4hjzszf2g4htpcqkszjne
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-12T14:20:20Z"
+    mac: ENC[AES256_GCM,data:W/lEjFJ16qbwM7890muO+vznPnmCNWFEw5Vq5qhXyRvNeK2V3TbrcQ6/3dX8XNKUAAYoYY2sWUMVKvY+AiutvnMm3HHKTuxeJnzBxjcoQAfSpAEe1cJGWYI6H8qLoYEfXHnEB3f0tpFcmeumOTMoW/5gRLNbOLZrEhQt8qbzpaM=,iv:O9dtpgLMZPq84qtsvMlBxMRpIDRlRz5/c56PocBIB5c=,tag:e/hRZ8zMRCEtIPR5FDWqSA==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Problem (post-cutover, live)
After #616 cut over, the `hermes` container CrashLoops and the pod is stuck **2/3**. `HERMES_DASHBOARD=1` is set but the `HERMES_DASHBOARD_BASIC_AUTH_*` env the migrate pod had was never committed. The v0.18.2 dashboard hard-refuses to bind (9119) without an auth provider, and that refusal loops and blocks the **gateway API (8642)** from binding at all → `hermes` fails its `:8642` probe → CrashLoop. (hindsight + ssh are fine; memory is fine — 369 units restored & persisting.)

## Fix
Add the three dashboard basic-auth env (username / password / session-signing secret) to the `hermes` container, sourced from a stable Secret `hermes-agent-shell-dashboard-auth`. Same three keys the migrate deployment used from its `-migrate-dashboard-auth` Secret.

The Secret follows the repo's **SOPS-bootstrap, applied out-of-band** pattern (like `ssh-keys`; NOT ArgoCD-managed — see `secrets/hermes-agent-shell/README.md`). It is **not `optional`**: the dashboard genuinely needs the values to bind, so the pod must not start until the Secret exists.

## Merge order (REQUIRED)
1. Create + apply the `hermes-agent-shell-dashboard-auth` Secret (bootstrap steps handed over separately).
2. Then merge this PR → ArgoCD reconciles → dashboard binds → gateway up → pod 3/3.

The migrate deployment + its `-migrate-dashboard-auth` Secret remain as the working reference until this is confirmed.