### PR TITLE
chore(gpu): record gpu-1 realtek-firmware apply — verified live 2026-07-16

### DIFF
--- a/docs/acceptance/matrix.yaml
+++ b/docs/acceptance/matrix.yaml
@@ -62,10 +62,13 @@ rows:
     origin:
     - frank:docs/superpowers/specs/2026-07-09--gpu--gpu-1-usb-25g-nic-design.md
     levels: {}
-    status: not-implemented
-    notes: siderolabs/realtek-firmware added to patches/phase04-gpu/402-gpu1-nvidia-extensions.yaml
-      (single per-machine list — overrides not merges). Operator re-applies via omnictl in a
-      gpu-1 maintenance window (image rebuild + reboot); verify no "rtl8156b-2.fw failed" in dmesg.
+    status: skipped
+    notes: 'Live manual proof 2026-07-16 — siderolabs/realtek-firmware (v20260309) applied to
+      402-gpu1-nvidia-extensions.yaml via omnictl; Omni recomputed schematic 54e23848, reinstalled
+      + rebooted gpu-1 (~76s NotReady). Post-boot: extension present, ZERO rtl_nic firmware-load
+      failures in dmesg (both rtl8156b USB and rtl8125b onboard cleared), gpu-1 Ready on
+      192.168.55.31 (USB NIC re-enumerated enp0s20f0u7->enp0s20f0u5, MAC-bound patch kept the
+      address), nvidia allocatable 1, 19/19 pods back, cilium datapath OK.'
   - id: gpu1-cilium-datapath-stable
     capability: gpu-1 network stability
     acceptance: Cilium on gpu-1 initializes and keeps a healthy direct-routing datapath

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -792,7 +792,7 @@ operations:
   - "# Capture the current (failing) firmware log line for before/after evidence.\ntalosctl -n 192.168.55.31 dmesg | grep -i 'rtl8156b-2.fw'   # expect: \"Direct firmware load ... failed\"\n\n# Apply the updated single per-machine extensions list (now includes siderolabs/realtek-firmware).\nsource .env_devops\nomnictl apply -f patches/phase04-gpu/402-gpu1-nvidia-extensions.yaml\n# gpu-1 rebuilds its image and reboots. Wait for it to return.\nsource .env\nkubectl get node gpu-1 -w   # wait until Ready\n"
   verify:
   - "source .env\ntalosctl -n 192.168.55.31 get extensions | grep realtek-firmware       # present\ntalosctl -n 192.168.55.31 dmesg | grep -i 'rtl8156b-2.fw'              # no \"failed\" line\nkubectl get node gpu-1 -o wide                                          # Ready on 192.168.55.31\nkubectl get node gpu-1 -o jsonpath='{.status.allocatable.nvidia\\.com/gpu}'  # still 1 (schematic override kept nvidia)\n"
-  status: pending
+  status: done
 - id: gpu-pcie-gen4
   layer: gpu
   app: gpu-operator

--- a/docs/superpowers/plans/2026-07-09--gpu--gpu-1-usb-25g-nic/_prose.md
+++ b/docs/superpowers/plans/2026-07-09--gpu--gpu-1-usb-25g-nic/_prose.md
@@ -69,6 +69,16 @@ Because a per-machine `ExtensionsConfiguration` overrides rather than merges, th
 firmware extension MUST go in that existing file (not a new one). Re-applying it
 rebuilds the image and reboots gpu-1 → operator-only, maintenance window (below).
 
+**APPLIED + verified 2026-07-16** (manual-op `gpu-gpu1-usb-25g-nic-firmware`, status
+`done`; acceptance `gpu1-usb-25g-firmware-present`). `omnictl apply` of the updated
+`402` → Omni recomputed schematic `54e23848` and reinstalled + rebooted gpu-1 (~76s
+NotReady, cordoned first). Post-boot: `realtek-firmware v20260309` present, **zero**
+`rtl_nic` firmware-load failures in dmesg (both the `rtl8156b` USB warning and the
+onboard `rtl8125b` warning cleared), gpu-1 Ready on `192.168.55.31`, nvidia
+allocatable `1`, 19/19 pods back, cilium datapath OK. The USB NIC re-enumerated
+`enp0s20f0u7`→`enp0s20f0u5` across the reboot; the MAC-bound patch kept `.31` on it —
+a live validation of the MAC-binding choice over interface-name binding.
+
 ```yaml
 # manual-operation
 id: gpu-gpu1-usb-25g-nic-firmware
@@ -93,7 +103,7 @@ verify: |
   talosctl -n 192.168.55.31 dmesg | grep -i 'rtl8156b-2.fw'              # no "failed" line
   kubectl get node gpu-1 -o wide                                          # Ready on 192.168.55.31
   kubectl get node gpu-1 -o jsonpath='{.status.allocatable.nvidia\.com/gpu}'  # still 1 (schematic override kept nvidia)
-status: pending
+status: done
 ```
 
 ## Post-Merge Test Plan


### PR DESCRIPTION
Closeout bookkeeping for the firmware fix merged in #641. I drove the manual op in the maintenance window and verified end-to-end.

## What I did
`omnictl apply` of the updated `patches/phase04-gpu/402-gpu1-nvidia-extensions.yaml` (now with `siderolabs/realtek-firmware`). Omni recomputed target schematic `54e23848`, pulled the rebuilt image, and reinstalled + rebooted gpu-1 (~76s NotReady; cordoned first, so the drain was graceful). Omni was **not** wedged — the schematic recompute and `phase 1 → phase 0` extension transition confirmed it was driving the reinstall.

## Verification (all green)
| Check | Result |
|-------|--------|
| Extension | `realtek-firmware v20260309` present in `talosctl get extensions` |
| Firmware warning | **Gone** — zero `rtl_nic … failed/unable` lines this boot (both `rtl8156b` USB **and** onboard `rtl8125b` cleared) |
| Node | gpu-1 Ready on `192.168.55.31`, nvidia allocatable `1` |
| Workloads | 19/19 baseline pods back, none stuck |
| Cilium | `cilium-dbg status --brief` → OK |

**MAC-binding validated live:** the USB NIC re-enumerated `enp0s20f0u7 → enp0s20f0u5` across the reboot, but the MAC-bound ConfigPatch (`6c:1f:f7:c6:e0:da`) kept `192.168.55.31` on it — a name-bound config would have missed the adapter.

## Status flips
- acceptance `gpu1-usb-25g-firmware-present`: `not-implemented` → `skipped` (live manual proof 2026-07-16)
- manual-op `gpu-gpu1-usb-25g-nic-firmware`: `pending` → `done`
- plan `2026-07-09--gpu--gpu-1-usb-25g-nic` deviation annotated with the applied/verified result

Docs/bookkeeping only — no cluster or manifest changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)