### PR TITLE
feat(obs): frank-alert-triage skill + alert-agent report fixes

### DIFF
--- a/agents/rules/repo-principles.md
+++ b/agents/rules/repo-principles.md
@@ -16,6 +16,6 @@
 
 ### Skills
 
-Skills are installed at user level via the `superpowers`, `super-fr`, and `super-fr-dispatch` plugins. They are NOT vendored in this repo. Frank-specific skills remain repo-local in `agents/skills/` (blog-post, bump-image, deploy-app, expose-service, falco-triage, media, oidc-onboard, papers, sync-runbook, update-readme).
+Skills are installed at user level via the `superpowers`, `super-fr`, and `super-fr-dispatch` plugins. They are NOT vendored in this repo. Frank-specific skills remain repo-local in `agents/skills/` (blog-post, bump-image, deploy-app, expose-service, falco-triage, frank-alert-triage, media, oidc-onboard, papers, sync-runbook, update-readme).
 
 Plan behavior is driven by the profile at `docs/superpowers/plan-config.yaml`.

--- a/agents/skills/frank-alert-triage/SKILL.md
+++ b/agents/skills/frank-alert-triage/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: frank-alert-triage
+description: Triage firing Grafana alerts on the Frank cluster — fetch the firing set, classify each (muted-canary / by-design / false-positive / unexplained), and print a compact verdict table. Use when "Grafana is alerting", "what is firing on Frank", "investigate this alert", "triage the alerts", "is this alert real". Classify-and-recommend only — never mutates the cluster.
+user-invocable: true
+disable-model-invocation: false
+arguments:
+  - name: alertname
+    description: Optional — a single alertname to focus on. Omit to triage the whole firing set.
+    required: false
+---
+
+# Triage Frank Grafana Alerts
+
+Investigate what is firing on Frank and classify each alert against the known
+decision tree, so the operator sees signal (what is real) instead of a wall of
+warnings. **Read-only: this skill classifies and recommends — it never mutates
+the cluster** (no pod deletes, no acks, no restarts). A genuinely-unexplained
+alert is handed off to `superpowers:systematic-debugging` / `fr-debugging`.
+
+The classification logic lives in `classify.py` (pure, unit-tested in
+`test_classify.py`) alongside this file. The alert-agent (`apps/alert-agent`)
+documents the same tree in its own SKILL.md — keep the two in sync.
+
+## Step 0 — cluster context
+
+```bash
+cd <frank-repo-root> && source .env      # relative KUBECONFIG — MUST cd first
+kubectl get nodes -o wide                 # sanity: are nodes actually Ready?
+```
+
+## Step 1 — fetch the firing set
+
+Grafana is the VictoriaMetrics stack instance on the `192.168.55.203`
+LoadBalancer (plain HTTP). Admin creds come from its secret.
+
+```bash
+PW=$(kubectl -n monitoring get secret victoria-metrics-grafana \
+       -o jsonpath='{.data.admin-password}' | base64 -d)
+curl -s -u "admin:$PW" \
+  "http://192.168.55.203/api/prometheus/grafana/api/v1/alerts" -o /tmp/frank-alerts.json
+```
+
+The rule state to filter on is **`Alerting`** (this Grafana prometheus-compat
+endpoint reports `Normal` / `Alerting` / `Normal (NoData)`, not `firing`).
+
+## Step 2 — resolve pod state for readiness alerts
+
+An alert whose `__name__` is `kube_pod_status_ready` fires on a pod being
+NotReady — but a **terminal or absent** pod (graceful-shutdown `Succeeded`
+tombstone left by a node reboot) holds a *stale* series and reads NotReady
+forever. So for each such alert, resolve the live pod phase:
+
+```bash
+kubectl -n <namespace-label> get pod <pod-label> \
+  -o jsonpath='{.status.phase}' 2>/dev/null   # empty ⇒ pod is gone (absent)
+```
+
+Pass the phase (or `None` when absent) as `pod_state` to `classify()`. For any
+non-readiness alert, `pod_state` is `None`.
+
+## Step 3 — classify and print the table
+
+Feed each alert's `labels` (+ resolved `pod_state`) through `classify.py` and
+print a compact PLAIN-TEXT verdict table (same column style as the alert-agent
+report): `alert | severity | verdict | reason/action`. Example driver:
+
+```bash
+cd <this-skill-dir>   # so `import classify` resolves
+python3 - "$@" <<'PY'
+import json, subprocess
+from classify import classify
+
+alerts = json.load(open("/tmp/frank-alerts.json"))["data"]["alerts"]
+rows = []
+for a in alerts:
+    if a.get("state") != "Alerting":
+        continue
+    lbl = a["labels"]
+    pod_state = None
+    if lbl.get("__name__") == "kube_pod_status_ready" and lbl.get("pod"):
+        out = subprocess.run(
+            ["kubectl", "-n", lbl.get("namespace", ""), "get", "pod", lbl["pod"],
+             "-o", "jsonpath={.status.phase}"],
+            capture_output=True, text=True)
+        pod_state = out.stdout.strip() or None
+    v = classify(lbl, pod_state)
+    rows.append((lbl.get("alertname", "?"), lbl.get("severity", "?"), v))
+
+w = max((len(r[0]) for r in rows), default=5)
+for name, sev, v in rows:
+    print(f"{name:<{w}}  {sev:<8}  {v.kind:<14}  {v.reason}")
+PY
+```
+
+## Step 4 — the decision tree (shared contract)
+
+| Signal (label) | Verdict | Meaning |
+|---|---|---|
+| `canary: true` | `muted` | Deliberately-firing canary (e.g. expired-cert canary #251) — never paged |
+| `gpu_timeshare: true` | `by-design` | gpu-1 hosts one of Ollama/ComfyUI at a time; one probe is always down. The only real pager is `gpu-node-both-down` |
+| `__name__: kube_pod_status_ready` + pod `Succeeded`/`Completed`/absent | `false-positive` | Stale kube-state-metrics series held by a graceful-shutdown tombstone. Recommend (do NOT run) deleting the terminal pod to clear it |
+| none of the above | `unexplained` | No known-benign pattern — **escalate** to `fr-debugging` |
+
+`github_issue: frank-ops#N` is captured as an orthogonal **tracker** annotation
+on any verdict — it links the alert to its tracker, but it is NOT a benign
+signal (a live NotReady pod carries it too).
+
+## Step 5 — recommend, never act
+
+- `muted` / `by-design` → note as expected; no action.
+- `false-positive` → state the safe cleanup (e.g. `kubectl delete pod <tombstone>`)
+  as a **recommendation for the operator to run** — this skill does not delete.
+- `unexplained` → hand off to `fr-debugging` with the alert + evidence gathered.
+
+## Notes
+
+- The `victoria-metrics-grafana` service is plain HTTP on `.203` — a `https://`
+  URL gets a TLS reset. Use `http://`.
+- `state == "Alerting"` on this endpoint is the rule state, distinct from the
+  Alertmanager instance `firing`.
+- Verify the fix worked by re-fetching after any operator cleanup: a deleted
+  tombstone's readiness series ages out of VictoriaMetrics on its ~5-min
+  staleness window, so the alert resolves on a short delay, not instantly.

--- a/agents/skills/frank-alert-triage/SKILL.md
+++ b/agents/skills/frank-alert-triage/SKILL.md
@@ -46,27 +46,39 @@ endpoint reports `Normal` / `Alerting` / `Normal (NoData)`, not `firing`).
 ## Step 2 — resolve pod state for readiness alerts
 
 An alert whose `__name__` is `kube_pod_status_ready` fires on a pod being
-NotReady — but a **terminal or absent** pod (graceful-shutdown `Succeeded`
+NotReady — but a **terminal or absent** pod (a graceful-shutdown `Succeeded`
 tombstone left by a node reboot) holds a *stale* series and reads NotReady
-forever. So for each such alert, resolve the live pod phase:
+forever. So for each such alert, resolve the live pod phase — and critically,
+**distinguish a genuinely-absent pod from a kubectl that merely failed**:
 
 ```bash
-kubectl -n <namespace-label> get pod <pod-label> \
-  -o jsonpath='{.status.phase}' 2>/dev/null   # empty ⇒ pod is gone (absent)
+kubectl -n <namespace-label> get pod <pod-label> -o jsonpath='{.status.phase}'
+# rc 0            → the phase (Running / Succeeded / …)
+# rc≠0 "NotFound" → the pod is genuinely gone (absent)
+# rc≠0 otherwise  → kubectl failed to connect — do NOT treat this as "absent"
 ```
 
-Pass the phase (or `None` when absent) as `pod_state` to `classify()`. For any
-non-readiness alert, `pod_state` is `None`.
+**`pod_state` semantics are load-bearing:** `None` passed to `classify()` MUST
+mean **resolved-absent** (→ tombstone → `false-positive`), NEVER "resolution
+failed". On any kubectl error that is not `NotFound`, pass a non-terminal
+sentinel (e.g. `"unresolved"`) so the alert fails **safe** to `unexplained`
+(escalate) instead of being silently suppressed as benign. For a non-readiness
+alert `pod_state` is `None` and the readiness branch never applies.
 
 ## Step 3 — classify and print the table
 
 Feed each alert's `labels` (+ resolved `pod_state`) through `classify.py` and
 print a compact PLAIN-TEXT verdict table (same column style as the alert-agent
-report): `alert | severity | verdict | reason/action`. Example driver:
+report): `alert | severity | verdict | reason/action`.
+
+**Run from the repo root** — do NOT `cd` into the skill dir: `.env` sets a
+`KUBECONFIG` relative to the repo root, so a `cd` breaks every `kubectl` in the
+driver (which then fails-open to `None` → a real NotReady pod misclassified as a
+tombstone). Keep cwd at the repo root and make `classify.py` importable via
+`PYTHONPATH` (path relative to the repo root):
 
 ```bash
-cd <this-skill-dir>   # so `import classify` resolves
-python3 - "$@" <<'PY'
+PYTHONPATH=agents/skills/frank-alert-triage python3 - <<'PY'
 import json, subprocess
 from classify import classify
 
@@ -82,13 +94,19 @@ for a in alerts:
             ["kubectl", "-n", lbl.get("namespace", ""), "get", "pod", lbl["pod"],
              "-o", "jsonpath={.status.phase}"],
             capture_output=True, text=True)
-        pod_state = out.stdout.strip() or None
+        if out.returncode == 0:
+            pod_state = out.stdout.strip() or None      # resolved phase
+        elif "NotFound" in out.stderr:
+            pod_state = None                            # genuinely absent → tombstone
+        else:
+            pod_state = "unresolved"                    # kubectl failed → NOT terminal → escalate
     v = classify(lbl, pod_state)
     rows.append((lbl.get("alertname", "?"), lbl.get("severity", "?"), v))
 
 w = max((len(r[0]) for r in rows), default=5)
 for name, sev, v in rows:
-    print(f"{name:<{w}}  {sev:<8}  {v.kind:<14}  {v.reason}")
+    tracker = f"  [{v.tracker}]" if v.tracker else ""
+    print(f"{name:<{w}}  {sev:<8}  {v.kind:<14}  {v.reason}{tracker}")
 PY
 ```
 
@@ -118,6 +136,10 @@ signal (a live NotReady pod carries it too).
   URL gets a TLS reset. Use `http://`.
 - `state == "Alerting"` on this endpoint is the rule state, distinct from the
   Alertmanager instance `firing`.
+- The readiness branch keys on the `__name__: kube_pod_status_ready` label being
+  present in the alert's label set — that is the load-bearing assumption. If a
+  Grafana version ever omits `__name__` from managed-alert labels, the branch
+  simply never matches and those alerts fail **safe** to `unexplained`.
 - Verify the fix worked by re-fetching after any operator cleanup: a deleted
   tombstone's readiness series ages out of VictoriaMetrics on its ~5-min
   staleness window, so the alert resolves on a short delay, not instantly.

--- a/agents/skills/frank-alert-triage/classify.py
+++ b/agents/skills/frank-alert-triage/classify.py
@@ -1,0 +1,79 @@
+"""Pure, stdlib-only classifier for Frank Grafana alerts.
+
+`classify(labels, pod_state)` maps one firing alert's label set (+ the caller-
+resolved pod phase, when the alert is readiness-based) to a `Verdict`. It never
+touches the cluster or the network — the SKILL.md playbook does the Grafana-API
+fetch and the `kubectl` pod-state resolution, then calls this. That keeps the
+decision tree deterministically unit-testable.
+
+The tree, in priority order (first match wins):
+
+1. `canary: true`          → **muted**          — a deliberately-firing canary
+   (e.g. the expired-cert canary, issue #251); never paged.
+2. `gpu_timeshare: true`   → **by-design**      — gpu-1 hosts one of Ollama/
+   ComfyUI at a time, so one feature-health probe is always down by design; the
+   only real pager is `gpu-node-both-down`.
+3. readiness rule (`__name__ == kube_pod_status_ready`) AND the referenced pod
+   is terminal/absent (`Succeeded`/`Completed`/None) → **false-positive** — a
+   stale kube-state-metrics series held by a graceful-shutdown tombstone.
+4. otherwise                → **unexplained**    — no known-benign pattern; escalate.
+
+`github_issue` is captured into `Verdict.tracker` as an ORTHOGONAL annotation,
+never a verdict: the label only says "this alert type has a tracker", not that
+the current firing is benign (a genuinely Running-but-NotReady pod carries the
+same label and must still escalate).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# A pod that is gone, or reported terminal, cannot be "NotReady" in any
+# meaningful sense — the readiness alert is holding a stale metric series.
+_TERMINAL_POD_STATES = frozenset({"Succeeded", "Completed", None})
+
+_READINESS_METRIC = "kube_pod_status_ready"
+
+
+@dataclass(frozen=True)
+class Verdict:
+    """One alert's classification. `kind` drives the triage; `reason` is the
+    operator one-liner; `tracker` is the linked issue when the alert carries one."""
+
+    kind: str            # muted | by-design | false-positive | unexplained
+    reason: str
+    tracker: str | None = None
+
+
+def _is_readiness_rule(labels: dict) -> bool:
+    return labels.get("__name__") == _READINESS_METRIC
+
+
+def classify(labels: dict, pod_state: str | None = None) -> Verdict:
+    """Classify one firing alert. `pod_state` is the live pod phase the caller
+    resolved for readiness-based alerts (None when absent / not applicable)."""
+    tracker = labels.get("github_issue")
+
+    if labels.get("canary") == "true":
+        return Verdict("muted", "canary — expected, never paged (e.g. cert-expiry #251)", tracker)
+
+    if labels.get("gpu_timeshare") == "true":
+        return Verdict(
+            "by-design",
+            "GPU timeshared — one workload is down by design; the real pager is "
+            "gpu-node-both-down only",
+            tracker,
+        )
+
+    if _is_readiness_rule(labels) and pod_state in _TERMINAL_POD_STATES:
+        where = pod_state or "absent"
+        return Verdict(
+            "false-positive",
+            f"stale kube-state-metrics readiness series — pod is {where} "
+            "(graceful-shutdown tombstone); delete the terminal pod to clear it",
+            tracker,
+        )
+
+    esc = "no known-benign pattern matched — escalate"
+    if tracker:
+        esc += f" (tracked at {tracker})"
+    return Verdict("unexplained", esc, tracker)

--- a/agents/skills/frank-alert-triage/classify.py
+++ b/agents/skills/frank-alert-triage/classify.py
@@ -29,6 +29,9 @@ from dataclasses import dataclass
 
 # A pod that is gone, or reported terminal, cannot be "NotReady" in any
 # meaningful sense — the readiness alert is holding a stale metric series.
+# `None` here means the caller RESOLVED the pod as absent (a genuine tombstone),
+# never "pod resolution failed" — the driver must map a kubectl error to a
+# non-terminal sentinel so a real NotReady pod is not suppressed as benign.
 _TERMINAL_POD_STATES = frozenset({"Succeeded", "Completed", None})
 
 _READINESS_METRIC = "kube_pod_status_ready"

--- a/agents/skills/frank-alert-triage/test_classify.py
+++ b/agents/skills/frank-alert-triage/test_classify.py
@@ -1,0 +1,73 @@
+"""Decision-tree coverage for classify() — one case per branch, using the real
+Grafana alert label shapes captured during a live Frank triage (2026-07-13)."""
+from classify import classify, Verdict
+
+
+# Real labels from the live firing set this session.
+_CANARY = {
+    "alertname": "TLS cert expiring within 7 days",
+    "canary": "true",
+    "instance": "https://expired.badssl.com/",
+    "severity": "critical",
+}
+_GPU_TIMESHARE = {
+    "__name__": "probe_success",
+    "alertname": "Layer 11 Local Inference Degraded",
+    "gpu_timeshare": "true",
+    "github_issue": "frank-ops#11",
+    "layer": "11",
+    "severity": "warning",
+}
+_READINESS = {
+    "__name__": "kube_pod_status_ready",
+    "condition": "true",
+    "alertname": "Layer 3 Cilium Agent Down",
+    "github_issue": "frank-ops#3",
+    "namespace": "kube-system",
+    "pod": "cilium-operator-76d44bb8d-87tmm",
+    "severity": "warning",
+}
+
+
+def test_canary_is_muted():
+    v = classify(_CANARY, pod_state=None)
+    assert v.kind == "muted"
+
+
+def test_gpu_timeshare_is_by_design():
+    v = classify(_GPU_TIMESHARE, pod_state=None)
+    assert v.kind == "by-design"
+    assert "gpu-node-both-down" in v.reason   # names the real pager
+
+
+def test_readiness_with_terminal_pod_is_false_positive():
+    # A Succeeded/Completed/absent pod behind a readiness rule = stale KSM series.
+    for state in ("Succeeded", "Completed", None):
+        v = classify(_READINESS, pod_state=state)
+        assert v.kind == "false-positive", f"pod_state={state!r}"
+
+
+def test_readiness_with_live_pod_is_not_false_positive():
+    # A genuinely Running-but-NotReady pod is a REAL degradation → escalate.
+    v = classify(_READINESS, pod_state="Running")
+    assert v.kind == "unexplained"
+
+
+def test_github_issue_is_captured_as_tracker_annotation():
+    # tracker is orthogonal to kind — captured whenever the label is present,
+    # even on a false-positive.
+    v = classify(_READINESS, pod_state="Succeeded")
+    assert v.kind == "false-positive"
+    assert v.tracker == "frank-ops#3"
+
+
+def test_unexplained_when_no_pattern_matches():
+    v = classify({"alertname": "Something New", "severity": "warning"}, pod_state=None)
+    assert v.kind == "unexplained"
+    assert v.tracker is None
+
+
+def test_verdict_is_immutable_shape():
+    v = classify(_CANARY, pod_state=None)
+    assert isinstance(v, Verdict)
+    assert v.reason  # every verdict carries a human one-liner

--- a/agents/skills/frank-alert-triage/test_classify.py
+++ b/agents/skills/frank-alert-triage/test_classify.py
@@ -48,8 +48,17 @@ def test_readiness_with_terminal_pod_is_false_positive():
 
 
 def test_readiness_with_live_pod_is_not_false_positive():
-    # A genuinely Running-but-NotReady pod is a REAL degradation → escalate.
+    # A genuinely Running-but-NotReady pod is a REAL degradation → escalate,
+    # AND the tracker is still captured (orthogonality holds on the escalate path).
     v = classify(_READINESS, pod_state="Running")
+    assert v.kind == "unexplained"
+    assert v.tracker == "frank-ops#3"
+
+
+def test_readiness_with_unresolved_pod_escalates_not_false_positive():
+    # The driver passes a non-terminal sentinel when kubectl fails to resolve —
+    # it must NOT be swallowed as a benign tombstone (fail-safe = escalate).
+    v = classify(_READINESS, pod_state="unresolved")
     assert v.kind == "unexplained"
 
 

--- a/apps/alert-agent/handlers/handlers/orchestration.py
+++ b/apps/alert-agent/handlers/handlers/orchestration.py
@@ -78,8 +78,10 @@ def run_surge(now: datetime | None = None) -> bool:
     sheet = facts.build_for_surge(now - timedelta(hours=1), now)
     fallback = _render_surge(sheet, verdict)
     prompt = ("A blog traffic surge tripped the deterministic gate. Investigate and explain it "
-              "(is it Hacker News, a scraper, a real story?) using ONLY the facts below; cite "
-              "specifics. Reply as JSON {\"text\": \"<your narrative>\"}.\n\n"
+              "using ONLY the facts below: attribute the source from top_referrers and "
+              "top_user_agents and cite specifics; if the facts do not show it, say the source "
+              "is undetermined. Never name a source the facts do not support. "
+              "Reply in plain text — a few short lines or a compact table; no JSON, no markdown.\n\n"
               f"verdict={json.dumps(verdict)}\nfacts={json.dumps(sheet)}")
     resp = bridge.session_send(prompt, session_id="alert-agent-ops")
     bridge.deliver(resp, fallback)
@@ -103,7 +105,8 @@ def run_digest(now: datetime | None = None) -> None:
     sheet = facts.build_for_digest(since, until, now)
     fallback = _render_digest(sheet)
     prompt = ("Write the daily Frank digest (traffic + security) from ONLY the facts below — "
-              "concise, notable items only, no speculation. Reply as JSON {\"text\": \"<digest>\"}.\n\n"
+              "concise, notable items only, no speculation. Reply in plain text as a compact "
+              "table or a few short lines; no JSON, no markdown.\n\n"
               f"facts={json.dumps(sheet)}")
     resp = bridge.session_send(prompt, session_id="alert-agent-ops")
     bridge.deliver(resp, fallback)

--- a/apps/alert-agent/handlers/tests/test_orchestration.py
+++ b/apps/alert-agent/handlers/tests/test_orchestration.py
@@ -74,3 +74,24 @@ def test_run_digest_always_wakes_and_delivers_with_fallback(wired):
     assert any(s[0] == "session" for s in wired)
     deliver = [s for s in wired if s[0] == "deliver"][0]
     assert "Daily digest" in deliver[1]                  # deterministic fallback text built
+
+
+def _prompt_of(sent):
+    """The prompt string passed to the (mocked) session_send call."""
+    return next(a[0] for kind, a, k in sent if kind == "session")
+
+
+def test_surge_prompt_is_evidence_driven_no_named_source(wired, monkeypatch):
+    # The surge prompt must NOT pre-seed a named source (e.g. "Hacker News") —
+    # that anchors the model into confabulating attribution against thin facts.
+    monkeypatch.setattr(orch.surge, "compute",
+                        lambda: {"tier": "Major", "current": 600, "baseline": 30, "ratio": 20})
+    orch.run_surge(now=T0)
+    prompt = _prompt_of(wired)
+    assert "Hacker News" not in prompt
+    assert '{"text"' not in prompt          # no JSON envelope taught in the prompt
+
+
+def test_digest_prompt_has_no_json_envelope(wired):
+    orch.run_digest(now=T0)
+    assert '{"text"' not in _prompt_of(wired)

--- a/apps/alert-agent/manifests/files/SKILL.md
+++ b/apps/alert-agent/manifests/files/SKILL.md
@@ -8,18 +8,26 @@ event and reads back a JSON result you write.
 ## Your job (three trigger types)
 
 1. **Daily digest** — summarize the day's traffic + security from the supplied facts.
-2. **Traffic surge** — a deterministic gate already decided it's a real surge; explain
-   what it is (Hacker News? a scraper? a real story?) from the supplied facts.
+2. **Traffic surge** — a deterministic gate already decided it's a real surge; attribute
+   the source from the supplied referrers/user-agents, or say it is undetermined — never
+   name a source the facts do not support.
 3. **Grafana alert triage** — explain a firing alert: what it means + likely cause.
 4. **Inbound questions** — the operator may DM a question ("why did X fire?",
    "what's hitting the blog?"); investigate and answer.
 
 ## Output contract
 
-When the prompt asks for a result, reply with **raw JSON** `{"text": "<your message>"}`
-written to the file the prompt names — nothing else in that file. `text` is what
-gets posted to Telegram, so keep it tight and plain: **no `<`, `>`, or `&`** (the
-Telegram HTML sender 400s on them), no markdown tables, a few short lines.
+Reply in **plain text** — no JSON envelope, no markdown. The Telegram sender uses no
+parse_mode, so `<`, `>`, and `&` are safe. Prefer a **compact aligned table** (label /
+value / detail columns) over prose, under a hard budget of about **8 short lines**; no
+prose walls. This is the same compact-table format the `frank-alert-triage` skill emits —
+keep the two consistent.
+
+```
+L3 Cilium    OK     2/2 operators
+L11 Infer    DEGR   gpu-timeshare (ComfyUI active, by design)
+Edge req/h   118    baseline 95 (x1.2)
+```
 
 ## Tools (read-only, HTTP-only — you have NO kubernetes credential)
 
@@ -37,8 +45,10 @@ Ground every claim in a fact you pulled; if you can't determine something, say s
 ## Answering inbound DMs — be fast and focused
 
 The operator is waiting in a live chat. **Lead with `frank-facts`** (pre-computed,
-instant) and only the **one or two** most relevant probes/queries; answer in a few
-short lines. Do NOT exhaustively sweep every endpoint or fire many sequential
-queries unless the operator explicitly asks for a full audit — a focused answer in
-well under a minute beats a 5-minute one. If a deeper dive is warranted, say what
-you'd check next and let the operator ask.
+instant), then run **at most TWO** probes/queries — the most relevant ones — and
+**answer now** as a compact table. Never exhaustively sweep endpoints or fire many
+sequential queries: that is what blows the turn budget and makes the answer time out,
+which reads to the operator as "no reply". The only exception is when the operator
+explicitly asks for a full audit. A focused answer in well under a minute beats a
+5-minute one. If a deeper dive is warranted, name in one line what you'd check next
+and let the operator ask.

--- a/apps/alert-agent/telegram-bridge/tests/test_bridge.py
+++ b/apps/alert-agent/telegram-bridge/tests/test_bridge.py
@@ -100,6 +100,13 @@ def test_render_payload_leaves_non_envelope_json_verbatim():
     assert bridge.render_payload({"status": "ok", "payload": '["a", "b"]'}) == '["a", "b"]'
 
 
+def test_render_payload_ignores_non_string_text():
+    # A JSON object whose "text" is not a string is NOT a valid envelope — return
+    # the raw string, never coerce a number/list into the reply.
+    assert bridge.render_payload(
+        {"status": "ok", "payload": '{"text": 123}'}) == '{"text": 123}'
+
+
 def test_render_payload_dict_branch_unchanged():
     assert bridge.render_payload({"status": "ok", "payload": {"text": "x"}}) == "x"
 

--- a/apps/alert-agent/telegram-bridge/tests/test_bridge.py
+++ b/apps/alert-agent/telegram-bridge/tests/test_bridge.py
@@ -79,6 +79,31 @@ def test_deliver_uses_agent_payload_when_present(calls):
     assert _sent(calls, "/sendMessage")[0]["text"] == "agent narrative"
 
 
+def test_render_payload_unwraps_json_envelope_string():
+    # The agent is taught to reply in plain text, but if a turn still emits the
+    # legacy {"text": ...} envelope AS ITS MESSAGE, the session server hands it
+    # back as a STRING payload — which must be unwrapped, not posted raw (else
+    # the operator sees literal JSON in Telegram).
+    assert bridge.render_payload(
+        {"status": "ok", "payload": '{"text": "hello there"}'}) == "hello there"
+
+
+def test_render_payload_passes_plain_string_through():
+    assert bridge.render_payload({"status": "ok", "payload": "just words"}) == "just words"
+
+
+def test_render_payload_leaves_non_envelope_json_verbatim():
+    # A string that happens to start like JSON but isn't a {"text": ...} envelope
+    # is returned unchanged — no accidental mangling of a normal answer.
+    assert bridge.render_payload({"status": "ok", "payload": "not json {"}) == "not json {"
+    # A JSON list, or a JSON object without a "text" key, is not an envelope.
+    assert bridge.render_payload({"status": "ok", "payload": '["a", "b"]'}) == '["a", "b"]'
+
+
+def test_render_payload_dict_branch_unchanged():
+    assert bridge.render_payload({"status": "ok", "payload": {"text": "x"}}) == "x"
+
+
 # --- Thread B: slash commands (expand_command + COMMANDS registry) -------------
 
 CATALOG = ["/help", "/digest", "/surge", "/edge_traffic", "/security", "/status"]

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -160,8 +160,12 @@ def session_send(message: str, session_id: str | None = None, timeout_s: float =
 def render_payload(resp: dict) -> str | None:
     """Human text from an agent-session response, or None if it didn't complete.
 
-    The agent's output contract (taught in SKILL.md): write {"text": "..."}. We
-    accept a bare string payload too. None when status != ok or payload is empty.
+    The agent's output contract (taught in SKILL.md) is now PLAIN TEXT. But a
+    turn that still emits the legacy {"text": "..."} envelope arrives here as a
+    STRING payload (the session server returns the agent's final message
+    verbatim) — so we defensively unwrap a {"text": ...} envelope, else the
+    operator sees literal JSON in Telegram. Any other string passes through.
+    None when status != ok or payload is empty.
     """
     if not resp or resp.get("status") != "ok":
         return None
@@ -169,6 +173,12 @@ def render_payload(resp: dict) -> str | None:
     if payload is None:
         return None
     if isinstance(payload, str):
+        try:
+            obj = json.loads(payload)
+        except (ValueError, TypeError):
+            return payload
+        if isinstance(obj, dict) and isinstance(obj.get("text"), str):
+            return obj["text"]
         return payload
     if isinstance(payload, dict):
         return payload.get("text") or json.dumps(payload)

--- a/docs/acceptance/matrix.yaml
+++ b/docs/acceptance/matrix.yaml
@@ -130,3 +130,40 @@ rows:
       :9119/login -> 200). In-repo surface exists; becomes live-provable once this PR
       merges and ArgoCD reconciles the traefik-system IngressRoutes. SSO via authentik
       is a possible later follow-up.'
+  - id: obs-alert-triage-classifies
+    capability: Frank alert triage
+    acceptance: The operator can invoke the frank-alert-triage skill and receive a per-alert
+      verdict table classifying every firing Grafana alert (muted-canary, by-design,
+      false-positive, known-tracker, or unexplained) without mutating the cluster.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''
+  - id: obs-alert-agent-evidence-not-hn
+    capability: alert-agent report quality
+    acceptance: The alert-agent attributes a traffic surge from evidence (top referrers/user-agents)
+      or states undetermined; it never defaults to a named source such as Hacker News.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''
+  - id: obs-alert-agent-plain-text-table
+    capability: alert-agent report quality
+    acceptance: Operator DM and digest replies from the alert-agent are compact plain-text
+      tables, never a raw JSON envelope or a prose wall.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''
+  - id: obs-alert-agent-answers-explicit-asks
+    capability: alert-agent report quality
+    acceptance: A focused explicit DM question to the alert-agent returns a real answer
+      within the turn budget, not a timeout fallback.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''

--- a/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/01.yaml
+++ b/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/01.yaml
@@ -1,0 +1,66 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Shared classifier (classify.py) — TDD
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+  acceptance:
+  - obs-alert-triage-classifies
+tasks:
+- number: 1
+  title: Pure classify(labels, pod_state) -> Verdict, test-first
+  steps:
+  - id: P1.T1.S1
+    text: |
+      RED. Create `agents/skills/frank-alert-triage/test_classify.py` with one case per
+      decision-tree branch, using the REAL label dicts captured this session:
+      (a) `{"canary":"true", ...}` -> verdict `muted` (expected/canary, never paged);
+      (b) `{"gpu_timeshare":"true","layer":"11", ...}` -> verdict `by-design` (mentions the
+         real pager is `gpu-node-both-down` only);
+      (c) readiness rule labels `{"__name__":"kube_pod_status_ready","condition":"true",
+         "pod":"cilium-operator-...","alertname":"Layer 3 Cilium Agent Down"}` with
+         pod_state in {"Succeeded","Completed",None} -> verdict `false-positive`
+         (stale KSM series / graceful-shutdown tombstone);
+      (d) same readiness labels with pod_state `"Running"` -> NOT false-positive
+         (verdict `unexplained` or `live` — a genuinely NotReady live pod);
+      (e) any labels carrying `{"github_issue":"frank-ops#3"}` -> verdict carries the
+         known-tracker ref `frank-ops#3`;
+      (f) plain labels, none of the above -> verdict `unexplained`.
+      Run `fr isolation exec -- bash -lc 'cd apps/../ ; python -m pytest agents/skills/frank-alert-triage/test_classify.py'`
+      (adjust path) and confirm it FAILS (module/functions absent).
+  - id: P1.T1.S2
+    text: |
+      GREEN. Implement `agents/skills/frank-alert-triage/classify.py`: stdlib-only, pure,
+      NO kube/network access. Expose `classify(labels: dict, pod_state: str | None) -> Verdict`
+      where `Verdict` is a small dataclass/namedtuple `(kind, reason, tracker)` with `kind` in
+      {muted, by-design, false-positive, known-tracker, unexplained, live}. Encode the tree in
+      the priority order from the spec: canary -> gpu_timeshare -> readiness+terminal/absent pod
+      -> github_issue annotation -> else unexplained. `pod_state` is supplied by the caller
+      (the skill resolves it via kubectl); the classifier itself never calls out. Re-run the
+      test -> all branches GREEN.
+  - id: P1.T1.S3
+    text: |
+      REFACTOR (optional). If the branch ladder or Verdict construction has duplication,
+      tidy it (extract a helper, name the terminal-pod set once). Stay green; add no behavior.
+      Skip if nothing to clean.
+state:
+  steps:
+    P1.T1.S1:
+      state: x
+      ticked_at: '2026-07-13T17:05:31+00:00'
+      note: null
+    P1.T1.S2:
+      state: x
+      ticked_at: '2026-07-13T17:05:34+00:00'
+      note: null
+    P1.T1.S3:
+      state: '-'
+      ticked_at: '2026-07-13T17:05:37+00:00'
+      note: no cleanup needed — classify() is already DRY
+  completion:
+    at: '2026-07-13T17:05:40+00:00'
+    note: 'classify.py + test_classify.py: 7/7 green via uv --with pytest; github_issue
+      treated as orthogonal tracker annotation (not a benign verdict) to avoid masking
+      a live NotReady pod'
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/02.yaml
+++ b/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/02.yaml
@@ -1,0 +1,61 @@
+schema_version: 2
+phase:
+  number: 2
+  title: frank-alert-triage skill playbook
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+  acceptance:
+  - obs-alert-triage-classifies
+tasks:
+- number: 1
+  title: Author the SKILL.md playbook
+  steps:
+  - id: P2.T1.S1
+    text: |
+      Write `agents/skills/frank-alert-triage/SKILL.md` with YAML frontmatter (`name:
+      frank-alert-triage`; `description:` triggering on "Grafana is alerting on Frank",
+      "investigate a Frank alert", "what is firing", "triage this alert"). Body documents the
+      flow: (1) fetch firing alerts from `http://192.168.55.203/api/prometheus/grafana/api/v1/alerts`
+      using admin creds from the `monitoring/victoria-metrics-grafana` secret (state `Alerting`);
+      (2) per alert, resolve any readiness-rule `pod` label against the live cluster with
+      `kubectl -n <ns> get pod <pod> -o jsonpath='{.status.phase}'` (live vs Succeeded/absent
+      ghost); (3) call `classify(labels, pod_state)`; (4) emit a COMPACT PLAIN-TEXT verdict
+      table with columns `alert | severity | verdict | reason/action`. Include the shared
+      decision-tree table verbatim (the contract the alert-agent mirrors). State the hard
+      boundary: CLASSIFY-AND-RECOMMEND ONLY, never mutate (no pod deletes/acks — the auto-mode
+      classifier blocks them); genuinely-unexplained alerts hand off to `fr-debugging`.
+  - id: P2.T1.S2
+    text: |
+      Make the skill discoverable: check how repo-local skills under `agents/skills/` are
+      indexed (grep `AGENTS.md` and `agents/` for an existing skill like `falco-triage` or
+      `expose-service`) and add `frank-alert-triage` wherever those are registered, matching
+      the existing pattern exactly.
+- number: 2
+  title: Validate skill structure
+  steps:
+  - id: P2.T2.S1
+    text: |
+      Run `fr isolation exec -- bash -lc 'scripts/validate-agent-config.sh'` (and any skill
+      linter it invokes). Fix frontmatter/path issues until clean.
+state:
+  steps:
+    P2.T1.S1:
+      state: x
+      ticked_at: '2026-07-13T17:07:38+00:00'
+      note: null
+    P2.T1.S2:
+      state: x
+      ticked_at: '2026-07-13T17:07:40+00:00'
+      note: null
+    P2.T2.S1:
+      state: x
+      ticked_at: '2026-07-13T17:07:42+00:00'
+      note: null
+  completion:
+    at: '2026-07-13T17:07:44+00:00'
+    note: SKILL.md playbook written (fetch→resolve-pod→classify→table, no-mutation
+      boundary, fr-debugging handoff); registered in repo-principles skill list; validate-agent-config
+      passed
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/03.yaml
+++ b/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/03.yaml
@@ -1,0 +1,103 @@
+schema_version: 2
+phase:
+  number: 3
+  title: alert-agent report fixes — TDD
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+  acceptance:
+  - obs-alert-agent-evidence-not-hn
+  - obs-alert-agent-plain-text-table
+  - obs-alert-agent-answers-explicit-asks
+tasks:
+- number: 1
+  title: render_payload defensive JSON-envelope unwrap (TDD)
+  steps:
+  - id: P3.T1.S1
+    text: |
+      RED. Add to `apps/alert-agent/telegram-bridge/tests/test_bridge.py`:
+      `test_render_payload_unwraps_json_envelope_string` — a resp `{"status":"ok","payload":
+      '{"text": "hello"}'}` (payload is a STRING) -> `render_payload` returns `"hello"`; a plain
+      string payload `"hi"` -> `"hi"`; a non-JSON string `"not json {"` -> returned verbatim;
+      the existing dict-payload branch still returns `.text`. Run
+      `fr isolation exec -- bash -lc 'cd apps/alert-agent/telegram-bridge && python -m pytest tests/test_bridge.py -k render_payload'`
+      -> FAILS (string envelope currently returned verbatim).
+  - id: P3.T1.S2
+    text: |
+      GREEN. In `apps/alert-agent/telegram-bridge/tg_bridge/bridge.py` `render_payload`, before
+      returning a `str` payload verbatim, try `json.loads`; if it yields a `dict` with a `text`
+      key, return that. Non-JSON / non-envelope strings fall through unchanged. Re-run -> GREEN;
+      run the FULL `test_bridge.py` to confirm no regression.
+- number: 2
+  title: De-Hacker-News + plain-text contract in prompts
+  steps:
+  - id: P3.T2.S1
+    text: |
+      RED-ish. In `apps/alert-agent/handlers/tests/test_orchestration.py` add an assertion that
+      the surge prompt built by `run_surge` and the digest prompt built by `run_digest` contain
+      NO "Hacker News" literal and NO `{"text"` envelope literal (patch `bridge.session_send`
+      to capture the prompt). Run -> FAILS on the current prompts.
+  - id: P3.T2.S2
+    text: |
+      GREEN. In `apps/alert-agent/handlers/handlers/orchestration.py`: (line ~81) replace the
+      surge prompt's "(is it Hacker News, a scraper, a real story?)" with evidence-driven
+      phrasing — "identify the source from top_referrers / top_user_agents; if the facts do not
+      show it, say 'undetermined'" (name NO example source); (lines ~82, ~106) replace
+      `Reply as JSON {"text": "..."}` in BOTH surge and digest prompts with a plain-text compact
+      instruction ("Reply in plain text, a few short lines / a compact table; no JSON, no
+      markdown"). Re-run the orchestration tests -> GREEN.
+- number: 3
+  title: Rewrite the alert-agent SKILL.md output contract
+  steps:
+  - id: P3.T3.S1
+    text: |
+      Rewrite `apps/alert-agent/manifests/files/SKILL.md`: (line 12) drop the "Hacker News?"
+      example from the surge trigger — describe it as "attribute the source from the supplied
+      referrers/user-agents, else undetermined"; (lines 17-22, Output contract) replace the raw
+      `{"text":...}` JSON envelope + the stale "no markdown tables / no <>&" constraint with:
+      reply in PLAIN TEXT (the sender uses no parse_mode, so <>& are safe) as a COMPACT ALIGNED
+      TABLE (label / value / detail columns) under a hard line budget (e.g. <= ~8 lines); no
+      prose walls. Add a note that this format matches the `frank-alert-triage` skill. In the
+      "Answering inbound DMs" section, bound an interactive turn to <= 2 probes then answer now
+      (do NOT raise DM_TIMEOUT_S). Keep the read-only / no-mutation boundary intact.
+- number: 4
+  title: Full alert-agent suite green
+  steps:
+  - id: P3.T4.S1
+    text: |
+      Run the whole alert-agent test suite via
+      `fr isolation exec -- bash -lc 'cd apps/alert-agent && for d in telegram-bridge handlers frank-facts; do (cd $d && python -m pytest -q) || exit 1; done'`
+      -> all GREEN. Fix any fallout.
+state:
+  steps:
+    P3.T1.S1:
+      state: x
+      ticked_at: '2026-07-13T17:13:25+00:00'
+      note: null
+    P3.T1.S2:
+      state: x
+      ticked_at: '2026-07-13T17:13:37+00:00'
+      note: null
+    P3.T2.S1:
+      state: x
+      ticked_at: '2026-07-13T17:13:45+00:00'
+      note: null
+    P3.T2.S2:
+      state: x
+      ticked_at: '2026-07-13T17:13:52+00:00'
+      note: null
+    P3.T3.S1:
+      state: x
+      ticked_at: '2026-07-13T17:13:58+00:00'
+      note: null
+    P3.T4.S1:
+      state: x
+      ticked_at: '2026-07-13T17:14:03+00:00'
+      note: null
+  completion:
+    at: '2026-07-13T17:14:07+00:00'
+    note: render_payload envelope-unwrap (TDD, bridge 29 green); de-HN + plain-text
+      prompts (orchestration 15 green, prompt-content asserts); SKILL.md output contract
+      rewritten to compact plain-text table + <=2-probe DM bound; frank-facts 13 green;
+      no residual Hacker News / JSON envelope
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/04.yaml
+++ b/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/04.yaml
@@ -1,0 +1,49 @@
+schema_version: 2
+phase:
+  number: 4
+  title: Post-merge live verification (Test Plan)
+  tag: manual
+  depends_on:
+  - 2
+  - 3
+  tracking_issue: null
+  acceptance:
+  - obs-alert-triage-classifies
+  - obs-alert-agent-evidence-not-hn
+  - obs-alert-agent-plain-text-table
+  - obs-alert-agent-answers-explicit-asks
+tasks:
+- number: 1
+  title: Verify the skill against live alerts (host, post-merge)
+  steps:
+  - id: P4.T1.S1
+    text: |
+      manual-operation. From the kube-credentialed host, invoke `frank-alert-triage` against the
+      current firing set. Confirm the verdict table matches manual triage: canaries -> muted,
+      gpu_timeshare (Layer 11/16) -> by-design, any readiness alert on a Succeeded/absent pod ->
+      false-positive. Confirm the skill performs NO mutation.
+- number: 2
+  title: Verify the alert-agent report (host, post-merge)
+  steps:
+  - id: P4.T2.S1
+    text: |
+      manual-operation. After ArgoCD rolls the alert-agent ConfigMaps (hash-suffixed -> pod
+      rolls automatically), send a live Telegram DM (`/status` and a free-text "why is X
+      firing?") and, if convenient, trigger `/digest` / `/surge`. Confirm: reply is a compact
+      plain-text table (not prose, not a raw {"text":...} envelope), never mentions "Hacker
+      News", and an explicit question returns within the turn budget (no timeout fallback /
+      no thinking-face reaction).
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/_meta.yaml
+++ b/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-07-13--obs--alert-triage-agent-fixes
+spec: docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.7.0,<4.0.0'
+created: '2026-07-13'

--- a/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/_prose.md
+++ b/docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/_prose.md
@@ -1,0 +1,52 @@
+# Frank alert-triage skill + alert-agent report fixes
+
+**Layer:** obs · **Spec:** `docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md`
+
+Two related deliverables, one PR, unified by a shared alert-classification
+decision tree and a compact plain-text report format.
+
+## Why
+
+"Grafana is alerting on Frank" is a recurring, fully-deterministic triage: every
+firing alert maps to a documented pattern (canary → muted; `gpu_timeshare` →
+by-design; a terminal/absent pod behind a readiness rule → false-positive;
+`github_issue` label → known tracker). That belongs in a skill. Separately, the
+autonomous alert-agent misbehaves in five operator-visible ways — all root-caused
+to a **stale `SKILL.md`** (written against an earlier Telegram sender) plus a
+hard-coded "Hacker News" example and a leaky JSON envelope.
+
+## Approach
+
+- **Phase 1** builds the shared brain: a pure, stdlib-only
+  `classify(labels, pod_state) → Verdict` with a test per decision-tree branch,
+  using the real alert label shapes captured during this session's live triage.
+  Pure means the classifier never touches the cluster — the caller supplies the
+  resolved pod state — so it is deterministically unit-tested.
+- **Phase 2** wraps it in the operator-facing `frank-alert-triage` skill: fetch
+  firing alerts from the Grafana API, resolve readiness-rule pods live (the
+  live-vs-ghost-tombstone check), classify, and print a compact table.
+  Classify-and-recommend only — never mutate (the auto-mode classifier correctly
+  blocks pod deletes).
+- **Phase 3** fixes the alert-agent, TDD-first where there's logic
+  (`render_payload` string-envelope unwrap; prompt-content assertions), edits
+  where it's prose (`SKILL.md`). The key realisation: `tg_send` already sends
+  plain text with no `parse_mode`, so the "no tables / no `<>&`" rule is stale
+  and actively prevents the table the operator wants.
+- **Phase 4** is the back-loaded manual Test Plan: the skill and the agent both
+  need a kube-credentialed host + the live Telegram bot to prove, so they are
+  verified after merge, operator-driven.
+
+## Deployment
+
+Every alert-agent file (`SKILL.md`, `orchestration.py`, `bridge.py`) is mounted
+from a **hash-suffixed ConfigMap** — any edit changes the hash and rolls the pod
+automatically (the Application has `prune: true`). Deploy = git merge + ArgoCD
+sync; **no image rebuild**. The `frank-alert-triage` skill is repo-only (no
+cluster artifact).
+
+## Non-goals
+
+No cluster mutation from the skill; no auto-remediation; no raising
+`DM_TIMEOUT_S` (the timeout fix is behavioural — bound the turn); the skill and
+agent stay separate implementations (different execution contexts) sharing only
+the documented decision-tree + format contract.

--- a/docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md
+++ b/docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md
@@ -1,0 +1,128 @@
+# Design: Frank alert-triage skill + alert-agent report fixes
+
+**Status:** Draft
+**Layer:** obs
+**Branch:** feat/alert-triage-and-agent-fixes
+**Date:** 2026-07-13
+
+## Context
+
+Two related deliverables, built in one workspace / one PR because they share a
+format contract:
+
+1. A new operator-invoked **`frank-alert-triage`** skill — the interactive
+   counterpart to the autonomous alert-agent. Today, "Grafana is alerting on
+   Frank" is investigated ad-hoc (6+ exploratory tool calls: fetch firing
+   alerts, inspect pods, cross-reference known-benign patterns). Every step is
+   deterministic and repo-documented, so it belongs in a skill.
+2. Five operator-reported **alert-agent** misbehaviours, all root-caused this
+   session, all deploying via the existing hash-suffixed ConfigMap roll (no
+   image rebuild).
+
+The two share one thing: the **alert-classification decision tree** and the
+**compact report format**. They stay separate implementations (different
+execution contexts — a kube-credentialed laptop vs an HTTP-only pod) but cite
+the same documented contract.
+
+## Deliverable 1 — `frank-alert-triage` skill
+
+Repo-local skill at `agents/skills/frank-alert-triage/`. A markdown playbook
+(`SKILL.md`) plus a small **stdlib-only pure classifier** (`classify.py` +
+`test_classify.py`) — no new runtime service. Invoked by the operator from the
+laptop, where `kubectl` + the Grafana alert API are reachable.
+
+`classify.py` exposes `classify(labels: dict, pod_state: str | None) -> Verdict`
+— pure, no kube/network dependency (the caller supplies the resolved pod state),
+so it is deterministically unit-tested. The skill's `SKILL.md` drives the fetch
+(Grafana API) + pod-resolution (`kubectl`) and calls `classify()` per alert. The
+alert-agent does **not** import it (separate HTTP-only ConfigMap) — it documents
+the same tree in its own `SKILL.md`.
+
+### Flow
+1. Fetch firing alerts (`/api/prometheus/grafana/api/v1/alerts`, admin creds
+   from the `victoria-metrics-grafana` secret; state `Alerting`).
+2. Classify each via a **label-driven decision tree**:
+   | Signal | Verdict |
+   |---|---|
+   | `canary: true` | **muted/expected** — canary, never paged (e.g. cert-expiry #251) |
+   | `gpu_timeshare: true` | **by-design** — one GPU workload down by design; real pager is `gpu-node-both-down` only |
+   | readiness rule + referenced pod is `Succeeded`/`Completed`/absent | **false-positive** — stale KSM series / graceful-shutdown tombstone |
+   | `github_issue: frank-ops#N` | annotate with the **known tracker** |
+   | none of the above | **unexplained** — escalate |
+3. For readiness-based alerts, resolve the alert's `pod` label against the live
+   cluster (live vs ghost tombstone) — the check that distinguishes a real
+   NotReady from a graceful-shutdown artifact.
+4. Emit a **compact table verdict** (same column style as the agent report):
+   `alert | severity | verdict | one-line reason/action`.
+5. **Classify-and-recommend only** — never mutate (no pod deletes/acks; the
+   auto-mode classifier correctly blocks these). Genuinely-unexplained alerts
+   hand off to `fr-debugging`.
+
+### Non-goals
+- No cluster mutation. No auto-remediation. No new deployed service.
+- Not a replacement for the alert-agent (autonomous/Telegram) — the interactive
+  sibling.
+
+## Deliverable 2 — alert-agent fixes
+
+All in `apps/alert-agent/`. Root causes and fixes:
+
+| # | Symptom | Root cause | Fix |
+|---|---|---|---|
+| 1 | Fixates on "Hacker News" | Hard-coded example in `SKILL.md:12` + `orchestration.py:81` | Evidence-driven phrasing (name source from `top_referrers`/`top_user_agents`, else "undetermined"); name **no** example |
+| 2 | Replies with raw JSON | `{"text":…}` envelope contract (`SKILL.md:19`); `render_payload` posts a string envelope verbatim (`bridge.py:160`) | Drop the envelope from the taught contract (plain-text reply); `render_payload` defensively unwraps a `{"text":…}` **string** as belt-and-braces |
+| 3 | Too talkative / no tables | `SKILL.md:17-22` forbids tables + `<>&` — **stale** (sender is plain-text, no parse_mode, `bridge.py:5,51`) | Rewrite output contract: **prefer** a compact plain-text aligned table + a hard line budget |
+| 4 | Times out on explicit asks | `DM_TIMEOUT_S=600` but the agent probe-sweeps past it | **Behavioural**: bound a DM turn to ≤2 probes + "answer now"; the table format forces brevity. NOT a bigger timeout |
+
+### Decided design
+- **Telegram output = compact PLAIN-TEXT aligned lines**, no parse_mode — immune
+  to the historic `<>&` 400 gotcha. "Table-like" = aligned `label value detail`
+  columns, not a monospaced grid (Telegram plain text isn't monospaced).
+- **Unify the contract to plain-text everywhere.** Drop the `{"text":…}` JSON
+  envelope from the DM path *and* the cron digest/surge prompts
+  (`orchestration.py:82,106`); `render_payload`'s dict branch + a new
+  string-unwrap branch stay purely as defensive fallbacks. Removes the
+  dual-contract the model has to juggle.
+- **Skill and agent stay separate**, sharing the decision tree + table format as
+  a documented convention (the agent SKILL.md notes it matches the skill's).
+
+### Testing
+- `classify.py` → `test_classify.py`: one case per decision-tree branch
+  (canary, gpu_timeshare, readiness+ghost pod, readiness+live pod, known
+  tracker, unexplained) using the real label shapes captured this session.
+- `render_payload` string-envelope unwrap → new unit test in `test_bridge.py`
+  (existing patterns: canned `_http_post_json`, dict-payload assertions).
+- No behavioural regression to allowlist / routing / reaction / threading tests.
+- Prompt-content assertions: no "Hacker News" literal; plain-text contract.
+
+## Deployment
+- `SKILL.md`, `orchestration.py`, `bridge.py` are all hash-suffixed
+  ConfigMap-mounted → any edit rolls the pod (Application has `prune: true`).
+  Deploy = git merge + ArgoCD sync. No image rebuild.
+- The `frank-alert-triage` skill is repo-only (no cluster artifact).
+
+## Test Plan (post-merge, operator-driven, from host)
+
+These prove real deployment; they need the operator's kube-credentialed host +
+the live Telegram bot, so they run after merge (not in CI).
+
+1. **Skill** (`obs-alert-triage-classifies`) — run `frank-alert-triage` against
+   the live firing set; the verdict table matches this session's manual triage
+   (canaries → muted, `gpu_timeshare` → by-design, a readiness false-positive
+   flagged when a `Succeeded`/absent pod is present), with zero cluster
+   mutation.
+2. **Agent — no Hacker News** (`obs-alert-agent-evidence-not-hn`) — trigger a
+   digest/surge (or `/surge`); the narrative attributes the source from
+   evidence or says "undetermined", never "Hacker News".
+3. **Agent — plain-text table** (`obs-alert-agent-plain-text-table`) — DM the
+   agent (`/status` or a free-text question); the reply is a compact plain-text
+   table, no raw `{"text":…}` envelope, no prose wall.
+4. **Agent — answers explicit asks** (`obs-alert-agent-answers-explicit-asks`) —
+   a focused explicit question returns a real answer within the turn budget,
+   not the timeout fallback.
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+| ---- | ---- | ---- | ---------- |
+| 2026-07-13--obs--alert-triage-agent-fixes | `derio-net/frank` | `2026-07-13--obs--alert-triage-agent-fixes` | — |


### PR DESCRIPTION
## Summary

Two related observability deliverables, unified by a shared alert-classification
decision tree + compact plain-text report format.

**1. New `frank-alert-triage` skill** (`agents/skills/frank-alert-triage/`) — an
operator-invoked classifier for "Grafana is alerting on Frank". Fetches the
firing set from the Grafana API, classifies each alert (`muted-canary` /
`by-design` / `false-positive` / `unexplained`), resolves readiness-alert pods
live (the live-vs-tombstone check), and prints a compact verdict table.
**Classify-and-recommend only — never mutates the cluster.** Logic lives in a
pure, unit-tested `classify.py`; `SKILL.md` is the playbook.

**2. alert-agent report fixes** (`apps/alert-agent/`) — five operator-reported
misbehaviours, root-caused to a stale `SKILL.md` + a hard-coded example + a leaky
JSON envelope:

| Symptom | Fix |
|---|---|
| Fixates on "Hacker News" | De-anchored the surge prompt (`orchestration.py`) + `SKILL.md` — evidence-driven attribution or "undetermined", no named example |
| Replies with raw JSON | Dropped the `{"text":…}` envelope from the taught contract; `render_payload` defensively unwraps a `{"text":…}` **string** as belt-and-braces |
| Too talkative / no tables | Rewrote the output contract to a compact plain-text aligned table; removed the **stale** "no tables / no `<>&`" rule (the sender is already plain-text, no `parse_mode`) |
| Times out on explicit asks | Bounded interactive DM turns to ≤2 probes + "answer now" — behavioural, **not** a bigger `DM_TIMEOUT_S` |

All alert-agent files are hash-suffixed ConfigMap-mounted → **deploy = merge +
ArgoCD sync, no image rebuild**.

## Design decision (refined during TDD)

`github_issue` is treated as an **orthogonal tracker annotation, not a benign
verdict**: the label only means "this alert type has a tracker", so a genuinely
Running-but-NotReady pod (which also carries it) still classifies as
`unexplained`/escalate rather than being masked.

## Spec / Plan
- Spec: `docs/superpowers/specs/2026-07-13--obs--alert-triage-and-agent-report-fixes-design.md`
- Plan: `docs/superpowers/plans/2026-07-13--obs--alert-triage-agent-fixes/`

## Tests
Unit tests all green in isolation (`uv run --with pytest`):
- `test_classify.py` — 7 (one per decision-tree branch, real captured label shapes)
- `telegram-bridge` — 29 (incl. 5 new `render_payload` envelope-unwrap cases)
- `handlers` — 15 (incl. 2 new prompt-content asserts: no "Hacker News", no envelope)
- `frank-facts` — 13 (unchanged, no regression)

## Manual phase (ships unimplemented — operator pushes to this PR)
**Phase 4** is the back-loaded, operator-driven **post-merge Test Plan** — it
needs the kube-credentialed host + the live Telegram bot, so it can't run in CI:
1. Run `frank-alert-triage` against the live firing set → table matches manual triage, zero mutation.
2. Trigger `/surge`/`/digest` → attribution is evidence-based, never "Hacker News".
3. DM the agent → compact plain-text table, no JSON envelope.
4. A focused explicit question → real answer within the turn budget (no timeout fallback).

## Acceptance debt
Four rows added since brainstorm (origin = this spec), all `not-implemented`
pending the post-merge Test Plan above — they are live/host-verified by nature:
`obs-alert-triage-classifies`, `obs-alert-agent-evidence-not-hn`,
`obs-alert-agent-plain-text-table`, `obs-alert-agent-answers-explicit-asks`.
The unit tests are supporting evidence; the rows flip when the operator runs the
Test Plan.

## Code review (independent reviewer) — all findings fixed

Assessment: *Fix-then-merge* — classifier + agent fixes ready as-is, one
Important finding in the skill driver.

- **Important — driver misclassified real alerts as benign** (`SKILL.md` Step 3
  driver): it `cd`-ed into the skill dir, breaking the repo-root-relative
  `KUBECONFIG` from `.env` → `kubectl` fails → `pod_state` fell open to `None` →
  a real `Running`-but-NotReady pod classified `false-positive`, recommending
  deletion of a *live* pod. **Fixed** (`8012b59c`): driver runs from repo root
  via `PYTHONPATH` (no `cd`); `NotFound` (→ absent → `false-positive`) is now
  distinguished from any other kubectl error (→ `"unresolved"` sentinel →
  non-terminal → escalate) — fail-safe, never suppress.
- **Minor** — documented load-bearing `pod_state`/`__name__` semantics (SKILL +
  `classify.py`); added tests asserting the tracker is captured on the escalate
  path, an `unresolved`-sentinel escalation case, and a non-string-`text`
  `render_payload` case. All fixed in `8012b59c`.
- Reviewer confirmed: classifier is genuinely pure, branch priority correct,
  `github_issue`-as-orthogonal-tracker honored, `render_payload` fails safe on
  every malformed shape, zero residual "Hacker News"/JSON-envelope instructions.

Final: classify 8 · telegram-bridge 30 · handlers 15 · frank-facts 13 — **66 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)