### PR TITLE
fix(cnc): bump image pins to current releases + node tmux-restore

### DIFF
--- a/apps/cnc-base/manifests/deployment-cncd.yaml
+++ b/apps/cnc-base/manifests/deployment-cncd.yaml
@@ -32,7 +32,7 @@ spec:
         fsGroup: 65532
       containers:
         - name: cncd
-          image: ghcr.io/agentic-stoa/cnc-frd:0.14.0
+          image: ghcr.io/agentic-stoa/cnc-frd:0.18.0
           imagePullPolicy: IfNotPresent
           # distroless ENTRYPOINT is ["/cncd"]; `args` supplies the subcommand.
           # `command:` would REPLACE the entrypoint and exec a nonexistent

--- a/apps/cnc-base/manifests/deployment-fru.yaml
+++ b/apps/cnc-base/manifests/deployment-fru.yaml
@@ -20,7 +20,7 @@ spec:
         - name: cnc-ghcr-pull
       containers:
         - name: cnc-fru
-          image: ghcr.io/agentic-stoa/cnc-fru:0.7.1
+          image: ghcr.io/agentic-stoa/cnc-fru:0.7.5
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/apps/cnc-base/manifests/statefulset-node.yaml
+++ b/apps/cnc-base/manifests/statefulset-node.yaml
@@ -25,11 +25,18 @@ spec:
         fsGroup: 1000
       containers:
         - name: node
-          image: ghcr.io/derio-net/multi-agent-shell:22637aab0fc3ada4d667509ca1dd9aab71788773
+          image: ghcr.io/derio-net/multi-agent-shell:a59f49998b0001cd49d635dd261e9ef238ed89a8
           imagePullPolicy: IfNotPresent
           env:
             - name: AGENT_SESSION_SERVE
               value: "1"
+            # tmux-continuum ships @continuum-restore 'on' in the
+            # multi-agent-shell image; without this the node bricks on any pod
+            # restart with `duplicate session` (the cnc-fr compose fix, PR #86).
+            # The driver owns sessions, so continuum must never resurrect one.
+            # Mirrors alert-agent / n8n-01.
+            - name: AGENT_TMUX_RESTORE
+              value: "off"
             - name: AGENT_SESSION_PORT
               value: "8765"
             # The v1 agent-session server binds 127.0.0.1 by default; the

--- a/apps/cnc-prod/manifests/kustomization.yaml
+++ b/apps/cnc-prod/manifests/kustomization.yaml
@@ -10,6 +10,6 @@ patches:
   - path: app-patch.yaml
 images:
   - name: ghcr.io/agentic-stoa/cnc-frd
-    newTag: "0.14.0"
+    newTag: "0.18.0"
   - name: ghcr.io/agentic-stoa/cnc-fru
-    newTag: "0.7.1"
+    newTag: "0.7.5"

--- a/apps/cnc-prod/manifests/migration-job.yaml
+++ b/apps/cnc-prod/manifests/migration-job.yaml
@@ -15,7 +15,7 @@ spec:
       imagePullSecrets: [{name: cnc-ghcr-pull}]
       containers:
         - name: migrate
-          image: ghcr.io/agentic-stoa/cnc-frd:0.14.0
+          image: ghcr.io/agentic-stoa/cnc-frd:0.18.0
           args: ["migrate"]
           env:
             - name: PG_PASSWORD

--- a/apps/cnc-staging/manifests/kustomization.yaml
+++ b/apps/cnc-staging/manifests/kustomization.yaml
@@ -10,6 +10,6 @@ patches:
   - path: app-patch.yaml
 images:
   - name: ghcr.io/agentic-stoa/cnc-frd
-    newTag: "0.14.0"
+    newTag: "0.18.0"
   - name: ghcr.io/agentic-stoa/cnc-fru
-    newTag: "0.7.1"
+    newTag: "0.7.5"

--- a/apps/cnc-staging/manifests/migration-job.yaml
+++ b/apps/cnc-staging/manifests/migration-job.yaml
@@ -18,7 +18,7 @@ spec:
       imagePullSecrets: [{name: cnc-ghcr-pull}]
       containers:
         - name: migrate
-          image: ghcr.io/agentic-stoa/cnc-frd:0.14.0
+          image: ghcr.io/agentic-stoa/cnc-frd:0.18.0
           args: ["migrate"]
           env:
             - name: PG_PASSWORD

--- a/apps/cnc-staging/manifests/reseed-job.yaml
+++ b/apps/cnc-staging/manifests/reseed-job.yaml
@@ -58,7 +58,7 @@ spec:
               cp -a /tmp/cnc-fr/demo/bundle/. /bundle/
       containers:
         - name: reseed
-          image: ghcr.io/agentic-stoa/cnc-frd:0.14.0
+          image: ghcr.io/agentic-stoa/cnc-frd:0.18.0
           # distroless entrypoint /cncd; `args` supplies the subcommand.
           # `cncd ingest` opens the store directly (in-process admin), so it
           # needs no forward-auth identity.


### PR DESCRIPTION
## What

Bring the permanent CNC deployment current: bump the CNC image pins to the
latest released versions, and add `AGENT_TMUX_RESTORE=off` to the node
statefulset.

## Changes

1. **cncd (`agentic-stoa/cnc-frd`): `0.14.0` → `0.18.0`**
2. **cnc-fru (`agentic-stoa/cnc-fru`): `0.7.1` → `0.7.5`**
3. **node (`multi-agent-shell`): `22637aab…` → `a59f4999…`** (current build).
   The `agent-images-bump.yml` workflow self-heals this pin on its next run
   (`multi-agent-shell` is in its `AGENT_IMAGES` list); pinned explicitly here
   for a deterministic rollout.
4. **`AGENT_TMUX_RESTORE=off` on the node** — it is set on `apps/alert-agent`
   and `apps/n8n-01` but was missing on the cnc-node statefulset. The
   multi-agent-shell image ships tmux-continuum with `@continuum-restore 'on'`
   by default; a driver-owned session must set it off, or a pod restart
   collides on the persisted tmux session (`duplicate session`). Added to the
   node container env, mirroring the other agent pods.

## Files changed

- `apps/cnc-base/manifests/deployment-cncd.yaml` — cncd `0.14.0` → `0.18.0`
- `apps/cnc-base/manifests/deployment-fru.yaml` — fru `0.7.1` → `0.7.5`
- `apps/cnc-base/manifests/statefulset-node.yaml` — node image bump; add
  `AGENT_TMUX_RESTORE=off` to the node container env
- `apps/cnc-prod/manifests/kustomization.yaml` — `newTag` bumps (frd, fru)
- `apps/cnc-prod/manifests/migration-job.yaml` — cnc-frd `0.14.0` → `0.18.0`
- `apps/cnc-staging/manifests/kustomization.yaml` — `newTag` bumps (frd, fru)
- `apps/cnc-staging/manifests/migration-job.yaml` — cnc-frd `0.14.0` → `0.18.0`
- `apps/cnc-staging/manifests/reseed-job.yaml` — cnc-frd `0.14.0` → `0.18.0`

## Verification

- No stale pins remain under `apps/cnc-base|cnc-prod|cnc-staging`.
- `kustomize build` passes for all three overlays (cnc-base → 17 objects,
  cnc-prod → 20, cnc-staging → 20); rendered images correct across overlays,
  `AGENT_TMUX_RESTORE=off` present on the node.
