### PR TITLE
fix(cnc): enable vCluster external-secrets integration for cnc-staging

### DIFF
--- a/apps/vclusters/cnc-staging/values.yaml
+++ b/apps/vclusters/cnc-staging/values.yaml
@@ -19,3 +19,28 @@ policies:
       requests.cpu: "8"
       requests.memory: 16Gi
       count/pods: "50"
+
+# Blocker B.5 (frank CNC permanent-deployment rollout) — enable vCluster's
+# External-Secrets integration so THIS vCluster's ExternalSecrets
+# (cnc-secrets / cnc-ghcr-pull / cnc-runner-auth) resolve using the HOST's ESO
+# controller + the `infisical` ClusterSecretStore. Without it there is no ESO
+# controller or store inside the vCluster, so those ExternalSecrets never
+# reconcile and cncd/node/fru cannot mount their secrets. Requires a resync of
+# cnc-staging-vcluster (control-plane restarts to pick up the syncer change).
+integrations:
+  externalSecrets:
+    enabled: true
+    sync:
+      # Push vCluster ExternalSecrets to the host ns; host ESO processes them and
+      # the resulting Secret syncs back into the vCluster.
+      toHost:
+        externalSecrets:
+          selector:
+            matchLabels: {}
+      # Make host ClusterSecretStores (incl. `infisical`) visible inside the
+      # vCluster so `secretStoreRef {name: infisical, kind: ClusterSecretStore}` resolves.
+      fromHost:
+        clusterStores:
+          enabled: true
+          selector:
+            matchLabels: {}


### PR DESCRIPTION
## What

Enable vCluster's External-Secrets integration for the **cnc-staging** vCluster (`apps/vclusters/cnc-staging/values.yaml`).

## Why (Blocker B.5 of the CNC permanent-deployment rollout)

The cnc-staging ExternalSecrets — `cnc-secrets` (cncd master key), `cnc-ghcr-pull` (image pull), `cnc-runner-auth` (agent-session runner token) — are applied **inside** the cnc-staging vCluster (the `cnc-staging` ArgoCD app targets `destination.name: cnc-staging`). But the vCluster had **no ESO controller and no `infisical` ClusterSecretStore** (`integrations.externalSecrets` defaulted `enabled: false`). So those ExternalSecrets never reconcile in-vCluster, and cncd/node/fru cannot mount their secrets → staging workloads can't come up even once the vCluster is registered as an ArgoCD target.

This change turns on the integration so the **host's** ESO controller processes the vCluster's ExternalSecrets and the host `infisical` ClusterSecretStore is visible inside the vCluster.

## Scope / caveats

- **Staging vCluster only.** Prod runs in the host `cnc` namespace where ESO + `infisical` already work — unaffected.
- **Requires a resync of `cnc-staging-vcluster` on merge** (the vCluster control-plane restarts to pick up the syncer config change).
- **Companion out-of-band step (separate, not in this PR):** register the cnc-staging vCluster as an ArgoCD `cluster` Secret named `cnc-staging` (the values file's own comment flags this as a required out-of-band registration). B.5 (this PR) + that registration land together before staging workloads are expected.
- **Open item:** `cnc-source-token` uses a ClusterGenerator (`github-app-stoa`), which this integration may not sync the same way as store-backed ExternalSecrets. It powers the demo reseed (not the agent-session acceptance walk), so it's off the first-rollout critical path — handled separately if it lags.

## Validation

- `helm template cnc-staging loft/vcluster --version 0.32.1 -f apps/vclusters/template/values.yaml -f apps/vclusters/cnc-staging/values.yaml` — **passes** the schema-strict (`additionalProperties: false`) vcluster 0.32.1 values schema.
- Rendered output includes `external-secrets.io` RBAC → the integration is activated, not silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
