### PR TITLE
feat(hermes-agent-shell): enable gateway API server (:8642) via API_SERVER_* env

### DIFF
--- a/apps/hermes-agent-shell/manifests/deployment.yaml
+++ b/apps/hermes-agent-shell/manifests/deployment.yaml
@@ -130,6 +130,30 @@ spec:
                 secretKeyRef:
                   name: hermes-agent-shell-dashboard-auth
                   key: HERMES_DASHBOARD_BASIC_AUTH_SECRET
+            # Gateway programmatic API server (:8642 = the `api` port the
+            # readiness/liveness probes below hit). ENV-DRIVEN, not config-driven:
+            # there is no `api_server:` section in config.yaml — these three env
+            # are the ONLY mechanism that binds :8642. Without them the `hermes`
+            # container boots (gateway + dashboard :9119 come up) but NOTHING
+            # listens on :8642, so the tcpSocket probe on `api` never succeeds and
+            # the pod is stuck 2/3. Diagnosed by env-diffing the working temporary
+            # `hermes-agent-shell-migrate` deployment (which carried these) against
+            # prod (which lacked them). API_SERVER_KEY comes from a SOPS-bootstrapped
+            # Secret applied out-of-band (same pattern as the dashboard-auth /
+            # ssh-keys Secrets above — NOT ArgoCD-managed; see secrets/
+            # hermes-agent-shell/README.md). The migrate deployment used this exact
+            # key from hermes-agent-shell-migrate-api-key; prod uses the stable name.
+            # NOT optional: the API server needs the key, so the pod must not start
+            # until the Secret exists (apply it before merging this).
+            - name: API_SERVER_ENABLED
+              value: "1"
+            - name: API_SERVER_HOST
+              value: "0.0.0.0"
+            - name: API_SERVER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-agent-shell-api-key
+                  key: API_SERVER_KEY
             # Image-blessed ownership remap: the official image's internal `hermes`
             # user is UID/GID 10000. Setting these makes the s6 boot (running as
             # root) remap that user to 1000 and chown /opt/data, so shared-PVC

--- a/secrets/hermes-agent-shell/api-key.yaml
+++ b/secrets/hermes-agent-shell/api-key.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    API_SERVER_KEY: ENC[AES256_GCM,data:EdVVxqrZMfIO8Kh86VXr0SfbqxaoTeGAIwXQyV+0EiPnARLR5yxDbu7nuOyGwvbzL/8os4M24J/k3MmUwE7UJw==,iv:nwFKfDZ9o0wyTkAraI6DwjEgyASGwwB355RKaCXohUc=,tag:WJ+kbXgorxMDY7PNLk52Vw==,type:str]
+kind: Secret
+metadata:
+    name: hermes-agent-shell-api-key
+    namespace: hermes-agent-shell
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGbXRJbjNLbW1PdEo2bE45
+            MjZWMSs2RitueHhYeVR5SytGcm1NRzdEUlZjCmJpayszK3A0UUlSVkdqc3pJNUZq
+            U1g3V002UnpRc1FnWFRDSmVPUjJVcG8KLS0tIFRlUnFKalBRSUVsYTZ0VnZsNXFs
+            V1dVa3BxVURCcUdnWTRnN2crZnhvd3cKLA9zLT0SkasrZgMiajK0bY8vYP9ce7YZ
+            ew4YXTmsn77pDRblWpJMxHNRy9eTFUZ2N9w4kIVD7tbpMxyUNcABmw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ufxvcn4us3cue5dglwn4uk8ctjfpuaw6dqlwu4hjzszf2g4htpcqkszjne
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-07-12T15:35:35Z"
+    mac: ENC[AES256_GCM,data:cQO4QLj9+GTi/t6DonM5IIOr5hqOyI5sZTI83+ITt5LthhB9JTMskCbjcpNqmGVNtWhGIemh6dmmQ6HDJtxqhLXxjQjdT97xa+l4EvjmCHiPWHUO3nXG0pBJ4g44woRyGm1B0p+1rUa7TAQi0mEQIPUtYvmsFxeZinO58oQDBCw=,iv:/HzdmEG0VCKHSaiIQbVkS4SemCAPsvWAXCWl0cNMd5I=,tag:ywKCxynu1GXz3kZVWhYYiw==,type:str]
+    version: 3.13.1


### PR DESCRIPTION
## Problem (post-cutover, live — pod stuck 2/3)

After #616 cut over to the official image and #626 wired dashboard-auth, the `hermes` container's gateway + dashboard (:9119) boot fine — but its readiness/liveness probes hit the `api` port **:8642**, and **nothing binds there**, so `hermes` never becomes ready and the pod is stuck **2/3** (ssh + hindsight are fine).

## Root cause

Confirmed by env-diffing the working temporary `hermes-agent-shell-migrate` deployment against prod: the gateway's programmatic **API server (:8642) is ENV-DRIVEN, not config-driven**. There is no `api_server:` section in `config.yaml` — three env vars are the only mechanism, and prod lacked all three:

- `API_SERVER_ENABLED = "1"` (plain)
- `API_SERVER_HOST = "0.0.0.0"` (plain)
- `API_SERVER_KEY` (from a Secret)

## Fix

Add the three env to the `hermes` container. `API_SERVER_KEY` is sourced from a **SOPS-bootstrapped Secret `hermes-agent-shell-api-key`** applied **out-of-band** — same pattern as the dashboard-auth / ssh-keys Secrets (NOT ArgoCD-managed; see `secrets/hermes-agent-shell/README.md`). The key value is **reused verbatim** from the migrate pod's `hermes-agent-shell-migrate-api-key` for continuity. The `secretKeyRef` is **not optional**: the API server needs the key, so the pod must not start until the Secret exists.

## Merge order (REQUIRED)

1. Apply the Secret out-of-band:
   ```
   sops -d secrets/hermes-agent-shell/api-key.yaml | kubectl -n hermes-agent-shell apply -f -
   ```
2. Then merge this PR → ArgoCD selfHeal rolls the pod → :8642 binds → **pod 3/3**.

Merging is the **intended cutover restart**: the pod roll also picks up the freshly-seeded Willikins `/opt/data` profile + fresh hindsight initdb. The migrate deployment + its `-migrate-api-key` Secret remain as the working backup until 3/3 is confirmed.

## Precedent / tracking

Mirrors #626 (dashboard-auth) exactly. Tracks willikins#285 (Hermes official-image migration).

---

Left as **draft** — the operator merges this deliberately as the cutover restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)