### PR TITLE
fix(obs): alert-agent replies — restore {text} envelope + deterministic DM fallback

### DIFF
--- a/apps/alert-agent/handlers/handlers/orchestration.py
+++ b/apps/alert-agent/handlers/handlers/orchestration.py
@@ -81,7 +81,8 @@ def run_surge(now: datetime | None = None) -> bool:
               "using ONLY the facts below: attribute the source from top_referrers and "
               "top_user_agents and cite specifics; if the facts do not show it, say the source "
               "is undetermined. Never name a source the facts do not support. "
-              "Reply in plain text — a few short lines or a compact table; no JSON, no markdown.\n\n"
+              "Reply as JSON {\"text\": \"<a few short lines or a compact plain-text table>\"} — "
+              "the table goes inside text.\n\n"
               f"verdict={json.dumps(verdict)}\nfacts={json.dumps(sheet)}")
     resp = bridge.session_send(prompt, session_id="alert-agent-ops")
     bridge.deliver(resp, fallback)
@@ -105,8 +106,9 @@ def run_digest(now: datetime | None = None) -> None:
     sheet = facts.build_for_digest(since, until, now)
     fallback = _render_digest(sheet)
     prompt = ("Write the daily Frank digest (traffic + security) from ONLY the facts below — "
-              "concise, notable items only, no speculation. Reply in plain text as a compact "
-              "table or a few short lines; no JSON, no markdown.\n\n"
+              "concise, notable items only, no speculation. "
+              "Reply as JSON {\"text\": \"<a compact plain-text table or a few short lines>\"} — "
+              "the table goes inside text.\n\n"
               f"facts={json.dumps(sheet)}")
     resp = bridge.session_send(prompt, session_id="alert-agent-ops")
     bridge.deliver(resp, fallback)

--- a/apps/alert-agent/handlers/tests/test_orchestration.py
+++ b/apps/alert-agent/handlers/tests/test_orchestration.py
@@ -81,17 +81,19 @@ def _prompt_of(sent):
     return next(a[0] for kind, a, k in sent if kind == "session")
 
 
-def test_surge_prompt_is_evidence_driven_no_named_source(wired, monkeypatch):
+def test_surge_prompt_is_evidence_driven_and_uses_text_envelope(wired, monkeypatch):
     # The surge prompt must NOT pre-seed a named source (e.g. "Hacker News") —
-    # that anchors the model into confabulating attribution against thin facts.
+    # that anchors the model. BUT it MUST ask for the {"text": ...} envelope: the
+    # agent-session server reads back a JSON file result, so a bare-narrative /
+    # rich-JSON reply has no `text` field and leaks raw JSON to Telegram.
     monkeypatch.setattr(orch.surge, "compute",
                         lambda: {"tier": "Major", "current": 600, "baseline": 30, "ratio": 20})
     orch.run_surge(now=T0)
     prompt = _prompt_of(wired)
-    assert "Hacker News" not in prompt
-    assert '{"text"' not in prompt          # no JSON envelope taught in the prompt
+    assert "Hacker News" not in prompt       # de-Hacker-News stays
+    assert '{"text"' in prompt               # envelope REQUIRED (file-result contract)
 
 
-def test_digest_prompt_has_no_json_envelope(wired):
+def test_digest_prompt_uses_text_envelope(wired):
     orch.run_digest(now=T0)
-    assert '{"text"' not in _prompt_of(wired)
+    assert '{"text"' in _prompt_of(wired)

--- a/apps/alert-agent/manifests/files/SKILL.md
+++ b/apps/alert-agent/manifests/files/SKILL.md
@@ -17,17 +17,21 @@ event and reads back a JSON result you write.
 
 ## Output contract
 
-Reply in **plain text** — no JSON envelope, no markdown. The Telegram sender uses no
-parse_mode, so `<`, `>`, and `&` are safe. Prefer a **compact aligned table** (label /
-value / detail columns) over prose, under a hard budget of about **8 short lines**; no
-prose walls. This is the same compact-table format the `frank-alert-triage` skill emits —
-keep the two consistent.
+The orchestration reads back a JSON result you write to the file the prompt names, so your
+whole reply MUST be the envelope `{"text": "<your message>"}` — nothing else in that file.
+Put a **compact plain-text table** INSIDE the `text` value (aligned label / value / detail
+columns), under a hard budget of about **8 short lines**; no prose walls. The sender posts
+`text` as plain text (no parse_mode), so `<`, `>`, and `&` are safe inside it. This is the
+same compact-table format the `frank-alert-triage` skill emits — keep the two consistent.
+
+The whole reply is the JSON; the table lives in `text` (note the `\n` line breaks):
 
 ```
-L3 Cilium    OK     2/2 operators
-L11 Infer    DEGR   gpu-timeshare (ComfyUI active, by design)
-Edge req/h   118    baseline 95 (x1.2)
+{"text": "L3 Cilium    OK     2/2 operators\nL11 Infer    DEGR   gpu-timeshare (ComfyUI, by design)\nEdge req/h   118    baseline 95 (x1.2)"}
 ```
+
+Do NOT write a bare narrative or a rich JSON object with other keys — a result without a
+`text` field is posted to the operator as raw JSON.
 
 ## Tools (read-only, HTTP-only — you have NO kubernetes credential)
 

--- a/apps/alert-agent/telegram-bridge/tests/test_bridge.py
+++ b/apps/alert-agent/telegram-bridge/tests/test_bridge.py
@@ -111,6 +111,43 @@ def test_render_payload_dict_branch_unchanged():
     assert bridge.render_payload({"status": "ok", "payload": {"text": "x"}}) == "x"
 
 
+# --- DM path: deterministic fallback (never a bare "(no reply)" / silent death) ---
+
+def test_dm_timeout_posts_deterministic_fallback(calls, monkeypatch):
+    # A timed-out/empty agent turn must post a DETERMINISTIC snapshot, not the
+    # bare "(the agent did not return a reply…)" that reads as a dead bot.
+    calls.canned["/session/send"] = {"status": "timeout", "payload": None}
+    monkeypatch.setattr(bridge, "_deterministic_snapshot", lambda: "SNAPSHOT surge tier=None")
+    bridge.process_update({"message": {"message_id": 5, "chat": {"id": 100}, "text": "/status"}})
+    replies = _sent(calls, "/sendMessage")
+    assert replies and "SNAPSHOT" in replies[-1]["text"]
+    assert "did not return a reply" not in replies[-1]["text"]
+    assert _reactions(calls)[-1] == "🤔"     # fallback → thinking-face, not thumbs-up
+
+
+def test_dm_session_exception_does_not_kill_turn(calls, monkeypatch):
+    # If session_send RAISES (HTTP timeout), the turn must survive and still post
+    # the deterministic fallback — never die silently leaving the operator with
+    # nothing (the original silent-no-reply bug).
+    def boom(*a, **k):
+        raise RuntimeError("http read timed out")
+    monkeypatch.setattr(bridge, "session_send", boom)
+    monkeypatch.setattr(bridge, "_deterministic_snapshot", lambda: "SNAPSHOT fallback")
+    bridge.process_update({"message": {"message_id": 6, "chat": {"id": 100}, "text": "why is X firing?"}})
+    replies = _sent(calls, "/sendMessage")
+    assert replies and "SNAPSHOT fallback" in replies[-1]["text"]
+
+
+def test_dm_success_still_posts_agent_text(calls, monkeypatch):
+    # The happy path is unchanged: a real payload is posted, 👍, no fallback.
+    calls.canned["/session/send"] = {"status": "ok", "payload": {"text": "real answer"}}
+    monkeypatch.setattr(bridge, "_deterministic_snapshot", lambda: "SHOULD NOT APPEAR")
+    bridge.process_update({"message": {"message_id": 7, "chat": {"id": 100}, "text": "hi"}})
+    replies = _sent(calls, "/sendMessage")
+    assert replies[-1]["text"] == "real answer"
+    assert _reactions(calls)[-1] == "👍"
+
+
 # --- Thread B: slash commands (expand_command + COMMANDS registry) -------------
 
 CATALOG = ["/help", "/digest", "/surge", "/edge_traffic", "/security", "/status"]

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import subprocess
 import sys
 import threading
 import time
@@ -27,13 +28,15 @@ ALLOWED_CHATS = set(_CHATS)
 SESSION_URL = os.environ.get("AGENT_SESSION_URL", "http://localhost:8765")
 SESSION_AGENT = os.environ.get("AGENT_SESSION_AGENT", "claude")
 SESSION_ID = os.environ.get("AGENT_SESSION_ID", "alert-agent")
-# How long to wait for an interactive DM turn. The old 120s cut off legitimate
-# answers — a thorough probe-based "cluster status" investigation runs ~5 min. The
-# 120s was a pre-threading guard against freezing the single getUpdates consumer;
-# Fix D moved turns to per-session worker threads, so a slow turn no longer blocks
-# the consumer or static /help — only a second DM to the SAME chat waits. So allow
-# DM turns to run long enough to actually finish.
-DM_TIMEOUT_S = float(os.environ.get("DM_TIMEOUT_S", "600"))
+# How long to wait for an interactive DM turn. Per-session worker threads (Fix D)
+# mean a slow turn blocks only a second DM to the SAME chat, never the getUpdates
+# consumer or static /help — so this bound is purely about operator responsiveness.
+# Bounded so a probe-sweeping turn can't leave the operator waiting minutes. A
+# focused turn (≤2 probes, per the SKILL) finishes well inside this; when the
+# model over-investigates past it, _run_agent_turn posts a deterministic
+# frank-facts snapshot instead of the useless "(no reply)" — the mechanical
+# backstop the soft prompt nudge lacks (a --resume'd session can ignore it).
+DM_TIMEOUT_S = float(os.environ.get("DM_TIMEOUT_S", "150"))
 
 
 def _http_post_json(url: str, payload: dict, timeout: float = 310) -> dict:
@@ -249,20 +252,45 @@ def _receipt_and_route(chat_id, message_id, text):
     return text   # no leading slash → free-text Q&A verbatim
 
 
+def _deterministic_snapshot() -> str:
+    """A fast, deterministic frank-facts snapshot for the DM fallback — so a slow
+    or failed agent turn still returns REAL data, never a bare '(no reply)'. Pure
+    stdlib: shells the frank-facts CLI (the same tool the agent uses), defensive on
+    any failure. Patched in tests."""
+    try:
+        # `surge-compute` returns the verdict {tier,current,baseline,ratio};
+        # `-m frank_facts.cli` avoids depending on the bin dir being on PATH
+        # (frank_facts is on PYTHONPATH=/opt/pylib in the bridge container).
+        out = subprocess.run([sys.executable, "-m", "frank_facts.cli", "surge-compute"],
+                             capture_output=True, text=True, timeout=20)
+        verdict = json.loads(out.stdout) if out.returncode == 0 and out.stdout.strip() else {}
+    except Exception as exc:  # noqa: BLE001 — the fallback must never itself raise
+        print(f"WARN telegram-bridge: deterministic snapshot failed: {exc}", file=sys.stderr)
+        verdict = {}
+    if verdict:
+        return ("agent busy — deterministic snapshot: surge "
+                f"tier={verdict.get('tier')} current={verdict.get('current')} "
+                f"baseline={verdict.get('baseline')} (x{verdict.get('ratio', 0)})")
+    return ("the agent is taking too long — try again shortly, or use a slash "
+            "command like /status")
+
+
 def _run_agent_turn(chat_id, message_id, message) -> None:
     """Drive the agent for one turn under the per-session lock, reply, react 👍/🤔.
-    The lock serializes same-session turns (no interleaved pastes); the wait spans
-    only session_send so a finished turn frees the session immediately."""
+    The lock serializes same-session turns; the wait spans only session_send so a
+    finished turn frees the session immediately. A transport failure OR a timed-out/
+    empty turn NEVER kills the thread silently — it posts a deterministic snapshot."""
     react = _react_fn(chat_id, message_id)
     session_id = f"{SESSION_ID}-tg-{chat_id}"
-    with _session_lock(session_id):
-        # Long enough for a thorough turn to finish (DM_TIMEOUT_S). Safe under
-        # threading: a slow turn holds only THIS session's lock, not the consumer.
-        resp = session_send(message, session_id=session_id, timeout_s=DM_TIMEOUT_S)
+    try:
+        with _session_lock(session_id):
+            resp = session_send(message, session_id=session_id, timeout_s=DM_TIMEOUT_S)
+    except Exception as exc:  # noqa: BLE001 — an HTTP timeout/error must not drop the reply
+        print(f"WARN telegram-bridge: session_send failed: {exc}", file=sys.stderr)
+        resp = None
     rendered = render_payload(resp)
-    tg_send(rendered or "(the agent did not return a reply — it may be busy or unauthenticated)",
-            str(chat_id))
-    react("👍" if rendered is not None else "🤔")   # 🤔 = only the deterministic fallback was posted
+    tg_send(rendered if rendered is not None else _deterministic_snapshot(), str(chat_id))
+    react("👍" if rendered is not None else "🤔")   # 🤔 = deterministic fallback was posted
 
 
 def process_update(update: dict) -> bool:

--- a/docs/superpowers/debugging/2026-07-13--obs--alert-agent-dm-json-regression.md
+++ b/docs/superpowers/debugging/2026-07-13--obs--alert-agent-dm-json-regression.md
@@ -1,0 +1,91 @@
+# Debugging: alert-agent replies as raw JSON + never answers slow DMs
+
+**Date:** 2026-07-13 · **Layer:** obs · **Branch:** fix/alert-agent-dm-json-regression
+**Regression of:** #631 (frank-alert-triage skill + alert-agent report fixes)
+
+## Symptom & reproduction
+
+During #631's post-merge Test Plan, the operator DM'd `@agent_zero_cc_bot`:
+`/status`, `/digest`, `/surge`, `/edge_traffic`. Result:
+1. ~10 min of no reply, then
+2. all four came back as **raw structured JSON blobs**, not the intended compact
+   plain-text tables.
+
+Repro: DM any command to the bot on the #631-deployed pod; observe raw JSON
+(and, for a command that makes the model investigate, a multi-minute wait).
+
+## Evidence
+
+- **Live tmux pane** of the per-chat session (`claude --resume 63abf571…`, elapsed
+  12 min): `● Surge-compute shows a Major tier. Let me get attacker IPs… ● Running
+  3 shell commands… ✢ Hyperspacing (47s · thinking)` — the turn was probe-sweeping
+  (surge-compute → attacker-IP `ipinfo.io` curls), not hung.
+- **agent-session server** `/usr/local/bin/agent-session` (image-level, multi-agent-shell):
+  - line ~367: appends `"[agent-session] When done, write ONLY the JSON result to
+    the file <path> — raw JSON, overwrite it, nothing else."` to every turn.
+  - line ~380: `payload = json.load(fh)` — the file's JSON **is** the payload the
+    bridge receives.
+- **`bridge.render_payload`**: a dict payload without a `text` key →
+  `json.dumps(payload)` → the raw JSON is what gets posted.
+- **`bridge._run_agent_turn`**: `DM_TIMEOUT_S=600`; `session_send` is not wrapped,
+  and on timeout/empty it posts only `"(the agent did not return a reply…)"`.
+
+## Root cause
+
+**Two independent causes, both confirmed:**
+
+1. **JSON leak (regression #631 introduced).** The agent↔session-server contract is
+   *file-based JSON*: the agent MUST write a JSON object whose `text` field carries the
+   message, and `render_payload` extracts `.text`. #631 wrongly "fixed the JSON reply"
+   by *removing* the `{"text": …}` envelope from `SKILL.md` and the `orchestration.py`
+   cron prompts (told the agent "plain text, no JSON"). But the session wrapper still
+   mandates "write raw JSON result". Conflicted, the agent writes a *rich* JSON object
+   with no `text` key → `render_payload` re-serializes it → **raw JSON to Telegram**.
+   The `{"text": …}` envelope was never the bug; it is the load-bearing transport. The
+   real fix is "the compact table lives *inside* `text`", not "drop the envelope".
+
+2. **Slow turn + no mechanical backstop (pre-existing).** #631's "≤2 probes, answer
+   now" is a *soft prompt nudge*; the bridge spawns `claude --resume`, whose restored
+   transcript carries deep-dive momentum that overrides the freshly-loaded CLAUDE.md.
+   And `_run_agent_turn` has no deterministic fallback (unlike the cron `deliver()`),
+   so an over-investigating turn yields only a useless 10-min `"(no reply)"` — or, if
+   the HTTP call raises on timeout, a silently-dead worker thread and nothing at all.
+
+## Fix
+
+1. **Restore the `{"text": "<compact plain-text table>"}` contract** in
+   `apps/alert-agent/manifests/files/SKILL.md` and the `run_surge`/`run_digest`
+   prompts (`orchestration.py`) — the table goes inside `text`. Kept #631's
+   de-Hacker-News/evidence-driven phrasing (proven correct live: the surge reply
+   attributed "Chrome/120 stale UA… crawler", no Hacker News) and the
+   `render_payload` `{"text":…}`-string unwrap (still valid belt-and-braces).
+2. **Mechanical DM backstop** in `bridge.py`: `DM_TIMEOUT_S` 600→150; wrap
+   `session_send` so a transport error never kills the turn; on timeout/empty/error
+   post `_deterministic_snapshot()` — a `python3 -m frank_facts.cli surge-compute`
+   verdict (verified live: `tier=Notable current=58 baseline=9 x6.44`) — instead of
+   the bare "(no reply)".
+
+**Failing tests pinning it:** `test_orchestration.py` envelope asserts flipped
+(`{"text"` MUST be present, `"Hacker News"` MUST NOT); `test_bridge.py`
+`test_dm_timeout_posts_deterministic_fallback`, `test_dm_session_exception_does_not_kill_turn`,
+`test_dm_success_still_posts_agent_text`. Full suite: bridge 33 · handlers 15 · frank-facts 13.
+
+## Rejected hypotheses
+
+- *"The bridge is dead / not polling"* — ruled out: `python3 telegram-bridge` is pid 1;
+  empty logs are Python block-buffering, not a dead process.
+- *"The claude session hung / crashed / OOM"* — ruled out: the pane showed it actively
+  running tool calls; `claude` pid alive, RSS ~500 MB, 0 container restarts.
+- *"Cold-start / auth failure"* — ruled out: `native-claude 2.1.207 already installed`,
+  `.credentials.json` present, the turn was executing.
+- *"Only the DM path is affected"* — ruled out: the cron digest/surge prompts share the
+  same `session_send` file-result contract and were broken identically; fixed both.
+
+## Lesson
+
+In-pod instruction *presence* ≠ correct *output*. #631's unit tests fed
+`render_payload` a `{"text":…}` dict directly and never exercised the real
+agent↔session-server contract; the deploy was called "verified" from the mounted
+instructions, not observed output. Only the live DM caught it — exactly the
+"test workflows before declaring Deployed" rule. This fix's acceptance is
+gated on a live DM, not a green unit run.


### PR DESCRIPTION
## Summary

Regression fix for #631, caught by **its own post-merge Test Plan**: a live DM to
the alert-agent returned four **raw JSON blobs after ~10 minutes** instead of the
intended compact plain-text tables. Two independent root causes, both fixed at
source. All alert-agent code is hash-suffixed ConfigMap-mounted → deploy = merge +
ArgoCD sync, no image rebuild.

## Root cause 1 — JSON leak (the regression #631 introduced)

The agent ↔ session-server contract is a **JSON file result**: `agent-session`
(image-level) tells every turn to "write ONLY the JSON result to the file", then
`payload = json.load(fh)`. The working shape is `{"text": "<message>"}`, and
`render_payload` extracts `.text`. **#631 wrongly removed that envelope** (rewrote
`SKILL.md` + the cron prompts to "plain text, no JSON"), so the agent — still told
by the session wrapper to write JSON — emits a *rich* object with no `text` key →
`render_payload` re-serializes it → **raw JSON to Telegram**.

The `{"text":…}` envelope was never the bug; it's the load-bearing transport. Fix:
**restore the envelope; the compact plain-text table lives *inside* `text`.** Kept
#631's de-Hacker-News change (proven correct live — the surge reply attributed
"Chrome/120 stale UA… crawler", no Hacker News) and the `render_payload`
`{"text":…}`-string unwrap.

## Root cause 2 — slow turn + no backstop (pre-existing)

The turn probe-swept for ~10 min because the bridge spawns `claude --resume`, whose
restored transcript carries deep-dive momentum that overrides the freshly-loaded
`CLAUDE.md` (the "≤2 probes" nudge is soft). And `_run_agent_turn` had no
deterministic fallback — an overrun yielded only a useless `"(no reply)"`, or, if
the HTTP call raised on timeout, a silently-dead worker thread. Fix:

- `DM_TIMEOUT_S` 600 → **150** (responsiveness).
- Wrap `session_send` so a transport error can never silently drop the reply.
- On timeout/empty/error, post `_deterministic_snapshot()` — a
  `python3 -m frank_facts.cli surge-compute` verdict — instead of `"(no reply)"`.
  **Verified live** in the bridge container: `tier=Notable current=58 baseline=9 x6.44`.

## Tests

- `test_orchestration.py`: envelope assertions **flipped** — `{"text"` MUST be
  present (file-result contract), `"Hacker News"` MUST NOT (de-HN preserved).
- `test_bridge.py`: 3 new — deterministic fallback on timeout, on `session_send`
  exception, and the happy path unchanged.
- Full suite: **bridge 33 · handlers 15 · frank-facts 13** green.

## Debugging log
`docs/superpowers/debugging/2026-07-13--obs--alert-agent-dm-json-regression.md`
(symptom, evidence, root cause, fix, rejected hypotheses).

## Test Plan (post-merge, operator-driven — REQUIRED)

The #631 lesson is that in-pod instruction *presence* ≠ correct *output* — only a
live DM proves it. After merge + ArgoCD roll:
1. DM `@agent_zero_cc_bot` `/status` → a **compact plain-text table**, not raw JSON,
   within the bounded budget.
2. Force/await a slow turn → the **deterministic snapshot** lands (not "(no reply)").
3. A digest/surge → evidence-based, no "Hacker News".

This closes the behavioral half of #631's acceptance rows
(`obs-alert-agent-plain-text-table`, `obs-alert-agent-answers-explicit-asks`), which
stay open until this live check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)