### PR TITLE
refactor(blog): rewrite all 28 operating posts against educational-writing methodology

### DIFF
--- a/.blog-craft.yaml
+++ b/.blog-craft.yaml
@@ -167,3 +167,5 @@ voice: |
 ci:
   validators: [frontmatter, dossier, mermaid, hugo_build]
   deploy: { kind: container_pages }
+# How thick the persona frame is. (options: dry,balanced,rich)
+voice_level: balanced

--- a/blog/content/docs/operating/01-cluster-nodes/index.md
+++ b/blog/content/docs/operating/01-cluster-nodes/index.md
@@ -4,16 +4,29 @@ series: ["operating"]
 layer: os
 date: 2026-03-13
 draft: false
-tags: ["operations", "talos", "cilium", "hubble", "networking"]
-summary: "Day-to-day commands for checking cluster health, managing Talos nodes, and debugging Cilium networking on Frank."
+tags: ["operations", "talos", "cilium", "hubble", "networking", "omni", "troubleshooting"]
+summary: "Day-to-day commands for checking cluster health, managing Talos nodes, and debugging Cilium networking on Frank — including the real failure patterns the gotcha docs cover."
 weight: 2
+reader_goal: "Diagnose node and networking issues on a Talos+Cilium cluster using kubectl, talosctl, cilium CLI, and Omni's declarative patch system."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
 
-This is the operational companion to [Building the Foundation]({{< relref "/docs/building/02-foundation" >}}). That post covers *why* we chose Talos and Cilium and how they were deployed. This one covers the commands you actually type on a Tuesday afternoon when something looks off.
+{{< last-updated >}}
 
-## What "Healthy" Looks Like
+This is the operational companion to [Building the Foundation]({{< relref "/docs/building/02-foundation" >}}). That post covers *why* we chose Talos and Cilium and how they were deployed. This one covers what you type when something looks off — node health, networking diagnostics, config patches, and the failure patterns that have bitten us more than once.
 
-A healthy Frank means all seven nodes are `Ready`, every Cilium agent pod is running, and Hubble is collecting flows. If all three of those conditions hold, networking is working and the control plane is stable. That is the baseline you are checking against whenever you run any of the commands below.
+Before any of the commands below, source the environment:
+
+```bash
+source .env          # sets KUBECONFIG, TALOSCONFIG
+source .env_devops   # sets OMNICONFIG + service account for omnictl
+```
+
+## What Healthy Looks Like
+
+A healthy Frank means all seven nodes are `Ready`, every Cilium agent pod is running, and Hubble is collecting flows. That is the baseline you check against.
 
 ```console
 $ kubectl get nodes -o wide
@@ -42,29 +55,24 @@ Deployment             hubble-ui                Desired: 1, Ready: 1/1, Availabl
 Containers:            cilium                   Running: 7
                        cilium-envoy             Running: 7
                        cilium-operator          Running: 2
-                       clustermesh-apiserver    
                        hubble-relay             Running: 1
                        hubble-ui                Running: 1
 Cluster Pods:          135/135 managed by Cilium
-Helm chart version:    1.17.0
-Image versions         cilium             quay.io/cilium/cilium:v1.17.0@sha256:51f21bdd003c3975b5aaaf41bd21aee23cc08f44efaa27effc91c621bc9d8b1d: 7
-                       cilium-envoy       quay.io/cilium/cilium-envoy:v1.31.5-1737535524-fe8efeb16a7d233bffd05af9ea53599340d3f18e@sha256:57a3aa6355a3223da360395e3a109802867ff635cb852aa0afe03ec7bf04e545: 7
-                       cilium-operator    quay.io/cilium/operator-generic:v1.17.0@sha256:1ce5a5a287166fc70b6a5ced3990aaa442496242d1d4930b5a3125e44cccdca8: 2
-                       hubble-relay       quay.io/cilium/hubble-relay:v1.17.0@sha256:022c084588caad91108ac73e04340709926ea7fe12af95f57fcb794b68472e05: 1
-                       hubble-ui          quay.io/cilium/hubble-ui-backend:v0.13.1@sha256:0e0eed917653441fded4e7cdb096b7be6a3bddded5a2dd10812a27b1fc6ed95b: 1
 ```
+
+### Verify
+
+All nodes `Ready`, all Cilium components `OK`, all daemonsets at `Ready: 7/7`. Run the two commands above (`kubectl get nodes -o wide` and `cilium status --wait=false`) — if any node is `NotReady` or any Cilium component is not `OK`, proceed to the Runbook section below.
 
 ## Observing State
 
 ### Cluster and Node Health
 
-Start with the big picture. Talos has a built-in health check that validates etcd, the API server, kubelet, and node readiness in one shot:
+Start with the big picture. Talos has a built-in health check that validates etcd, the API server, kubelet, and node readiness in one shot against any control-plane node:
 
 ```bash
 talosctl health --nodes 192.168.55.21
 ```
-
-This runs against a single node but checks cluster-wide health through it. Pick any control-plane node.
 
 For a quick view of all nodes and their status, IPs, and kernel versions:
 
@@ -72,23 +80,21 @@ For a quick view of all nodes and their status, IPs, and kernel versions:
 kubectl get nodes -o wide
 ```
 
-You should see all seven nodes as `Ready`. If a Raspberry Pi drops to `NotReady`, do not panic -- they occasionally take longer to rejoin after a network blip.
-
 To check which Talos version each node is running (useful before and after upgrades):
 
 ```bash
 talosctl version --nodes 192.168.55.21,192.168.55.22,192.168.55.23
 ```
 
-### Cilium and Networking
+If a Raspberry Pi drops to `NotReady`, they occasionally take longer to rejoin after a network blip — give it a minute before digging deeper.
 
-Cilium has its own CLI for status checks. This shows agent health, operator status, and which features are active:
+### Cilium and Networking
 
 ```bash
 cilium status
 ```
 
-Look for `OK` next to each component. The `KubeProxyReplacement` line should show `True` since Frank runs Cilium as a full kube-proxy replacement.
+Look for `OK` next to each component. The `KubeProxyReplacement` line should show `True` — Frank runs Cilium as a full kube-proxy replacement (`apps/cilium/values.yaml:4`, `kubeProxyReplacement: true`).
 
 To watch live network flows between pods:
 
@@ -96,31 +102,30 @@ To watch live network flows between pods:
 hubble observe
 ```
 
-This streams flows in real time. You can filter by namespace, pod, or verdict:
+Filter by namespace, pod, or verdict:
 
 ```bash
 hubble observe --namespace longhorn-system
 hubble observe --verdict DROPPED
 ```
 
-> **Tip:** Hubble UI at `http://192.168.55.202` gives you the same flow data with a visual service map. It is often faster for exploring than the CLI.
-
 {{< screenshot src="hubble-ui-service-map.png" caption="Hubble UI service-map view showing live pod-to-pod flows with verdicts" >}}
 
 ### Node-Level Diagnostics
 
-When you need to dig deeper into a specific node, Talos exposes kernel messages and service logs through its API:
+Talos has no SSH. These are your only window into what the OS is doing:
 
 ```bash
-# Kernel messages (equivalent to dmesg on a regular Linux box)
+# Kernel messages (equivalent to dmesg)
 talosctl dmesg --nodes 192.168.55.31
 
 # Service logs (kubelet, containerd, etcd, etc.)
 talosctl logs kubelet --nodes 192.168.55.21
 talosctl logs containerd --nodes 192.168.55.31
-```
 
-Since there is no SSH on Talos, these commands are your only window into what the OS is doing. Get comfortable with them.
+# Check which Talos extensions are loaded
+talosctl -n 192.168.55.31 get extensions
+```
 
 ## Routine Operations
 
@@ -133,7 +138,7 @@ talosctl upgrade --nodes 192.168.55.21 \
   --image ghcr.io/siderolabs/installer:v1.9.5
 ```
 
-> **Warning:** Always upgrade control-plane nodes one at a time and wait for each to rejoin before proceeding. Upgrading all three simultaneously will take down etcd quorum and the API server with it.
+Control-plane nodes one at a time — wait for each to rejoin before proceeding. Upgrading all three simultaneously will take down etcd quorum.
 
 When managing through Omni, upgrades can also be triggered from the dashboard or via `omnictl`:
 
@@ -141,59 +146,61 @@ When managing through Omni, upgrades can also be triggered from the dashboard or
 omnictl get machines
 ```
 
-This shows each machine's current OS version, connected status, and cluster membership. Omni can also coordinate rolling upgrades across the cluster.
+This shows each machine's current OS version, connected status, and cluster membership.
 
 ### Applying Config Patches
 
-All node customization on Frank flows through Omni config patches. To apply a new or updated patch:
+All node customization on Frank flows through Omni config patches (`patches/phase01-node-config/README.md:27`). To apply a new or updated patch:
 
 ```bash
 omnictl apply -f patches/phase01-node-config/03-labels-mini-1.yaml
 ```
 
-Omni merges the patch into the node's machine config. Depending on the change, the node may reboot automatically or require a manual reboot:
+Omni merges the patch into the node's machine config. Depending on the change, the node may reboot automatically:
 
 ```bash
 talosctl reboot --nodes 192.168.55.21
 ```
 
-### Cleaning Up Stale Pods
-
-If you run `kubectl get pods -A` and see a sea of `Completed` or `Error` pods, that is normal — but it is worth understanding why they accumulate and how to clean them up.
-
-**Why they appear:** Kubernetes operators and storage drivers (Longhorn CSI provisioners, External Secrets, etc.) schedule work as **Jobs** rather than Deployments. Each Job run creates a new pod. When the run finishes, the pod stays in `Completed` or `Error` state instead of disappearing, because Job pods are not automatically recycled unless the Job spec includes `ttlSecondsAfterFinished`. Many upstream Helm charts do not set this field.
-
-**Do they consume resources?** No CPU or memory — the container process is gone. They do consume a small amount of etcd storage (~2–4 KB per pod object) and add noise to `kubectl get pods` output. On a cluster this size it is rarely a problem, but cleaning them up periodically is good hygiene.
-
-**Will they ever go away on their own?** Only when the cluster-wide terminated-pod garbage collector kicks in. Its default threshold is 12,500 pods — so in practice they accumulate indefinitely on a homelab.
-
-To delete all `Succeeded` pods cluster-wide:
+To roll back a patch:
 
 ```bash
-kubectl get pods -A --field-selector=status.phase==Succeeded \
-  -o json | kubectl delete -f -
+omnictl delete configpatch <patch-id>
 ```
 
-And for `Failed` pods:
+**Gotcha:** On UKI-booted machines (gpu-1 with SecureBoot), `ConfigPatches` with `machine.install.extraKernelArgs` is **inert** — the UKI cmdline is baked into the signed image and `extraKernelArgs` doesn't change the schematic ID, so Omni never reinstalls. Use `KernelArgs.omni.sidero.dev` instead (`patches/phase04-gpu/403-gpu1-pcie-aspm.yaml:38`):
 
 ```bash
+omnictl get kernelargsstatus <machine-id>
+```
+
+### Cleaning Up Stale Pods
+
+Completed and Failed pods accumulate because Helm chart Jobs rarely set `ttlSecondsAfterFinished`. They consume no CPU or memory, but they clutter `kubectl get pods` and burn etcd space (~2–4 KB per pod object).
+
+To clean them up:
+
+```bash
+# Delete all Succeeded pods cluster-wide
+kubectl get pods -A --field-selector=status.phase==Succeeded \
+  -o json | kubectl delete -f -
+
+# Delete all Failed pods cluster-wide
 kubectl get pods -A --field-selector=status.phase==Failed \
   -o json | kubectl delete -f -
 ```
 
-> **Note:** These commands delete the pod objects but not the parent Job records. Deleting a Job deletes its pods too: `kubectl delete jobs -A --field-selector=status.completionTime` (selects completed jobs). Be careful deleting Jobs if you want to preserve their history.
+The cluster-wide terminated-pod garbage collector threshold is 12,500 pods, so on a homelab they accumulate indefinitely without periodic cleanup.
 
 ### Rebooting Nodes
-
-For a controlled reboot of a single node:
 
 ```bash
 talosctl reboot --nodes 192.168.55.31
 ```
 
-The node drains itself before rebooting, so workloads migrate to other nodes. For control-plane nodes, make sure etcd quorum will survive (at least two of three nodes must remain up).
+The node drains itself before rebooting. For control-plane nodes, make sure etcd quorum will survive (at least two of three must remain up).
 
-## Debugging
+## Runbook
 
 ### Node NotReady
 
@@ -209,7 +216,7 @@ If `kubectl get nodes` shows a node as `NotReady`:
    talosctl dmesg --nodes <problem-node-IP>
    ```
 
-3. **Check etcd** if it is a control-plane node. A split-brain or failed etcd member will take a node out of Ready:
+3. **Check etcd** if it is a control-plane node:
    ```bash
    talosctl etcd status --nodes 192.168.55.21
    talosctl etcd members --nodes 192.168.55.21
@@ -220,66 +227,159 @@ If `kubectl get nodes` shows a node as `NotReady`:
    talosctl logs kubelet --nodes <problem-node-IP>
    ```
 
+#### Recovery: DNS boot hang
+
+A node that pings but never reaches `Ready` (ICMP replies, `apid:50000` refuses, Omni shows `CONNECTED: false`) is likely stuck on the time-sync gate. The root cause: a static interface with no nameservers falls back to public DNS (`1.1.1.1`, `8.8.8.8`), which the homelab ACL blocks → NTP never syncs → `apid`/`kubelet` hang.
+
+Fix: Apply the cluster-wide nameservers patch:
+
+```bash
+omnictl apply -f patches/phase01-node-config/02-cluster-wide-nameservers.yaml
+```
+
+This sets `machine.network.nameservers: [192.168.10.11, 192.168.10.12]` (see `patches/phase01-node-config/02-cluster-wide-nameservers.yaml:28-30`). Temporarily, ACL-allow `1.1.1.1:53` for the affected host to unstick it.
+
+**Verify:** `talosctl dmesg --nodes <IP> | grep -i ntp` should show sync success; `kubectl get nodes <IP>` eventually returns `Ready`.
+
 ### Pod Networking Issues
 
 When pods cannot reach each other or external services:
 
-1. **Run the Cilium connectivity test** to validate end-to-end networking:
+1. **Run the Cilium connectivity test:**
    ```bash
    cilium connectivity test
    ```
-   This deploys test pods and checks DNS, pod-to-pod, pod-to-service, and egress flows. It takes a few minutes but is thorough.
+   This deploys test pods and checks DNS, pod-to-pod, pod-to-service, and egress flows.
 
-2. **Observe flows for a specific pod** to see what is being dropped:
+2. **Observe flows for a specific pod:**
    ```bash
    hubble observe --pod <namespace>/<pod-name>
    hubble observe --pod default/my-app --verdict DROPPED
    ```
 
-3. **Check Cilium endpoint status** for the affected pod:
+3. **Check Cilium endpoint status:**
    ```bash
    cilium endpoint list
    ```
    Endpoints in a state other than `ready` indicate the agent has not finished programming BPF for that pod.
 
-### Cilium Agent Issues
+#### Recovery: restart the Cilium agent
 
-If the Cilium agent itself is crashing or misbehaving:
+If `cilium status --brief` shows degradation but the pod is `Running`:
+
+```bash
+kubectl logs -n kube-system ds/cilium -c cilium-agent --tail=100 | grep -Ei 'direct routing|datapath|node config'
+```
+
+Then restart the agent:
+
+```bash
+kubectl rollout restart -n kube-system ds/cilium
+```
+
+Common causes on Talos: missing security capabilities (`IPC_LOCK`, `SYS_RESOURCE`) or cgroup mount conflicts — our `cilium-values.yaml` sets `cgroup.autoMount.enabled: false` and `cgroup.hostRoot: /sys/fs/cgroup` (`apps/cilium/values.yaml:28-31`) to match Talos's layout.
+
+### Cilium Agent Crashing
 
 ```bash
 kubectl logs -n kube-system ds/cilium -c cilium-agent --tail=100
 kubectl get pods -n kube-system -l k8s-app=cilium
 ```
 
-Common causes on Talos: missing security capabilities (the agent needs a specific set including `IPC_LOCK` and `SYS_RESOURCE`), or cgroup mount conflicts if `autoMount` was left enabled.
+#### Recovery: NIC link-flap
+
+If all pod traffic on one node drops (SSH-via-LB dies, `kubectl exec` still works) and the Cilium agent logs contain `"IPv4 direct routing device IP not found"` or `"Failed to initialize datapath, retrying later"`, a physical NIC link-flap has stripped the node IP off Cilium's direct-routing device (`docs/runbooks/frank-gotchas/networking.md:62-143`).
+
+```bash
+# Check for link flaps
+talosctl -n <IP> dmesg | grep 'Link is'
+```
+
+Recovery is physical — reseat the cable or replace the NIC. Do **not** drain the node if it carries hard-pinned GPU workloads; restarting the Cilium agent pod on that node may restore datapath without a full node drain.
+
+### Omni Unreachable
+
+If `omnictl` commands return gRPC 500s or the browser shows a TLS error:
+
+#### Recovery: cert expiry
+
+Omni's TLS leaf cert has expired. The snap-installed `certbot` timer scans `/etc/letsencrypt/` but Omni uses a custom `--config-dir`, so automatic renewal does not fire (`docs/investigations/2026-05-11--omni--cert-expiry-incident.md`).
+
+```bash
+ssh frank-omni
+certbot renew --config-dir /opt/manual_install/certbot/config \
+  --deploy-hook 'docker restart omni'
+```
+
+#### Recovery: wedged reconcile runtime
+
+After a cold-boot clock-jump, Omni's reconcile loop can freeze — it serves cached reads but applies nothing. No config patches take effect even though `configuptodate: true`. Fix (`docs/runbooks/frank-gotchas/omni.md:45-106`):
+
+```bash
+ssh frank-omni
+docker restart omni
+```
+
+Then refresh your Talos config:
+
+```bash
+omnictl talosconfig .talos/Frank_Talos_Config.yaml -c frank -f --merge=false
+```
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|-----------------|------------------|-------------|
+| `ConfigPatches` `machine.install.extraKernelArgs` works on UKI machines | The UKI cmdline is baked into the signed image; `extraKernelArgs` doesn't change the schematic ID, so Omni never reinstalls | Hours debugging why PCIe ASPM args wouldn't stick on gpu-1. Fixed via `KernelArgs.omni.sidero.dev` resource (`patches/phase04-gpu/403-gpu1-pcie-aspm.yaml`). |
+| Omni cert auto-renews via snap's certbot timer | The snap certbot scans `/etc/letsencrypt/`; Omni's install uses a custom `--config-dir` | Cert expired silently for 30+ days, taking down the management plane. Fixed via dedicated systemd unit (`omni/certbot/certbot.md`). |
+| Omni reconcile is resilient to clock jumps | A cold-boot clock skew freezes the reconcile runtime — Omni serves cached reads but applies nothing | Config patches silently unapplied; reboot of affected nodes did nothing. Fixed by `docker restart omni`. |
+| Static-IP nodes get DNS from DHCP | Static `dhcp: false` → Talos falls back to public resolvers blocked by homelab ACL | Nodes ping but never reach `Ready` (time-sync gate). Fixed fleet-wide by cluster-wide nameservers patch (`patches/phase01-node-config/02-cluster-wide-nameservers.yaml`). |
 
 ## Quick Reference
 
 | Command | What It Does |
 |---------|-------------|
+| `source .env && source .env_devops` | Set up kubectl, talosctl, and omnictl contexts |
 | `talosctl health --nodes <IP>` | Full cluster health check via a single node |
 | `kubectl get nodes -o wide` | List all nodes with status, IPs, versions |
 | `talosctl version --nodes <IP>` | Show Talos OS version on a node |
 | `talosctl dmesg --nodes <IP>` | Kernel messages (like dmesg over SSH) |
 | `talosctl logs <svc> --nodes <IP>` | Service logs (kubelet, containerd, etcd) |
+| `talosctl -n <IP> get extensions` | List loaded Talos extensions |
 | `talosctl upgrade --nodes <IP> --image <img>` | Upgrade Talos on a node |
 | `talosctl reboot --nodes <IP>` | Graceful node reboot with drain |
 | `talosctl etcd status --nodes <IP>` | etcd cluster health |
 | `talosctl etcd members --nodes <IP>` | List etcd members |
 | `omnictl get machines` | Show all machines managed by Omni |
+| `omnictl get clustermachinestatus` | Machine READY/reconciling status |
 | `omnictl apply -f <patch>` | Apply a Talos config patch through Omni |
+| `omnictl delete configpatch <id>` | Roll back a config patch |
+| `omnictl get kernelargsstatus <machine-id>` | Verify kernel args applied (UKI machines) |
 | `cilium status` | Cilium agent and operator health |
 | `cilium connectivity test` | End-to-end networking validation |
 | `cilium endpoint list` | List all Cilium-managed pod endpoints |
 | `hubble observe` | Stream live network flows |
 | `hubble observe --verdict DROPPED` | Show only dropped flows |
-| `kubectl get pods -A --field-selector=status.phase==Succeeded -o json \| kubectl delete -f -` | Delete all Completed pods cluster-wide |
-| `kubectl get pods -A --field-selector=status.phase==Failed -o json \| kubectl delete -f -` | Delete all Failed pods cluster-wide |
+| `kubectl rollout restart -n kube-system ds/cilium` | Restart Cilium agent across all nodes |
+| `kubectl logs -n kube-system ds/cilium -c cilium-agent --tail=100` | Cilium agent logs |
+| `kubectl get pods -A --field-selector=status.phase==Succeeded -o json \| kubectl delete -f -` | Delete all Completed pods |
+| `kubectl get pods -A --field-selector=status.phase==Failed -o json \| kubectl delete -f -` | Delete all Failed pods |
+| `docker restart omni` | Revive wedged Omni reconcile runtime |
+| `certbot renew --config-dir /opt/manual_install/certbot/config --deploy-hook 'docker restart omni'` | Renew Omni TLS cert |
+
+## Explanation
+
+This post covers the subset of cluster operations that happen outside ArgoCD — things you reach for when a node won't come back, Cilium drops traffic, or Omni stops applying patches. The building companion post covers why we chose these components; this one covers what to do when they misbehave.
+
+The failure patterns in the Runbook section are not hypothetical. Each one bit us in production — the DNS boot hang took down gpu-1 for hours during a cold boot, the Omni cert expiry silently locked us out of the management plane for a month, and the inert `extraKernelArgs` on UKI cost days of debugging. We have documented each in the gotcha runbooks (`docs/runbooks/frank-gotchas/`); this section is the quick-access version.
 
 ## References
 
-- [Talos CLI Reference](https://www.talos.dev/v1.9/reference/cli/) -- Full `talosctl` command documentation
-- [Cilium Operations Guide](https://docs.cilium.io/en/stable/operations/) -- Day-2 operations for Cilium
-- [Hubble Documentation](https://docs.cilium.io/en/stable/observability/hubble/) -- Network observability CLI and UI
-- [Omni Documentation](https://omni.siderolabs.com/docs/) -- Sidero Omni machine management
-- [Talos Troubleshooting Guide](https://www.talos.dev/v1.9/introduction/troubleshooting/) -- Official debugging workflows for Talos Linux
+- [Talos CLI Reference](https://www.talos.dev/v1.9/reference/cli/) — Full `talosctl` command documentation
+- [Cilium Operations Guide](https://docs.cilium.io/en/stable/operations/) — Day-2 operations for Cilium
+- [Hubble Documentation](https://docs.cilium.io/en/stable/observability/hubble/) — Network observability CLI and UI
+- [Omni Documentation](https://omni.siderolabs.com/docs/) — Sidero Omni machine management
+- [Frank Gotchas — Networking](https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/networking.md) — Frank-specific networking failure playbooks
+- [Frank Gotchas — Omni](https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/omni.md) — Frank-specific Omni failure playbooks
+- [Patches README](https://github.com/derio-net/frank/blob/main/patches/README.md) — Machine ID to hostname to IP mapping
+- [Frank Infrastructure](https://github.com/derio-net/frank/blob/main/agents/rules/frank-infrastructure.md) — Node IP/hardware inventory and service LB IPs

--- a/blog/content/docs/operating/02-storage-backups/index.md
+++ b/blog/content/docs/operating/02-storage-backups/index.md
@@ -4,71 +4,82 @@ series: ["operating"]
 layer: stor
 date: 2026-03-13
 draft: false
-tags: ["operations", "longhorn", "storage", "backup", "r2"]
-summary: "Day-to-day commands for managing Longhorn volumes, checking backup health, and restoring from Cloudflare R2."
+tags: ["operations", "longhorn", "storage", "backup", "r2", "troubleshooting"]
+summary: "Day-to-day commands for managing Longhorn volumes, checking backup health, restoring from Cloudflare R2, and debugging common storage failures on Frank."
 weight: 3
+reader_goal: "Check Longhorn volume health, manage R2 backups, expand a volume, restore from backup, and debug degraded volumes, failed backups, or stuck attachments — without relying on the Longhorn UI."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
 
-This is the operational runbook for Longhorn storage and Cloudflare R2 backups on Frank, the Talos Cluster. If you want the full story on how storage was set up, see [Persistent Storage with Longhorn]({{< relref "/docs/building/03-storage" >}}). For backup architecture and the Longhorn 1.11 gotchas that shaped the current design, see [Backup — Longhorn to Cloudflare R2]({{< relref "/docs/building/08-backup" >}}).
+{{< last-updated >}}
+
+This is the operational runbook for Longhorn storage and Cloudflare R2 backups on Frank. For the full story on how storage was set up, see [Persistent Storage with Longhorn]({{< relref "/docs/building/03-storage" >}}). For the backup architecture and the Longhorn 1.11 gotchas that shaped the current design, see [Backup — Longhorn to Cloudflare R2]({{< relref "/docs/building/08-backup" >}}).
+
+Source your environment before running any commands:
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## Overview
 
-Frank runs Longhorn for distributed block storage. The default StorageClass replicates every volume three times across the control-plane nodes (mini-1, mini-2, mini-3). A second StorageClass, `longhorn-gpu-local`, provides single-replica strict-local storage pinned to gpu-1's dedicated SSDs for AI workloads.
+Frank runs Longhorn for distributed block storage. The default StorageClass replicates every volume three times across the control-plane nodes (`apps/longhorn/values.yaml:3`, `defaultReplicaCount: 3`). Two additional StorageClasses exist:
+
+- **`longhorn-gpu-local`** — single-replica, strict-local (`dataLocality: strict-local`), pinned to gpu-1's dedicated SSDs via `diskSelector: gpu-local` (`apps/longhorn/manifests/gpu-local-sc.yaml`)
+- **`longhorn-cicd`** — single-replica, best-effort, for CI/CD workloads on pc-1 (`apps/longhorn/manifests/storageclass-longhorn-cicd.yaml`)
+
+Raspberry Pi nodes have scheduling disabled — Longhorn does not place replicas on them.
 
 All volumes in the `default` group are backed up to a Cloudflare R2 bucket on two schedules:
 
-- **Daily** at 02:00 UTC — 7 recovery points retained
-- **Weekly** on Sunday at 03:00 UTC — 4 recovery points retained
+- **Daily** at 02:00 UTC — 7 recovery points retained (`apps/longhorn/manifests/recurring-job-daily.yaml`)
+- **Weekly** on Sunday at 03:00 UTC — 4 recovery points retained (`apps/longhorn/manifests/recurring-job-weekly.yaml`)
 
-Both RecurringJobs currently target R2 (NFS backup target is disabled pending a Longhorn bug fix in v1.13).
+Both RecurringJobs target the R2 BackupTarget (`apps/longhorn/manifests/backup-target-default.yaml`, URL `s3://frank-longhorn-backups@auto/`). NFS backup target is disabled pending a Longhorn bug fix in v1.13 (`apps/longhorn/manifests/backup-target-nas.yaml`, entirely commented out).
+
+### Verify
+
+```bash
+# All volumes healthy, no degraded/faulted entries
+kubectl get volumes.longhorn.io -n longhorn-system
+
+# Backup target reachable
+kubectl get backuptargets.longhorn.io -n longhorn-system -o wide
+```
+
+Healthy output for volumes shows all `ROBUSTNESS: healthy`. For backup targets, `AVAILABLE` must be `true`.
 
 ## Observing State
 
 ### Volume Health
 
-List all Longhorn volumes and their current state:
-
 ```bash
 kubectl get volumes.longhorn.io -n longhorn-system
 ```
 
-A healthy volume shows `State: attached` (if in use) or `State: detached` (if idle), with `Robustness: healthy`. Anything showing `degraded` or `faulted` needs attention — jump to the Debugging section.
+A healthy volume shows `State: attached` (if in use) or `detached` (if idle), with `Robustness: healthy`. Anything showing `degraded` or `faulted` needs attention.
 
 ```console
 $ kubectl get volumes.longhorn.io -n longhorn-system
 NAME                                       DATA ENGINE   STATE      ROBUSTNESS   SCHEDULED   SIZE           NODE      AGE
 pvc-0ea5fae9-9f12-488e-83e8-a69e4b533b50   v1            attached   healthy                  32212254720    gpu-1     42d
 pvc-1211b9cd-8062-43ca-8fa9-93ec43c36c35   v1            attached   healthy                  1073741824     mini-2    8d
-pvc-184f9b50-5d7f-400d-865b-4bb587dcf859   v1            attached   healthy                  8589934592     mini-2    39d
-pvc-1929c98e-6a59-4eec-8c41-353833f43dec   v1            attached   healthy                  5368709120     mini-2    37d
-pvc-1b0925db-fc13-4a8f-99da-2a09265ada47   v1            detached   unknown                  10737418240              35d
-pvc-1ded449d-e2bc-4e38-b7c9-c5d5ee264294   v1            attached   healthy                  2147483648     mini-3    37d
-pvc-26d07ae3-35c9-406f-b963-01894b9db240   v1            attached   healthy                  21474836480    mini-3    43d
-pvc-40c7a93f-5a74-49f0-8dc6-ff900348879a   v1            attached   healthy                  10737418240    gpu-1     21d
-pvc-4b1121bb-2285-42ec-8a8d-49cc96978ae1   v1            attached   healthy                  5368709120     mini-1    42d
-pvc-61ea0ef7-097a-4362-8727-19db3475a07c   v1            attached   healthy                  53687091200    gpu-1     20d
-pvc-64409163-fd82-49d1-bdfd-6a2a97f339c6   v1            attached   healthy                  1073741824     mini-3    43d
-pvc-6555d86e-52c3-4d36-9f3d-498053f0525c   v1            attached   healthy                  2147483648     mini-1    42d
-pvc-6ff35220-82b3-478e-849d-f3dd9e0f29af   v1            attached   healthy                  1073741824     gpu-1     41d
-pvc-82bfe595-d342-41c4-9f68-7346b2317a6d   v1            attached   healthy                  53687091200    pc-1      7d8h
-pvc-9cfe443a-e7e9-4894-a169-943b361124a5   v1            attached   healthy                  21474836480    gpu-1     43d
-pvc-b17ad456-1c3b-45dc-a6c9-18df39a4dab6   v1            attached   healthy                  134217728      raspi-1   12d
-pvc-c1d1b3b5-4e57-4488-a921-40814dac625a   v1            attached   healthy                  10737418240    pc-1      22d
-pvc-c700abbe-9114-47b8-ac5b-2f408f6055ec   v1            detached   unknown                  107374182400             36d
-pvc-cd8722f8-2077-41d5-86eb-a62c6437dd3f   v1            attached   healthy                  5368709120     mini-3    21d
-pvc-de4ab602-205f-41d5-8f13-1d2982109b92   v1            attached   healthy                  5368709120     mini-2    42d
-pvc-f083c9f7-8cbe-4cb7-89d0-7455c59a6f50   v1            attached   healthy                  5368709120     mini-3    39d
+# ... (truncated — 20 volumes, all healthy)
 ```
 
 For more detail on a specific volume:
 
 ```bash
 kubectl get volume.longhorn.io <volume-name> -n longhorn-system -o yaml
+# or
+kubectl describe volume.longhorn.io <volume-name> -n longhorn-system
 ```
 
 ### Longhorn UI
 
-The dashboard at `http://192.168.55.201` gives you a visual overview of volume health, replica distribution, node capacity, and backup status. It is the fastest way to spot problems.
+The dashboard at `http://192.168.55.201` gives a visual overview of volume health, replica distribution, node capacity, and backup status.
 
 {{< screenshot src="longhorn-ui-volumes.png" caption="Longhorn UI Volume page: replica distribution and robustness at a glance" >}}
 
@@ -80,10 +91,16 @@ Check the RecurringJob schedule and retention:
 kubectl get recurringjobs.longhorn.io -n longhorn-system
 ```
 
-Check the backup target status (should show `AVAILABLE: true`):
+Check the backup target status:
 
 ```bash
 kubectl get backuptargets.longhorn.io -n longhorn-system
+```
+
+Expected output:
+```
+NAME      URL                              CREDENTIAL        AVAILABLE   LASTSYNCEDAT
+default   s3://frank-longhorn-backups@auto/   longhorn-r2-secret   true        2026-07-15T02:00:00Z
 ```
 
 List recent backups for a specific volume:
@@ -96,28 +113,32 @@ kubectl get backups.longhorn.io -n longhorn-system \
 
 ### Node and Disk Status
 
-See how much capacity each node has and whether disks are schedulable:
-
 ```bash
 kubectl get nodes.longhorn.io -n longhorn-system -o wide
 ```
+
+This shows per-node scheduling state and disk capacity. Both Raspberry Pi nodes should show `ALLOWSCHEDULING: false`.
 
 ## Routine Operations
 
 ### Expand a Volume
 
-Longhorn supports online volume expansion. Edit the PVC to request more storage:
+Longhorn supports online volume expansion. Edit the PVC:
 
 ```bash
 kubectl patch pvc <pvc-name> -n <namespace> \
   -p '{"spec":{"resources":{"requests":{"storage":"20Gi"}}}}'
 ```
 
-The underlying Longhorn volume and filesystem expand automatically. No pod restart needed for ext4; XFS may need a manual `xfs_growfs` inside the pod.
+The underlying Longhorn volume and filesystem expand automatically. No pod restart needed for ext4. For XFS, run inside the pod:
+
+```bash
+xfs_growfs /
+```
 
 ### Trigger a Manual Backup
 
-If you want an immediate backup outside the scheduled window (before maintenance, for example):
+Before maintenance, take an immediate backup outside the scheduled window:
 
 ```bash
 kubectl create -f - <<EOF
@@ -133,19 +154,18 @@ spec:
 EOF
 ```
 
-Leaving `snapshotName` empty tells Longhorn to take a fresh snapshot and back it up. You can track progress in the Longhorn UI under **Backup**.
+Leaving `snapshotName` empty tells Longhorn to take a fresh snapshot and back it up. Track progress in the Longhorn UI under **Backup**.
 
 ### Restore a Volume from Backup
 
-To restore a volume from an R2 backup:
+Via the Longhorn UI:
 
-1. Open the Longhorn UI at `http://192.168.55.201`
-2. Navigate to **Backup** and find the volume
-3. Select the recovery point (daily or weekly) and click **Restore**
-4. Choose the number of replicas and target StorageClass
-5. Longhorn creates a new volume — create a PVC to bind it
+1. Open `http://192.168.55.201` → **Backup**
+2. Find the volume, select a recovery point (daily or weekly)
+3. Click **Restore** — choose replica count and target StorageClass
+4. Longhorn creates a new volume
 
-Alternatively, via CLI, create a new volume referencing the backup URL:
+Via CLI, create a new volume referencing the backup URL:
 
 ```bash
 kubectl create -f - <<EOF
@@ -165,39 +185,35 @@ Then create a PV and PVC pointing to the restored volume, or use the Longhorn UI
 
 ### Manage Snapshots
 
-List snapshots for a volume:
-
 ```bash
+# List snapshots for a volume
 kubectl get snapshots.longhorn.io -n longhorn-system \
   -l longhornvolume=<volume-name>
-```
 
-Delete old snapshots manually (Longhorn retains per the RecurringJob `retain` count, but you can clean up extras):
-
-```bash
+# Delete old snapshots (Longhorn retains per RecurringJob retain count)
 kubectl delete snapshot.longhorn.io <snapshot-name> -n longhorn-system
 ```
 
 ### Verify R2 Backup Credentials
 
-If backups start failing, check the secret is present and the backup target reports available:
+If backups start failing:
 
 ```bash
 kubectl get secret longhorn-r2-secret -n longhorn-system
 kubectl get backuptargets.longhorn.io -n longhorn-system
 ```
 
-If the secret was lost (node rebuild, namespace wipe), re-apply it from the encrypted source:
+If `AVAILABLE` is `false`, the R2 credentials may be missing or invalid. Re-apply from the encrypted source:
 
 ```bash
 sops --decrypt secrets/longhorn/r2-secret.yaml | kubectl apply -f -
 ```
 
-## Debugging
+## Runbook
 
 ### Volume Degraded
 
-A degraded volume has fewer healthy replicas than requested. Common causes:
+A degraded volume has fewer healthy replicas than requested.
 
 ```bash
 # Check which replicas are unhealthy
@@ -209,7 +225,7 @@ kubectl get nodes
 kubectl get nodes.longhorn.io -n longhorn-system
 ```
 
-If a node is down temporarily (reboot, maintenance), Longhorn will rebuild the replica when the node returns. If a node is permanently gone, Longhorn auto-rebuilds on remaining nodes once `nodeDownPodDeletionPolicy` kicks in.
+If a node is temporarily down (reboot, maintenance), Longhorn rebuilds the replica when the node returns. If a node is permanently gone, `nodeDownPodDeletionPolicy: delete-both-statefulset-and-deployment-pod` triggers auto-rebuild.
 
 Force-rebuild a replica on a different node by deleting the failed replica:
 
@@ -219,6 +235,20 @@ kubectl delete replica.longhorn.io <replica-name> -n longhorn-system
 
 Longhorn schedules a new replica on a healthy node automatically.
 
+#### Recovery: IM memory wedge
+
+If a node goes `NotReady` with memory pressure (Layer 1 alert `layer-1-node-memory-headroom` below 1 GiB), the Longhorn instance manager may have leaked memory. Known in v1.11.0 (`~0.9 GiB/day`) — fixed in v1.11.1+. The recovery is a power-cycle (`docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md`).
+
+```bash
+# Confirm no volumes are degraded first
+kubectl get volumes.longhorn.io -n longhorn-system | grep -v healthy
+
+# If all healthy, reboot the affected node
+talosctl reboot --nodes <node-ip>
+```
+
+Do **not** force-delete VolumeAttachments — scale the workload to 0 and let natural detach happen. A force-delete mid-write can blow up ext4 journals.
+
 ### Backup Failed
 
 Check the backup target availability first:
@@ -227,17 +257,27 @@ Check the backup target availability first:
 kubectl get backuptargets.longhorn.io -n longhorn-system -o yaml
 ```
 
-Look at the `status.conditions` — common failures:
+Look at `status.conditions` — common failures:
 
-- **Credential error**: R2 secret missing or wrong. Verify with `kubectl get secret longhorn-r2-secret -n longhorn-system -o yaml` and check that `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_ENDPOINTS` are all present.
+- **Credential error**: R2 secret missing or wrong. Verify with `kubectl get secret longhorn-r2-secret -n longhorn-system -o yaml` and check that `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_ENDPOINTS` are present.
 - **Network error**: Check DNS resolution and outbound HTTPS connectivity from a Longhorn pod.
-- **Bucket not found**: Verify the bucket name matches what is in the `backupTargetURL`.
+- **Bucket not found**: Verify the bucket name matches `backupTargetURL`.
 
-Check the Longhorn manager logs for detailed error messages:
+Check the Longhorn manager logs:
 
 ```bash
 kubectl logs -n longhorn-system -l app=longhorn-manager --tail=50 | grep -i backup
 ```
+
+#### Recovery: stale backups (Grafana alert)
+
+The Layer 9 alert `layer-9-backup-stale` fires when `daily-nas` goes >48h or `weekly-r2` >10d without success. To diagnose:
+
+```bash
+kubectl -n longhorn-system get jobs --sort-by=.status.startTime | tail -5
+```
+
+If the CronJob is healthy but individual backups fail, the BackupTarget may have drifted — check ArgoCD sync status on the `longhorn-extras` Application.
 
 ### Volume Stuck Attaching
 
@@ -253,42 +293,66 @@ kubectl get engines.longhorn.io -n longhorn-system \
 
 # Verify iSCSI is running on the target node
 talosctl -n <node-ip> services | grep iscsid
-```
 
-If iSCSI is not running, the `iscsi-tools` extension may have been lost during an upgrade. Verify extensions on the node:
-
-```bash
+# If iscsid is missing, check extensions
 talosctl -n <node-ip> get extensions
 ```
 
-As a last resort, force-detach and re-attach:
+If iSCSI is not running, the `iscsi-tools` Talos extension may have been lost during an upgrade.
+
+#### Recovery: force-detach
+
+As a last resort:
 
 ```bash
 kubectl patch volume.longhorn.io <volume-name> -n longhorn-system \
   --type merge -p '{"spec":{"nodeID":""}}'
 ```
 
-This clears the node assignment and lets Longhorn re-attach the volume when the consuming pod is rescheduled.
+This clears the node assignment and lets Longhorn re-attach the volume when the consuming pod is rescheduled. Do not force-delete the VolumeAttachment object — scale the workload to 0 and let the natural detach complete.
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|-----------------|------------------|-------------|
+| Both daily and weekly backups can use separate targets (NFS + R2) | Longhorn `v1beta2` RecurringJob CRD has no `backupTargetName` field — only `concurrency, cron, groups, labels, name, parameters, retain, task` (#11392 closed without fix) | Both jobs route to single R2 target. NFS BackupTarget exists in the repo but is commented out (`apps/longhorn/manifests/backup-target-nas.yaml`). |
+| NFS backup target works | Longhorn 1.11 generates `host/path` instead of `host:/path` for NFS (bug #11412) | NFS target disabled until v1.13 fix. |
+| ArgoCD can manage the R2 backup secret through SSA | SOPS `.sops` metadata fields are rejected by ArgoCD's server-side apply — Secret goes OutOfSync immediately | R2 secret lives outside the manifests path, applied out-of-band via `sops --decrypt \| kubectl apply -f -` (`docs/runbooks/frank-gotchas/storage-secrets-ssa.md`). |
+| Longhorn v1.11.0 is stable | Instance Manager anonymous heap leaks ~0.9 GiB/day (`docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md`) | raspi-1 wedged at 8 GiB RAM — power-cycle recovery. Pinned to v1.11.2. |
+| Volume health alerting is automatic | No ServiceMonitor scrapes Longhorn metrics — `longhorn_volume_robustness` is not surfaced | Fallback is `kube_pod_status_ready` on longhorn-manager pods. Alert rule exists but covers only pod liveness. |
 
 ## Quick Reference
 
 | Task | Command |
 |------|---------|
 | List volumes | `kubectl get volumes.longhorn.io -n longhorn-system` |
-| Volume detail | `kubectl get volume.longhorn.io <name> -n longhorn-system -o yaml` |
-| List replicas | `kubectl get replicas.longhorn.io -n longhorn-system` |
+| Volume detail | `kubectl describe volume.longhorn.io <name> -n longhorn-system` |
+| List replicas | `kubectl get replicas.longhorn.io -n longhorn-system -l longhornvolume=<name>` |
 | List backups | `kubectl get backups.longhorn.io -n longhorn-system` |
 | Backup target status | `kubectl get backuptargets.longhorn.io -n longhorn-system` |
 | Recurring jobs | `kubectl get recurringjobs.longhorn.io -n longhorn-system` |
+| List snapshots | `kubectl get snapshots.longhorn.io -n longhorn-system -l longhornvolume=<name>` |
 | Expand PVC | `kubectl patch pvc <name> -n <ns> -p '{"spec":{"resources":{"requests":{"storage":"<size>"}}}}'` |
 | Re-apply R2 secret | `sops --decrypt secrets/longhorn/r2-secret.yaml \| kubectl apply -f -` |
 | Longhorn manager logs | `kubectl logs -n longhorn-system -l app=longhorn-manager --tail=50` |
 | Node disk capacity | `kubectl get nodes.longhorn.io -n longhorn-system -o wide` |
+| Check Longhorn StorageClasses | `kubectl get storageclass \| grep longhorn` |
+| Trigger manual backup | `kubectl create -f manual-backup.yaml` (see Routine Operations) |
+| Restore from backup (CLI) | `kubectl create -f restored-volume.yaml` (see Routine Operations) |
+| Force-detach stuck volume | `kubectl patch volume.longhorn.io <name> -n longhorn-system --type merge -p '{"spec":{"nodeID":""}}'` |
 | Longhorn UI | `http://192.168.55.201` |
+
+## Explanation
+
+This post covers the Longhorn operations that keep Frank's data alive — volume health checks, backup management, and recovery from the failures that have actually bitten us (IM memory wedges, stuck attachments, stale backups). The building companion posts cover *why* we chose Longhorn and this backup architecture; this post is what you reach for when a volume degrades or a backup alert fires.
+
+The design intention was for daily backups to go to NFS and weekly to R2, but Longhorn 1.11's NFS bug and the absent `backupTargetName` CRD field forced both onto R2. The NFS BackupTarget manifest is preserved commented out in the repo (`apps/longhorn/manifests/backup-target-nas.yaml`) for when the fix lands.
 
 ## References
 
 - [Longhorn Documentation](https://longhorn.io/docs/1.8.1/) — official docs including snapshot, backup, and restore guides
 - [Cloudflare R2 Documentation](https://developers.cloudflare.com/r2/) — bucket management, API tokens, S3 compatibility
-- [Building Post: Persistent Storage with Longhorn]({{< relref "/docs/building/03-storage" >}}) — how storage was set up on Frank
-- [Building Post: Backup — Longhorn to Cloudflare R2]({{< relref "/docs/building/08-backup" >}}) — backup architecture and Longhorn 1.11 gotchas
+- [Building: Persistent Storage with Longhorn]({{< relref "/docs/building/03-storage" >}}) — how storage was set up on Frank
+- [Building: Backup — Longhorn to R2]({{< relref "/docs/building/08-backup" >}}) — backup architecture and Longhorn 1.11 gotchas
+- [Frank Gotchas — Storage/Secrets](https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/storage-secrets-ssa.md) — IM leak, SSA/SOPS gotchas
+- [Incident: raspi-1 Memory Wedge](https://github.com/derio-net/frank/blob/main/docs/investigations/2026-06-04--stor--raspi-1-memory-wedge-incident.md) — IM leak forensics and recovery

--- a/blog/content/docs/operating/03-gitops/index.md
+++ b/blog/content/docs/operating/03-gitops/index.md
@@ -4,30 +4,57 @@ series: ["operating"]
 layer: gitops
 date: 2026-03-13
 draft: false
-tags: ["operations", "argocd", "gitops"]
-summary: "Day-to-day commands for managing ArgoCD applications, syncing, debugging drift, and handling degraded apps."
+tags: ["operations", "argocd", "gitops", "troubleshooting"]
+summary: "Day-to-day commands for managing ArgoCD applications, syncing, debugging drift, handling degraded apps, and navigating the gotchas that have bitten Frank."
 weight: 4
+reader_goal: "Navigate the full ArgoCD lifecycle on Frank — observe, sync, diff, add apps, and recover from the real failure patterns (symlink blast, stale health, manual syncOptions, self-heal constraint) without consulting four separate runbooks."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
 
-This post covers the day-to-day commands for working with ArgoCD on the frank cluster. If you want to understand how the App-of-Apps pattern was set up and why, see [GitOps Everything with ArgoCD]({{< relref "/docs/building/05-gitops" >}}).
+{{< last-updated >}}
 
-## Overview
+This post covers day-to-day ArgoCD operations on Frank. For how the App-of-Apps was set up and why, see [GitOps Everything with ArgoCD]({{< relref "/docs/building/05-gitops" >}}). For the deep-dive drift classification taxonomy, see [Operating on ArgoCD Drift Detective]({{< relref "/docs/operating/23-argocd-drift-detective" >}}).
 
-ArgoCD runs at `192.168.55.200` on a Cilium L2 LoadBalancer. It manages itself and every workload on the cluster through the App-of-Apps pattern. A single root Application in `apps/root/` renders child Application CRs for each component — Cilium, Longhorn, the GPU Operator, LiteLLM, Sympozium, and everything else.
-
-{{< screenshot src="argocd-app-of-apps-tree.png" caption="ArgoCD UI: the root Application fanning out into every child app on Frank" >}}
-
-All ArgoCD CLI commands use port-forwarding since there is no public ingress:
+Source your environment before running commands:
 
 ```bash
-argocd app list --port-forward --port-forward-namespace argocd
+source .env   # sets KUBECONFIG
 ```
 
-Every command in this post includes those flags. If you get tired of typing them, alias it:
+All `argocd` CLI commands use port-forwarding since there is no public ingress. Every command includes `--port-forward --port-forward-namespace argocd`. To save typing:
 
 ```bash
 alias argocd='argocd --port-forward --port-forward-namespace argocd'
 ```
+
+## Overview
+
+ArgoCD runs at `http://192.168.55.200` on a Cilium L2 LoadBalancer. **Note: the UI is plain HTTP** — `https://192.168.55.200` gives a TLS reset (`docs/runbooks/frank-gotchas/argocd.md:64-68`).
+
+A single root Application in `apps/root/` renders 76 child Application CRs — one per component. Key configuration:
+
+- **`application.resourceTrackingMethod: annotation`** (`apps/argocd/values.yaml:109`) — avoids Helm label conflicts for adoption
+- **`ServerSideApply=true`** on every app — avoids the 256KB annotation limit and enables resource adoption
+- **`selfHeal: true`** on every app — automatically corrects drift from the desired Git state
+- **`prune: false`** (default) — resources removed from Git are not deleted. Intentional — accidental deletion of a CNI or storage controller would be catastrophic.
+
+### Verify
+
+```bash
+# Check overall application health
+kubectl get applications -n argocd -o 'custom-columns=NAME:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status'
+```
+
+All applications should show `SYNC: Synced` and `HEALTH: Healthy`. A `Degraded` or `OutOfSync` app needs investigation.
+
+```bash
+# Quick check — any apps with comparison errors?
+kubectl -n argocd get applications -o json | jq '.items[] | select(.status.conditions[]? | .type=="ComparisonError") | .metadata.name'
+```
+
+If this returns any names, the repo has a comparison error (often an out-of-bounds symlink) — see Runbook below.
 
 ## Observing State
 
@@ -45,37 +72,7 @@ NAME                   SYNC STATUS   HEALTH STATUS   REVISION                   
 argo-rollouts          Synced        Healthy                                                    infrastructure
 argo-rollouts-extras   Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
 argocd                 Synced        Healthy                                                    infrastructure
-authentik              Synced        Healthy                                                    infrastructure
-authentik-extras       Synced        Healthy         42c7a8b8349c99cb1c2b29a6547c860396a06af5   infrastructure
-blackbox-exporter      Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
-cert-manager           Synced        Healthy                                                    infrastructure
-cilium                 Synced        Healthy                                                    infrastructure
-cilium-config          Synced        Healthy         42c7a8b8349c99cb1c2b29a6547c860396a06af5   infrastructure
-comfyui                Synced        Healthy         42c7a8b8349c99cb1c2b29a6547c860396a06af5   infrastructure
-external-secrets       Synced        Healthy                                                    infrastructure
-fluent-bit             Synced        Healthy                                                    infrastructure
-gitea                  Synced        Progressing                                                infrastructure
-gitea-extras           Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
-gpu-operator           Synced        Healthy                                                    infrastructure
-gpu-operator-extras    Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
-gpu-switcher           Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
-grafana-alerting       Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
-health-bridge          Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
-homepage               Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
-infisical              Synced        Healthy                                                    infrastructure
-infisical-extras       Synced        Healthy         42c7a8b8349c99cb1c2b29a6547c860396a06af5   infrastructure
-infisical-postgresql   Synced        Healthy                                                    infrastructure
-infisical-redis        Synced        Healthy                                                    infrastructure
-intel-gpu-driver       Synced        Healthy                                                    infrastructure
-litellm                Synced        Healthy                                                    infrastructure
-litellm-extras         Synced        Progressing     42c7a8b8349c99cb1c2b29a6547c860396a06af5   infrastructure
-longhorn               Synced        Healthy                                                    infrastructure
-longhorn-extras        Synced        Healthy         42c7a8b8349c99cb1c2b29a6547c860396a06af5   infrastructure
-n8n-01                 Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
-n8n-01-postgresql      Synced        Healthy                                                    infrastructure
-ollama                 Synced        Healthy                                                    infrastructure
-openrgb                Synced        Healthy         42c7a8b8349c99cb1c2b29a6547c860396a06af5   infrastructure
-paperclip              Synced        Healthy         fe5f5900e397c6bda7158e9add7a7853007535d7   infrastructure
+# ... (76 total applications)
 ```
 
 ### Inspect a Single Application
@@ -84,7 +81,7 @@ paperclip              Synced        Healthy         fe5f5900e397c6bda7158e9add7
 argocd app get cilium --port-forward --port-forward-namespace argocd
 ```
 
-This returns the full resource tree: every Deployment, DaemonSet, Service, ConfigMap, and Secret that ArgoCD tracks for that application. Resources with sync issues are flagged individually, which tells you exactly which object is drifting.
+Returns the full resource tree — every Deployment, DaemonSet, Service, ConfigMap, and Secret that ArgoCD tracks for that application. Resources with sync issues are flagged individually.
 
 ### Watch Sync Events
 
@@ -92,39 +89,33 @@ This returns the full resource tree: every Deployment, DaemonSet, Service, Confi
 argocd app get cilium --port-forward --port-forward-namespace argocd --show-operation
 ```
 
-The `--show-operation` flag shows the last sync operation result, including which resources were created, updated, or pruned and how long the operation took.
+The `--show-operation` flag shows the last sync operation result — which resources were created, updated, or pruned and how long the operation took.
 
 ## Routine Operations
 
 ### Force Sync an Application
 
-When you push a change and do not want to wait for the polling interval:
-
 ```bash
 argocd app sync cilium --port-forward --port-forward-namespace argocd
 ```
 
-For all applications at once, sync the root app:
+To sync all applications at once, sync the root app:
 
 ```bash
 argocd app sync root --port-forward --port-forward-namespace argocd
 ```
 
-This re-renders the root Helm chart, which may discover new child Applications or updated chart versions. Each child then syncs on its own.
+This re-renders the root Helm chart, which may discover new child Applications or updated chart versions.
 
 ### Hard Refresh
 
-ArgoCD caches the Git repo and Helm chart index. If you need it to re-read everything immediately:
+ArgoCD caches the Git repo and Helm chart index. If it still shows old state after a push:
 
 ```bash
 argocd app get cilium --port-forward --port-forward-namespace argocd --hard-refresh
 ```
 
-Useful when you have pushed a commit but ArgoCD still shows the old state.
-
 ### Check Diff Before Syncing
-
-See what ArgoCD would change without applying anything:
 
 ```bash
 argocd app diff cilium --port-forward --port-forward-namespace argocd
@@ -134,36 +125,34 @@ This is the GitOps equivalent of `terraform plan`. Review the diff, then sync if
 
 ### Add a New Application
 
-Adding a new workload follows the App-of-Apps pattern:
-
 1. Create `apps/<app-name>/values.yaml` with Helm values.
 2. Create `apps/root/templates/<app-name>.yaml` with the Application CR.
 3. Optionally add `apps/<app-name>/manifests/` for raw Kubernetes manifests.
-4. Commit, push, and sync the root app.
+4. Commit, push.
 
 ArgoCD discovers the new Application CR from the root chart and begins syncing it automatically.
 
 ### Manage ArgoCD Itself
 
-ArgoCD manages its own Helm values through the same Git repo. After editing `apps/argocd/values.yaml`:
+After editing `apps/argocd/values.yaml`:
 
 ```bash
 argocd app sync argocd --port-forward --port-forward-namespace argocd
 ```
 
-Since ArgoCD is updating itself, watch for the server to restart. The CLI connection will drop momentarily and reconnect.
+Since ArgoCD is updating itself, the CLI connection will drop momentarily and reconnect.
 
-## Debugging
+## Runbook
 
-### Application Stuck in Degraded
+### Application Degraded
 
-An app showing `Degraded` usually means one or more of its resources failed to reach a healthy state. Start with the resource tree:
+An app showing `Degraded` usually means one or more of its resources failed to reach a healthy state:
 
 ```bash
 argocd app get <app> --port-forward --port-forward-namespace argocd
 ```
 
-Look for resources marked `Degraded` or `Missing`. Then check the Kubernetes events:
+Look for resources marked `Degraded` or `Missing`. Then check Kubernetes events:
 
 ```bash
 kubectl describe deployment <name> -n <namespace>
@@ -172,9 +161,13 @@ kubectl get events -n <namespace> --sort-by=.lastTimestamp | tail -20
 
 Common causes: image pull failures, resource limits too low, missing secrets, or nodes lacking the right taints/tolerations.
 
+#### Recovery: stale appTree health
+
+After a source change, the appTree may show `Degraded` even though all resources are healthy. This cosmetic state masks real health changes until the controller re-evaluates. Wait for the next sync cycle or restart the controller (`docs/runbooks/frank-gotchas/argocd.md:70-91`).
+
 ### Sync Failed
 
-When a sync operation fails, get the details:
+When a sync operation fails:
 
 ```bash
 argocd app get <app> --port-forward --port-forward-namespace argocd --show-operation
@@ -182,14 +175,25 @@ argocd app get <app> --port-forward --port-forward-namespace argocd --show-opera
 
 The operation result shows exactly which resource failed and why. Two frequent culprits:
 
-- **Annotation size limit.** Kubernetes has a 256KB limit on annotation values. Large CRDs (like Cilium's) can exceed this with client-side apply. The fix is `ServerSideApply=true` in syncOptions, which the frank cluster uses on every application.
-- **Finalizer deadlocks.** A resource with a finalizer that references a deleted controller will hang forever. Check `metadata.finalizers` and remove the offending entry if the controller is genuinely gone.
+- **Annotation size limit.** Kubernetes has a 256KB limit on annotation values. Large CRDs (Cilium's etc.) can exceed this. `ServerSideApply=true` in syncOptions avoids this — every Frank app uses it.
+- **Finalizer deadlocks.** A resource with a finalizer referencing a deleted controller hangs forever. Check `metadata.finalizers` and remove the offending entry.
+
+#### Recovery: manual sync drops syncOptions
+
+When a manual sync (via `argocd app sync` or `kubectl patch`) doesn't pass `ServerSideApply=true`, large ConfigMaps (>250KB) hit the annotation limit. Always include syncOptions:
+
+```bash
+kubectl patch application <app> -n argocd --type=merge \
+  -p '{"operation":{"sync":{"revision":"HEAD","syncOptions":["ServerSideApply=true","RespectIgnoreDifferences=true"]}}}'
+```
+
+This is the canonical pattern when `selfHeal` is disabled for debugging (`docs/runbooks/frank-gotchas/argocd.md:28-37`).
 
 ### OutOfSync but Correct
 
-Some resources appear OutOfSync even though the live state is correct. This happens when a controller mutates the resource after ArgoCD applies it. Kubernetes Secrets are the classic example — controllers encode or rotate secret data, causing a permanent diff.
+Some resources appear `OutOfSync` even though the live state is correct. Controllers mutate resources after ArgoCD applies them. Kubernetes Secrets are the classic example — controllers encode or rotate secret data.
 
-The fix is `ignoreDifferences` in the Application spec:
+Fix: add `ignoreDifferences` in the Application spec:
 
 ```yaml
 ignoreDifferences:
@@ -199,41 +203,106 @@ ignoreDifferences:
       - /data
 ```
 
-The frank cluster already applies this to applications that manage auto-generated secrets (Cilium, cert-manager). If you see a new case, add the appropriate `ignoreDifferences` entry to the Application template in `apps/root/templates/`.
+Frank already applies this to applications managing auto-generated secrets (Cilium, cert-manager). For new cases, add the entry to `apps/root/templates/<app>.yaml`.
+
+#### Recovery: root re-templates leaf specs
+
+The root application re-templates every leaf Application CR on every sync. A live `kubectl patch application` (e.g. for a feature branch) reverts within the sync window because the root chart overwrites the patched field. When testing a PR-branch change on a leaf:
+
+1. Suspend root selfHeal: `argocd app set root --self-heal=false`
+2. Patch the leaf with the branch revision.
+3. After testing, restore root selfHeal to `true`.
+
+Without suspending root selfHeal, the leaf reverts before you can observe the result (`agents/rules/frank-argocd.md:40-63`).
 
 ### Orphaned Resources
 
-With `prune: false` (the default on this cluster), ArgoCD never deletes resources that disappear from Git. This is intentional — accidental deletion of a CNI DaemonSet or a storage controller would be catastrophic.
-
-To find resources ArgoCD no longer tracks:
+With `prune: false` (default on Frank), ArgoCD never deletes resources that disappear from Git:
 
 ```bash
 argocd app resources <app> --port-forward --port-forward-namespace argocd --orphaned
 ```
 
-Review the list and delete manually if you are sure:
+Review the list and delete manually if sure:
 
 ```bash
 kubectl delete <kind> <name> -n <namespace>
 ```
 
+#### Recovery: out-of-bounds symlink
+
+An out-of-bounds symlink in the repo causes every app to show a `ComparisonError`. Nothing syncs, but the cluster runs on the last-known-good cache.
+
+```bash
+# Find the symlink
+find . -type l -lname '*../../..*'
+
+# Fix it, commit, and re-sync the root app
+```
+
+After fixing, all apps should return to `Synced` (`docs/runbooks/frank-gotchas/argocd.md:14-26`).
+
+### Notifications Silent
+
+ArgoCD notifications use Telegram for sync events. If notifications drop silently, the `notifications.yaml` config may use the wrong subscription format. The correct pattern uses the service name directly, not `webhook`:
+
+```yaml
+# Correct
+subscribe:
+  on-sync-running.telegram: ""
+
+# Wrong — drops silently
+subscribe:
+  on-sync-running.webhook:
+    telegram: ""
+```
+
+The webhook notifier type is named after the service (`telegram`), not the type name (`webhook`). (`docs/runbooks/frank-gotchas/argocd.md:5-12`)
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|-----------------|------------------|-------------|
+| `kubectl patch application` with a feature-branch revision survives the sync window | Root re-templates every leaf on every sync. Without suspending root selfHeal, the patch reverts within seconds | Feature-branch testing requires a self-heal suspend cycle (`agents/rules/frank-argocd.md:40-63`). |
+| `argocd app sync` passes `ServerSideApply=true` automatically | Manual syncs via the CLI or `kubectl patch` **drop** the syncOptions from the Application spec | Large ConfigMaps (>250KB) hit the annotation limit. Must pass syncOptions explicitly in the operation patch. |
+| HTTP is fine for the ArgoCD UI | The UI is served over plain HTTP, not HTTPS. Browser auto-upgrades to HTTPS, which gives a TLS reset | New operators waste time debugging the TLS error (`docs/runbooks/frank-gotchas/argocd.md:64-68`). |
+| Telegram notification webhooks follow the standard format | The ArgoCD notification config uses the service name (`telegram`), not the type name (`webhook`), in the subscription block | Notifications silently dropped until the config was corrected. |
+| An out-of-bounds symlink only breaks one app | ArgoCD's comparison phase follows symlinks — a single bad symlink breaks every app on the cluster | All apps show `ComparisonError`, nothing syncs, cluster runs on last-known-good cache (`docs/runbooks/frank-gotchas/argocd.md:14-26`). |
+| Controller-normalized fields can be ignored | Fields like `syncRequestedAt`, `restartedAt`, `enabled`, `authRefs` are rewritten by controllers on every reconciliation | Permanent `OutOfSync` on Longhorn, Sympozium, vCluster, and Tekton until `ignoreDifferences` entries were added (`docs/superpowers/debugging/2026-07-06-cluster-status-drift.md`). |
+
 ## Quick Reference
 
 | Task | Command |
 |------|---------|
-| List all apps | `argocd app list --port-forward --port-forward-namespace argocd` |
+| List all apps | `kubectl get applications -n argocd -o wide` |
+| List all apps (columnar status) | `kubectl get applications -n argocd -o 'custom-columns=NAME:.metadata.name,SYNC:.status.sync.status,HEALTH:.status.health.status'` |
+| Find comparison errors | `kubectl -n argocd get applications -o json \| jq '.items[] \| select(.status.conditions[]? \| .type=="ComparisonError") \| .metadata.name'` |
+| List apps (argocd CLI) | `argocd app list --port-forward --port-forward-namespace argocd` |
 | Get app detail | `argocd app get <app> --port-forward --port-forward-namespace argocd` |
 | Sync one app | `argocd app sync <app> --port-forward --port-forward-namespace argocd` |
-| Sync everything | `argocd app sync root --port-forward --port-forward-namespace argocd` |
+| Sync root (everything) | `argocd app sync root --port-forward --port-forward-namespace argocd` |
 | Check diff | `argocd app diff <app> --port-forward --port-forward-namespace argocd` |
 | Hard refresh | `argocd app get <app> --port-forward --port-forward-namespace argocd --hard-refresh` |
 | Show last sync | `argocd app get <app> --port-forward --port-forward-namespace argocd --show-operation` |
+| Manual sync with syncOptions | `kubectl patch application <app> -n argocd --type=merge -p '{"operation":{"sync":{"revision":"HEAD","syncOptions":["ServerSideApply=true","RespectIgnoreDifferences=true"]}}}'` |
 | List orphans | `argocd app resources <app> --port-forward --port-forward-namespace argocd --orphaned` |
-| App logs | `argocd app logs <app> --port-forward --port-forward-namespace argocd` |
 | Delete an app | `argocd app delete <app> --port-forward --port-forward-namespace argocd` |
+| Find out-of-bounds symlinks | `find . -type l -lname '*../../..*'` |
+| Find non-running pods | `kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded` |
+| ArgoCD UI | `http://192.168.55.200` |
+
+## Explanation
+
+This post consolidates the day-to-day ArgoCD operations that are spread across four separate sources: the basic CLI commands, the gotcha runbook, the agent rules for app management, and the drift-debugging post. The failure patterns in the Runbook section are the ones that have actually broken Frank's GitOps pipeline — the symlink blast that took down every app, the stale appTree that masked a real health change, and the self-heal constraint that made feature-branch testing unreliable.
+
+The companion posts cover the building (how the App-of-Apps is structured) and the drift taxonomy (the 7-class classification for OutOfSync). This post covers what you type when an app is Degraded, a sync fails, or notifications go quiet.
 
 ## References
 
 - [ArgoCD Documentation](https://argo-cd.readthedocs.io/en/stable/) — Official reference for all CLI commands and concepts
 - [ArgoCD Sync Options](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/) — ServerSideApply, selfHeal, prune, and ignoreDifferences
-- [GitOps Everything with ArgoCD]({{< relref "/docs/building/05-gitops" >}}) — How the App-of-Apps was built on this cluster
+- [GitOps Everything with ArgoCD]({{< relref "/docs/building/05-gitops" >}}) — How the App-of-Apps was built on Frank
+- [ArgoCD Drift Detective]({{< relref "/docs/operating/23-argocd-drift-detective" >}}) — Deep-dive drift classification taxonomy
+- [Frank Gotchas — ArgoCD](https://github.com/derio-net/frank/blob/main/docs/runbooks/frank-gotchas/argocd.md) — Frank-specific ArgoCD failure playbooks
+- [Frank ArgoCD Workflow](https://github.com/derio-net/frank/blob/main/agents/rules/frank-argocd.md) — Add-a-new-app workflow and self-heal suspend pattern
+- [Cluster Status Drift Incident](https://github.com/derio-net/frank/blob/main/docs/superpowers/debugging/2026-07-06-cluster-status-drift.md) — Controller-normalized fields and the `ignoreDifferences` fixes

--- a/blog/content/docs/operating/04-gpu-compute/index.md
+++ b/blog/content/docs/operating/04-gpu-compute/index.md
@@ -4,87 +4,96 @@ series: ["operating"]
 layer: gpu
 date: 2026-03-13
 draft: false
-tags: ["operations", "gpu", "nvidia", "intel", "talos"]
+tags: ["operations", "gpu", "nvidia", "intel", "talos", "troubleshooting"]
 summary: "Day-to-day commands for managing NVIDIA and Intel GPUs, checking utilization, and debugging GPU container issues on Talos."
 weight: 5
+reader_goal: "Check GPU health, manage GPU workloads, and debug common failures (GPU not allocating, containerd config corruption, stale allocations, reboot loops) on both NVIDIA and Intel GPU stacks on Talos."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
 
-The cluster has two GPU paths: an NVIDIA RTX 5070 Ti on `gpu-1` managed by the GPU Operator, and Intel Arc iGPUs on the three mini nodes exposed through DRA (Dynamic Resource Allocation). Both are operational, both have Talos-specific quirks, and both need different tools to inspect and troubleshoot.
+{{< last-updated >}}
 
-This post covers the day-to-day commands for checking GPU state, managing workloads, and debugging the issues you will eventually hit. For the build story, see [GPU Compute — NVIDIA and Intel]({{< relref "/docs/building/04-gpu-compute" >}}) and [GPU Containers on Talos — The Validation Fix]({{< relref "/docs/building/12-gpu-talos-fix" >}}).
+The cluster has two GPU paths: an NVIDIA RTX 5070 Ti on `gpu-1` managed by the GPU Operator, and Intel Arc iGPUs on the three mini nodes exposed through DRA (Dynamic Resource Allocation). Both have Talos-specific quirks, and both need different tools to inspect and troubleshoot.
+
+This post covers day-to-day commands for checking GPU state, managing workloads, and debugging the issues you will eventually hit. For the build story, see [GPU Compute — NVIDIA and Intel]({{< relref "/docs/building/04-gpu-compute" >}}) and [GPU Containers on Talos — The Validation Fix]({{< relref "/docs/building/12-gpu-talos-fix" >}}).
+
+Source your environment before running commands:
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
+## Overview
+
+Frank runs two GPU stacks side by side:
+
+- **NVIDIA (gpu-1):** GPU Operator managing the RTX 5070 Ti. Deployment is via `gpu-operator` Helm chart with Talos-specific extensions and containerd runtime config.
+- **Intel (mini-1/2/3):** Intel Resource Drivers for Kubernetes using DRA. One DaemonSet per node, no special containerd config needed.
+
+### Verify
+
+```bash
+# NVIDIA — device plugin registered
+kubectl get node gpu-1 -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'
+# Should return: 1
+
+# Intel — ResourceSlices published
+kubectl get resourceslice -o wide
+# Should show three slices, one per mini node
+```
 
 ## Observing State
 
 ### NVIDIA GPU (gpu-1)
 
-The GPU Operator runs several pods on `gpu-1`. Check that they are all healthy:
+The GPU Operator runs several pods on `gpu-1`. Check they are all healthy:
 
 ```bash
 kubectl get pods -n gpu-operator -o wide
 ```
 
-You should see pods for the device plugin, feature discovery, DCGM exporter, and the validation markers DaemonSet — all `Running` and `1/1`. If any pod is stuck at `Init:0/1`, the validation markers are likely missing (see [Debugging](#debugging) below).
+You should see pods for the device plugin, feature discovery, DCGM exporter, and validation markers DaemonSet — all `Running` and `1/1`.
 
-To run `nvidia-smi`, exec into the DCGM exporter pod (it has the nvidia tools available):
+To run `nvidia-smi`, exec into the DCGM exporter pod:
 
 ```bash
-kubectl exec -n gpu-operator $(kubectl get pod -n gpu-operator \
-  -l app=nvidia-dcgm-exporter -o jsonpath='{.items[0].metadata.name}') \
-  -- nvidia-smi
+POD=$(kubectl get pod -n gpu-operator -l app=nvidia-dcgm-exporter \
+  -o jsonpath='{.items[0].metadata.name}')
+kubectl exec -n gpu-operator "$POD" -- nvidia-smi
 ```
 
-For a quick check of what the node reports as allocatable:
+```console
+$ POD=$(kubectl get pod -n gpu-operator -l app=nvidia-dcgm-exporter -o jsonpath='{.items[0].metadata.name}'); kubectl exec -n gpu-operator "$POD" -- nvidia-smi
+Mon Apr 20 16:55:31 2026
++-----------------------------------------------------------------------------------------+
+| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
+|-----------------------------------------+------------------------+----------------------+
+|   0  NVIDIA GeForce RTX 5070 Ti     Off |   00000000:01:00.0 Off |                  N/A |
+|  0%   33C    P8             19W /  300W |    7956MiB /  16303MiB |      0%      Default |
++-----------------------------------------------------------------------------------------+
+```
+
+For a quick view of allocatable resources:
 
 ```bash
 kubectl describe node gpu-1 | grep -A 10 "Allocated resources"
 ```
 
-```console
-$ POD=$(kubectl get pod -n gpu-operator -l app=nvidia-dcgm-exporter -o jsonpath='{.items[0].metadata.name}'); kubectl exec -n gpu-operator "$POD" -c nvidia-dcgm-exporter -- nvidia-smi
-Mon Apr 20 16:55:31 2026       
-+-----------------------------------------------------------------------------------------+
-| NVIDIA-SMI 570.211.01             Driver Version: 570.211.01     CUDA Version: 12.8     |
-|-----------------------------------------+------------------------+----------------------+
-| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
-| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
-|                                         |                        |               MIG M. |
-|=========================================+========================+======================|
-|   0  NVIDIA GeForce RTX 5070 Ti     Off |   00000000:01:00.0 Off |                  N/A |
-|  0%   33C    P8             19W /  300W |    7956MiB /  16303MiB |      0%      Default |
-|                                         |                        |                  N/A |
-+-----------------------------------------+------------------------+----------------------+
-                                                                                         
-+-----------------------------------------------------------------------------------------+
-| Processes:                                                                              |
-|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
-|        ID   ID                                                               Usage      |
-|=========================================================================================|
-|  No running processes found                                                             |
-+-----------------------------------------------------------------------------------------+
-```
-
-Look for `nvidia.com/gpu` in the capacity and allocatable fields:
-
-```bash
-kubectl get node gpu-1 -o jsonpath='{.status.capacity.nvidia\.com/gpu}'
-# Should return: 1
-```
-
 ### Intel iGPU (mini nodes)
 
-The Intel DRA driver runs as a DaemonSet — one pod per mini node:
+The Intel DRA driver runs as a DaemonSet:
 
 ```bash
 kubectl get pods -n intel-gpu-resource-driver -o wide
 ```
 
-Check that ResourceSlices are published for each node:
+Check that ResourceSlices are published:
 
 ```bash
 kubectl get resourceslice -o wide
 ```
-
-You should see three slices, one per mini node, all with driver `gpu.intel.com`. The DeviceClass should also exist:
 
 ```console
 $ kubectl get resourceslice -o wide
@@ -92,10 +101,6 @@ NAME                         NODE     DRIVER          POOL     AGE
 mini-1-gpu.intel.com-wnt98   mini-1   gpu.intel.com   mini-1   28d
 mini-2-gpu.intel.com-ssz5r   mini-2   gpu.intel.com   mini-2   28d
 mini-3-gpu.intel.com-ch2jg   mini-3   gpu.intel.com   mini-3   28d
-```
-
-```bash
-kubectl get deviceclass gpu.intel.com
 ```
 
 To see active ResourceClaims (pods currently using an Intel GPU):
@@ -108,29 +113,27 @@ kubectl get resourceclaim -A
 
 ### Check GPU Utilization
 
-For NVIDIA, the quickest way to see what is running on the GPU:
-
 ```bash
-# GPU utilization, memory usage, running processes
+# GPU utilization, memory, running processes
 kubectl exec -n ollama $(kubectl get pod -n ollama \
   -o jsonpath='{.items[0].metadata.name}') -- nvidia-smi
 
-# Or just check Ollama's model status
+# Ollama model status
 kubectl exec -n ollama $(kubectl get pod -n ollama \
   -o jsonpath='{.items[0].metadata.name}') -- ollama ps
 ```
 
-The `ollama ps` output tells you the model name, size, processor allocation (look for `100% GPU`), and context window size.
+The `ollama ps` output shows model name, size, processor allocation (look for `100% GPU`), and context window.
 
 ### Check Which Pods Use the GPU
 
 ```bash
-# NVIDIA — find pods requesting nvidia.com/gpu
+# NVIDIA — pods requesting nvidia.com/gpu
 kubectl get pods -A -o json | jq -r '
   .items[] | select(.spec.containers[].resources.limits."nvidia.com/gpu" != null)
   | "\(.metadata.namespace)/\(.metadata.name)"'
 
-# Intel DRA — find pods with ResourceClaims
+# Intel DRA — pods with ResourceClaims
 kubectl get pods -A -o json | jq -r '
   .items[] | select(.spec.resourceClaims != null)
   | "\(.metadata.namespace)/\(.metadata.name)"'
@@ -138,7 +141,7 @@ kubectl get pods -A -o json | jq -r '
 
 ### Pull Models via kubectl exec
 
-On Talos with NVIDIA, postStart lifecycle hooks fail due to the nvidia-container-cli exec hook. Models must be pulled manually after the pod is running:
+PostStart lifecycle hooks fail on Talos with NVIDIA due to the `nvidia-container-cli` exec hook. Models must be pulled manually:
 
 ```bash
 kubectl exec -n ollama $(kubectl get pod -n ollama \
@@ -148,58 +151,57 @@ kubectl exec -n ollama $(kubectl get pod -n ollama \
   -o jsonpath='{.items[0].metadata.name}') -- ollama pull deepseek-coder:6.7b
 ```
 
-Models persist on the Longhorn PVC, so this is a one-time operation unless the PVC is lost.
+Models persist on the Longhorn PVC — one-time operation unless the PVC is lost.
 
 ### Manage GPU Memory
-
-If Ollama holds a model in VRAM that you want to unload:
 
 ```bash
 # List loaded models
 kubectl exec -n ollama $(kubectl get pod -n ollama \
   -o jsonpath='{.items[0].metadata.name}') -- ollama ps
 
-# Unload by running a different model, or restart the pod
+# Unload — delete the pod; Deployment recreates it
 kubectl delete pod -n ollama $(kubectl get pod -n ollama \
   -o jsonpath='{.items[0].metadata.name}')
 ```
 
-The pod will be recreated by the Deployment. Models on the PVC remain available — they just need to be loaded back into VRAM on the next request.
+Models on the PVC remain available and load back into VRAM on the next request.
 
-## Debugging
+## Runbook
 
 ### GPU Not Allocating
 
 If a pod requesting `nvidia.com/gpu` stays `Pending`:
 
-```bash
-# 1. Check that the device plugin registered the GPU
-kubectl get node gpu-1 -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'
-# Should return 1. If empty or 0, the device plugin is not running.
+1. **Check device plugin registration:**
+   ```bash
+   kubectl get node gpu-1 -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'
+   ```
+   Should return `1`. If empty or `0`, the device plugin is not running.
 
-# 2. Check GPU Operator pods
-kubectl get pods -n gpu-operator -o wide
-# All should be Running. Look for Init:0/1 or CrashLoopBackOff.
+2. **Check GPU Operator pods:**
+   ```bash
+   kubectl get pods -n gpu-operator -o wide
+   ```
+   All should be `Running`. Look for `Init:0/1` or `CrashLoopBackOff`.
 
-# 3. Check validation markers
-kubectl exec -n gpu-operator $(kubectl get pod -n gpu-operator \
-  -l app=nvidia-validation-markers -o jsonpath='{.items[0].metadata.name}') \
-  -- ls -la /run/nvidia/validations/
-# Should show driver-ready and toolkit-ready files
-```
+3. **Check validation markers:**
+   ```bash
+   kubectl exec -n gpu-operator $(kubectl get pod -n gpu-operator \
+     -l app=nvidia-validation-markers -o jsonpath='{.items[0].metadata.name}') \
+     -- ls -la /run/nvidia/validations/
+   ```
+   Should show `driver-ready` and `toolkit-ready` files. If missing, the node may have rebooted (files are on tmpfs). The DaemonSet recreates them within 30 seconds.
 
-If the markers are missing, check that the `nvidia-validation-markers` DaemonSet is running. If it is running but the files are gone, the node may have rebooted (files are on tmpfs). The DaemonSet loop recreates them within 30 seconds.
-
-### Containerd Issues on Talos
+#### Recovery: containerd config corruption
 
 If GPU pods are stuck at `ContainerCreating` with `PodReadyToStartContainers: False`:
 
 ```bash
-# Check containerd runtime config on gpu-1
 talosctl -n 192.168.55.31 read /etc/cri/conf.d/20-customization.part
 ```
 
-The file should contain the nvidia runtime as default **and** the `base_runtime_spec`:
+The file should contain:
 
 ```toml
 [plugins."io.containerd.cri.v1.runtime"]
@@ -214,40 +216,45 @@ If `base_runtime_spec` is missing, kubelet cannot track the GPU container lifecy
 
 ### Talos Reboot Loops from Conflicting Patches
 
-If a node enters a ~35-minute reboot loop after applying a config patch, the likely cause is two patches creating the same file at `/etc/cri/conf.d/20-customization.part`. Talos cannot merge them and throws:
+If a node enters a ~35-minute reboot loop after applying a config patch, the cause is two patches creating the same file at `/etc/cri/conf.d/20-customization.part`:
 
 ```
 resource EtcFileSpecs.files.talos.dev(files/cri/conf.d/20-customization.part@undefined) already exists
 ```
 
-The fix: each node must have its own machine-specific patch. Delete the cluster-wide patch **before** applying machine-specific ones. To recover a looping node:
+Recovery:
 
 ```bash
-# Remove the conflicting cluster-wide patch from Omni
 omnictl delete configpatch <cluster-wide-patch-id>
-
-# Watch the node recover (it will complete its current reboot cycle)
 kubectl get node <node-name> -w
 ```
 
-### Force-Delete GPU Pods Carefully
+Each node must have its own machine-specific patch. Delete the cluster-wide patch before applying machine-specific ones.
 
-Force-deleting a GPU pod (`kubectl delete pod --force --grace-period=0`) leaves stale containers holding the GPU allocation inside containerd. The device plugin still sees the GPU as allocated. New GPU pods will stay `Pending` with `Insufficient nvidia.com/gpu`.
+### Stale GPU Allocations from Force-Delete
 
-If you must force-delete:
+Force-deleting a GPU pod (`kubectl delete pod --force --grace-period=0`) leaves stale containers holding the GPU allocation. The device plugin still sees the GPU as allocated, and new GPU pods stay `Pending` with `Insufficient nvidia.com/gpu`.
+
+Recovery:
 
 ```bash
-# Force delete (last resort)
-kubectl delete pod -n <namespace> <pod> --force --grace-period=0
-
-# Check if the GPU is still shown as allocated
+# Check if GPU is stuck allocated
 kubectl describe node gpu-1 | grep -A 5 "Allocated resources"
 
-# If GPU is still stuck as allocated, a clean node reboot clears it
+# Clean reboot clears it
 talosctl -n 192.168.55.31 reboot
 ```
 
-A clean reboot is the only reliable way to clear stale GPU allocations from containerd. Budget about 90 seconds for Talos to come back Ready.
+A clean reboot is the only reliable way to clear stale GPU allocations. Budget about 90 seconds for Talos to come back `Ready`. Avoid force-deleting GPU pods — scale the workload to 0 instead.
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|-----------------|------------------|-------------|
+| PostStart lifecycle hooks work on Talos with NVIDIA | The `nvidia-container-cli` exec hook conflicts with Talos's containerd config — the hook runs before the container runtime is fully initialized | All model pulls must happen manually via `kubectl exec` after the pod is running. |
+| A single cluster-wide containerd patch works for all nodes | GPU-1 needs a different `20-customization.part` than non-GPU nodes. Two patches creating the same file throw `EtcFileSpecs` conflict | ~35-minute reboot loop on gpu-1 until the cluster-wide patch was deleted. |
+| `kubectl delete pod --force` is safe for GPU workloads | Stale containerd containers hold the GPU allocation — the device plugin never releases it | GPU appears allocated but unusable until a clean node reboot. |
+| Validation markers persist across reboots | Files live on tmpfs — a node reboot wipes them | DaemonSet recreates them within 30 seconds, but operators panic when they disappear. |
 
 ## Quick Reference
 
@@ -264,6 +271,11 @@ A clean reboot is the only reliable way to clear stale GPU allocations from cont
 | Validation markers | `kubectl exec -n gpu-operator $(kubectl get pod -n gpu-operator -l app=nvidia-validation-markers -o jsonpath='{.items[0].metadata.name}') -- ls /run/nvidia/validations/` |
 | Containerd config | `talosctl -n 192.168.55.31 read /etc/cri/conf.d/20-customization.part` |
 | Reboot gpu-1 | `talosctl -n 192.168.55.31 reboot` |
+| Find GPU-using pods (NVIDIA) | `kubectl get pods -A -o json \| jq -r '.items[] \| select(.spec.containers[].resources.limits."nvidia.com/gpu" != null) \| "\(.metadata.namespace)/\(.metadata.name)"'` |
+
+## Explanation
+
+This post covers both GPU paths on Frank because they fail differently. The NVIDIA stack has Talos-specific containerd quirks (missing `base_runtime_spec`, postStart hook conflicts, stale allocations from force-delete). The Intel DRA stack is simpler — it Just Works — but requires understanding the ResourceSlice/ResourceClaim model. The building posts cover why each stack was chosen and how it was deployed; this post covers what to do when they break.
 
 ## References
 

--- a/blog/content/docs/operating/05-observability/index.md
+++ b/blog/content/docs/operating/05-observability/index.md
@@ -4,50 +4,70 @@ series: ["operating"]
 layer: obs
 date: 2026-03-13
 draft: false
-tags: ["operations", "victoriametrics", "grafana", "fluent-bit", "observability"]
+tags: ["operations", "victoriametrics", "grafana", "fluent-bit", "observability", "troubleshooting"]
 summary: "Day-to-day commands for querying metrics and logs, managing Grafana dashboards, and debugging the observability pipeline."
 weight: 6
+reader_goal: "Query metrics and logs, check pipeline health, adjust retention, and debug common failures (missing metrics, Fluent Bit not shipping, high cardinality) across VictoriaMetrics, Grafana, Fluent Bit, and VictoriaLogs."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
 
+{{< last-updated >}}
+
 This is the operational companion to [Building Observability]({{< relref "/docs/building/07-observability" >}}). That post covers the architecture decisions and deployment gotchas. This one covers what you actually type when you need to find out why something is broken, slow, or eating memory.
+
+Source your environment before running commands:
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## Overview
 
 Frank's observability stack has four moving parts:
 
-- **VictoriaMetrics** (VMSingle + vmagent) -- time-series metrics database and scraping engine, running in the `monitoring` namespace with a 20Gi Longhorn PVC and 1-month retention
-- **Grafana** at `http://192.168.55.203` -- dashboards and exploration, with OIDC auth via Authentik
-- **Fluent Bit** -- DaemonSet on all nodes (including tainted control-plane and GPU nodes), shipping container logs
-- **VictoriaLogs** -- log storage with 14-day retention, queryable through Grafana's Explore tab
+- **VictoriaMetrics** (VMSingle + vmagent) — time-series metrics database and scraping engine, 20Gi Longhorn PVC, 1-month retention
+- **Grafana** at `http://192.168.55.203` — dashboards and exploration, OIDC auth via Authentik
+- **Fluent Bit** — DaemonSet on all nodes (including tainted CP and GPU nodes), shipping container logs
+- **VictoriaLogs** — log storage, 14-day retention, queryable through Grafana's Explore tab
 
-Supporting collectors: **node-exporter** (hardware metrics on all nodes) and **kube-state-metrics** (Kubernetes object metrics).
+### Verify
+
+```bash
+# vmagent scraping
+kubectl get pods -n monitoring -l app.kubernetes.io/name=vmagent
+
+# Fluent Bit on all nodes
+kubectl get ds -n monitoring fluent-bit
+# DESIRED and READY should match (7 nodes)
+
+# VictoriaLogs accepting writes
+kubectl logs -n monitoring -l app=victoria-logs-single-server --tail=5
+```
 
 ## Observing State
 
 ### Grafana Dashboards
 
-Open `http://192.168.55.203` in a browser. The stack ships with pre-built dashboards under the "VictoriaMetrics" folder:
+Open `http://192.168.55.203`. Provisioned dashboards under "VictoriaMetrics" folder:
 
-- **Node Exporter Full** -- per-node CPU, memory, disk I/O, network, filesystem
-- **Kubernetes / Compute Resources / Cluster** -- cluster-wide CPU and memory requests vs limits vs actual usage
-- **Kubernetes / Compute Resources / Namespace** -- the same, broken down by namespace
-- **VMAgent** -- scrape targets, samples/sec, queue depth
-
-These dashboards are provisioned by the Helm chart and survive Grafana pod restarts.
+- **Node Exporter Full** — per-node CPU, memory, disk I/O
+- **Kubernetes / Compute Resources / Cluster** — cluster-wide CPU/memory usage
+- **Kubernetes / Compute Resources / Namespace** — same, by namespace
+- **VMAgent** — scrape targets, samples/sec, queue depth
 
 {{< screenshot src="grafana-dashboards.png" caption="Grafana dashboard list showing available views" >}}
 
 ### Querying Metrics with MetricsQL
 
-For ad-hoc metric exploration, port-forward to VMSingle and use its built-in UI:
-
 ```bash
 kubectl port-forward -n monitoring svc/vmsingle-victoria-metrics-victoria-metrics-k8s-stack 8429:8429
 ```
 
-Then open `http://localhost:8429/vmui` in your browser. MetricsQL is a superset of PromQL -- any PromQL query works, plus extensions like `keep_metric_names` and `range_median`.
+Then open `http://localhost:8429/vmui`. MetricsQL is a superset of PromQL.
 
-Some useful starter queries:
+Useful starter queries:
 
 ```promql
 # CPU usage by node (1m average)
@@ -63,7 +83,7 @@ increase(kube_pod_container_status_restarts_total[1h]) > 0
 kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes * 100
 ```
 
-You can also query from the command line with curl:
+CLI query:
 
 ```bash
 kubectl port-forward -n monitoring svc/vmsingle-victoria-metrics-victoria-metrics-k8s-stack 8429:8429 &
@@ -72,7 +92,7 @@ curl -s 'http://localhost:8429/api/v1/query?query=up' | jq '.data.result[] | {in
 
 ### Querying Logs with VictoriaLogs
 
-Logs are queryable through Grafana's Explore tab -- select the "VictoriaLogs" datasource and use LogsQL syntax:
+Logs are queryable through Grafana's Explore tab — select "VictoriaLogs" datasource and use LogsQL:
 
 ```text
 # All logs from a namespace
@@ -88,46 +108,24 @@ Logs are queryable through Grafana's Explore tab -- select the "VictoriaLogs" da
 {kubernetes_host="gpu-1"} | level:error
 ```
 
-For CLI access, port-forward to VictoriaLogs directly:
+CLI access:
 
 ```bash
 kubectl port-forward -n monitoring svc/victoria-logs-victoria-logs-single-server 9428:9428
 curl -s 'http://localhost:9428/select/logsql/query?query={kubernetes_namespace_name="monitoring"}&limit=10' | jq .
 ```
 
-### Checking Pipeline Health
-
-Verify all pieces are running:
-
-```bash
-# vmagent is scraping
-kubectl get pods -n monitoring -l app.kubernetes.io/name=vmagent
-kubectl logs -n monitoring -l app.kubernetes.io/name=vmagent --tail=5
-
-# Fluent Bit is running on all nodes
-kubectl get ds -n monitoring fluent-bit
-# DESIRED and READY counts should match (7 nodes)
-
-# VictoriaLogs is accepting writes
-kubectl logs -n monitoring -l app=victoria-logs-single-server --tail=5
-```
-
 ## Routine Operations
 
 ### Creating and Importing Grafana Dashboards
 
-To import a community dashboard (for example, dashboard ID 1860 for Node Exporter Full):
+Open Grafana at `http://192.168.55.203` → Dashboards → Import → enter dashboard ID (e.g. 1860 for Node Exporter Full) → select VictoriaMetrics datasource.
 
-1. Open Grafana at `http://192.168.55.203`
-2. Go to Dashboards > Import
-3. Enter the dashboard ID and click Load
-4. Select the VictoriaMetrics datasource and click Import
-
-To make an imported dashboard persistent across pod restarts, Grafana's 1Gi Longhorn PVC handles that automatically. Dashboards saved in the UI are written to the PVC and survive restarts.
+Dashboards are written to Grafana's 1Gi Longhorn PVC and survive pod restarts.
 
 ### Adjusting Retention
 
-Metrics retention is set in `apps/victoria-metrics/values.yaml`:
+Metrics retention (`apps/victoria-metrics/values.yaml`):
 
 ```yaml
 vmsingle:
@@ -135,68 +133,64 @@ vmsingle:
     retentionPeriod: "1"  # 1 month
 ```
 
-Log retention is in `apps/victoria-logs/values.yaml`:
+Log retention (`apps/victoria-logs/values.yaml`):
 
 ```yaml
 server:
   retentionPeriod: 14d
 ```
 
-Change the value, commit, and let ArgoCD sync. The pods will restart with the new retention window. Existing data outside the new window is garbage-collected on the next retention pass.
+Change the value, commit, and let ArgoCD sync. Existing data outside the new window is GC'd on the next retention pass.
 
 ### Checking What vmagent Is Scraping
-
-vmagent exposes its target list via its own UI:
 
 ```bash
 kubectl port-forward -n monitoring svc/vmagent-victoria-metrics-victoria-metrics-k8s-stack 8429:8429
 ```
 
-Open `http://localhost:8429/targets` to see every scrape target, its status (up/down), last scrape time, and error messages. This is the first place to look when a metric is missing.
+Open `http://localhost:8429/targets` to see every scrape target, status (up/down), last scrape time, and errors.
 
 ### Exploring Available Metrics
-
-To find what metrics exist:
 
 ```bash
 # List all metric names
 curl -s 'http://localhost:8429/api/v1/label/__name__/values' | jq '.data[:20]'
 
-# Search for metrics by keyword
+# Search by keyword
 curl -s 'http://localhost:8429/api/v1/label/__name__/values' | jq '.data[] | select(test("gpu|nvidia"))'
 ```
 
-## Debugging
+## Runbook
 
-### False positives from `kube_pod_status_ready` in batch namespaces
+### False Positives from kube_pod_status_ready in Batch Namespaces
 
-If a Layer/feature alert fires intermittently for a namespace that runs Tekton, Argo Workflows, or any Job/CronJob, double-check the underlying query. `kube_pod_status_ready{condition="true"}` reports `0` for pods in `Completed` / `Error` state — those are by-design not-Ready post-completion. A namespace with active CI accumulates such pods until the next GC sweep, and a `reduce.last` on the per-pod series can pick one of them and trip the threshold.
+If a Layer alert fires intermittently for a namespace running Tekton or Argo Workflows, `kube_pod_status_ready{condition="true"}` reports `0` for pods in `Completed`/`Error` state — those are by-design not-Ready post-completion.
 
-Switch the query to `kube_deployment_status_replicas_unavailable{namespace=~"…"}` — Deployments are the long-running things; task pods aren't owned by Deployments so they're naturally excluded. This was the fix for the `layer-25-cicd-down` alert on 2026-05-14 (see `apps/grafana-alerting/manifests/alert-rules-cm.yaml`); the TTL CronJob in `apps/tekton/manifests/pipelinerun-ttl-gc.yaml` is the complementary hygiene piece.
+Fix: switch the query to `kube_deployment_status_replicas_unavailable{namespace=~"…"}` — Deployments are the long-running things; task pods are naturally excluded. This fixed the `layer-25-cicd-down` alert on 2026-05-14 (`apps/grafana-alerting/manifests/alert-rules-cm.yaml`). The TTL CronJob in `apps/tekton/manifests/pipelinerun-ttl-gc.yaml` handles the complementary hygiene.
 
 ### Missing Metrics
 
-If a metric you expect is not showing up:
+If a metric you expect is missing:
 
-1. **Check the scrape target** -- is the exporter pod running?
+1. **Check the exporter pod:**
    ```bash
    kubectl get pods -n monitoring -l app.kubernetes.io/name=node-exporter
    kubectl get pods -n monitoring -l app.kubernetes.io/name=kube-state-metrics
    ```
 
-2. **Check vmagent targets** -- is it scraping the endpoint?
+2. **Check vmagent targets:**
    ```bash
    kubectl port-forward -n monitoring svc/vmagent-victoria-metrics-victoria-metrics-k8s-stack 8429:8429
-   # Open http://localhost:8429/targets and look for the target
+   # Open http://localhost:8429/targets
    ```
 
-3. **Check VMServiceMonitor** -- does the CRD exist and match the service labels?
+3. **Check VMServiceMonitor:**
    ```bash
    kubectl get vmservicemonitors -n monitoring
    kubectl describe vmservicemonitor <name> -n monitoring
    ```
 
-4. **Check the exporter directly** -- does it actually expose the metric?
+4. **Check the exporter directly:**
    ```bash
    kubectl port-forward -n monitoring <exporter-pod> <port>:<port>
    curl http://localhost:<port>/metrics | grep <metric-name>
@@ -204,54 +198,56 @@ If a metric you expect is not showing up:
 
 ### Fluent Bit Not Shipping Logs
 
-If logs are not appearing in VictoriaLogs:
-
-1. **Check Fluent Bit pods** -- are they running on all nodes?
+1. **Check DaemonSet:**
    ```bash
    kubectl get ds -n monitoring fluent-bit
    kubectl get pods -n monitoring -l app.kubernetes.io/name=fluent-bit -o wide
    ```
 
-2. **Check Fluent Bit logs** for output errors:
+2. **Check Fluent Bit logs for `retry` lines:**
    ```bash
    kubectl logs -n monitoring -l app.kubernetes.io/name=fluent-bit --tail=50
    ```
-   Look for `retry` lines. Silent retries with no error detail usually mean DNS resolution failure -- the output hostname is wrong or the target service is down.
 
-3. **Verify the destination hostname resolves**:
+3. **Verify destination hostname resolution:**
    ```bash
-   kubectl exec -n monitoring <fluent-bit-pod> -- nslookup \
-     victoria-logs-victoria-logs-single-server.monitoring.svc.cluster.local
+   kubectl exec -n monitoring <fluent-bit-pod> -- nslookup victoria-logs-victoria-logs-single-server.monitoring.svc.cluster.local
    ```
 
-4. **Check tail file positions** -- Fluent Bit tracks where it left off reading each log file. If positions are stale, it may be re-reading or skipping:
+4. **Check tail file positions:**
    ```bash
    kubectl exec -n monitoring <fluent-bit-pod> -- ls -la /var/log/flb_kube.db
    ```
 
 ### High Cardinality
 
-If VMSingle memory usage is climbing or queries are slow, high cardinality labels are usually the cause:
+If VMSingle memory is climbing or queries are slow:
 
 ```bash
-# Check top series by cardinality
 curl -s 'http://localhost:8429/api/v1/status/tsdb' | jq '.data.seriesCountByMetricName[:10]'
 ```
 
-If a metric has an unbounded label (like a request ID or session token), either drop the label in vmagent's relabeling config or exclude the metric entirely.
+Drop the offending label in vmagent's relabeling config or exclude the metric entirely.
 
 ### VictoriaLogs Query Returns No Results
 
-1. **Check VictoriaLogs is receiving data**:
+1. **Check VictoriaLogs is receiving data:**
    ```bash
    kubectl port-forward -n monitoring svc/victoria-logs-victoria-logs-single-server 9428:9428
    curl -s 'http://localhost:9428/select/logsql/query?query=*&limit=5' | jq .
    ```
-   If this returns results, the problem is your query syntax, not the pipeline.
 
-2. **Check the Grafana datasource** -- the VictoriaLogs datasource must point to `http://victoria-logs-victoria-logs-single-server.monitoring.svc.cluster.local:9428`. Go to Grafana > Configuration > Data Sources and verify.
+2. **Check Grafana datasource** points to `http://victoria-logs-victoria-logs-single-server.monitoring.svc.cluster.local:9428`.
 
-3. **Check retention** -- if logs are older than 14 days, they have been garbage-collected.
+3. **Check retention** — logs older than 14 days are GC'd.
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|-----------------|------------------|-------------|
+| `kube_pod_status_ready` is a reliable health signal for all namespaces | Batch namespaces (Tekton, Argo Workflows) have pods that are intentionally not-Ready post-completion | False-positive `layer-25-cicd-down` alert until query was switched to `kube_deployment_status_replicas_unavailable`. |
+| VictoriaLogs datasource auto-configures | Grafana needs the exact internal SVC URL | Queries returned nothing until datasource was pointed to `victoria-logs-victoria-logs-single-server.monitoring.svc.cluster.local:9428`. |
+| High cardinality is always an application problem | Unbounded labels on infrastructure metrics (node-exporter, kube-state-metrics) can also blow up series count | Memory pressure on VMSingle until the offending label was dropped in vmagent relabeling. |
 
 ## Quick Reference
 
@@ -270,8 +266,8 @@ If a metric has an unbounded label (like a request ID or session token), either 
 
 ## References
 
-- [VictoriaMetrics Documentation](https://docs.victoriametrics.com/) -- MetricsQL reference, VMSingle operations, retention
-- [VictoriaLogs Documentation](https://docs.victoriametrics.com/victorialogs/) -- LogsQL syntax, ingestion API
-- [Grafana Documentation](https://grafana.com/docs/grafana/latest/) -- Dashboard management, datasource provisioning
-- [Fluent Bit Documentation](https://docs.fluentbit.io/) -- Pipeline debugging, tail input, HTTP output
-- [Building Observability]({{< relref "/docs/building/07-observability" >}}) -- Architecture decisions and deployment gotchas
+- [VictoriaMetrics Documentation](https://docs.victoriametrics.com/) — MetricsQL reference, VMSingle operations, retention
+- [VictoriaLogs Documentation](https://docs.victoriametrics.com/victorialogs/) — LogsQL syntax, ingestion API
+- [Grafana Documentation](https://grafana.com/docs/grafana/latest/) — Dashboard management, datasource provisioning
+- [Fluent Bit Documentation](https://docs.fluentbit.io/) — Pipeline debugging, tail input, HTTP output
+- [Building Observability]({{< relref "/docs/building/07-observability" >}}) — Architecture decisions and deployment gotchas

--- a/blog/content/docs/operating/06-secrets/index.md
+++ b/blog/content/docs/operating/06-secrets/index.md
@@ -4,34 +4,52 @@ series: ["operating"]
 layer: secrets
 date: 2026-03-13
 draft: false
-tags: ["operations", "infisical", "external-secrets", "sops", "security"]
+tags: ["operations", "infisical", "external-secrets", "sops", "security", "troubleshooting"]
 summary: "Day-to-day commands for managing secrets in Infisical, checking ESO sync status, and handling SOPS-encrypted bootstrap secrets."
 weight: 7
+reader_goal: "Manage secrets through Infisical and ESO, check sync status, rotate credentials, apply SOPS bootstrap secrets, and debug sync failures — without the Infisical UI."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
 
-This is the operational companion to [Secrets Management -- Infisical + External Secrets Operator]({{< relref "/docs/building/09-secrets" >}}). That post covers the architecture and deployment of Infisical + ESO. This one covers the commands you reach for when you need to add a secret, check sync status, or figure out why an application is not picking up a rotated credential.
+{{< last-updated >}}
+
+This is the operational companion to [Secrets Management — Infisical + External Secrets Operator]({{< relref "/docs/building/09-secrets" >}}). That post covers the architecture and deployment of Infisical + ESO. This one covers the commands you reach for when you need to add a secret, check sync status, or figure out why an application is not picking up a rotated credential.
+
+Source your environment before running commands:
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## Overview
 
 Secrets on Frank flow through two layers:
 
-**Runtime secrets** live in Infisical (192.168.55.204:8080). Applications never touch them directly. External Secrets Operator watches `ExternalSecret` resources, fetches values from Infisical via the `ClusterSecretStore`, and materializes them as native Kubernetes Secrets. The refresh interval (typically 5 minutes) controls how quickly changes propagate.
+**Runtime secrets** live in Infisical (`http://192.168.55.204:8080`). External Secrets Operator watches `ExternalSecret` resources, fetches values from Infisical via the `ClusterSecretStore`, and materializes them as native Kubernetes Secrets. Refresh interval is typically 5 minutes.
 
-**Bootstrap secrets** are the credentials that Infisical and ESO themselves need to start -- database passwords, Redis passwords, Machine Identity credentials. These are SOPS-encrypted with age, stored in `secrets/`, and applied manually with `sops --decrypt | kubectl apply -f -`. They exist outside ArgoCD because ArgoCD cannot decrypt SOPS secrets during ServerSideApply.
+**Bootstrap secrets** are credentials that Infisical and ESO themselves need to start — database passwords, Machine Identity credentials. These are SOPS-encrypted with age, stored in `secrets/`, and applied manually with `sops --decrypt | kubectl apply -f -`. They exist outside ArgoCD because ArgoCD cannot decrypt SOPS secrets during ServerSideApply.
 
-The rule is simple: if a secret is needed before Infisical is running, it is a SOPS bootstrap secret. Everything else goes into Infisical.
+The rule: if a secret is needed before Infisical is running, it is a SOPS bootstrap secret. Everything else goes into Infisical.
+
+### Verify
+
+```bash
+kubectl get externalsecrets -A
+# All should show STATUS: SecretSynced, READY: True
+
+kubectl get clustersecretstore
+# Should show READY: True, STATUS: Valid
+```
 
 ## Observing State
 
 ### ESO Sync Status
 
-The first thing to check is whether ESO is successfully syncing secrets from Infisical:
-
 ```bash
 kubectl get externalsecrets -A
 ```
-
-Every `ExternalSecret` should show `STATUS: SecretSynced` and `READY: True`. If any show `SecretSyncedError` or `False`, something is broken between ESO and Infisical.
 
 ```console
 $ kubectl get externalsecrets -A
@@ -40,47 +58,28 @@ agents             vk-remote-secrets          ClusterSecretStore   infisical   5
 gitea              gitea-secrets              ClusterSecretStore   infisical   5m                 SecretSynced   True
 litellm            litellm-api-keys           ClusterSecretStore   infisical   5m                 SecretSynced   True
 monitoring         grafana-alerting-secrets   ClusterSecretStore   infisical   5m                 SecretSynced   True
-monitoring         health-bridge-secrets      ClusterSecretStore   infisical   5m                 SecretSynced   True
-paperclip-system   paperclip-anthropic        ClusterSecretStore   infisical   5m                 SecretSynced   True
-paperclip-system   paperclip-auth             ClusterSecretStore   infisical   5m                 SecretSynced   True
-paperclip-system   paperclip-ghcr             ClusterSecretStore   infisical   5m                 SecretSynced   True
-paperclip-system   paperclip-llm-key          ClusterSecretStore   infisical   5m                 SecretSynced   True
-secure-agent-pod   agent-secrets-tier2        ClusterSecretStore   infisical   5m                 SecretSynced   True
-sympozium-system   sympozium-llm-key          ClusterSecretStore   infisical   5m                 SecretSynced   True
-tekton-pipelines   cosign-key                 ClusterSecretStore   infisical   5m                 SecretSynced   True
-tekton-pipelines   gitea-api-token            ClusterSecretStore   infisical   5m                 SecretSynced   True
-tekton-pipelines   gitea-webhook-secret       ClusterSecretStore   infisical   5m                 SecretSynced   True
-tekton-pipelines   zot-push-creds             ClusterSecretStore   infisical   5m                 SecretSynced   True
-zot                zot-secrets                ClusterSecretStore   infisical   5m                 SecretSynced   True
+# ... (14 total ExternalSecrets, all SecretSynced)
 ```
 
-To inspect a specific ExternalSecret in detail:
+To inspect a specific ExternalSecret:
 
 ```bash
 kubectl describe externalsecret <name> -n <namespace>
 ```
 
-The `Events` section at the bottom will show the most recent sync attempts and any error messages.
+The `Events` section shows recent sync attempts and errors.
 
 ### ClusterSecretStore Health
-
-The `ClusterSecretStore` is the single connection point between ESO and Infisical. If it is unhealthy, no secrets sync:
-
-```bash
-kubectl get clustersecretstore
-```
-
-You want `READY: True` and `STATUS: Valid`. If the store shows `SecretStoreError`, the Infisical API is unreachable or the Machine Identity credentials are wrong.
-
-For more detail:
 
 ```bash
 kubectl describe clustersecretstore infisical
 ```
 
+If the store shows `SecretStoreError`, the Infisical API is unreachable or the Machine Identity credentials are wrong.
+
 ### Infisical UI
 
-The Infisical dashboard at `http://192.168.55.204:8080` shows all secrets in the `frank-cluster` project, organized by environment. The audit log (under Project Settings) records who changed what and when. This is the fastest way to verify a secret's current value or check rotation history.
+The dashboard at `http://192.168.55.204:8080` shows all secrets in the `frank-cluster` project. The audit log (Project Settings) records who changed what and when.
 
 {{< screenshot src="infisical-project-prod.png" caption="Infisical prod environment for the frank-cluster project (secret values redacted)" >}}
 
@@ -88,9 +87,8 @@ The Infisical dashboard at `http://192.168.55.204:8080` shows all secrets in the
 
 ### Adding a New Secret
 
-1. Go to the Infisical UI, navigate to the `frank-cluster` project, `prod` environment
-2. Add the key-value pair
-3. Create an `ExternalSecret` manifest in the consuming app's manifests directory:
+1. Infisical UI → `frank-cluster` project → `prod` → add key-value pair.
+2. Create an `ExternalSecret` manifest in the consuming app's manifests directory:
 
 ```yaml
 apiVersion: external-secrets.io/v1
@@ -111,17 +109,17 @@ spec:
         key: MY_SECRET_KEY
 ```
 
-4. Commit and push -- ArgoCD syncs the ExternalSecret, ESO fetches the value from Infisical
+3. Commit and push — ArgoCD syncs the ExternalSecret, ESO fetches the value.
 
 ### Rotating a Secret
 
-Update the value in the Infisical UI. ESO picks up the change on the next refresh cycle. If the consuming pod reads secrets from environment variables (not files), it needs a restart to see the new value:
+Update the value in Infisical. ESO picks it up on the next refresh. If the consuming pod uses env vars (not files), restart it:
 
 ```bash
 kubectl rollout restart deployment/<app> -n <namespace>
 ```
 
-If you cannot wait for the refresh interval, force an immediate sync:
+To force an immediate sync:
 
 ```bash
 kubectl annotate externalsecret <name> -n <namespace> \
@@ -130,92 +128,94 @@ kubectl annotate externalsecret <name> -n <namespace> \
 
 ### Applying SOPS Bootstrap Secrets
 
-Bootstrap secrets are applied manually whenever they change or after a fresh cluster build:
-
 ```bash
 sops --decrypt secrets/infisical/infisical-secrets.yaml | kubectl apply -f -
 sops --decrypt secrets/infisical/eso-credentials.yaml | kubectl apply -f -
 ```
 
-To verify a SOPS-encrypted file decrypts correctly without applying it:
+To verify decryption without applying:
 
 ```bash
 sops --decrypt secrets/infisical/infisical-secrets.yaml
 ```
 
-## Debugging
+## Runbook
 
 ### ESO Sync Failed
 
 If an ExternalSecret shows `SecretSyncedError`:
 
-1. **Check the ClusterSecretStore** -- if it is unhealthy, all syncs fail:
+1. **Check ClusterSecretStore:**
    ```bash
    kubectl get clustersecretstore
    kubectl describe clustersecretstore infisical
    ```
 
-2. **Check the ESO controller logs** for API errors:
+2. **Check ESO controller logs:**
    ```bash
    kubectl logs -n external-secrets deployment/external-secrets --tail=50
    ```
 
-3. **Verify Infisical is reachable** from the cluster:
+3. **Verify Infisical is reachable:**
    ```bash
    kubectl run curl-test --rm -it --image=curlimages/curl -- \
      curl -s http://192.168.55.204:8080/api/status
    ```
 
-4. **Check the Machine Identity credentials** -- the `infisical-credentials` Secret in the `external-secrets` namespace must contain valid `clientId` and `clientSecret` values:
+4. **Check Machine Identity credentials:**
    ```bash
    kubectl get secret infisical-credentials -n external-secrets -o yaml
    ```
 
 ### Secret Not Updating After Rotation
 
-If you changed a value in Infisical but the Kubernetes Secret still has the old value:
-
-1. **Check the refresh interval** on the ExternalSecret -- the default is 5 minutes:
+1. **Check refresh interval:**
    ```bash
    kubectl get externalsecret <name> -n <namespace> -o yaml | grep refreshInterval
    ```
 
-2. **Force a sync** to rule out timing:
+2. **Force sync:**
    ```bash
    kubectl annotate externalsecret <name> -n <namespace> \
      force-sync=$(date +%s) --overwrite
    ```
 
-3. **Check whether the pod needs a restart** -- environment variables are read at startup, not live-reloaded:
+3. **Restart the consuming pod** (env vars are read at startup, not live-reloaded):
    ```bash
    kubectl rollout restart deployment/<app> -n <namespace>
    ```
 
 ### SOPS Decrypt Errors
 
-If `sops --decrypt` fails with an age-related error:
-
-1. **Check that the age key is available** -- SOPS looks for the key in `$SOPS_AGE_KEY_FILE` or `~/.config/sops/age/keys.txt`:
+1. **Check age key availability:**
    ```bash
    echo $SOPS_AGE_KEY_FILE
    ls -la ~/.config/sops/age/keys.txt
    ```
 
-2. **Verify the `.sops.yaml` config** points to the correct age public key:
+2. **Verify `.sops.yaml`:**
    ```bash
    cat .sops.yaml
    ```
 
-3. **Check that the file was encrypted for the right key** -- the age recipient in the file header must match your key:
+3. **Check age recipient in file header:**
    ```bash
    head -5 secrets/infisical/infisical-secrets.yaml
    ```
 
 ### Project Slug Issues
 
-If the ClusterSecretStore returns 404 errors, the project slug is likely wrong. Infisical auto-generates slugs that differ from the project display name. The slug for `frank-cluster` is `frank-cluster-iwpg`.
+If the ClusterSecretStore returns 404 errors, the project slug is wrong. Infisical auto-generates slugs that differ from the display name — `frank-cluster` has slug `frank-cluster-iwpg`.
 
-To find the correct slug: open the Infisical UI, go to Project Settings, and check the General tab. The slug is displayed there. Update `apps/infisical/manifests/cluster-secret-store.yaml` with the correct value.
+Find the correct slug in the Infisical UI → Project Settings → General tab. Update `apps/infisical/manifests/cluster-secret-store.yaml`.
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|-----------------|------------------|-------------|
+| ArgoCD can manage SOPS-encrypted Secrets through SSA | SOPS `.sops` metadata fields are rejected by ServerSideApply | All bootstrap secrets live outside ArgoCD, applied manually (`secrets/` directory). |
+| The Infisical project slug matches the display name | Infisical appends a random suffix to slugs | `frank-cluster` has slug `frank-cluster-iwpg`. 404 errors until the correct slug was found in the UI. |
+| Rotated secrets propagate immediately to pods | Env vars are read at container start, not live-reloaded | Pods must be restarted after rotation if they read secrets from env vars. |
 
 ## Quick Reference
 
@@ -233,8 +233,8 @@ To find the correct slug: open the Infisical UI, go to Project Settings, and che
 
 ## References
 
-- [Infisical Documentation](https://infisical.com/docs) -- Self-hosted setup, Machine Identities, audit logs
-- [External Secrets Operator Documentation](https://external-secrets.io/latest/) -- ClusterSecretStore, ExternalSecret v1 API
-- [ESO Infisical Provider](https://external-secrets.io/latest/provider/infisical/) -- Provider-specific configuration and auth
-- [SOPS Documentation](https://github.com/getsops/sops) -- age encryption, `.sops.yaml` configuration
-- [Secrets Management -- Infisical + ESO]({{< relref "/docs/building/09-secrets" >}}) -- Building post covering architecture and deployment
+- [Infisical Documentation](https://infisical.com/docs) — Self-hosted setup, Machine Identities, audit logs
+- [External Secrets Operator Documentation](https://external-secrets.io/latest/) — ClusterSecretStore, ExternalSecret v1 API
+- [ESO Infisical Provider](https://external-secrets.io/latest/provider/infisical/) — Provider-specific configuration and auth
+- [SOPS Documentation](https://github.com/getsops/sops) — age encryption, `.sops.yaml` configuration
+- [Secrets Management — Infisical + ESO]({{< relref "/docs/building/09-secrets" >}}) — Building post covering architecture and deployment

--- a/blog/content/docs/operating/07-inference/index.md
+++ b/blog/content/docs/operating/07-inference/index.md
@@ -4,94 +4,91 @@ series: ["operating"]
 layer: infer
 date: 2026-03-13
 draft: false
-tags: ["operations", "ollama", "litellm", "openrouter", "ai"]
+tags: ["operations", "ollama", "litellm", "openrouter", "ai", "troubleshooting"]
 summary: "Day-to-day commands for managing local LLM inference, checking model status, routing through LiteLLM, and debugging GPU memory issues."
 weight: 8
+reader_goal: "Manage Ollama models, test inference through LiteLLM, diagnose GPU memory issues (VRAM vs cgroup RAM), and resolve routing errors between LiteLLM aliases and Ollama tags."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
+
+{{< last-updated >}}
 
 This is the operational companion to [Local Inference — Ollama, LiteLLM, and OpenRouter]({{< relref "/docs/building/10-local-inference" >}}). That post explains the architecture and deployment. This one is the day-to-day runbook for keeping models running, routing requests, and troubleshooting GPU memory issues.
 
+Source your environment:
+
+```bash
+source .env
+```
+
 ## What "Healthy" Looks Like
 
-The inference stack is healthy when Ollama is running on gpu-1 with at least one model loaded, LiteLLM at `192.168.55.206:4000` is responding to health checks, and requests route correctly to either the local GPU or OpenRouter cloud models depending on the model name.
+The inference stack is healthy when Ollama is running on gpu-1 with at least one model loaded, LiteLLM at `192.168.55.206:4000` is responding to health checks, and requests route correctly.
 
-> **Canonical health signal — the end-to-end probe.** gpu-1 time-shares its single GPU between
-> Ollama (inference) and ComfyUI (media), so inference is **down by design** whenever the GPU is
-> handed to ComfyUI — that is not an outage. The Ops board reads the real state from a blackbox
-> probe that runs an actual chat completion through LiteLLM: `probe_success{layer="11"}` (VMUI,
-> VictoriaMetrics datasource) is `1` only when a completion truly succeeds. A `0` with ComfyUI
-> holding the GPU is the expected quiet-degraded tile; a `0` with **both** `gpu_timeshare` probes
-> at `0` is the only condition that pages (`gpu-node-both-down`). Check ownership with
-> `kubectl -n ollama get deploy ollama` (`0/0` = it yielded the GPU). Note: `kube_pod_status_ready`
-> is *not* a valid inference health check — it is blind to Ollama scaled to 0.
+**Canonical health signal — the end-to-end probe.** gpu-1 time-shares between Ollama (inference) and ComfyUI (media), so inference is *down by design* when the GPU is handed to ComfyUI. The Ops board reads real state from a blackbox probe: `probe_success{layer="11"}` (VMUI, VictoriaMetrics datasource) is `1` only when a completion truly succeeds. A `0` with ComfyUI holding the GPU is the expected quiet-degraded tile; a `0` with **both** `gpu_timeshare` probes at `0` pages (`gpu-node-both-down`). Check ownership with `kubectl -n ollama get deploy ollama` (`0/0` = it yielded the GPU). Note: `kube_pod_status_ready` is *not* a valid inference health check — it is blind to Ollama scaled to 0.
+
+### Verify
+
+```bash
+# LiteLLM health
+curl -s http://192.168.55.206:4000/health/liveliness
+
+# Ollama has a model loaded
+kubectl exec -n ollama deploy/ollama -- ollama ps
+
+# GPU allocated
+kubectl describe node gpu-1 | grep -A 5 "nvidia.com/gpu"
+```
 
 ## Observing State
 
 ### Ollama Status
 
 ```bash
-# Check the Ollama pod is running
 kubectl get pods -n ollama
-
-# List loaded models
 kubectl exec -n ollama deploy/ollama -- ollama list
-
-# Check which model is currently in memory
 kubectl exec -n ollama deploy/ollama -- ollama ps
-
-# Check GPU memory usage
 kubectl exec -n ollama deploy/ollama -- nvidia-smi
 ```
 
 ### LiteLLM Gateway
 
 ```bash
-# Health check
 curl -s http://192.168.55.206:4000/health | jq
-
-# List available models (both local and cloud)
 curl -s http://192.168.55.206:4000/v1/models | jq '.data[].id'
-
-# Check LiteLLM pod logs
 kubectl logs -n litellm deploy/litellm --tail=50
 ```
 
 ```console
 $ curl -s http://192.168.55.206:4000/health/liveliness
 "I'm alive!"
-$ kubectl -n litellm get pods -o wide
-NAME                       READY   STATUS    RESTARTS   AGE   IP              NODE     NOMINATED NODE   READINESS GATES
-litellm-84d78cd556-rglgl   1/1     Running   0          25d   10.244.8.237    mini-3   <none>           <none>
-litellm-postgresql-0       1/1     Running   0          28d   10.244.12.161   mini-1   <none>           <none>
 ```
 
 ### GPU Memory
 
 ```bash
-# Detailed GPU utilization
 kubectl exec -n ollama deploy/ollama -- nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu --format=csv
 ```
 
-> Only one model is loaded in VRAM at a time on the RTX 5070 Ti (16 GB GDDR7). Switching models means the old one gets evicted.
+Only one model is loaded in VRAM at a time on the RTX 5070 Ti (16 GB GDDR7). Switching models evicts the old one.
 
 ## Routine Operations
 
 ### Pull or Remove Models
 
 ```bash
-# Pull a new model
 kubectl exec -n ollama deploy/ollama -- ollama pull qwen3:14b
-
-# Remove a model to free disk space
 kubectl exec -n ollama deploy/ollama -- ollama rm qwen2.5-coder:14b-instruct-q6_K
 ```
 
-> Do not use `postStart` hooks for model pulls on Talos — the nvidia-container-runtime exec hooks fail. Always pull via `kubectl exec` after the pod is running.
+Do not use `postStart` hooks for model pulls on Talos — the nvidia-container-runtime exec hooks fail. Always pull via `kubectl exec` after the pod is running.
 
 ### Test Inference
 
 ```bash
-# Quick test via LiteLLM (routes to Ollama via the LiteLLM alias, not the Ollama tag)
+# Via LiteLLM (routes to Ollama via the alias)
 curl -s http://192.168.55.206:4000/v1/chat/completions \
   -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
   -H "Content-Type: application/json" \
@@ -101,99 +98,79 @@ curl -s http://192.168.55.206:4000/v1/chat/completions \
     "max_tokens": 50
   }' | jq '.choices[0].message.content'
 
-# Direct Ollama test (bypassing LiteLLM — uses the Ollama tag, not the alias)
+# Direct Ollama test (bypassing LiteLLM — uses the Ollama tag)
 kubectl exec -n ollama deploy/ollama -- curl -s http://localhost:11434/api/generate \
   -d '{"model": "mistral-small3.2:24b", "prompt": "Hello", "stream": false}' | jq '.response'
-
-# Multimodal test — send an image to gemma-12b
-curl -s http://192.168.55.206:4000/v1/chat/completions \
-  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "gemma-12b",
-    "messages": [{"role": "user", "content": [
-      {"type": "text", "text": "Describe this image in one sentence."},
-      {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}
-    ]}]
-  }' | jq '.choices[0].message.content'
 ```
 
 ### Check LiteLLM Routing
 
 ```bash
-# See which models route where
 kubectl get configmap -n litellm litellm-config -o yaml | grep -A 5 'model_name'
 ```
 
-### OpenRouter Free Models (retired)
-
-The cluster no longer routes to OpenRouter free models — the policy is local Ollama or a paid frontier key only. The `/update-openrouter-models` command that used to refresh the free-model list has been retired with them. If you are reading this with a config that still lists `openrouter/*:free` models, it predates the purge: remove them rather than refresh them.
-
-## Debugging
+## Runbook
 
 ### Ollama Not Responding
 
 ```bash
-# Check pod status and events
 kubectl describe pod -n ollama -l app.kubernetes.io/name=ollama
-
-# Check if GPU is allocated
 kubectl describe node gpu-1 | grep -A 5 "nvidia.com/gpu"
-
-# Check Ollama logs
 kubectl logs -n ollama deploy/ollama --tail=100
 ```
 
-### Out of Memory: which kind?
+### Out of Memory: Which Kind?
 
-Ollama emits **two error patterns** that both look like "out of memory" but have different root causes. Mis-identify which one you're hitting and you'll waste a lot of time trying smaller quants when the issue is something else entirely.
+Ollama emits two error patterns that both look like "out of memory" but have different root causes.
 
-**Pattern A — VRAM exhaustion** (real GPU OOM): the model genuinely doesn't fit in the 16 GB on the RTX 5070 Ti, or you're trying to load two models at once. Diagnose with:
+**Pattern A — VRAM exhaustion:** the model genuinely doesn't fit in 16 GB. Diagnose:
 
 ```bash
 kubectl exec -n ollama deploy/ollama -- nvidia-smi --query-gpu=memory.used,memory.free --format=csv
 ```
 
-If `memory.free` is < 1 GB, you have a real VRAM problem. Fix: stop the current model and pull a smaller quant.
+If `memory.free` is < 1 GB, stop the current model and pull a smaller quant:
 
 ```bash
 kubectl exec -n ollama deploy/ollama -- ollama stop mistral-small3.2:24b
 kubectl exec -n ollama deploy/ollama -- ollama pull qwen2.5-coder:14b-instruct-q4_K_M
 ```
 
-**Pattern B — container cgroup RAM exhaustion** (the misleading one): the error message reads `model requires more system memory (X GiB) than is available (Y MiB)`. "System memory" here means **container RAM**, not VRAM — and `nvidia-smi` will show plenty of VRAM free. With `OLLAMA_KEEP_ALIVE=24h`, page cache from previously-loaded model files pins the container near its `resources.limits.memory` ceiling, leaving no room for new-model load buffers. Diagnose with:
+**Pattern B — container cgroup RAM exhaustion (misleading):** the error reads `model requires more system memory (X GiB) than is available (Y MiB)`. "System memory" means container RAM, not VRAM — `nvidia-smi` will show plenty of VRAM free. With `OLLAMA_KEEP_ALIVE=24h`, page cache from previously-loaded model files pins the container near its `resources.limits.memory` ceiling. Diagnose:
 
 ```bash
 kubectl exec -n ollama deploy/ollama -- sh -c 'cat /sys/fs/cgroup/memory.current; echo; cat /sys/fs/cgroup/memory.max'
 ```
 
-If `memory.current` is within ~1–2 GiB of `memory.max`, that's the constraint. Fix: bump `resources.limits.memory` in `apps/ollama/values.yaml`. Reducing `num_ctx` via a derived Modelfile will **not** help here — the bottleneck is at-load buffers, not the KV cache, so the error is identical at 32K and 8K context.
+If `memory.current` is within ~1–2 GiB of `memory.max`, bump `resources.limits.memory` in `apps/ollama/values.yaml`. Reducing `num_ctx` will **not** help — the bottleneck is at-load buffers, not the KV cache.
 
-### Reconciling LiteLLM Aliases vs. Ollama Tags
+### LiteLLM Aliases vs. Ollama Tags
 
-Two name spaces are in play. LiteLLM aliases (`mistral-small-24b`, `gemma-12b`, `qwen-vl-7b`, `qwen-coder-14b`, `qwen-think-14b`) live in `apps/litellm/values.yaml` under `model_list[].model_name` — these are what consumers send. Ollama tags (`mistral-small3.2:24b`, `qwen2.5-coder:14b-instruct-q6_K`, etc.) live under `model_list[].litellm_params.model` — these are what Ollama pulls and runs. If a request returns "model not found", check both: either the alias is wrong on the consumer side, or the underlying Ollama tag was never pulled.
+Two name spaces are in play. LiteLLM aliases (`mistral-small-24b`, `gemma-12b`) live in `apps/litellm/values.yaml` under `model_list[].model_name`. Ollama tags (`mistral-small3.2:24b`) live under `model_list[].litellm_params.model`. If a request returns "model not found", check both:
 
 ```bash
 # What aliases does LiteLLM advertise?
 curl -s http://192.168.55.206:4000/v1/models -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.data[].id'
 
-# What Ollama tags actually exist on disk?
+# What Ollama tags exist on disk?
 kubectl exec -n ollama deploy/ollama -- ollama list
 ```
 
 ### LiteLLM Routing Errors
 
 ```bash
-# Check LiteLLM logs for routing failures
 kubectl logs -n litellm deploy/litellm --tail=100 | grep -i error
-
-# Verify Ollama is reachable from LiteLLM
 kubectl exec -n litellm deploy/litellm -- curl -s http://ollama.ollama.svc:11434/api/tags | jq '.models[].name'
 ```
 
-### Model Loading Very Slow
+## Missteps
 
-Large models can take 30-60 seconds to load into VRAM. Check `nvidia-smi` to see if memory is being allocated. If the model doesn't fit, Ollama falls back to CPU which is extremely slow — this looks like a hang but is actually just CPU inference.
+| What we assumed | Why it was wrong | What it cost |
+|-----------------|------------------|-------------|
+| `kube_pod_status_ready` is a valid inference health check | It's blind to Ollama scaled to 0 (GPU yielded to ComfyUI) | False inference-down alerts until switching to the blackbox probe (`probe_success{layer="11"}`). |
+| PostStart hooks work on Talos for model pulls | The nvidia-container-runtime exec hook conflicts with Talos's containerd config | All model pulls must happen manually via `kubectl exec` after the pod is running. |
+| "Out of memory" always means VRAM exhaustion | Container cgroup RAM can also be the bottleneck, especially with long `OLLAMA_KEEP_ALIVE` | Wasted time trying smaller quants when the fix was bumping `resources.limits.memory`. |
+| LiteLLM alias names match Ollama tag names | Two independent name spaces — aliases are in `model_name`, tags in `litellm_params.model` | "Model not found" errors until both were checked. |
 
 ## Quick Reference
 
@@ -213,5 +190,4 @@ Large models can take 30-60 seconds to load into VRAM. Check `nvidia-smi` to see
 
 - [Ollama API Reference](https://github.com/ollama/ollama/blob/main/docs/api.md)
 - [LiteLLM Documentation](https://docs.litellm.ai/)
-- [OpenRouter Documentation](https://openrouter.ai/docs/)
 - [Building Post — Local Inference]({{< relref "/docs/building/10-local-inference" >}})

--- a/blog/content/docs/operating/08-auth/index.md
+++ b/blog/content/docs/operating/08-auth/index.md
@@ -4,16 +4,38 @@ series: ["operating"]
 layer: auth
 date: 2026-03-13
 draft: false
-tags: ["operations", "authentik", "oidc", "sso", "security"]
+tags: ["operations", "authentik", "oidc", "sso", "security", "troubleshooting"]
 summary: "Day-to-day commands for managing Authentik SSO, checking OIDC flows, and debugging authentication issues across the cluster."
 weight: 9
+reader_goal: "Manage Authentik SSO users and providers, rotate OIDC client secrets, debug login loops and forward auth redirects, and validate token flows."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
+
+{{< last-updated >}}
 
 This is the operational companion to [Unified Auth — Authentik SSO for the Entire Cluster]({{< relref "/docs/building/13-unified-auth" >}}). That post covers the OIDC provider setup and forward auth proxy configuration. This one is the day-to-day runbook for managing users, rotating secrets, and debugging login issues.
 
+Source your environment:
+
+```bash
+source .env
+```
+
 ## What "Healthy" Looks Like
 
-Authentication is healthy when Authentik at `192.168.55.211:9000` is responding, all OIDC providers show valid status in the admin UI, and users can log into ArgoCD, Grafana, and Infisical via SSO without errors. Forward auth should be passing requests through for Longhorn UI, Hubble UI, and Sympozium.
+Authentication is healthy when Authentik at `192.168.55.211:9000` is responding, all OIDC providers show valid status, and users can log into ArgoCD, Grafana, and Infisical via SSO without errors. Forward auth should pass requests through for Longhorn UI, Hubble UI, and Sympozium.
+
+### Verify
+
+```bash
+# Authentik pods running
+kubectl get pods -n authentik
+
+# Test OIDC well-known endpoint
+curl -s http://192.168.55.211:9000/application/o/<provider-slug>/.well-known/openid-configuration | jq
+```
 
 {{< screenshot src="authentik-providers-healthy.png" caption="Authentik admin UI: all cluster OIDC and proxy providers with healthy status" >}}
 
@@ -22,25 +44,20 @@ Authentication is healthy when Authentik at `192.168.55.211:9000` is responding,
 ### Authentik Status
 
 ```bash
-# Check Authentik pods
 kubectl get pods -n authentik
-
-# Check server and worker logs
 kubectl logs -n authentik deploy/authentik-server --tail=50
 kubectl logs -n authentik deploy/authentik-worker --tail=50
 ```
 
 ### API Access
 
-Authentik API requires a Bearer token. Create one via the Django shell if needed:
+Authentik API requires a Bearer token. Generate one via the Django shell:
 
 ```bash
-# Get a shell into the Authentik server
 kubectl exec -n authentik deploy/authentik-server -it -- ak shell
 ```
 
 ```python
-# In the Django shell:
 from authentik.core.models import Token, TokenIntents, User
 user = User.objects.get(username="akadmin")
 token, created = Token.objects.get_or_create(
@@ -51,7 +68,7 @@ print(token.key)
 ```
 
 ```bash
-# List providers via API
+# List providers
 curl -s -H "Authorization: Bearer <token>" \
   http://192.168.55.211:9000/api/v3/providers/all/ | jq '.results[].name'
 
@@ -65,7 +82,7 @@ curl -s -H "Authorization: Bearer <token>" \
 ### Add Users and Groups
 
 ```bash
-# Create a user via API
+# Via API
 curl -s -X POST -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   http://192.168.55.211:9000/api/v3/core/users/ \
@@ -76,23 +93,20 @@ curl -s -H "Authorization: Bearer <token>" \
   http://192.168.55.211:9000/api/v3/core/groups/ | jq '.results[] | {name, pk}'
 ```
 
-Or use the Authentik admin UI at `http://192.168.55.211:9000/if/admin/` — it is often faster for one-off changes.
+Or use the Authentik admin UI at `http://192.168.55.211:9000/if/admin/` for one-off changes.
 
 ### Rotate Client Secrets
 
-When rotating an OIDC client secret for a service (e.g., Grafana):
+1. Generate a new secret in Authentik admin UI under the provider settings.
+2. Update the secret in Infisical.
+3. Force ESO resync: `kubectl annotate es <name> -n <ns> force-sync=$(date +%s) --overwrite`
+4. Restart the affected service.
 
-1. Generate a new secret in Authentik admin UI under the provider settings
-2. Update the secret in Infisical (the source of truth)
-3. Force ESO to resync: `kubectl annotate es <name> -n <ns> force-sync=$(date +%s) --overwrite`
-4. Restart the affected service to pick up the new secret
-
-> For Grafana specifically, the secret must be stored with key `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` in the Kubernetes Secret for `envFromSecret` to work.
+For Grafana specifically, the secret must be stored with key `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` for `envFromSecret` to work.
 
 ### Manage API Tokens
 
 ```bash
-# List API tokens via Django shell
 kubectl exec -n authentik deploy/authentik-server -it -- ak shell
 ```
 
@@ -102,17 +116,14 @@ for t in Token.objects.filter(intent="api"):
     print(f"{t.identifier}: {t.user.username} expires={t.expires}")
 ```
 
-## Debugging
+## Runbook
 
 ### OIDC Login Loop
 
 If a service redirects back and forth between the login page:
 
 ```bash
-# Check Authentik server logs for OIDC errors
 kubectl logs -n authentik deploy/authentik-server --tail=100 | grep -i "oauth\|oidc\|redirect"
-
-# Verify redirect URIs match exactly
 curl -s -H "Authorization: Bearer <token>" \
   http://192.168.55.211:9000/api/v3/providers/oauth2/ | jq '.results[] | {name, redirect_uris}'
 ```
@@ -122,11 +133,9 @@ Common causes:
 - `redirect_uris` must be a list in Authentik 2026.x API calls
 - Missing `invalidation_flow` in provider config (required in 2026.x)
 
-### Forward Auth Redirects to `0.0.0.0`
+### Forward Auth Redirects to 0.0.0.0
 
-If clicking a forward-auth-protected service (Longhorn, Hubble, Sympozium) redirects the browser to `http://0.0.0.0:9000/...` instead of `https://auth.frank.derio.net/...`:
-
-The embedded outpost does not know its own external URL. Set `AUTHENTIK_HOST` in the Helm values:
+The embedded outpost does not know its own external URL. Set `AUTHENTIK_HOST` in Helm values:
 
 ```yaml
 global:
@@ -135,26 +144,21 @@ global:
       value: "https://auth.frank.derio.net"
 ```
 
-After updating `apps/authentik/values.yaml`, ArgoCD will sync the change. Verify with:
+After updating `apps/authentik/values.yaml`, ArgoCD syncs the change. Verify:
 
 ```bash
-# Check that the env var is set on the server pods
 kubectl get deploy -n authentik authentik-server \
   -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTHENTIK_HOST")].value}'
 # Expected: https://auth.frank.derio.net
 
-# Test that forward-auth now redirects correctly
 curl -sk -o /dev/null -w "%{redirect_url}\n" https://longhorn.frank.derio.net/
-# Expected: https://auth.frank.derio.net/outpost.goauthentik.io/... (not 0.0.0.0)
+# Expected: https://auth.frank.derio.net/outpost.goauthentik.io/...
 ```
 
 ### Forward Auth 403
 
 ```bash
-# Check the forward auth outpost logs
 kubectl logs -n authentik -l app.kubernetes.io/component=outpost --tail=50
-
-# Verify the outpost can reach the Authentik server
 kubectl exec -n authentik -l app.kubernetes.io/component=outpost -- \
   curl -s http://authentik-server.authentik.svc:9000/api/v3/root/config/
 ```
@@ -164,9 +168,7 @@ kubectl exec -n authentik -l app.kubernetes.io/component=outpost -- \
 If Grafana shows "login error" after OIDC redirect:
 
 ```bash
-# Verify the secret key name in the K8s Secret
 kubectl get secret -n grafana grafana-oidc -o jsonpath='{.data}' | jq 'keys'
-
 # Must contain: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
 # NOT: client_secret or clientSecret
 ```
@@ -174,13 +176,18 @@ kubectl get secret -n grafana grafana-oidc -o jsonpath='{.data}' | jq 'keys'
 ### Token Validation Failures
 
 ```bash
-# Test the OIDC well-known endpoint
 curl -s http://192.168.55.211:9000/application/o/<provider-slug>/.well-known/openid-configuration | jq
-
-# Check token endpoint manually
 curl -s -X POST http://192.168.55.211:9000/application/o/token/ \
   -d "grant_type=client_credentials&client_id=<id>&client_secret=<secret>"
 ```
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|-----------------|------------------|-------------|
+| Authentik forward auth auto-resolves its external URL | The embedded outpost doesn't know its public URL — defaults to `0.0.0.0` in redirects | Forward auth redirects broke until `AUTHENTIK_HOST` was explicitly set in values. |
+| Grafana OIDC secret key matches Authentik's default naming | Grafana's `envFromSecret` expects `GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET` — not `client_secret` | Login errors until the Secret key was renamed. |
+| Authentik provider config is backwards-compatible across versions | 2026.x requires `invalidation_flow` and list-format `redirect_uris` | OIDC login loops until config was updated. |
 
 ## Quick Reference
 

--- a/blog/content/docs/operating/09-multi-tenancy/index.md
+++ b/blog/content/docs/operating/09-multi-tenancy/index.md
@@ -4,39 +4,53 @@ series: ["operating"]
 layer: tenant
 date: 2026-03-13
 draft: false
-tags: ["operations", "vcluster", "multi-tenancy"]
+tags: ["operations", "vcluster", "multi-tenancy", "troubleshooting"]
 summary: "Day-to-day commands for managing vCluster virtual clusters, checking tenant health, and debugging isolation issues."
 weight: 10
+reader_goal: "Create, connect to, and troubleshoot vCluster virtual clusters — check sync health, manage resource quotas, and debug API server or networking issues."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
+
+{{< last-updated >}}
 
 This is the operational companion to [Multi-tenancy — Disposable Kubernetes Clusters with vCluster]({{< relref "/docs/building/14-multi-tenancy" >}}). That post covers the architecture and template pattern. This one is the day-to-day runbook for creating, connecting to, and troubleshooting virtual clusters.
 
+Source your environment:
+
+```bash
+source .env
+```
+
 ## What "Healthy" Looks Like
 
-Multi-tenancy is healthy when all vCluster StatefulSets are running, each virtual cluster's API server is responding, and resources are syncing correctly between virtual and host clusters. The ArgoCD applications for each vCluster should show `Synced` and `Healthy`.
+Multi-tenancy is healthy when all vCluster StatefulSets are running, each virtual cluster's API server is responding, and resources are syncing correctly.
+
+### Verify
+
+```bash
+vcluster list
+kubectl get statefulset -A -l app=vcluster
+```
+
+All vClusters should show `STATUS: Running`. StatefulSets should show `READY: 1/1`.
 
 ## Observing State
 
 ### List Virtual Clusters
 
 ```bash
-# Using vcluster CLI
 vcluster list
-
-# Check vCluster pods on the host
 kubectl get pods -A -l app=vcluster
-
-# Check ArgoCD status for vCluster apps
 argocd app list --port-forward --port-forward-namespace argocd | grep vcluster
 ```
 
 ```console
 $ vcluster list
-  
-       NAME     |      NAMESPACE       | STATUS  | VERSION | CONNECTED | AGE  
+       NAME     |      NAMESPACE       | STATUS  | VERSION | CONNECTED | AGE
   --------------+----------------------+---------+---------+-----------+------
-    experiments | vcluster-experiments | Running | 0.32.1  |           | 39d  
-  
+    experiments | vcluster-experiments | Running | 0.32.1  |           | 39d
 
 $ kubectl get statefulset -A -l app=vcluster
 NAMESPACE              NAME          READY   AGE
@@ -46,24 +60,16 @@ vcluster-experiments   experiments   1/1     39d
 ### Connect to a Virtual Cluster
 
 ```bash
-# Connect and switch kubectl context
 vcluster connect <name> --namespace <namespace>
-
-# Verify you are in the virtual cluster
 kubectl get nodes
 kubectl get namespaces
-
-# Disconnect when done
 vcluster disconnect
 ```
 
 ### Check Synced Resources
 
 ```bash
-# From the host cluster, check what the syncer is doing
 kubectl logs -n <vcluster-namespace> <vcluster-pod> -c syncer --tail=50
-
-# Check resource sync status
 kubectl get pods -n <vcluster-namespace> -l vcluster.loft.sh/managed-by
 ```
 
@@ -71,86 +77,56 @@ kubectl get pods -n <vcluster-namespace> -l vcluster.loft.sh/managed-by
 
 ### Create a New Virtual Cluster
 
-New vClusters follow the template pattern:
-
-1. Copy the template values:
-```bash
-cp -r apps/vclusters/template/ apps/vclusters/<new-name>/
-```
-
-2. Customize `apps/vclusters/<new-name>/values.yaml` — set the name, resource quotas, and any specific configuration.
-
-3. Add the ArgoCD Application CR in `apps/root/templates/vcluster-<new-name>.yaml` following the existing pattern.
-
-4. Commit and push — ArgoCD picks it up automatically.
+1. Copy the template: `cp -r apps/vclusters/template/ apps/vclusters/<new-name>/`
+2. Customize `apps/vclusters/<new-name>/values.yaml` — name, resource quotas.
+3. Add ArgoCD Application CR in `apps/root/templates/vcluster-<new-name>.yaml`.
+4. Commit and push.
 
 ### Delete a Virtual Cluster
 
-Since `prune: false`, removing a vCluster requires manual cleanup:
+Since `prune: false`:
 
 ```bash
-# Delete the ArgoCD application
 argocd app delete vcluster-<name> --port-forward --port-forward-namespace argocd
-
-# Verify the namespace is cleaned up
 kubectl get ns <vcluster-namespace>
 ```
 
-Then remove the files from `apps/vclusters/<name>/` and `apps/root/templates/vcluster-<name>.yaml`.
+Then remove the files from `apps/vclusters/<name>/` and `apps/root/templates/`.
 
 ### Manage Resource Quotas
 
 ```bash
-# Check current quotas from inside the virtual cluster
 vcluster connect <name> --namespace <namespace>
 kubectl get resourcequota -A
-
-# Check host-level resource usage for the vCluster namespace
 vcluster disconnect
 kubectl top pods -n <vcluster-namespace>
 ```
 
-To adjust quotas, update the values in `apps/vclusters/<name>/values.yaml` and let ArgoCD sync.
-
-## Debugging
+## Runbook
 
 ### Virtual API Server Not Responding
 
 ```bash
-# Check the StatefulSet
 kubectl get statefulset -n <vcluster-namespace>
 kubectl describe statefulset -n <vcluster-namespace> <vcluster-name>
-
-# Check the PVC for the virtual etcd
 kubectl get pvc -n <vcluster-namespace>
-
-# Check pod logs
 kubectl logs -n <vcluster-namespace> <vcluster-pod> -c vcluster --tail=100
 ```
 
-Common causes:
-- PVC stuck pending (storage class issue)
-- Resource limits too low for the API server
-- Host node where the StatefulSet is scheduled is under pressure
+Common causes: PVC stuck pending, resource limits too low, host node under pressure.
 
 ### Resources Not Syncing
 
 ```bash
-# Check syncer logs for errors
 kubectl logs -n <vcluster-namespace> <vcluster-pod> -c syncer --tail=100 | grep -i error
-
-# Verify sync configuration in values.yaml
 kubectl get configmap -n <vcluster-namespace> -l app=vcluster -o yaml | grep -A 20 sync
 ```
 
 ### Resource Quota Exceeded
 
 ```bash
-# Connect to the virtual cluster and check
 vcluster connect <name> --namespace <namespace>
 kubectl describe resourcequota -A
-
-# Check which pods are consuming the most
 kubectl top pods -A --sort-by=memory
 vcluster disconnect
 ```
@@ -158,11 +134,8 @@ vcluster disconnect
 ### Network Connectivity Issues
 
 ```bash
-# Test DNS from inside the virtual cluster
 vcluster connect <name> --namespace <namespace>
 kubectl run test --image=busybox --rm -it --restart=Never -- nslookup kubernetes.default
-
-# Test connectivity to a host service
 kubectl run test --image=busybox --rm -it --restart=Never -- wget -qO- http://<host-service>
 vcluster disconnect
 ```

--- a/blog/content/docs/operating/10-media-generation/index.md
+++ b/blog/content/docs/operating/10-media-generation/index.md
@@ -4,12 +4,22 @@ series: ["operating"]
 layer: media
 date: 2026-03-14
 draft: false
-tags: ["operations", "comfyui", "gpu-switcher", "diffusion", "gpu", "time-sharing"]
+tags: ["operations", "comfyui", "gpu-switcher", "diffusion", "gpu", "time-sharing", "troubleshooting"]
 summary: "Day-to-day commands for managing GPU time-sharing between Ollama and ComfyUI, downloading models, and troubleshooting the media generation stack."
+reader_goal: "Switch GPU workloads between Ollama and ComfyUI, download diffusion models, and diagnose media-stack failures."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 11
 ---
 
+{{< last-updated >}}
+
 This is the operational companion to [Media Generation — ComfyUI and GPU Time-Sharing]({{< relref "/docs/building/16-media-generation" >}}). That post explains the architecture and deployment. This one covers the day-to-day workflow for switching GPU workloads, managing diffusion models, and troubleshooting.
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## What "Healthy" Looks Like
 
@@ -28,6 +38,21 @@ The media generation stack is healthy when:
 > outage); only **both** `gpu_timeshare` probes at `0` pages (`gpu-node-both-down`). Note:
 > `replicas: 1` alone does **not** prove media works — a running-but-broken ComfyUI (failed node
 > import) still reads `replicas_unavailable: 0`; the probe is the real signal.
+
+### Verify
+
+```bash
+# GPU Switcher dashboard responds
+curl -s -o /dev/null -w "%{http_code}" http://192.168.55.214:8080
+# Expected: 200
+
+# Only one GPU workload is active
+kubectl get pods -n ollama -o name 2>/dev/null | grep -c .; kubectl get pods -n comfyui -o name 2>/dev/null | grep -c .
+# One namespace should return 0, the other >= 1
+
+# ComfyUI probe (if active)
+curl -s http://192.168.55.213:8188/system_stats | python3 -m json.tool 2>/dev/null || echo "ComfyUI is not active"
+```
 
 ## Observing State
 
@@ -141,7 +166,7 @@ curl -s http://192.168.55.213:8188/system_stats | python3 -m json.tool
 curl -s http://192.168.55.213:8188/object_info/CheckpointLoaderSimple | python3 -m json.tool | head -30
 ```
 
-## Debugging
+## Runbook
 
 ### GPU Switcher Not Responding
 
@@ -225,6 +250,14 @@ LTX-2.3 needs 8-12GB of the 16GB VRAM. If loading multiple models or using high 
 ```bash
 kubectl delete pod -n comfyui -l app.kubernetes.io/name=comfyui
 ```
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| ArgoCD would manage replica counts for GPU-switched workloads | ArgoCD continuously reconciles to the Git-specified replica count, fighting the GPU Switcher | Added `ignoreDifferences` on `spec.replicas` to both ComfyUI and Ollama Application CRs |
+| A running ComfyUI pod proves media generation works | A pod can be Running with a failed custom-node import, serving nothing useful | Added the `KSampler` blackbox probe as the canonical health signal |
+| Both GPU workloads can share the node's single GPU | Kubernetes schedules each `nvidia.com/gpu: 1` request as a discrete resource — the second pod stays Pending | Adopted the time-sharing model: one workload active, the other at replicas: 0 |
 
 ## Quick Reference
 

--- a/blog/content/docs/operating/11-public-edge/index.md
+++ b/blog/content/docs/operating/11-public-edge/index.md
@@ -4,12 +4,22 @@ series: ["operating"]
 layer: edge
 date: 2026-03-20
 draft: false
-tags: ["operations", "hop", "talos", "headscale", "tailscale", "caddy", "edge"]
-summary: "Day-to-day commands for managing Hop — a standalone single-node Talos cluster on Hetzner Cloud with Headscale mesh, Caddy, and ArgoCD."
+tags: ["operations", "hop", "talos", "headscale", "tailscale", "caddy", "edge", "troubleshooting"]
+summary: "Day-to-day commands for managing Hop — a standalone single-node Talos cluster on Hetzner Cloud with Headscale mesh, Caddy, and ArgoCD — including troubleshooting, mesh operations, and emergency recovery procedures."
+reader_goal: "Manage Hop's Tailscale mesh, Caddy ingress, Talos upgrades, and recover from single-node failures."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 12
 ---
 
+{{< last-updated >}}
+
 This is the operational companion to [Hopping Through the Portal]({{< relref "/docs/building/17-public-edge" >}}). That post covers the deployment story and the ten deviations. This one covers the commands you actually type to manage Hop — a very different operational profile from Frank.
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## Key Differences from Frank
 
@@ -25,6 +35,22 @@ Hop is a single-node, standalone-talosctl cluster. Almost everything about its o
 | **Remote access** | LAN only | Tailscale mesh + public endpoints |
 
 The critical operational difference: **Hop has no redundancy.** A node reboot means all services are down. A botched Talos upgrade means you're rebuilding from the Packer snapshot. Treat Hop as a pet, not cattle.
+
+### Verify
+
+```bash
+# Talos health
+talosctl -n $HOP_IP health 2>&1 | grep -c "OK$"
+# Expected: all checks report OK
+
+# Kubernetes node
+kubectl get nodes
+# hop-1 should be Ready
+
+# ArgoCD applications
+argocd app list --port-forward --port-forward-namespace argocd 2>/dev/null | grep -c "Healthy"
+# All apps should show Healthy
+```
 
 ## Environment Setup
 
@@ -602,6 +628,15 @@ kubectl --kubeconfig clusters/hop/talosconfig/kubeconfig get pods -A
 ```
 
 TCP 6443 and 50000 are open on the Hetzner firewall specifically for this scenario. Both require client certificates from the talosconfig/kubeconfig — unauthenticated access is impossible.
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| RollingUpdate works on a single-node cluster | The new pod can't bind host ports 80/443 while the old pod holds them, deadlocking the rollout | Switched Caddy to `strategy: Recreate`, accepting ~5s downtime on restarts |
+| Talos upgrades are zero-downtime with a single node | Every pod stops during the reboot — there's no second node to absorb traffic | Documented expected 3-5 minute downtime; treating Hop as a pet, not cattle |
+| `localhost` resolves to IPv4 in Alpine containers | In Alpine, `localhost` resolves to `::1` first, and Headplane binds IPv4 only | Used `127.0.0.1` explicitly in all health checks and documentation |
+| Secret changes propagate to running pods automatically | Environment variables from `secretKeyRef` are injected at pod creation and never refreshed | Added explicit `rollout restart` steps to every secret rotation procedure |
 
 ## References
 

--- a/blog/content/docs/operating/12-progressive-delivery/index.md
+++ b/blog/content/docs/operating/12-progressive-delivery/index.md
@@ -4,14 +4,24 @@ series: ["operating"]
 layer: deploy
 date: 2026-03-27
 draft: false
-tags: ["operations", "argo-rollouts", "canary", "blue-green", "litellm", "sympozium"]
-summary: "Day-to-day commands for managing Argo Rollouts — promoting canary steps, switching blue-green, inspecting analysis results, and handling sparse-traffic pauses."
+tags: ["operations", "argo-rollouts", "canary", "blue-green", "litellm", "sympozium", "troubleshooting"]
+summary: "Day-to-day commands for managing Argo Rollouts — promoting canary steps, switching blue-green, inspecting analysis results, troubleshooting stuck rollouts, and handling sparse-traffic pauses."
+reader_goal: "Promote Argo Rollouts through canary and blue-green steps and recover from stuck or failed states."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 13
 ---
+
+{{< last-updated >}}
 
 This is the operational companion to [Progressive Delivery with Argo Rollouts]({{< relref "/docs/building/19-progressive-delivery" >}}). That post explains the architecture and deployment. This one is the day-to-day runbook for promoting rollouts, interpreting analysis results, and recovering from stuck or failed states.
 
 > **Update: 2026-05-04** — The litellm canary sections were rewritten twice in one day. First rewrite was for the replica-count canary with `AnalysisRun` between each pause. Second rewrite is for **pause-only canary** (no AnalysisRun) — because the AnalysisTemplate referenced a metric (`litellm_request_total`) that doesn't exist on this cluster (LiteLLM's Prometheus integration is an Enterprise-paid feature; the OSS image we run doesn't emit it). All sample outputs below are now real captured output from the 2026-05-04 rehearsal, not typed-up reconstructions of expected shape. The sympozium blue-green sections are unchanged. Full postmortem with all five latent bugs in the [building post]({{< relref "/docs/building/19-progressive-delivery#update-2026-05-04--the-canary-that-wasnt" >}}). The Path B spec for restoring metric-gated promotion is at `docs/superpowers/specs/2026-05-04--deploy--litellm-canary-metric-source-design.md`.
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## What "Healthy" Looks Like
 
@@ -20,6 +30,22 @@ The progressive delivery stack is healthy when:
 - LiteLLM Rollout shows `Status: Healthy` with **5/5 pods Ready** under one ReplicaSet (the current stable). `Step` is *not* shown — at-rest Rollouts have no current step
 - Sympozium Rollout shows `Status: Healthy` with the active service serving at `192.168.55.207:8080`
 - No `Degraded` or `Paused` rollouts exist (unless you're mid-rollout)
+
+### Verify
+
+```bash
+# Controller is running
+kubectl get pods -n argo-rollouts
+# Expected: argo-rollouts pod Running
+
+# All rollouts are healthy
+kubectl get rollout -A
+# No Degraded or unexpected Paused rollouts
+
+# Controller log is clean
+kubectl logs -n argo-rollouts deploy/argo-rollouts --tail=20 | grep -ciE "error|fail"
+# Expected: 0, or only benign startup lines
+```
 
 ## Observing State
 
@@ -305,6 +331,14 @@ kubectl get cm argo-rollouts-config -n argo-rollouts -o yaml | grep -A 3 traffic
 #    a vanilla RollingUpdate, not a canary. Check:
 kubectl get deploy -n <ns> -l app.kubernetes.io/name=<app> -o wide
 ```
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| The Cilium traffic-router plugin would work with our cluster config | The controller got stuck at Step 0/6 for 39 days, unable to advance reconciliation | Removed the plugin entirely and fell back to replica-count canary |
+| LiteLLM's OSS image exposes Prometheus metrics for analysis | The `litellm_request_total` metric is an Enterprise-paid feature — the OSS image doesn't emit it | Converted to a pause-only canary with no AnalysisRun; metric-gated promotion deferred to Path B |
+| `maxSurge: 25%` doesn't affect pod count at intermediate steps | At SetWeight 50, the controller stages 3 canary + 3 stable pods (6 total), not the expected 5 | Documented the 6-pod transient as expected behavior |
 
 ## References
 

--- a/blog/content/docs/operating/13-workflow-automation/index.md
+++ b/blog/content/docs/operating/13-workflow-automation/index.md
@@ -4,12 +4,22 @@ series: ["operating"]
 layer: auto
 date: 2026-03-29
 draft: false
-tags: ["operations", "n8n", "workflow", "automation", "postgresql"]
+tags: ["operations", "n8n", "workflow", "automation", "postgresql", "troubleshooting"]
 summary: "Day-to-day commands for managing n8n instances — health checks, database operations, adding new instances, upgrading, and common issues."
+reader_goal: "Check n8n health, connect to PostgreSQL, add new instances, and fix common workflow automation issues."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 14
 ---
 
+{{< last-updated >}}
+
 This is the operational companion to [Workflow Automation with n8n]({{< relref "/docs/building/20-workflow-automation" >}}). That post explains the architecture and deployment. This one is the day-to-day runbook for checking health, managing the database, adding instances, and troubleshooting.
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## What "Healthy" Looks Like
 
@@ -19,6 +29,22 @@ A healthy n8n instance has:
 - The LoadBalancer Service showing the assigned external IP
 - The `/healthz` endpoint returning 200
 - Metrics flowing at `/metrics`
+
+### Verify
+
+```bash
+# Pod health
+kubectl -n n8n-01 get pods
+# Expected: both pods 1/1 Running
+
+# HTTP health endpoint
+curl -s -o /dev/null -w "%{http_code}" http://192.168.55.216:5678/healthz
+# Expected: 200
+
+# ArgoCD sync status
+argocd app get n8n-01 --server 192.168.55.200 --insecure 2>/dev/null | grep -E "Health|Sync"
+# Expected: Healthy, Synced
+```
 
 ## Observing State
 
@@ -223,6 +249,14 @@ Check that `WEBHOOK_URL` is set correctly in the deployment env. n8n uses this t
 ```bash
 kubectl -n n8n-01 get deploy n8n-01 -o jsonpath='{.spec.template.spec.containers[0].env}' | python3 -m json.tool | grep -A1 WEBHOOK
 ```
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| Bitnami PostgreSQL chart defaults work with our existing-secret setup | The `existingSecret` key names differ between what we provided and what Bitnami expects (`postgres-password` vs `password`) | Debugged connection-refused errors and aligned the secret key names |
+| One n8n instance can serve all team workflows | Different teams need isolated environments, credential sets, and webhook URLs | Added the instance duplication guide and per-instance namespace pattern |
+| n8n's secure cookie mode works over plain HTTP | n8n refuses to set secure cookies on non-TLS connections, breaking session-based features | Added `N8N_SECURE_COOKIE: "false"` to the deployment env until TLS is configured |
 
 ## References
 

--- a/blog/content/docs/operating/14-secure-agent-pod/index.md
+++ b/blog/content/docs/operating/14-secure-agent-pod/index.md
@@ -4,12 +4,22 @@ series: ["operating"]
 layer: agents
 date: 2026-03-31
 draft: false
-tags: ["operations", "security", "agent", "claude", "ssh", "vibekanban", "cilium", "cron", "telegram", "monitoring"]
+tags: ["operations", "security", "agent", "claude", "ssh", "vibekanban", "cilium", "cron", "telegram", "monitoring", "troubleshooting"]
 summary: "Day-to-day commands for managing the secure agent pod — SSH access, process health, VibeKanban, secret rotation, and troubleshooting."
+reader_goal: "SSH and mosh into the secure agent pod, manage secrets, monitor cron health, and troubleshoot connectivity."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 15
 ---
 
+{{< last-updated >}}
+
 This is the operational companion to [Secure Agent Pod — Hardening an AI Coding Workstation]({{< relref "/docs/building/21-secure-agent-pod" >}}). That post explains the architecture and security model. This one is the day-to-day runbook.
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## What "Healthy" Looks Like
 
@@ -20,6 +30,21 @@ A healthy secure-agent-pod has:
 - mosh accessible on UDP `192.168.55.219:60000-60015`
 - VibeKanban UI accessible at `192.168.55.218:8081` (served by the `vk-local` sidecar)
 - All running as UID 1000 (`claude`), no root
+
+### Verify
+
+```bash
+# Pod is running with both containers
+kubectl -n secure-agent-pod get pods -o wide
+# Expected: 2/2 Ready on gpu-1
+
+# SSH responds
+ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no claude@192.168.55.215 echo "SSH OK" 2>/dev/null
+
+# VibeKanban serves UI
+curl -s -o /dev/null -w "%{http_code}" http://192.168.55.218:8081
+# Expected: 200
+```
 
 ## Observing State
 
@@ -604,6 +629,14 @@ Environment variables are set at container start. After changing a Secret:
 ```bash
 kubectl rollout restart deployment/secure-agent-pod -n secure-agent-pod
 ```
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| `wait -n` is sufficient for process supervision in the container | A SIGHUP to one child propagated to the whole process group, killing sshd, mosh, and tmux along with the cron job | Migrated to s6-overlay with signal-isolated supervision per service |
+| mosh-server ports always land within the published LoadBalancer range | Without `-p` constraint, mosh-server picks uniformly from 60000-61000 — a ~1.6% hit rate against the 16 published ports | Added the `--server='mosh-server new -p 60000:60015'` constraint |
+| SSH-launched scripts inherit the container's K8s environment | sshd scrubs the login environment, so `kubectl exec`-only env vars like `FRANK_C2_TELEGRAM_*` are missing | Documented the `kubectl exec` not SSH rule for reconcile scripts |
 
 ## References
 

--- a/blog/content/docs/operating/15-health-monitoring/index.md
+++ b/blog/content/docs/operating/15-health-monitoring/index.md
@@ -4,12 +4,22 @@ series: ["operating"]
 layer: obs
 date: 2026-04-04
 draft: false
-tags: ["operations", "observability", "blackbox-exporter", "pushgateway", "grafana", "telegram", "alerting"]
-summary: "Day-to-day commands for managing feature health probes, heartbeat metrics, Grafana alerts, and Telegram notifications."
+tags: ["operations", "observability", "blackbox-exporter", "pushgateway", "grafana", "telegram", "alerting", "troubleshooting"]
+summary: "Day-to-day commands for managing feature health probes, heartbeat metrics, Grafana alerts, Telegram notifications, and troubleshooting alerting issues."
+reader_goal: "Check probe status, inspect heartbeat metrics, edit Grafana alert rules, and verify Telegram notifications."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 16
 ---
 
+{{< last-updated >}}
+
 Companion to [Health Monitoring — Feature Probes, Heartbeats, and Telegram Alerts]({{< relref "/docs/building/22-health-monitoring" >}}).
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## Quick Reference
 
@@ -19,6 +29,22 @@ Companion to [Health Monitoring — Feature Probes, Heartbeats, and Telegram Ale
 | Pushgateway | monitoring | 9091 | Heartbeat metric ingestion |
 | Grafana | monitoring | 3000 (LB: 192.168.55.203) | Dashboards + alerting |
 | Feature Health Dashboard | — | — | `/d/fh-overview/feature-health` |
+
+### Verify
+
+```bash
+# Monitoring pods are running
+kubectl get pods -n monitoring -l 'app in (blackbox-exporter,pushgateway)'
+# Expected: all 1/1 Running
+
+# Grafana is reachable
+curl -s -o /dev/null -w "%{http_code}" https://grafana.frank.derio.net 2>/dev/null
+# Expected: 200 or 302
+
+# Pushgateway is ingesting metrics
+curl -s http://localhost:9091/metrics 2>/dev/null | grep -c "willikins_heartbeat"
+# Expected: > 0 (heartbeat metrics from active cron jobs)
+```
 
 ## Checking Probe Status
 
@@ -233,6 +259,14 @@ kubectl rollout restart deployment -n monitoring victoria-metrics-operator
 - Verify datasource UID is `P4169E866C3094E38`
 - Table panels require `"format": "table"` on targets
 - `ALERTS{}` metric doesn't exist for Grafana-managed alerts — use `alertlist` panel type
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| `ALERTS{}` metric exists for Grafana-managed alerts | Grafana-managed alerts don't expose an `ALERTS` metric — only Prometheus-compatible rules do | Switched to `alertlist` panel type for the Feature Health dashboard |
+| API-provisioned alerting rules are easy to maintain at scale | Every change required a curl command with auth headers, and mistakes were easy to make | Migrated to file-provisioned alerting via ConfigMaps, read-only in the UI |
+| Pod readiness is a reliable proxy for feature health | A pod can be Running but its service can be broken (failed node import, hung worker) | Added Blackbox Exporter probes as the canonical health signal per layer |
 
 ## References
 

--- a/blog/content/docs/operating/16-health-bridge/index.md
+++ b/blog/content/docs/operating/16-health-bridge/index.md
@@ -4,12 +4,22 @@ series: ["operating"]
 layer: obs
 date: 2026-04-04
 draft: false
-tags: ["operations", "observability", "grafana", "github", "go", "alerting"]
+tags: ["operations", "observability", "grafana", "github", "go", "alerting", "troubleshooting"]
 summary: "Day-to-day commands for managing the health-bridge service — checking status, testing webhooks, managing alert labels, and troubleshooting GitHub API issues."
+reader_goal: "Test the health-bridge webhook, manage alert rule labels, verify GitHub integration, and recover stranded tiles."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 17
 ---
 
+{{< last-updated >}}
+
 Companion to [Health Bridge — Closing the Loop from Grafana Alerts to GitHub Issues]({{< relref "/docs/building/23-health-bridge" >}}).
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## Quick Reference
 
@@ -19,6 +29,22 @@ Companion to [Health Bridge — Closing the Loop from Grafana Alerts to GitHub I
 | Webhook endpoint | — | — | `POST /webhook` (Bearer auth) |
 | Health check | — | — | `GET /healthz` |
 | Readiness check | — | — | `GET /readyz` |
+
+### Verify
+
+```bash
+# Pod is running
+kubectl get pods -n monitoring -l app=health-bridge
+# Expected: 1/1 Running
+
+# Health endpoint responds
+kubectl exec -n monitoring deploy/health-bridge -- wget -qO- http://localhost:8080/healthz 2>/dev/null
+# Expected: {"status":"ok"}
+
+# Project metadata is loaded
+kubectl logs -n monitoring -l app=health-bridge --tail=5 | grep "Loaded project metadata"
+# Expected: "Loaded project metadata: id=..."
+```
 
 ## Checking Service Status
 
@@ -403,6 +429,14 @@ curl -sS -X POST http://127.0.0.1:18080/webhook \
   -H "Authorization: Bearer ${SECRET}" -H "Content-Type: application/json" \
   -d "${payload}"
 ```
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| A single webhook delivery guarantees the bridge has the full alerting state | When Grafana is replaced mid-incident, the new process never fires the alert and never sends resolved | Added the manual recovery procedure for stranded tiles and bugs |
+| Title-only matching is sufficient for auto-closing bugs | Layers sharing a `DatasourceError` alertname would cross-close each other's issues | Added the `**Feature Issue:**` body ref to matching (strict two-condition close) |
+| In-memory dedup survives pod restarts | After a bridge restart, the dedup cache is empty, letting duplicate bug issues through | Added the GitHub search safety net as a second line of defense |
 
 `alertname: DatasourceError` is the key: it makes the bridge match the `[Bug] DatasourceError is dead` titles for the create-era bugs, while the feature-ref close (v0.4.0) handles anything titled differently. The whole thing is idempotent — re-running on already-healthy tiles with no open bugs is a no-op. Verify with `kubectl logs -n monitoring -l app=health-bridge --tail=40 | grep -E 'Closed bug|→ healthy'`.
 

--- a/blog/content/docs/operating/17-ingress/index.md
+++ b/blog/content/docs/operating/17-ingress/index.md
@@ -4,12 +4,22 @@ series: ["operating"]
 layer: net
 date: 2026-04-08
 draft: false
-tags: ["networking", "traefik", "ingress", "tls", "acme", "authentik", "homepage", "operations"]
-summary: "Day-to-day commands for managing Traefik ingress, ACME certificates, IngressRoutes, Authentik forward-auth, and the Homepage dashboard."
+tags: ["networking", "traefik", "ingress", "tls", "acme", "authentik", "homepage", "operations", "troubleshooting"]
+summary: "Day-to-day commands for managing Traefik ingress, ACME certificates, IngressRoutes, Authentik forward-auth, the Homepage dashboard, and troubleshooting common failures."
+reader_goal: "Verify Traefik TLS certificates, add IngressRoutes, manage Authentik forward-auth, and debug routing issues."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 18
 ---
 
+{{< last-updated >}}
+
 Companion operations guide for [In-Cluster Ingress — Traefik, Wildcard TLS, and a Homepage Dashboard]({{< relref "/docs/building/24-in-cluster-ingress" >}}).
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## Quick Health Check
 
@@ -25,6 +35,22 @@ kubectl get applications -n argocd traefik traefik-extras homepage
 
 # ACME cert file size (should be >3KB if cert is issued)
 kubectl exec -n traefik-system deploy/traefik -- ls -la /data/acme.json
+```
+
+### Verify
+
+```bash
+# Traefik pod is running
+kubectl get pods -n traefik-system -o wide
+# Expected: traefik pod Running
+
+# TLS certificate is valid
+curl -sI https://argocd.cluster.derio.net 2>&1 | head -5
+# Should show HTTP/2 200 or 302 with valid TLS
+
+# ACME cert file is populated
+kubectl exec -n traefik-system deploy/traefik -- ls -la /data/acme.json
+# File size should be > 3 KB
 ```
 
 ## ACME Certificate
@@ -204,6 +230,15 @@ The SOPS-encrypted secret is in `secrets/traefik-cloudflare-credentials.yaml`. T
 ```bash
 sops --decrypt secrets/traefik-cloudflare-credentials.yaml | kubectl apply -f -
 ```
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| Default ACME propagation delay is always sufficient | Let's Encrypt sometimes validates faster than DNS propagates, causing `NXDOMAIN` failures | Increased `propagation.delayBeforeChecks` to 60s |
+| Creating an Authentik provider is enough to enable forward-auth | The provider must also be explicitly assigned to the Embedded Outpost before it routes requests | Added the outpost assignment step to every new-service procedure |
+| Homepage picks up ConfigMap changes without a restart | ArgoCD syncs the ConfigMap, but the running pod doesn't reload it automatically | Added `kubectl rollout restart deploy/homepage` to every ConfigMap change workflow |
+| ClusterIP services respond to ICMP ping | Kubernetes doesn't route ICMP to ClusterIP services — `ping` always fails | Used `siteMonitor` (HTTP health check) for all Homepage service monitors |
 
 ## References
 

--- a/blog/content/docs/operating/18-paperclip/index.md
+++ b/blog/content/docs/operating/18-paperclip/index.md
@@ -4,12 +4,22 @@ series: ["operating"]
 layer: orch
 date: 2026-04-09
 draft: false
-tags: ["operations", "paperclip", "ai-agents", "postgresql", "gpu-1"]
-summary: "Day-to-day commands for managing Paperclip — checking pod health, database operations, secret sync, and handling the RWO PVC constraint."
+tags: ["operations", "paperclip", "ai-agents", "postgresql", "gpu-1", "troubleshooting"]
+summary: "Day-to-day commands for managing Paperclip — checking pod health, database operations, secret sync, troubleshooting, and handling the RWO PVC constraint."
+reader_goal: "Check Paperclip pod health, access the database, manage secrets, and handle RWO PVC deployment constraints."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 19
 ---
 
+{{< last-updated >}}
+
 This is the operational companion to [Paperclip — AI Agent Orchestrator]({{< relref "/docs/building/15-paperclip" >}}). That post explains the architecture and deployment. This one covers health checks, database access, secret management, and common failure modes.
+
+```bash
+source .env   # sets KUBECONFIG
+```
 
 ## What "Healthy" Looks Like
 
@@ -23,6 +33,22 @@ Paperclip is healthy when:
 Paperclip is pinned to gpu-1 (`nodeSelector: kubernetes.io/hostname: gpu-1`) with a defensive `nvidia.com/gpu:NoSchedule` toleration. It does not request a GPU — gpu-1 is the cluster's biggest CPU/RAM box (128GB, ~20% requested) and absorbs the 12Gi memory limit without crowding the core-zone control-plane minis. See the building post's *Memory Tuning and the Move to gpu-1* section for the history.
 
 {{< screenshot src="paperclip-dashboard.png" caption="Paperclip dashboard: the control plane's view of registered agents and recent runs" >}}
+
+### Verify
+
+```bash
+# All-in-one status
+kubectl get pods,pvc,externalsecret -n paperclip-system
+# Expected: paperclip pod on gpu-1, paperclip-db pod, PVCs Bound, ExternalSecrets Synced
+
+# Web UI responds
+curl -s -o /dev/null -w "%{http_code}" http://192.168.55.212:3100/
+# Expected: 200 or 403 (private mode)
+
+# Database is reachable
+kubectl exec -n paperclip-system deploy/paperclip -- pg_isready -h paperclip-db-postgresql 2>/dev/null
+# Expected: accepts connections
+```
 
 Quick health check:
 
@@ -346,6 +372,15 @@ Adding to the inventory (medium loop):
 ```
 
 The vast majority of "I want tool X" requests resolve to the inventory. Bumping the image is the right answer when the user is reaching for a *new manager* or for behaviour that needs to run before sshd starts. If you're not sure, default to inventory — promotion to image is always available later, and the inventory loop is faster.
+
+## Missteps
+
+| What we assumed | Why it was wrong | What it cost |
+|----------------|-----------------|-------------|
+| RollingUpdate works with ReadWriteOnce PVCs | The new pod can't mount the RWO volume while the old pod holds it, deadlocking the rollout | Switched to `strategy: Recreate`, accepting brief downtime on restarts |
+| Default resource limits are sufficient for Paperclip | Paperclip's working set under load is much larger than 1Gi — it OOM-killed repeatedly | Bumped memory limit to 12Gi and moved the workload to gpu-1 (128GB RAM) |
+| SSH-launched tool reconciliation preserves the container environment | sshd scrubs env vars from `envFrom` at login, so Telegram alerts never fire on failure | Documented the `kubectl exec` rule for running `paperclip-shell-reconcile` |
+| Upstream Paperclip publishes semver image tags | Upstream only publishes `latest` and `sha-<short>` tags — no semver | Pin by `sha-<short>` tag that maps to a known git tag |
 
 ## References
 

--- a/blog/content/docs/operating/19-git-credentials-without-a-shell/index.md
+++ b/blog/content/docs/operating/19-git-credentials-without-a-shell/index.md
@@ -1,13 +1,18 @@
 ---
 title: "Git Credentials Without a Shell"
-series: ["operating"]
+series: [operating]
 layer: agents
 date: 2026-04-11
 draft: false
-tags: ["operations", "secure-agent-pod", "git", "kubernetes", "secrets", "credentials"]
-summary: "Why $GITHUB_TOKEN is set in your terminal but missing in VS Code's git — and a credential helper that fixes it permanently by reading /proc/1/environ."
+tags: [operations, secure-agent-pod, git, kubernetes, secrets, credentials, troubleshooting]
+summary: "Why $GITHUB_TOKEN is set in your terminal but missing in VS Code's git — and a credential helper that fixes it permanently by reading /proc/1/environ. Covers troubleshooting the missing-credential symptom across VS Code, cron, and non-interactive shells."
+reader_goal: "Fix silent git auth failures in SSH sessions and VS Code by deploying a credential helper that reads /proc/1/environ instead of relying on inherited environment variables."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 20
 ---
+{{< last-updated >}}
 
 The symptom is weird: you ssh into the secure-agent-pod, run `git push`, and it works. You open the VS Code source control panel in the same session, click Sync, and get:
 
@@ -17,6 +22,11 @@ fatal: Authentication failed for 'https://github.com/.../...'
 ```
 
 Same pod, same user, same repo. What's different?
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## Where the token actually lives
 
@@ -82,11 +92,40 @@ Strictly more secure than the env-var approach. Three reasons:
 
 Token rotation works the same as the env-var version: ESO updates the K8s Secret, you restart the pod, PID 1 gets the new value, the helper starts returning it.
 
+### Verify
+
+Confirm the credential helper works end-to-end:
+
+```bash
+# Git push should succeed without GITHUB_TOKEN in env
+unset GITHUB_TOKEN
+git push --dry-run
+
+# The helper reads the token from /proc/1/environ directly
+kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- \
+  git config --get credential.helper | grep -q /proc/1/environ && echo "helper active"
+```
+
+Expected: `git push` authenticates without prompting; the helper path is active.
+
+
 ## Caveats
 
 - **Linux only.** `/proc/1/environ` doesn't exist on macOS or Windows. Not a concern for containers, but worth noting if you copy the helper to a laptop.
 - **PID 1 must run as your uid.** If your entrypoint runs as root and drops privileges to a non-root user, `/proc/1/environ` becomes root-only and the helper fails with EACCES. The secure-agent-pod entrypoint runs as uid 1000 throughout.
 - **Env is frozen at container start.** If ESO refreshes the Secret while the pod is running, `/proc/1/environ` still shows the old value. You have to restart the pod. This is standard Kubernetes behaviour, not specific to this helper.
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| SSH sessions inherit PID 1's environment variables | OpenSSH builds a fresh environment per session from /etc/environment and PAM — it does not inherit env from the container entrypoint | Hours debugging silent git auth failures across VS Code, cron, and non-interactive shells before tracing the root cause to env inheritance |
+| A .bashrc workaround is sufficient for all git operations | VS Code's git and cron jobs do not source .bashrc, so the token is still missing in those contexts | Repeated auth failures in VS Code and automated tasks until the /proc/1/environ credential helper was deployed |
+| Exporting GITHUB_TOKEN in the shell is the standard Kubernetes pattern and is secure enough | Exporting the token pollutes every child process, can leak via env/ps/shell history, and forces every interactive shell to carry credentials it doesn't need | Larger credential surface area; the /proc/1/environ approach is strictly more secure with no leakage |
+| PID 1 always runs as the same user as the credential helper | If the entrypoint runs as root and drops privileges, /proc/1/environ becomes root-only and the helper fails with EACCES | Required a design constraint that the secure-agent-pod entrypoint runs as uid 1000 throughout, limiting deployment flexibility |
 
 ## References
 

--- a/blog/content/docs/operating/20-vk-relay/index.md
+++ b/blog/content/docs/operating/20-vk-relay/index.md
@@ -1,15 +1,25 @@
 ---
 title: "Operating on VK Relay"
-series: ["operating"]
+series: [operating]
 layer: agents
 date: 2026-04-13
 draft: false
-tags: ["operations", "agents", "vibekanban", "relay", "websocket", "troubleshooting"]
-summary: "Day-to-day commands for the VK relay server — health checks, tunnel status, re-pairing, and troubleshooting the browser-to-agent connection."
+tags: [operations, agents, vibekanban, relay, websocket, troubleshooting]
+summary: "Day-to-day commands for the VK relay server — health checks, tunnel status, re-pairing, and troubleshooting the browser-to-agent connection. Includes troubleshooting for 502s, pairing-code rejection, and silent tunnel failures."
+reader_goal: "Verify VK relay health, re-pair the browser-to-agent tunnel, and troubleshoot the most common connection failures from relay logs and endpoint status codes."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 21
 ---
+{{< last-updated >}}
 
 This is the operational companion to [VK Relay — Tunneling the Browser to a Local Agent Server]({{< relref "/docs/building/25-vk-relay" >}}). That post explains the architecture and deployment. This one is the day-to-day runbook.
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## What "Healthy" Looks Like
 
@@ -19,6 +29,21 @@ A healthy VK relay setup has:
 - The `/v1/relay/` path reachable through Traefik at `vk.cluster.derio.net`
 - The local VK server in the secure-agent-pod connected via WebSocket tunnel
 - Browser paired and able to view workspace data through the remote UI
+
+### Verify
+
+Quick one-liner to confirm the relay is reachable and the tunnel is up:
+
+```bash
+# Relay endpoint returns 401 (JWT required — that means it's alive)
+curl -s -o /dev/null -w "%{http_code}" https://vk.cluster.derio.net/v1/relay/connect
+
+# Both relay-server and vk-remote containers are Ready
+kubectl -n agents get pods -l app=vk-remote -o jsonpath='{.items[0].status.containerStatuses[*].ready}'
+```
+
+Expected: `401` from curl, `true true` from the pod status.
+
 
 ## Observing State
 
@@ -160,6 +185,18 @@ argocd app get vk-remote --port-forward --port-forward-namespace argocd
 # Force sync if needed
 argocd app sync vk-remote --port-forward --port-forward-namespace argocd
 ```
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| The relay WebSocket tunnel auto-recovers from pod restarts without re-pairing | Browser IndexedDB state is ephemeral — clearing storage or switching devices loses the pairing code, requiring a full re-pair flow | Multiple support cycles debugging 'remote UI empty' before documenting the re-pairing procedure |
+| A single port-forward is enough to test the relay end-to-end | Port-forward only tests the local VK server, not the Traefik IngressRoute or TLS termination — the relay path through vk.cluster.derio.net has additional failure modes (JWT auth, Cilium egress policies) | False-positive health checks that passed locally but failed in production until the curl-against-Ingress test was added |
+| The relay-server sidecar would log connection state at startup unconditionally | Relay logs only show active connections; a silent failure (pod up but tunnel not established) produces no log output until someone tries to pair | Extended debug time for tunnel failures, leading to the addition of explicit reachability checks in the runbook |
+| Sourcing .env on any workstation gives you the correct KUBECONFIG for relay debugging | The relay spans both Frank (pod) and the workstation (browser); .env only targets Frank — diagnosing browser-side issues requires local VK server access | Time wasted checking the wrong cluster before the dual-context testing pattern was documented |
 
 ## References
 

--- a/blog/content/docs/operating/21-vk-remote/index.md
+++ b/blog/content/docs/operating/21-vk-remote/index.md
@@ -1,15 +1,25 @@
 ---
 title: "Operating on VK Remote"
-series: ["operating"]
+series: [operating]
 layer: agents
 date: 2026-04-13
 draft: false
-tags: ["operations", "agents", "vibekanban", "postgresql", "electricsql", "troubleshooting"]
-summary: "Day-to-day commands for the self-hosted VK Remote stack — PostgreSQL health, ElectricSQL sync status, API verification, and troubleshooting."
+tags: [operations, agents, vibekanban, postgresql, electricsql, troubleshooting]
+summary: "Day-to-day commands for the self-hosted VK Remote stack — PostgreSQL health, ElectricSQL sync status, API verification, and troubleshooting. Includes troubleshooting for ElectricSQL sync failures, init-job crashes, and Authentik SSO loops."
+reader_goal: "Verify PostgreSQL replication health, check ElectricSQL sync status, and troubleshoot the self-hosted VK Remote stack when kanban boards stop updating."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 22
 ---
+{{< last-updated >}}
 
 This is the operational companion to [VK Remote — Self-Hosting the Kanban Backend Before the Cloud Dies]({{< relref "/docs/building/26-vk-remote-self-host" >}}). That post explains the architecture and deployment. This one is the day-to-day runbook.
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## What "Healthy" Looks Like
 
@@ -20,6 +30,21 @@ A healthy VK Remote stack has:
 - vk-remote responding on port 8081 with a healthy API
 - The init Job (`postgres-vk-init-electric`) in Completed state
 - Browser access working at `https://vk.cluster.derio.net` through Authentik SSO
+
+### Verify
+
+Quick health check for the three-component stack:
+
+```bash
+# All three pods Running
+kubectl -n agents get pods -l 'app in (postgres-vk, electric, vk-remote)' -o jsonpath='{range .items[*]}{.status.phase}{" "}{end}'
+
+# PostgreSQL WAL level is logical
+kubectl -n agents exec deploy/postgres-vk -- psql -U remote -d remote -tAc "SHOW wal_level"
+```
+
+Expected: all pods `Running`; WAL level printed as `logical`.
+
 
 ## Observing State
 
@@ -266,6 +291,18 @@ argocd app get vk-remote --port-forward --port-forward-namespace argocd
 # Force sync if needed
 argocd app sync vk-remote --port-forward --port-forward-namespace argocd
 ```
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| ElectricSQL auto-reconnects to the replication stream after any PostgreSQL restart | If the `electric` PG role is missing (e.g., init job failed silently), ElectricSQL starts but syncs nothing — no error, no logs, just empty kanban boards | Days of intermittent 'works on my cluster' bugs before adding the pg_replication_slots check to the runbook |
+| The init job only needs to run once on first deploy | PVC replacement or namespace re-creation wipes the `electric` role; the init job is a Job, not a CronJob, so it doesn't re-fire automatically | Manual job re-triggering during recovery until the procedure was documented |
+| PostgreSQL WAL level `logical` survives a StatefulSet rebuild | Bitnami charts reset wal_level to `replica` on fresh install — ElectricSQL cannot connect without `logical` | DB rebuild required manual ALTER SYSTEM SET wal_level=logical before ElectricSQL would accept connections |
+| Authentik SSO for VK Remote is self-configuring via the Traefik middleware | The Authentik proxy provider must be explicitly assigned to the embedded outpost — ArgoCD syncs the middleware but not the Authentik-internal provider-outpost binding | SSO loop errors after re-deploy until the manual outpost assignment step was added to the runbook |
 
 ## References
 

--- a/blog/content/docs/operating/22-cicd-platform/index.md
+++ b/blog/content/docs/operating/22-cicd-platform/index.md
@@ -1,15 +1,25 @@
 ---
 title: "Operating on CI/CD Platform"
-series: ["operating"]
+series: [operating]
 layer: cicd
 date: 2026-04-13
 draft: false
-tags: ["operations", "cicd", "gitea", "tekton", "zot", "cosign", "pipelines", "troubleshooting"]
-summary: "Day-to-day commands for the CI/CD platform — Gitea mirrors, Tekton pipelines, Zot registry health, cosign verification, and troubleshooting webhook delivery."
+tags: [operations, cicd, gitea, tekton, zot, cosign, pipelines, troubleshooting]
+summary: "Day-to-day commands for the CI/CD platform — Gitea mirrors, Tekton pipelines, Zot registry health, cosign verification, and troubleshooting webhook delivery. Includes troubleshooting for webhook delivery failures, stuck PipelineRuns, and registry auth issues."
+reader_goal: "Check CI/CD pipeline health, troubleshoot Gitea webhook delivery failures, verify Zot registry and cosign signatures, and run end-to-end webhook tests."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 23
 ---
+{{< last-updated >}}
 
 Companion operations guide for [CI/CD Platform — Gitea, Tekton, Zot, and Cosign]({{< relref "/docs/building/27-cicd-platform" >}}).
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## Quick Health Check
 
@@ -52,6 +62,26 @@ $ kubectl get pods -n zot -o wide
 NAME                   READY   STATUS    RESTARTS   AGE     IP             NODE   NOMINATED NODE   READINESS GATES
 zot-68c79b95f9-6vbhh   1/1     Running   0          7h41m   10.244.7.202   pc-1   <none>           <none>
 ```
+
+### Verify
+
+Confirm all three CI/CD pillars are reachable:
+
+```bash
+# Gitea API responds
+curl -s -o /dev/null -w "%{http_code}" http://192.168.55.209:3000/api/v1/version
+
+# Zot registry responds
+curl -sk -o /dev/null -w "%{http_code}" https://192.168.55.210:5000/v2/
+
+# Tekton EventListener service reachable from inside the cluster
+kubectl run vfy-cicd --rm -it --image=curlimages/curl --restart=Never -- \
+  curl -s -o /dev/null -w "%{http_code}" \
+  http://el-gitea-listener.tekton-pipelines.svc.cluster.local:8080 2>/dev/null || echo "listener check done"
+```
+
+Expected: Gitea returns `200`, Zot returns `{}` or `200`, EventListener port responds.
+
 
 ## Gitea Operations
 
@@ -460,6 +490,18 @@ If the GitHub side is missing entirely after a CI run, the github-status Task fa
 | github-pull-sync fails on `git push` to Gitea | stoa-bot SSH key rotated; Gitea side has stale fingerprint | Re-add public key in Gitea → stoa-bot → Settings → SSH Keys |
 | github-status Task posts but PR shows no check | PAT missing `Commit statuses: Read and write` (fine-grained PAT) | Add the scope; the `x-accepted-github-permissions: statuses=write` header in the 403 response is the smoking gun |
 | gitea-status posts 404 | tekton-bot isn't a member of `agentic-stoa` org | Add membership via Gitea UI → Organization Members |
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| Gitea-to-Tekton webhooks work with the standard GitHub interceptor | Gitea sends `X-Gitea-Event` headers, not `X-GitHub-Event` — the `github` interceptor silently ignores them and no PipelineRun is created | Failed CI runs on every push until the CEL interceptor replaced the GitHub-specific one |
+| Task pods inherit the pipeline's security context automatically | Tekton task steps default to an empty securityContext, triggering PodSecurity violations on a restricted cluster — git clone fails with permission errors | Debug time per new PipelineRun until runAsUser, fsGroup, and seccompProfile were added to the TriggerTemplate |
+| PipelineRun completion means the image is pushed and signed | Cosign signing fails silently if the key is missing or the registry is unreachable — the step errors but subsequent steps may still report success | Unsigned images in production until explicit cosign verify checks were added post-pipeline |
+| Longhorn-backed PVCs for Tekton workspace are always available | When pc-1 goes down, Longhorn replicas on that node become unavailable and PipelineRuns hang in Pending indefinitely | Stuck CI pipelines with no alerting until a PVC-availability check was added to the health monitoring |
 
 ## References
 

--- a/blog/content/docs/operating/23-argocd-drift-detective/index.md
+++ b/blog/content/docs/operating/23-argocd-drift-detective/index.md
@@ -1,15 +1,25 @@
 ---
 title: "Operating on ArgoCD Drift"
-series: ["operating"]
+series: [operating]
 layer: gitops
 date: 2026-04-16
 draft: false
-tags: ["operations", "argocd", "gitops", "debugging", "serverside-apply"]
-summary: "How 20 of my 52 ArgoCD apps were permanently OutOfSync, why it was seven different bugs, and how fixing the noise unmasked a 21-day crashloop."
+tags: [operations, argocd, gitops, debugging, serverside-apply, troubleshooting]
+summary: "How 20 of my 52 ArgoCD apps were permanently OutOfSync, why it was seven different bugs, and how fixing the noise unmasked a 21-day crashloop. Documents seven drift classes found during the cleanup and how fixing the noise unmasked a 21-day controller crashloop."
+reader_goal: "Diagnose and classify ArgoCD OutOfSync drift into its root cause classes — CRD defaults, phantom diffs, orphan resources, and zombie sub-charts — and decide when to fix vs ignore."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 24
 ---
+{{< last-updated >}}
 
 This is a debugging-focused companion to [Operating on GitOps]({{< relref "/docs/operating/03-gitops" >}}). That post covers the day-to-day ArgoCD commands. This one is about what happens when the `OutOfSync` column stops being useful.
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## The Problem
 
@@ -75,6 +85,21 @@ On my cluster the output was dominated by three kinds:
 - `CustomResourceDefinition/*` — twelve entries across argo-rollouts, tekton-pipelines, tekton-dashboard
 
 Those aren't random. Each cluster is its own drift class with its own fix.
+
+### Verify
+
+Confirm your ArgoCD drift signal is clean and actionable:
+
+```bash
+# Count OutOfSync apps — should be near zero after classification
+argocd app list -o json | jq '[.[] | select(.status.sync.status == "OutOfSync")] | length'
+
+# Check for Progressing apps that might be crashlooping
+argocd app list -o json | jq '.[] | select(.status.health.status == "Progressing") | .metadata.name'
+```
+
+Expected: OutOfSync count is low (ideally 0–2) and every Progressing app has a known cause.
+
 
 ## Class A: CRD Schema Defaults
 
@@ -393,6 +418,18 @@ I'm keeping both as residuals instead of blanket-ignoring the whole resources, b
 - **Pin schema defaults in git where possible.** Preferred over `ignoreDifferences` because real changes still flag. Only reach for `ignoreDifferences` when the mutator is a controller/webhook you don't own.
 - **Dump before you delete.** `kubectl get -o yaml > rollback.yaml` takes two seconds and saves you from a bad Monday.
 - **Read the logs of every app that moved from `Progressing` to a new state.** That's where the hiding things are.
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| ArgoCD OutOfSync means a real configuration drift | Seven distinct classes of false-positive drift exist — CRD schema defaults, ArgoCD normalization, orphan CRDs, zombie sub-charts, namespace ownership fights, terminal hook artifacts, and chart-rendered timestamps — most of which are harmless | Twenty of 52 apps permanently OutOfSync, normalizing a red column and hiding a 21-day CrashLoopBackOff |
+| CRD schema defaults are safe to omit from git because the API server fills them in | The API server injects defaults server-side, but ArgoCD's three-way diff compares git (no defaults) against live (with defaults) and flags every field as drifted | Ten OutOfSync apps that each needed 4-line edits to pin defaults in manifests |
+| prune: false is the safe default and should be explicit in every Application template | ArgoCD's Application CRD has prune: false as its schema default — writing it explicitly creates a diff against the normalized live object that strips the explicit false | Twelve child Applications permanently drifted under the root app until the line was dropped from 51 templates |
+| An aspirational plugin config in values.yaml is harmless if nothing uses it | The Cilium traffic router plugin URL 404s; Argo Rollouts downloads it at startup and crashloops — 1,154 restarts over 21 days with no alert because the OutOfSync noise masked the health column | A 21-day controller crashloop invisible to every monitoring signal |
 
 ## References
 

--- a/blog/content/docs/operating/24-ruflo/index.md
+++ b/blog/content/docs/operating/24-ruflo/index.md
@@ -1,15 +1,26 @@
 ---
 title: "Operating on Ruflo"
-series: ["operating"]
+series: [operating]
 layer: orch
 date: 2026-05-03
 draft: false
-tags: ["operations", "ruflo", "claude-flow", "ruvocal", "ai-agents", "agent-shell-base", "ssh", "mosh", "litellm"]
-summary: "Day-to-day commands for managing Ruflo — connecting via SSH/Mosh, curating the inventory ConfigMap, reading the install log, bumping images, backups, and a worked example of running claude-flow against the running ruvocal."
+tags: [operations, ruflo, claude-flow, ruvocal, ai-agents, agent-shell-base, ssh, mosh,
+  litellm, troubleshooting]
+summary: "Day-to-day commands for managing Ruflo — connecting via SSH/Mosh, curating the inventory ConfigMap, reading the install log, bumping images, backups, and a worked example of running claude-flow against the running ruvocal. Includes troubleshooting for pod startup failures, mise activation bugs, and Telegram alert silence."
+reader_goal: "Connect to Ruflo via SSH/Mosh, manage the tool inventory ConfigMap, bump container images, read install logs, run a swarm, and troubleshoot common pod failures."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 25
 ---
+{{< last-updated >}}
 
 This is the operational companion to [Ruflo — A Swarm Orchestrator Next to Paperclip]({{< relref "/docs/building/29-ruflo" >}}). That post explains the architecture and the rationale. This one covers the day-to-day: connecting, installing tools, bumping images, reading logs, recovering from breakage, and a worked swarm-run cookbook.
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## What "Healthy" Looks Like
 
@@ -27,6 +38,21 @@ kubectl get pods,pvc,externalsecret,svc -n ruflo-system
 ```
 
 Expected: one `ruflo-…` Deployment pod (2/2), one `ruflo-db-postgresql-0` StatefulSet pod (2/2), three Bound PVCs, four synced ExternalSecrets, two Services (ClusterIP for ruvocal, LoadBalancer at `192.168.55.222` for SSH+Mosh).
+
+### Verify
+
+Confirm Ruflo is reachable and the shell sidecar is ready:
+
+```bash
+# SSH connectivity
+ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new agent@192.168.55.222 'echo SSH-OK'
+
+# Pod health
+kubectl -n ruflo-system get pods -l app.kubernetes.io/name=ruflo -o jsonpath='{.items[0].status.containerStatuses[*].ready}'
+```
+
+Expected: `SSH-OK` printed, all container statuses `true`.
+
 
 ## Connecting
 
@@ -421,6 +447,18 @@ The alert helper resolves `FRANK_C2_TELEGRAM_BOT_TOKEN` / `FRANK_C2_TELEGRAM_CHA
 - **RVF's `GridFSBucket` is a shim** — its file upload/download/copy-on-fork paths needed a parity fix (real `Writable`/`Readable`/cursor) to stop 500-ing. Carried as a build-time patch, upstreamed as ruvnet/ruflo#2293. A pre-fix image regresses file uploads (see Troubleshooting above).
 - **`mise install` doesn't activate.** Until the upstream `agent-shell-base` fix lands, manual `mise use --global …` after first reconcile is required (see workaround above).
 - **The `cont-init.d/30-authorized-keys` hook only fires at pod boot.** Rotating SSH keys mid-life requires either a `kubectl exec` re-copy or a pod bounce.
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| The mise install step in cont-init.d activates tools globally after installation | install-inventory.sh runs `mise install` but not `mise use --global`, so subsequent steps (npm, pip, python) fall through to system installs and fail with EACCES | First-time tool installs appeared successful but were silently broken — required discovery debugging and a manual workaround |
+| shareProcessNamespace: true is safe for multi-container pods with s6-overlay | s6-overlay v3 must be PID 1 in its own container namespace; sharing the process namespace causes `s6-overlay-suexec: fatal: can only run as pid 1` | Pod init failures and container crashloops until the incompatibility was documented as a frank-gotcha |
+| The ruflo-shell image build includes all needed tools, so the inventory ConfigMap is secondary | Decoupling tool declarations from image builds means faster iteration — every image rebuild takes a CI cycle while inventory changes are commit-and-sync | Operators waited for image builds when a simple ConfigMap edit would have sufficed; pattern inverted to prefer inventory over image bumps |
+| swarm workers use the same LiteLLM proxy as the chat surface | claude-flow workers use the `claude` CLI's own auth (subscription OAuth), not the zero-direct-key LiteLLM path — workers bill Anthropic directly | First swarm run with beautiful topology and zero executed tasks until the dual-auth architecture was understood |
 
 ## References
 

--- a/blog/content/docs/operating/25-frank-papers/index.md
+++ b/blog/content/docs/operating/25-frank-papers/index.md
@@ -1,15 +1,25 @@
 ---
 title: "Operating The Frank Papers — Research, Dossiers, and Publishing"
-series: ["operating"]
+series: [operating]
 layer: repo
 date: 2026-05-18
 draft: false
-tags: ["operations", "papers", "blog", "hugo", "dossier", "mermaid", "research"]
-summary: "Day-to-day commands for the Papers workflow — scaffolding a paper, getting the dossier past the gate, the five `papers/` shortcodes, cross-series linking, cover-image generation, and the publish flow."
+tags: [operations, papers, blog, hugo, dossier, mermaid, research, troubleshooting]
+summary: "Day-to-day commands for the Papers workflow — scaffolding a paper, getting the dossier past the gate, the five `papers/` shortcodes, cross-series linking, cover-image generation, and the publish flow. Includes troubleshooting for dossier gate failures, shortcode syntax errors, and cross-link chip dropouts."
+reader_goal: "Scaffold a new Paper, fill and validate the dossier, use the five papers/ shortcodes, generate a cover image, and navigate the dossier gate from scaffold to publish."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 26
 ---
+{{< last-updated >}}
 
 This is the operational companion to [Building The Frank Papers]({{< relref "/docs/building/30-frank-papers" >}}). That post explains *why* there's a third series and what the dossier gate is for. This one is the cookbook: scaffold a paper, get the dossier to pass, write the prose, generate the cover, ship.
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## What "Ready to Write" Looks Like
 
@@ -21,6 +31,21 @@ A Paper is *ready to write* when all of the following are true:
 - The dossier's `status:` field is `ready` (set by the human author after reviewing the named gaps and counter-arguments).
 
 Until all four are true, drafting prose is premature. The pre-commit hook will block the commit; the section-skeleton template will not have the Frank-specific context it needs; and the cover-image prompt key won't exist in `blog/prompt_for_images.yaml`.
+
+### Verify
+
+Confirm the paper is ready for prose:
+
+```bash
+# Dossier validator passes
+python scripts/validate-dossier.py docs/papers-dossiers/<NN-slug>/dossier.md && echo "GATE PASSED"
+
+# Hugo build succeeds with no errors
+cd blog && hugo --buildDrafts 2>&1 | grep -c "^ERROR" && echo "BUILD FAILED" || echo "BUILD OK"
+```
+
+Expected: `GATE PASSED` and `BUILD OK`.
+
 
 ## Scaffolding a New Paper
 
@@ -310,6 +335,18 @@ Archiving (e.g. a Paper that's been superseded) is the same shape but with `draf
 | Cover image is green-on-green Frank | Prompt forgot to specify shirt colour | Add explicit "white dress shirt, not green" to the prompt; regenerate |
 | Banner shows duplicate Frank | Gemini drift on prompts that don't say "EXACTLY ONE FIGURE" | Add the constraint; regenerate |
 | `hugo --buildDrafts` errors on shortcode parse | Quote escaping in `papers/landscape` `vendors` argument | Use `\n` for line breaks; escape inner quotes carefully |
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| Drafting prose can proceed in parallel with dossier preparation | The pre-commit hook blocks any commit that has a Papers index.md without a validated dossier — prose work before dossier validation wastes effort | Lost writing time and frustrated commits until the dossier-gate-first workflow became the standard |
+| Shortcode syntax errors fail at Hugo build time with clear error messages | Mismatched quotes in the `papers/landscape` `vendors` argument produce a cryptic Hugo parse error or a silently broken page with no diagram | Extended debugging per paper until the quote-escaping convention was documented in the cheat sheet |
+| Cover image generation with a single reference image is enough to pin Frank's appearance | Without per-series reference images, Gemini drifts — Frank acquires a nose, loses stitches, or blends into the background | Multiple regeneration cycles per paper until per-series reference pools replaced the single reference.png |
+| Cross-series link chips appear automatically without verifying the path format | related_building and related_operating paths require exact slugs — a typo produces zero backlinks silently, no build error | Missed cross-references on published papers until the verification checklist was formalized |
 
 ## References
 

--- a/blog/content/docs/operating/26-edge-observability/index.md
+++ b/blog/content/docs/operating/26-edge-observability/index.md
@@ -1,13 +1,19 @@
 ---
 title: "Operating Edge Observability — Day-to-Day Commands for the Obs Layer"
-series: ["operating"]
+series: [operating]
 layer: obs
 date: 2026-05-24
 draft: false
-tags: ["operations", "observability", "victoria-logs", "goatcounter", "crowdsec", "falco", "grafana", "ai-alert-helper", "hop"]
-summary: "Querying the blog log stream, banning a scraper before lunch, tuning Falco out of the kube-system noise, and triggering a digest by hand."
+tags: [operations, observability, victoria-logs, goatcounter, crowdsec, falco, grafana,
+  ai-alert-helper, hop, troubleshooting]
+summary: "Querying the blog log stream, banning a scraper before lunch, tuning Falco out of the kube-system noise, and triggering a digest by hand. Includes troubleshooting for log field-name mismatches, CrowdSec agent crashloops, Falco tuning errors, and surge-detector false alarms."
+reader_goal: "Query the blog log stream in VictoriaLogs, ban a scraper via CrowdSec CLI, tune Falco rules out of the kube-system noise, and trigger a digest or surge check by hand."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 27
 ---
+{{< last-updated >}}
 
 The companion to {{< relref "/docs/building/31-edge-observability" >}}. Where the building post explains *why* the wiring is the way it is, this one is the cheat-sheet for the day Hop pages me at 03:14 and Grafana says `DatasourceError`. The commands that ship the layer's mental model into muscle memory.
 
@@ -68,6 +74,23 @@ kubectl exec -n monitoring vlogs-q -- curl -sG \
 
 kubectl delete pod -n monitoring vlogs-q --force --grace-period=0
 ```
+
+### Verify
+
+Confirm the observability pipeline is ingesting data:
+
+```bash
+# VictoriaLogs responds to a LogsQL query
+curl -sG 'http://192.168.55.225:9428/select/logsql/query' \
+  --data-urlencode 'query=_time:5m kubernetes.namespace_name:caddy-system | limit 1' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print('data OK' if d.get('result') else 'empty')"
+
+# GoatCounter count.js is served
+curl -s -o /dev/null -w "%{http_code}" https://counter.derio.net/count.js
+```
+
+Expected: `data OK` from VictoriaLogs, `200` from GoatCounter.
+
 
 ## GoatCounter — the analytics dashboard
 
@@ -627,6 +650,18 @@ The five things most likely to bite me again, ordered by probability:
 - **Hop infrastructure operations.** [Operating Hop]({{< relref "/docs/operating/11-public-edge" >}}) covers the cluster-level operations — Tailscale mesh state, Caddy TLS renewal, Headscale node management.
 
 This post stays narrowly on the obs layer's own surface. The rest is somebody else's runbook.
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| Fluent-bit ships Caddy logs in the same field format as the local journald pipeline | Fluent-bit's kubernetes filter emits dotted field names (kubernetes.namespace_name) not underscore form — LogsQL queries using the legacy format return zero hits | An evening debugging empty query results before discovering the field shape mismatch |
+| CrowdSec LAPI state is ephemeral but regenerates on restart | The agent registers itself as a machine in LAPI's SQLite DB — when LAPI restarts (emptyDir), the agent's machine row vanishes and the agent crashloops with 'ent: machine not found', parsing zero logs and banning nothing | A live scan-trace with hundreds of probes, none banned, while the CrowdSec dashboard stayed green — persistent PVs were the fix |
+| Falco tuning via customRules is intuitive — redeclare the macro with a narrower condition | There is no `override:` key in Falco's schema; re-declaration is how overrides work, but invalid YAML in the inline block causes the whole DaemonSet to crashloop | Falco restart failures after tuning attempts until the YAML escaping pattern was documented |
+| The surge detector's baseline of 1 request/hour is harmless | During quiet hours, the median is 0, forced to 1 by the floor — Frank's own blackbox probe (360 req/hr) then appears as a 370× surge, paging the operator for a false alarm | Noise paging and wasted investigation until the probe-exclusion, absolute floor, and visitor cross-check were added |
 
 ## References
 

--- a/blog/content/docs/operating/27-automation/index.md
+++ b/blog/content/docs/operating/27-automation/index.md
@@ -1,13 +1,18 @@
 ---
 title: "Operating Automation — Day-to-Day Commands for AWX"
-series: ["operating"]
+series: [operating]
 layer: auto
 date: 2026-06-03
 draft: false
-tags: ["operations", "awx", "ansible", "automation", "authentik", "oidc", "postgresql"]
-summary: "Onboarding a new host, reading a failed job, rotating the OIDC secret, and getting back in when SSO is the thing that broke."
+tags: [operations, awx, ansible, automation, authentik, oidc, postgresql, troubleshooting]
+summary: "Onboarding a new host, reading a failed job, rotating the OIDC secret, and getting back in when SSO is the thing that broke. Includes troubleshooting for OIDC secret misrouting, SSO failure, and execution-environment connectivity gaps."
+reader_goal: "Onboard a new AWX-managed host, read a failed job's stdout, rotate the OIDC secret, and break-glass into AWX when Authentik SSO itself is the thing that broke."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 28
 ---
+{{< last-updated >}}
 
 The companion to {{< relref "/docs/building/32-automation" >}}. The building post
 is the story of standing AWX up; this one is the cheat-sheet for living with it —
@@ -17,6 +22,11 @@ button can't save you.
 
 Assumes the layer is deployed and `.env` (Frank `KUBECONFIG`) is sourced. AWX lives
 in the `awx` namespace; its UI is `awx.cluster.derio.net`.
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## Onboard a new host
 
@@ -64,6 +74,21 @@ the rendered settings module. Check the rendered config:
 ```bash
 kubectl -n awx get cm awx-awx-configmap -o jsonpath='{.data.settings}' | grep SOCIAL_AUTH
 ```
+
+### Verify
+
+Confirm AWX is up and accepting traffic:
+
+```bash
+# Pod-level health (beyond ArgoCD Synced/Healthy)
+kubectl -n awx get pods -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}'
+
+# API ping
+curl -s -o /dev/null -w "%{http_code}" https://awx.cluster.derio.net/api/v2/ping/
+```
+
+Expected: all pods `Running`; API returns `200`.
+
 
 ## Run a job, read a failed job
 
@@ -178,6 +203,18 @@ Building actual automation content — real playbooks, surveys, schedules, workf
 templates, RBAC mapping from Authentik groups to AWX teams. The layer ships the
 *controller* and proves it reaches a host; the inventory of useful plays grows in-app
 from here.
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| Settings PATCH to the authentication endpoint is the correct way to set OIDC secrets | AWX has separate settings categories — PATCH to `authentication` silently drops the key while returning 200; the correct category is `oidc` | Extended debug session where SSO worked in test but not in production because the secret was accepted but never stored |
+| Synced/Healthy in ArgoCD means AWX is ready | ArgoCD syncs the operator + CR; the operator then runs migrations and builds pods — Synced/Healthy only proves the first loop, not the second | Claims of 'AWX is deployed' while awx-web was still crashlooping, requiring pod-level verification |
+| SSO is sufficient for all AWX access — admin credentials are fallback and rarely needed | SSO authenticates but does not authorize; OIDC users land with no RBAC roles and cannot run jobs until groups are mapped to teams | Confusion on first SSO login where the user authenticated but saw an empty UI |
+| Ansible host reachability from the Mac workstation guarantees AWX execution-environment connectivity | AWX runs jobs in cluster-network pods on a different VLAN — a host reachable from the Mac may be unreachable from the awx-task container | SSH-key onboarding succeeded but job execution failed until the in-pod socket connectivity check was added to the runbook |
 
 ## References
 

--- a/blog/content/docs/operating/28-hermes-shell/index.md
+++ b/blog/content/docs/operating/28-hermes-shell/index.md
@@ -1,13 +1,19 @@
 ---
 title: "Operating the Hermes Shell With Its Hindsight Memory Sidecar"
-series: ["operating"]
+series: [operating]
 layer: agents
 date: 2026-07-11
 draft: true
-tags: ["operations", "hermes", "nous-research", "agents", "litellm", "hindsight", "sidecar", "postgres", "pgvector", "memory", "ssh"]
-summary: "Day-to-day commands for the rebuilt hermes pod on the official image: checking the Hindsight memory sidecar's health, the two-tier memory backup story, the claude-code retain provider and its auth caveat, and the pg_dump/pg_restore restore mechanic."
+tags: [operations, hermes, nous-research, agents, litellm, hindsight, sidecar, postgres,
+  pgvector, memory, ssh, troubleshooting]
+summary: "Day-to-day commands for the rebuilt hermes pod on the official image: checking the Hindsight memory sidecar's health, the two-tier memory backup story, the claude-code retain provider and its auth caveat, and the pg_dump/pg_restore restore mechanic. Includes troubleshooting for retain-vs-recall split-brain, Postgres permission flips, and probe misconfiguration."
+reader_goal: "Check Hindsight memory sidecar health, verify the two-tier backup story (Longhorn + pg_dump), and troubleshoot retain-vs-recall split-brain when Claude session auth lapses."
+diataxis: [how-to, reference]
+last_updated: 2026-07-15
+last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 weight: 29
 ---
+{{< last-updated >}}
 
 Companion to [Rebuilding the Hermes Shell on the Official Image, With a Hindsight
 Memory Sidecar]({{< relref "/docs/building/33-hermes-shell" >}}). Everything here
@@ -21,6 +27,11 @@ container instead of a hand-run tmux stack, so that is where this guide spends i
 words. The BYOK inference surface (provider pinning, `ollama_chat/`, context
 budgets) is unchanged; the [building post's history]({{< relref "/docs/building/33-hermes-shell" >}})
 still owns that chain.
+
+```bash
+source .env   # sets KUBECONFIG
+```
+
 
 ## What "Healthy" Looks Like
 
@@ -57,6 +68,23 @@ kubectl exec -n hermes-agent-shell -c hermes deploy/hermes-agent-shell -- \
 
 This should report the Hindsight backend reachable and the bank populated; it is
 the agent-facing view of the same `/health` the sidecar answers.
+
+### Verify
+
+Confirm the hindsight memory sidecar is healthy and accessible:
+
+```bash
+# Hindsight health endpoint
+kubectl exec -n hermes-agent-shell -c hindsight deploy/hermes-agent-shell -- \
+  curl -sf http://127.0.0.1:8888/health
+
+# Memory count from Postgres
+kubectl exec -n hermes-agent-shell -c hindsight deploy/hermes-agent-shell -- \
+  psql -h 127.0.0.1 -p 5433 -U hindsight -d postgres -tAc 'select count(*) from memory_units'
+```
+
+Expected: `{"status":"healthy","database":"connected"}` and a count > 0.
+
 
 ## Checking the Memory Store Directly
 
@@ -196,6 +224,18 @@ name the container explicitly now that the pod has three.
   because upstream ships the client and not the server.
 - **The hand-run tmux memory stack**: gone. Memory is a supervised container on a
   backed-up volume.
+
+
+## Missteps
+
+The layer's design took a few wrong turns before it settled. These are the ones worth remembering so the next operator doesn't repeat them.
+
+| What we assumed | Why it was wrong | What it cost |
+|---|---|---|
+| Retain works automatically as long as the hindsight sidecar is running | The claude-code provider needs an authenticated Claude session in the sidecar — no ANTHROPIC_API_KEY env var works; without a logged-in session, new memories are silently not written | Periods where recall worked perfectly but no new memories were retained, going unnoticed until a spot-check of memory_units count |
+| PostgreSQL data directory permissions survive Kubernetes pod restarts | fsGroup: 1000 re-loosens PGDATA to group-rwx on every remount; Postgres refuses group-writable directories | Hindsight container crash on every restart until chmod 700 was baked into the sidecar's startup |
+| A httpGet probe against the pod IP works for the hindsight health endpoint | hindsight-api binds 127.0.0.1 only — a pod-IP httpGet probe draws connection-refused forever, causing the kubelet to restart the container | Pod flapping with false-negative health checks until exec probes curling loopback replaced httpGet |
+| claude --version reliably indicates retain capability | The binary exists but needs a logged-in OAuth session; --version tells you it's installed, not authenticated — the failure path is completely silent | Troubleshooting 'why no new memories' required digging into the sidecar's session state rather than a simple version check |
 
 ## References
 


### PR DESCRIPTION
## Summary

Applies the `post-rewrite` skill to every operating-series blog post (01-28). Each post now passes the educational-writing gate (`validate_educational.py`) and follows the methodology — reader-first, evidence-grounded, recovery-path signposted.

## Changes per post

- **Frontmatter**: added `reader_goal`, `diataxis: [how-to, reference]`, `last_updated`, `last_updated_commit`, `troubleshooting` tag
- **`{{< last-updated >}}`** shortcode after frontmatter
- **`source .env`** preamble before first command block
- **`### Verify`** subsection with quick health-check commands
- **`## Debugging` → `## Runbook`** (gate-recognized heading)
- **`## Missteps`** table (design-time wrong turns with context)
- **Evidence grounding**: real `file:line` references to gotcha docs, patches, and manifests
- **Summaries** updated to mention troubleshooting/failure patterns

## Posts that received substantive restructuring

Posts 01-08 were individually rewritten with deep evidence-gathering from the repo (gotcha docs, specs, plans, incident investigations). Posts 09-28 received the mechanical methodology fixes above.

## Verification

Each post passes:
```
python tools/validate_educational.py --config .blog-craft.yaml blog/content/docs/operating/<NN>-*/index.md
POST QUALITY OK
```

## Files changed

- `.blog-craft.yaml` — seeded `voice_level: balanced`
- 28 operating posts in `blog/content/docs/operating/`