### PR TITLE
Revert #651: vCluster external-secrets integration is Pro-only (broke staging vcluster)

### DIFF
--- a/apps/vclusters/cnc-staging/values.yaml
+++ b/apps/vclusters/cnc-staging/values.yaml
@@ -19,28 +19,3 @@ policies:
       requests.cpu: "8"
       requests.memory: 16Gi
       count/pods: "50"
-
-# Blocker B.5 (frank CNC permanent-deployment rollout) — enable vCluster's
-# External-Secrets integration so THIS vCluster's ExternalSecrets
-# (cnc-secrets / cnc-ghcr-pull / cnc-runner-auth) resolve using the HOST's ESO
-# controller + the `infisical` ClusterSecretStore. Without it there is no ESO
-# controller or store inside the vCluster, so those ExternalSecrets never
-# reconcile and cncd/node/fru cannot mount their secrets. Requires a resync of
-# cnc-staging-vcluster (control-plane restarts to pick up the syncer change).
-integrations:
-  externalSecrets:
-    enabled: true
-    sync:
-      # Push vCluster ExternalSecrets to the host ns; host ESO processes them and
-      # the resulting Secret syncs back into the vCluster.
-      toHost:
-        externalSecrets:
-          selector:
-            matchLabels: {}
-      # Make host ClusterSecretStores (incl. `infisical`) visible inside the
-      # vCluster so `secretStoreRef {name: infisical, kind: ClusterSecretStore}` resolves.
-      fromHost:
-        clusterStores:
-          enabled: true
-          selector:
-            matchLabels: {}


### PR DESCRIPTION
## Reverts #651

**#651's approach is unworkable on this cluster and it broke the staging vCluster.**

`integrations.externalSecrets` (vCluster's External-Secrets integration) is a
**vCluster *Pro*** feature (`vcp-distro-integrations-external-secrets`). Frank runs
**OSS vCluster** (embedded SQLite, no license), so enabling it fails closed at
control-plane boot:

```
ERROR start integrations: you are trying to use a vCluster pro feature
'External Secrets Integration' … not available in the open source vcluster
```

`helm template` passed because the values *schema* accepts the key — but the
feature is runtime license-gated, so schema-valid ≠ edition-available.

### Impact + recovery (already done, live)
- Enabling it + restarting the control-plane → `cnc-staging-0` CrashLoopBackOff.
- Recovered by patching the live `vc-config` `/data` back to `enabled: false`
  (ArgoCD ignores Secret `/data`, so the manual edit sticks) + deleting the pod.
  Staging vCluster is healthy again (Ready, 0 restarts).

This revert removes the `enabled: true` **landmine** from git so a future forced
sync can't re-break it. After merge, git desired (`enabled: false`, chart default)
matches the live config — no further action on `vc-config`.

### Follow-up (not in this PR)
B.5's *goal* stands — the cnc-staging ExternalSecrets must resolve inside the
vCluster — but needs an **OSS-compatible** mechanism (host-side ExternalSecrets +
`sync.fromHost.secrets`). Being designed via a proper brainstorm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
