### PR TITLE
fix(obs): render any agent dict payload as a plain-text table (mechanical anti-JSON-leak)

### DIFF
--- a/apps/alert-agent/manifests/files/SKILL.md
+++ b/apps/alert-agent/manifests/files/SKILL.md
@@ -30,8 +30,10 @@ The whole reply is the JSON; the table lives in `text` (note the `\n` line break
 {"text": "L3 Cilium    OK     2/2 operators\nL11 Infer    DEGR   gpu-timeshare (ComfyUI, by design)\nEdge req/h   118    baseline 95 (x1.2)"}
 ```
 
-Do NOT write a bare narrative or a rich JSON object with other keys — a result without a
-`text` field is posted to the operator as raw JSON.
+Prefer `{"text": "<table>"}` — a table you compose reads best. If you instead write a
+**flat** JSON object of short `label → value` fields (no deep nesting), the bridge renders
+it as a `label  value` table automatically. Either way the operator sees a table, never
+raw JSON — but deep nesting renders as compacted one-line values, so keep it flat.
 
 ## Tools (read-only, HTTP-only — you have NO kubernetes credential)
 

--- a/apps/alert-agent/telegram-bridge/tests/test_bridge.py
+++ b/apps/alert-agent/telegram-bridge/tests/test_bridge.py
@@ -92,23 +92,51 @@ def test_render_payload_passes_plain_string_through():
     assert bridge.render_payload({"status": "ok", "payload": "just words"}) == "just words"
 
 
-def test_render_payload_leaves_non_envelope_json_verbatim():
-    # A string that happens to start like JSON but isn't a {"text": ...} envelope
-    # is returned unchanged — no accidental mangling of a normal answer.
+def test_render_payload_leaves_non_dict_json_verbatim():
+    # A non-JSON string, or a JSON *non-dict* (list/number), is not a report —
+    # returned unchanged, no accidental mangling of a normal answer.
     assert bridge.render_payload({"status": "ok", "payload": "not json {"}) == "not json {"
-    # A JSON list, or a JSON object without a "text" key, is not an envelope.
     assert bridge.render_payload({"status": "ok", "payload": '["a", "b"]'}) == '["a", "b"]'
-
-
-def test_render_payload_ignores_non_string_text():
-    # A JSON object whose "text" is not a string is NOT a valid envelope — return
-    # the raw string, never coerce a number/list into the reply.
-    assert bridge.render_payload(
-        {"status": "ok", "payload": '{"text": 123}'}) == '{"text": 123}'
 
 
 def test_render_payload_dict_branch_unchanged():
     assert bridge.render_payload({"status": "ok", "payload": {"text": "x"}}) == "x"
+
+
+# --- render_payload renders ANY dict as a table (the mechanical anti-JSON-leak) ---
+# The agent-session server hands the agent's raw JSON result straight through, and
+# the model often writes a domain-shaped object (no `text` field) despite the prompt.
+# render_payload must table it, NEVER post raw json.dumps — a mechanism the agent's
+# per-turn wrapper cannot override.
+
+def test_render_payload_textless_dict_becomes_table():
+    out = bridge.render_payload(
+        {"status": "ok", "payload": {"gpu_mode": "comfyui", "firing_alerts": "none"}})
+    assert "gpu_mode" in out and "comfyui" in out
+    assert "firing_alerts" in out and "none" in out
+    assert not out.lstrip().startswith("{")        # NOT raw JSON
+    assert out.count("\n") == 1                      # one row per top-level key
+
+
+def test_render_payload_textless_dict_string_becomes_table():
+    out = bridge.render_payload({"status": "ok", "payload": '{"a": 1, "b": "two"}'})
+    assert not out.lstrip().startswith("{")
+    assert "a" in out and "b" in out and "two" in out
+
+
+def test_render_payload_nested_dict_one_row_per_top_key():
+    out = bridge.render_payload(
+        {"status": "ok", "payload": {"summary": {"overall": "quiet"}, "count": 5}})
+    assert out.count("\n") == 1                      # 2 top-level keys → 2 rows
+    assert "summary" in out and "count" in out
+    assert "overall" in out                          # nested value compacted inline
+
+
+def test_render_payload_non_string_text_key_is_tabled_not_raw():
+    # {"text": <non-string>} is not a valid envelope → tabled, never posted raw.
+    out = bridge.render_payload({"status": "ok", "payload": '{"text": 123}'})
+    assert not out.lstrip().startswith("{")
+    assert "text" in out and "123" in out
 
 
 # --- DM path: deterministic fallback (never a bare "(no reply)" / silent death) ---

--- a/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
+++ b/apps/alert-agent/telegram-bridge/tg_bridge/bridge.py
@@ -160,15 +160,36 @@ def session_send(message: str, session_id: str | None = None, timeout_s: float =
     )
 
 
+def _dict_to_table(d: dict) -> str:
+    """Render a dict payload as a compact plain-text `key  value` table — so the
+    operator NEVER sees raw json.dumps. The bridge owns presentation: the
+    agent-session server hands the agent's raw JSON result straight through and
+    the model routinely writes a domain-shaped object (no `text` field) despite
+    the prompt, so a mechanism the model can't override is the only reliable fix.
+    Nested values compact to single-line JSON so each top-level key stays one row."""
+    if not d:
+        return "(empty result)"
+
+    def _val(v) -> str:
+        if isinstance(v, (dict, list)):
+            s = json.dumps(v, separators=(",", ":"), ensure_ascii=False)
+            return s if len(s) <= 200 else s[:197] + "..."
+        return str(v)
+
+    w = max(len(str(k)) for k in d)
+    return "\n".join(f"{str(k):<{w}}  {_val(v)}" for k, v in d.items())
+
+
 def render_payload(resp: dict) -> str | None:
     """Human text from an agent-session response, or None if it didn't complete.
 
-    The agent's output contract (taught in SKILL.md) is now PLAIN TEXT. But a
-    turn that still emits the legacy {"text": "..."} envelope arrives here as a
-    STRING payload (the session server returns the agent's final message
-    verbatim) — so we defensively unwrap a {"text": ...} envelope, else the
-    operator sees literal JSON in Telegram. Any other string passes through.
-    None when status != ok or payload is empty.
+    The session-server contract is a JSON file result. The preferred shape is
+    {"text": "<compact plain-text table>"} → we return `text`. But the model often
+    ignores that and writes a domain-shaped dict with no `text` field; rather than
+    leak raw JSON, we render ANY such dict as a `key  value` table
+    (`_dict_to_table`). A bare string passes through; a string that parses to a
+    dict is handled the same way (unwrap `text`, else table). None when status !=
+    ok or payload is empty.
     """
     if not resp or resp.get("status") != "ok":
         return None
@@ -179,13 +200,14 @@ def render_payload(resp: dict) -> str | None:
         try:
             obj = json.loads(payload)
         except (ValueError, TypeError):
-            return payload
-        if isinstance(obj, dict) and isinstance(obj.get("text"), str):
-            return obj["text"]
-        return payload
+            return payload                      # genuine plain text
+        payload = obj if isinstance(obj, dict) else payload
+        if not isinstance(payload, dict):
+            return payload                      # non-dict JSON (list/number) — leave as-is
     if isinstance(payload, dict):
-        return payload.get("text") or json.dumps(payload)
-    return json.dumps(payload)
+        text = payload.get("text")
+        return text if isinstance(text, str) else _dict_to_table(payload)
+    return str(payload)                          # non-str, non-dict (list/number)
 
 
 def deliver(resp: dict, fallback_text: str, chat_id: str | None = None) -> dict:

--- a/docs/superpowers/debugging/2026-07-13--obs--alert-agent-render-any-dict.md
+++ b/docs/superpowers/debugging/2026-07-13--obs--alert-agent-render-any-dict.md
@@ -1,0 +1,58 @@
+# Debugging: alert-agent STILL leaks raw JSON after #633 — the mechanical fix
+
+**Date:** 2026-07-13 · **Layer:** obs · **Branch:** fix/alert-agent-render-dict-table
+**Follows:** #633 (which restored the `{"text":…}` envelope *instruction*) — insufficient.
+
+## Symptom & reproduction
+
+After #633 merged and rolled, a **live session probe** (POST to the in-pod
+agent-session server, observing the actual payload — the step #631/#633 skipped)
+showed the agent STILL wrote a rich object with **no `text` field**:
+
+```
+STATUS: ok | HAS_TEXT_KEY: False
+{"gpu_mode": "unknown…", "firing_alerts": "none…", "edge_traffic": "3813 reqs…"}
+```
+
+`render_payload` `json.dumps`es that → raw JSON to Telegram. The turn itself was
+fast and correct (≤2 probes, no timeout, no Hacker News — #633's latency/de-HN
+parts work); only the JSON *presentation* was still broken.
+
+## Root cause (architecture, not another prompt)
+
+Two instruction-layer attempts failed: #631 removed the `{"text":…}` envelope,
+#633 restored it. Neither binds, because the **agent-session server appends
+`"write ONLY the JSON result to the file — raw JSON"` to every turn**, and that
+per-turn wrapper dominates the ambient `CLAUDE.md`. The model writes a
+domain-shaped JSON, not `{"text":…}`, no matter what the instructions say.
+
+Confirmed hard-stop signal (systematic-debugging Phase 4 step 5): repeated fixes
+at the same layer failing → the layer is wrong. **The bridge must own
+presentation** — a mechanism the agent's per-turn wrapper cannot override.
+
+## Fix
+
+`render_payload` renders **any** dict payload as a compact plain-text `key  value`
+table (`_dict_to_table`), instead of `json.dumps`:
+
+- `{"text": "<table>"}` → return `text` (preferred; agent-composed table).
+- any other dict → aligned `key  value` rows; nested values compacted to a
+  single-line JSON so each top-level key stays one row.
+- non-dict JSON (list/number) / bare string → unchanged.
+
+**Verified against the REAL leaked payload** (not a synthetic test): the exact
+`{"gpu_mode":…, "firing_alerts":…, "edge_traffic":…}` object now renders as a
+3-row aligned table, `is_raw_json=False`. SKILL.md updated to say a flat
+`label→value` object is fine (the bridge tables it) — deep nesting still
+compacts, so keep it flat.
+
+Tests: 4 new `render_payload` table cases; the two old tests that asserted
+"leave the textless dict raw" (the bug behaviour) updated. bridge 36 · handlers
+15 · frank-facts 13 green.
+
+## Rejected approach
+
+*A third instruction tweak* (e.g. a louder "you MUST use text"). Rejected: the
+live probe proved the session wrapper wins; a mechanism is the only reliable
+layer. This is the "in-pod instruction presence ≠ correct output" lesson,
+enforced by observing the actual payload this time.


### PR DESCRIPTION
## Summary

Follow-up to #633. #633 restored the `{"text":…}` envelope **instruction**, but a
**live session probe** (observing the agent's actual payload — the step #631/#633
skipped) proved it insufficient: the agent still writes a domain-shaped JSON with
no `text` field, so `render_payload` `json.dumps`ed it → raw JSON to the operator.

```
STATUS: ok | HAS_TEXT_KEY: False
{"gpu_mode": "unknown…", "firing_alerts": "none…", "edge_traffic": "3813 reqs…"}
```

## Why instruction fixes couldn't win

The agent-session server appends `"write ONLY the JSON result to the file — raw
JSON"` to **every turn**; that per-turn wrapper dominates the ambient `CLAUDE.md`,
so the model writes a structured object regardless of the prompt. After two
instruction-layer attempts (#631 removed the envelope, #633 restored it), the
signal was clear: **the fix must move to a layer the agent can't override.**

## Fix (mechanical — the bridge owns presentation)

`render_payload` now renders **any** dict payload as a compact plain-text
`key  value` table (`_dict_to_table`) instead of `json.dumps`:
- `{"text": "<table>"}` → return `text` (preferred, agent-composed).
- any other dict → aligned rows; nested values compact to one line per top key.
- non-dict JSON / bare string → unchanged.

**Verified against the EXACT payload the live agent leaked** — it now renders:
```
gpu_mode       unknown (not exposed by frank-facts digest)
firing_alerts  none (falco_critical_rules=[], crowdsec_decisions=0, …)
edge_traffic   3813 reqs/~1.75d (mostly 3xx redirects), heads.hop.derio.net top host; …
```
`is_raw_json=False`, 3 rows — not raw JSON.

## Tests
4 new `render_payload` table cases; the 2 old tests that asserted "leave the
textless dict raw" (the bug behaviour) updated. **bridge 36 · handlers 15 ·
frank-facts 13** green. SKILL.md updated: a flat `label→value` object is fine (the
bridge tables it); keep it flat (deep nesting compacts).

## Debugging log
`docs/superpowers/debugging/2026-07-13--obs--alert-agent-render-any-dict.md`

## Test Plan (post-merge)
After roll: DM `/status` → a plain-text table, never raw JSON (the mechanism
guarantees it regardless of the agent's output shape). This is the fix that
finally closes #631's `obs-alert-agent-plain-text-table` acceptance row. I'll
drive a live session probe again to confirm the rendered table before calling it done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
