### PR TITLE
feat(secrets): OSS-vcluster-compatible secret delivery for CNC staging

### DIFF
--- a/apps/cnc-staging-host/manifests/externalsecrets.yaml
+++ b/apps/cnc-staging-host/manifests/externalsecrets.yaml
@@ -1,0 +1,60 @@
+# Host-side resolution of the CNC staging secrets (approach A).
+#
+# The cnc-staging workloads run INSIDE the cnc-staging vCluster, which (OSS) has
+# no ESO controller or `infisical` ClusterSecretStore. So these ExternalSecrets
+# are resolved HERE, on the host, in the vCluster's own host namespace
+# (cnc-staging-vcluster), where host ESO + infisical work — then synced INTO the
+# vCluster (ns cnc-staging) via `sync.fromHost.secrets` in
+# apps/vclusters/cnc-staging/values.yaml.
+#
+# Spec identical to apps/cnc-base/manifests/externalsecrets.yaml (names/keys/
+# template preserved) so the delivered Secrets are byte-compatible with what
+# cncd/node/fru expect. Namespace is set by the kustomization.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnc-secrets
+spec:
+  refreshInterval: 5m
+  secretStoreRef: {name: infisical, kind: ClusterSecretStore}
+  target:
+    name: cnc-secrets
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: CNCD_SECRETS_MASTER_KEY
+      remoteRef: {key: CNCD_SECRETS_MASTER_KEY}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnc-ghcr-pull
+spec:
+  refreshInterval: 5m
+  secretStoreRef: {name: infisical, kind: ClusterSecretStore}
+  target:
+    name: cnc-ghcr-pull
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: "{{ .GHCR_DOCKERCONFIGJSON }}"
+  data:
+    - secretKey: GHCR_DOCKERCONFIGJSON
+      remoteRef: {key: GHCR_DOCKERCONFIGJSON}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cnc-runner-auth
+spec:
+  refreshInterval: 5m
+  secretStoreRef: {name: infisical, kind: ClusterSecretStore}
+  target:
+    name: cnc-runner-auth
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: token
+      remoteRef: {key: CNC_RUNNER_SESSION_TOKEN}

--- a/apps/cnc-staging-host/manifests/kustomization.yaml
+++ b/apps/cnc-staging-host/manifests/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cnc-staging-vcluster
+resources:
+  - externalsecrets.yaml

--- a/apps/cnc-staging/manifests/kustomization.yaml
+++ b/apps/cnc-staging/manifests/kustomization.yaml
@@ -8,6 +8,41 @@ resources:
   - source-token.yaml
 patches:
   - path: app-patch.yaml
+  # Approach A: these 3 ExternalSecrets are resolved HOST-side
+  # (apps/cnc-staging-host) and synced into this vCluster via
+  # sync.fromHost.secrets — they must NOT be created inside the vCluster (no ESO
+  # there). Drop them from the staging overlay only; cnc-base is untouched so
+  # prod keeps resolving them directly in host ns cnc.
+  - patch: |-
+      $patch: delete
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: cnc-secrets
+    target:
+      group: external-secrets.io
+      kind: ExternalSecret
+      name: cnc-secrets
+  - patch: |-
+      $patch: delete
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: cnc-ghcr-pull
+    target:
+      group: external-secrets.io
+      kind: ExternalSecret
+      name: cnc-ghcr-pull
+  - patch: |-
+      $patch: delete
+      apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      metadata:
+        name: cnc-runner-auth
+    target:
+      group: external-secrets.io
+      kind: ExternalSecret
+      name: cnc-runner-auth
 images:
   - name: ghcr.io/agentic-stoa/cnc-frd
     newTag: "0.18.0"

--- a/apps/cnc-staging/manifests/kustomization.yaml
+++ b/apps/cnc-staging/manifests/kustomization.yaml
@@ -4,8 +4,14 @@ namespace: cnc-staging
 resources:
   - ../../cnc-base/manifests
   - migration-job.yaml
-  - reseed-job.yaml
-  - source-token.yaml
+  # reseed-job.yaml + source-token.yaml are EXCLUDED for the first rollout:
+  # reseed is skipped, and cnc-source-token is a (ClusterGenerator-backed)
+  # ExternalSecret that cannot resolve inside the OSS vCluster (no ESO there) —
+  # left in, it sits SecretSyncError and drags the app to Degraded. Re-add both
+  # (and deliver cnc-source-token host-side, same pattern as the other 3) when
+  # reseed is enabled. Files kept in-tree for that follow-up.
+  # - reseed-job.yaml
+  # - source-token.yaml
 patches:
   - path: app-patch.yaml
   # Approach A: these 3 ExternalSecrets are resolved HOST-side

--- a/apps/root/templates/cnc-staging-host.yaml
+++ b/apps/root/templates/cnc-staging-host.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cnc-staging-host
+  namespace: argocd
+  annotations:
+    # Resolve the staging secrets host-side BEFORE the vCluster syncs them in
+    # (fromHost.secrets) and before staging workloads. The vCluster itself is
+    # provisioned at wave -1 (cnc-staging-vcluster); these ExternalSecrets land
+    # in that vCluster's host namespace, so they only need to exist before the
+    # in-vCluster workloads (wave 0/1) consume the synced copies.
+    argocd.argoproj.io/sync-wave: "-1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  source:
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.targetRevision }}
+    path: apps/cnc-staging-host/manifests
+  destination:
+    server: {{ .Values.destination.server }}
+    namespace: cnc-staging-vcluster
+  syncPolicy:
+    automated: {selfHeal: true}
+    syncOptions: [CreateNamespace=true, ServerSideApply=true, RespectIgnoreDifferences=true]
+  ignoreDifferences:
+    - kind: Secret
+      jsonPointers: [/data]

--- a/apps/root/templates/cnc-staging-host.yaml
+++ b/apps/root/templates/cnc-staging-host.yaml
@@ -4,11 +4,13 @@ metadata:
   name: cnc-staging-host
   namespace: argocd
   annotations:
-    # Resolve the staging secrets host-side BEFORE the vCluster syncs them in
-    # (fromHost.secrets) and before staging workloads. The vCluster itself is
-    # provisioned at wave -1 (cnc-staging-vcluster); these ExternalSecrets land
-    # in that vCluster's host namespace, so they only need to exist before the
-    # in-vCluster workloads (wave 0/1) consume the synced copies.
+    # Early wave so the root app creates this host-side ExternalSecrets app before
+    # the in-vCluster staging workloads (wave 0/1). NOTE: app-of-apps sync-wave
+    # orders when the child Application CRs are CREATED, not when their contents
+    # converge — the real "secrets exist before consumers" guarantee rests on
+    # ArgoCD health-gating + the vCluster syncer's continuous reconcile, both
+    # self-healing. Wave -1 collides with nothing (cnc-staging-vcluster, also -1,
+    # is independent).
     argocd.argoproj.io/sync-wave: "-1"
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/apps/vclusters/cnc-staging/values.yaml
+++ b/apps/vclusters/cnc-staging/values.yaml
@@ -19,3 +19,19 @@ policies:
       requests.cpu: "8"
       requests.memory: 16Gi
       count/pods: "50"
+
+# Approach A (frank secret-sync): the 3 CNC staging secrets are resolved
+# HOST-side by apps/cnc-staging-host (host ESO + infisical) in this vCluster's
+# own host namespace, then synced INTO the vCluster (ns cnc-staging, where the
+# pods consume them) by name. This is OSS-native sync — NOT the Pro-only
+# `integrations.externalSecrets` that crashed the control-plane (#651/#652).
+# Reading the vCluster's OWN host ns needs no extra RBAC.
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      mappings:
+        byName:
+          "cnc-staging-vcluster/cnc-secrets": "cnc-staging/cnc-secrets"
+          "cnc-staging-vcluster/cnc-ghcr-pull": "cnc-staging/cnc-ghcr-pull"
+          "cnc-staging-vcluster/cnc-runner-auth": "cnc-staging/cnc-runner-auth"

--- a/docs/acceptance/matrix.yaml
+++ b/docs/acceptance/matrix.yaml
@@ -205,3 +205,31 @@ rows:
       a deterministic frank-facts surge-compute snapshot, and a transport error can no
       longer silently drop the reply (#633). Bridge unit tests cover both the fallback
       and the exception path.
+  - id: cnc-staging-secrets-in-vcluster
+    capability: CNC staging secret delivery
+    acceptance: The three CNC staging secrets (cnc-secrets, cnc-ghcr-pull, cnc-runner-auth)
+      are present inside the cnc-staging vCluster with their expected names and keys,
+      so cncd/node/fru can mount them.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''
+  - id: cnc-staging-ghcr-pull-dockerconfigjson
+    capability: CNC staging secret delivery
+    acceptance: The cnc-ghcr-pull secret synced into the cnc-staging vCluster retains
+      type kubernetes.io/dockerconfigjson, so CNC image pulls from ghcr succeed.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''
+  - id: cnc-prod-secret-delivery-unaffected
+    capability: CNC staging secret delivery
+    acceptance: CNC prod secret delivery (ExternalSecrets resolved directly in host
+      namespace cnc) is unchanged by the staging secret-sync work.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''

--- a/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/01.yaml
+++ b/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/01.yaml
@@ -27,22 +27,22 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T11:55:23+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T11:55:25+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T11:55:27+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T11:55:30+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-07-19T11:55:32+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/01.yaml
+++ b/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/01.yaml
@@ -1,0 +1,48 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Host-side ExternalSecrets app
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: 'Guard test: host-side ExternalSecrets render correctly (red -> green)'
+  steps:
+  - id: P1.T1.S1
+    text: |
+      RED: add scripts/tests/test_cnc_staging_host_secrets.py — kustomize-build apps/cnc-staging-host/manifests and assert: exactly 3 ExternalSecrets named cnc-secrets / cnc-ghcr-pull / cnc-runner-auth; each targets the right key (CNCD_SECRETS_MASTER_KEY / .dockerconfigjson / token); all in namespace cnc-staging-vcluster; cnc-ghcr-pull's target.template.type == kubernetes.io/dockerconfigjson. Run it; it FAILS (dir absent).
+  - id: P1.T1.S2
+    text: |
+      GREEN: create apps/cnc-staging-host/manifests/externalsecrets.yaml (the 3 ExternalSecret CRs copied verbatim from apps/cnc-base/manifests/externalsecrets.yaml — same names/keys/store/template) and kustomization.yaml with `namespace: cnc-staging-vcluster` + resources: [externalsecrets.yaml]. Re-run the guard; it PASSES.
+- number: 2
+  title: Application CR wiring for the host-side app
+  steps:
+  - id: P1.T2.S1
+    text: |
+      Create apps/root/templates/cnc-staging-host.yaml (copy the shape of apps/root/templates/cnc-staging-db.yaml host variant): project infrastructure, single source path apps/cnc-staging-host/manifests, destination server {{ .Values.destination.server }} (HOST), namespace cnc-staging-vcluster, sync-wave "-1" (before the vcluster workloads at wave 0/1), syncPolicy automated selfHeal, syncOptions [CreateNamespace=true, ServerSideApply=true, RespectIgnoreDifferences=true], ignoreDifferences on Secret /data, finalizers resources-finalizer.
+  - id: P1.T2.S2
+    text: |
+      Verify the root app-of-apps still renders: `helm template apps/root --values apps/root/values.yaml` (or the repo's documented root render) succeeds and emits the cnc-staging-host Application with destination namespace cnc-staging-vcluster and sync-wave -1. Extend the guard test to assert the template file parses and carries those literal fields.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/02.yaml
+++ b/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/02.yaml
@@ -1,0 +1,34 @@
+schema_version: 2
+phase:
+  number: 2
+  title: vCluster fromHost secret sync + staging in-vcluster exclusion
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+  acceptance:
+  - cnc-prod-secret-delivery-unaffected
+tasks:
+- number: 1
+  title: 'Guard test: exclusion + vcluster mappings (red -> green)'
+  steps:
+  - id: P2.T1.S1
+    text: |
+      RED: extend scripts/tests/test_cnc_staging_host_secrets.py (or a sibling test) to assert: (a) kustomize build apps/cnc-staging/manifests EXCLUDES the 3 ExternalSecrets; (b) kustomize build apps/cnc-prod/manifests still INCLUDES all 3 (prod unaffected — pins cnc-prod-secret-delivery-unaffected); (c) `helm template` of the cnc-staging vcluster (template + cnc-staging values) renders sync.fromHost.secrets.enabled: true with the 3 byName mappings cnc-staging-vcluster/<n> -> cnc-staging/<n>. Run; FAILS.
+  - id: P2.T1.S2
+    text: |
+      GREEN: (1) add a `$patch: delete` entry for each of the 3 ExternalSecrets to apps/cnc-staging/manifests/kustomization.yaml (patches: with inline delete stubs, kind ExternalSecret, metadata.name each). (2) add sync.fromHost.secrets {enabled: true, mappings.byName: {three entries}} to apps/vclusters/cnc-staging/values.yaml. Re-run the guard; PASSES. Confirm the decoded vc-config render shows externalSecrets integration STILL disabled (we are NOT re-enabling the Pro feature).
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/02.yaml
+++ b/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/02.yaml
@@ -21,14 +21,14 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T11:59:37+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T11:59:39+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-07-19T11:59:41+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/03.yaml
+++ b/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/03.yaml
@@ -1,0 +1,59 @@
+schema_version: 2
+phase:
+  number: 3
+  title: On-cluster verification spike + deploy (MANUAL)
+  tag: manual
+  depends_on:
+  - 2
+  tracking_issue: null
+  acceptance:
+  - cnc-staging-secrets-in-vcluster
+  - cnc-staging-ghcr-pull-dockerconfigjson
+tasks:
+- number: 1
+  title: Deploy + prove the sync on-cluster
+  steps:
+  - id: P3.T1.S1
+    text: |
+      After merge, ArgoCD auto-syncs cnc-staging-host (host ExternalSecrets) and cnc-staging-vcluster (fromHost.secrets values). Confirm the 3 host Secrets exist and are resolved in ns cnc-staging-vcluster: `kubectl get externalsecret,secret -n cnc-staging-vcluster | grep cnc-`.
+  - id: P3.T1.S2
+    text: |
+      PRIMARY-RISK SPIKE — inside the vcluster (via its kubeconfig / `vcluster connect` / kubectl exec), assert the 3 secrets landed in ns cnc-staging with correct names+keys AND `kubectl get secret cnc-ghcr-pull -n cnc-staging -o jsonpath={.type}` == kubernetes.io/dockerconfigjson (NOT Opaque). If Opaque -> STOP, image pulls would break; revisit the mapping. Satisfies cnc-staging-ghcr-pull-dockerconfigjson + cnc-staging-secrets-in-vcluster.
+  - id: P3.T1.S3
+    text: |
+      Confirm vcluster RBAC read of the host ns worked (no sync errors in the vcluster syncer logs referencing secrets/cnc-staging-vcluster). Record the evidence (kubectl outputs) on the PR / in terminal-2.md.
+- number: 2
+  title: Runbook + dependency notes
+  steps:
+  - id: P3.T2.S1
+    text: |
+      Add a runbook note: staging secret path diverges from prod (prod = host-ESO direct in ns cnc; staging = host-ESO in ns cnc-staging-vcluster + fromHost sync hop into the vcluster; names/keys/type identical, mechanism differs).
+  - id: P3.T2.S2
+    text: |
+      Record that Blocker B (register the cnc-staging vcluster as an ArgoCD cluster) remains a SEPARATE out-of-band prerequisite for the full staging workload bring-up; the fromHost secret sync itself does NOT require it. cnc-source-token / reseed stay skipped for the first rollout.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/_meta.yaml
+++ b/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-07-19-cnc-staging-secret-sync
+spec: docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-07-19'

--- a/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/_prose.md
+++ b/docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/_prose.md
@@ -1,0 +1,42 @@
+# Plan: OSS-vCluster-compatible secret delivery for CNC staging
+
+Implements approach A from
+`docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md`:
+deliver the three CNC staging secrets (`cnc-secrets`, `cnc-ghcr-pull`,
+`cnc-runner-auth`) into the **OSS** `cnc-staging` vCluster by resolving the
+ExternalSecrets **host-side** (host ESO + `infisical` work there) and syncing the
+resolved Secrets **into** the vCluster via OSS-native `sync.fromHost.secrets`.
+
+This replaces the reverted Pro-only `integrations.externalSecrets` approach
+(frank #651, which crashed the OSS control-plane; reverted by #652).
+
+## Why this shape
+
+- **Agentic phases 1–2** are pure manifest work verifiable *statically* (kustomize
+  build / helm template + YAML assertions) — guard tests catch regressions and
+  pin the prod-unaffected invariant.
+- **Manual phase 3** carries everything that only a live cluster can prove. The
+  `dockerconfigjson` type-preservation through the host→vCluster sync and the
+  vCluster's RBAC read are **runtime** facts — `helm template` proves schema only,
+  and trusting a green template over runtime is exactly what caused the #651
+  incident. So the primary risk is verified on-cluster or the work is not done.
+
+## Product invariants (T1)
+
+Consuming specs (`cncd`/`node`/`fru`) are unchanged: they mount by name+key in ns
+`cnc-staging`. Preserve names, keys, `cnc-ghcr-pull` type `dockerconfigjson`, and
+the target namespace. The whole design is product-invisible when those hold.
+
+## Dependencies / scope
+
+- **Blocker B** (register the vCluster as an ArgoCD cluster `cnc-staging`) is a
+  separate out-of-band prerequisite for full staging workload bring-up; the
+  fromHost secret sync itself does not require it.
+- `cnc-source-token` / reseed stay skipped for the first rollout.
+- Node PVC one-time login is orthogonal. Prod is unchanged.
+
+## Rollback
+
+Revert the vcluster values + host-side app and drop the `$patch: delete`. No Pro
+feature is enabled on the control-plane, so this cannot crash the vCluster the way
+#651 did.

--- a/docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
+++ b/docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
@@ -60,10 +60,13 @@ Infisical --host ESO--> Secret in host ns cnc-staging-vcluster
   template), created in **host ns `cnc-staging-vcluster`**.
 - `manifests/kustomization.yaml` — `namespace: cnc-staging-vcluster`.
 - `apps/root/templates/cnc-staging-host.yaml` — Application CR, destination
-  **host cluster**, ns `cnc-staging-vcluster`, `sync-wave` **before** the vCluster
-  workloads sync (so the host Secrets exist before the vCluster syncs them in).
-  `ignoreDifferences` on Secret `/data` (ESO-managed), `prune: false`,
-  `ServerSideApply=true`.
+  **host cluster**, ns `cnc-staging-vcluster`, `sync-wave -1` (root creates it
+  before the in-vCluster workloads; the actual ordering guarantee rests on ArgoCD
+  health-gating + the vCluster syncer's reconcile, both self-healing).
+  `ignoreDifferences` on Secret `/data` (ESO-managed), `ServerSideApply=true`,
+  `selfHeal`. **`prune` is OMITTED, not set to `false`** — per the root
+  `values.yaml` convention (ArgoCD normalizes explicit `prune: false` to absent,
+  which caused permanent root-app drift), matching all sibling Application CRs.
 
 ### 2. Exclude the 3 ExternalSecrets from the in-vCluster staging deploy (D2)
 - In `apps/cnc-staging/manifests/kustomization.yaml`, add a `$patch: delete`

--- a/docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
+++ b/docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
@@ -122,6 +122,12 @@ vCluster. Names/keys/type identical, mechanism differs — so the staging
 acceptance walk proves the agent-session seam but **not** prod's exact secret
 delivery.
 
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-07-19-cnc-staging-secret-sync | `derio-net/frank` | `2026-07-19-cnc-staging-secret-sync` | — |
+
 ## Rollback
 - Revert the vCluster values (`sync.fromHost.secrets`) + the host-side app +
   restore the in-vCluster ExternalSecrets (drop the `$patch: delete`).

--- a/docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
+++ b/docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md
@@ -1,0 +1,129 @@
+# Design: OSS-vCluster-compatible secret delivery for CNC staging
+
+**Status:** Draft
+**Date:** 2026-07-19
+**Layer:** secrets
+**Branch:** feat/cnc-staging-secret-sync
+
+## Problem
+
+The CNC staging stack runs **inside the `cnc-staging` vCluster**. Its three
+secrets are defined as ExternalSecrets in `apps/cnc-base/manifests/externalsecrets.yaml`
+(shared with prod via the kustomize base) and, for staging, are created **inside
+the vCluster** (the `cnc-staging` overlay sets `namespace: cnc-staging`).
+
+They cannot resolve there: an OSS vCluster has **no ESO controller and no
+`infisical` ClusterSecretStore**. So `cncd`/`node`/`fru` can never mount their
+secrets, and staging workloads can't come up.
+
+The first attempt (frank #651) enabled vCluster's `integrations.externalSecrets`
+— but that is a **vCluster Pro** feature; on Frank's OSS vCluster it fails closed
+at control-plane boot (CrashLoopBackOff). Reverted by #652. See the incident
+record in the rollout cascade `terminal-2.md`.
+
+## The three secrets (invariants — must stay product-invisible)
+
+`cncd`/`node`/`fru` mount by name+key in their own namespace, blind to how the
+Secret was produced. Preserve:
+
+| Secret | Key(s) | Type | Consumed by |
+|---|---|---|---|
+| `cnc-secrets` | `CNCD_SECRETS_MASTER_KEY` | Opaque | cncd (env) |
+| `cnc-ghcr-pull` | `.dockerconfigjson` | `kubernetes.io/dockerconfigjson` | all (imagePullSecret) |
+| `cnc-runner-auth` | `token` | Opaque | cncd (env) + node (file mount) |
+
+Invariants: (1) names unchanged, (2) keys unchanged, (3) `cnc-ghcr-pull` stays
+`dockerconfigjson`, (4) they land in the **in-vCluster namespace the pods consume
+from** (`cnc-staging`). Consuming specs (`cnc-base` deployments/statefulset) do
+**not** change.
+
+## Approach (operator-chosen "A")
+
+Resolve the ExternalSecrets on the **host** (where ESO + `infisical` work) and
+sync the resolved Secrets **into** the vCluster via OSS-native
+`sync.fromHost.secrets`.
+
+```
+Infisical --host ESO--> Secret in host ns cnc-staging-vcluster
+          --vCluster fromHost sync (byName)--> Secret in vCluster ns cnc-staging
+          --> cncd/node/fru mount (unchanged)
+```
+
+`sync.fromHost.secrets` is confirmed present in the **OSS** rendered config
+(`enabled: false, mappings.byName: {}`) — core sync, not a Pro integration.
+
+## Changes
+
+### 1. New host-side app `apps/cnc-staging-host/`
+- `manifests/externalsecrets.yaml` — the 3 ExternalSecret CRs (copied from
+  `cnc-base`, unchanged spec: same names, keys, `cnc-ghcr-pull` dockerconfigjson
+  template), created in **host ns `cnc-staging-vcluster`**.
+- `manifests/kustomization.yaml` — `namespace: cnc-staging-vcluster`.
+- `apps/root/templates/cnc-staging-host.yaml` — Application CR, destination
+  **host cluster**, ns `cnc-staging-vcluster`, `sync-wave` **before** the vCluster
+  workloads sync (so the host Secrets exist before the vCluster syncs them in).
+  `ignoreDifferences` on Secret `/data` (ESO-managed), `prune: false`,
+  `ServerSideApply=true`.
+
+### 2. Exclude the 3 ExternalSecrets from the in-vCluster staging deploy (D2)
+- In `apps/cnc-staging/manifests/kustomization.yaml`, add a `$patch: delete`
+  entry for each of the 3 ExternalSecrets. `cnc-base` is untouched → **prod is
+  unaffected** (prod keeps resolving them directly in host ns `cnc`).
+
+### 3. vCluster `sync.fromHost.secrets` (D1: reuse the vcluster host ns)
+In `apps/vclusters/cnc-staging/values.yaml`:
+```yaml
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      mappings:
+        byName:
+          "cnc-staging-vcluster/cnc-secrets": "cnc-staging/cnc-secrets"
+          "cnc-staging-vcluster/cnc-ghcr-pull": "cnc-staging/cnc-ghcr-pull"
+          "cnc-staging-vcluster/cnc-runner-auth": "cnc-staging/cnc-runner-auth"
+```
+Host source ns = the vCluster's own host ns `cnc-staging-vcluster` (native RBAC).
+Target = vCluster ns `cnc-staging` (where pods consume).
+
+## Decisions
+- **D1 — host ns for the ExternalSecrets:** reuse `cnc-staging-vcluster` (the
+  vCluster reads its own host ns natively; no extra cross-ns RBAC). *(operator-confirmed)*
+- **D2 — exclusion mechanism:** kustomize `$patch: delete` in the staging overlay
+  (surgical; leaves `cnc-base`/prod untouched) rather than restructuring
+  `cnc-base` into components. *(operator-confirmed)*
+
+## Technical risks — VERIFY, do not assume (lesson from #651)
+
+A verification spike must run on-cluster **before B.5 is declared done**:
+1. **Type preservation** — does `sync.fromHost.secrets` copy the
+   `kubernetes.io/dockerconfigjson` **type**, or does `cnc-ghcr-pull` land as
+   `Opaque` (→ image pulls break)? PRIMARY risk.
+2. **RBAC** — does the vCluster syncer actually read the host `cnc-staging-vcluster`
+   ns without extra rules? (Native for own host ns, but confirm.)
+3. **Names/keys land intact** in vCluster ns `cnc-staging`.
+
+`helm template` proves schema-validity only, NOT runtime/edition behaviour
+(that is exactly what #651 missed). Verification is on-cluster or it does not count.
+
+## Out of scope / orthogonal
+- **Blocker B** (register the vCluster as an ArgoCD cluster `cnc-staging`) — still
+  separately required; unaffected by this design.
+- **`cnc-source-token`** (ClusterGenerator ExternalSecret) — powers the reseed job,
+  which is **skipped** for the first rollout; off the critical path. Same host-side
+  pattern can be applied later if reseed is enabled.
+- **Node PVC one-time `claude`/`agy`/`codex` login** — orthogonal harness auth.
+- **prod** — unchanged (host-ESO direct).
+
+## Divergence note (for the runbook)
+Staging's secret path now differs from prod: prod = host-ESO direct in ns `cnc`;
+staging = host-ESO in ns `cnc-staging-vcluster` + a `fromHost` sync hop into the
+vCluster. Names/keys/type identical, mechanism differs — so the staging
+acceptance walk proves the agent-session seam but **not** prod's exact secret
+delivery.
+
+## Rollback
+- Revert the vCluster values (`sync.fromHost.secrets`) + the host-side app +
+  restore the in-vCluster ExternalSecrets (drop the `$patch: delete`).
+- The vCluster control-plane is NOT reconfigured with any Pro feature, so this
+  design cannot crash it the way #651 did (`fromHost.secrets` is core OSS sync).

--- a/scripts/tests/test_cnc_staging_host_secrets.py
+++ b/scripts/tests/test_cnc_staging_host_secrets.py
@@ -14,6 +14,12 @@ These guards lock the STATIC invariants product code depends on. The
 the vCluster RBAC read are RUNTIME facts — proven by the manual Phase-3
 on-cluster spike, NOT here (helm/kustomize prove schema only; trusting that over
 runtime is exactly the #651 trap).
+
+These are LOCAL guards (frank does not run scripts/tests/ in CI). They shell out
+to `kustomize build` and `helm template --repo https://charts.loft.sh` and are
+fail-closed (non-zero return / missing render -> assertion error, never a
+false-green). In a runner without helm/kustomize or without egress they go red
+on infra, not logic — run them where those tools + network are available.
 """
 
 import base64
@@ -102,7 +108,10 @@ def test_secret_keys_are_preserved():
     )
 
 
-def test_ghcr_pull_keeps_dockerconfigjson_type():
+def test_host_declares_ghcr_pull_dockerconfigjson_type():
+    # NOTE: this asserts the host-side ExternalSecret's DECLARED template type.
+    # Whether the SYNCED copy inside the vCluster retains the type is a RUNTIME
+    # fact proven by the manual Phase-3 spike (the primary risk), not here.
     es = _externalsecrets(_kustomize(HOST_APP))
     assert (
         es["cnc-ghcr-pull"]["spec"]["target"]["template"]["type"]
@@ -124,12 +133,25 @@ def test_root_renders_host_app_with_host_destination_and_early_wave():
 # --- Phase 2: staging in-vCluster exclusion + vCluster fromHost sync ---------
 
 
-def test_staging_overlay_excludes_the_three_externalsecrets():
-    """Staging must NOT create these inside the vCluster (they can't resolve
-    there); they arrive via fromHost sync instead."""
+def test_staging_overlay_creates_no_externalsecrets_at_all():
+    """The OSS cnc-staging vCluster has NO ESO controller, so the overlay must
+    create ZERO ExternalSecrets — not just the 3 store-backed ones. This also
+    catches cnc-source-token (ClusterGenerator-backed), which would otherwise sit
+    SecretSyncError forever and drag the app to Degraded. The 3 app secrets arrive
+    via fromHost sync; source-token/reseed are excluded until reseed is enabled."""
     es = _externalsecrets(_kustomize(CNC_STAGING))
-    leaked = NAMES & set(es)
-    assert not leaked, f"staging overlay still creates in-vcluster ExternalSecrets: {leaked}"
+    assert es == {}, f"staging overlay must create NO ExternalSecrets in-vcluster, found: {sorted(es)}"
+
+
+def test_staging_overlay_excludes_reseed_job():
+    """reseed-job consumes cnc-source-token (unresolvable in-vcluster) and reseed
+    is skipped for the first rollout — the Job must not be created."""
+    jobs = {
+        d["metadata"]["name"]
+        for d in _kustomize(CNC_STAGING)
+        if d.get("kind") == "Job"
+    }
+    assert "cnc-staging-reseed" not in jobs, "reseed Job must be excluded until reseed is enabled"
 
 
 def test_prod_overlay_still_includes_the_three_externalsecrets():

--- a/scripts/tests/test_cnc_staging_host_secrets.py
+++ b/scripts/tests/test_cnc_staging_host_secrets.py
@@ -1,0 +1,98 @@
+"""Guard the CNC staging host-side ExternalSecrets app + fromHost secret sync.
+
+The three CNC staging secrets (cnc-secrets / cnc-ghcr-pull / cnc-runner-auth)
+cannot resolve INSIDE the OSS cnc-staging vCluster — there is no ESO controller
+or `infisical` ClusterSecretStore in there (and the vCluster External-Secrets
+INTEGRATION is a Pro feature that crashes OSS; frank #651 reverted by #652).
+
+Approach A: resolve the ExternalSecrets host-side in ns `cnc-staging-vcluster`
+(host ESO works), then sync the resolved Secrets INTO the vCluster ns
+`cnc-staging` via OSS-native `sync.fromHost.secrets`.
+
+These guards lock the STATIC invariants product code depends on. The
+`dockerconfigjson` TYPE preservation through the runtime host->vCluster sync and
+the vCluster RBAC read are RUNTIME facts — proven by the manual Phase-3
+on-cluster spike, NOT here (helm/kustomize prove schema only; trusting that over
+runtime is exactly the #651 trap).
+"""
+
+import subprocess
+from pathlib import Path
+
+import yaml  # hard dep (pyproject) — a missing yaml must ERROR, not skip
+
+REPO = Path(__file__).resolve().parents[2]
+HOST_APP = REPO / "apps/cnc-staging-host/manifests"
+ROOT_APP = REPO / "apps/root"
+
+NAMES = {"cnc-secrets", "cnc-ghcr-pull", "cnc-runner-auth"}
+
+
+def _helm_template(path: Path):
+    out = subprocess.run(
+        ["helm", "template", "root", str(path)], capture_output=True, text=True
+    )
+    assert out.returncode == 0, f"helm template {path} failed:\n{out.stderr}"
+    return [d for d in yaml.safe_load_all(out.stdout) if d]
+
+
+def _application(docs, name):
+    for d in docs:
+        if d.get("kind") == "Application" and d["metadata"]["name"] == name:
+            return d
+    raise AssertionError(f"Application {name} not rendered by the root app")
+
+
+def _kustomize(path: Path):
+    out = subprocess.run(
+        ["kustomize", "build", str(path)], capture_output=True, text=True
+    )
+    assert out.returncode == 0, f"kustomize build {path} failed:\n{out.stderr}"
+    return [d for d in yaml.safe_load_all(out.stdout) if d]
+
+
+def _externalsecrets(docs):
+    return {
+        d["metadata"]["name"]: d for d in docs if d.get("kind") == "ExternalSecret"
+    }
+
+
+def test_host_app_renders_the_three_externalsecrets():
+    es = _externalsecrets(_kustomize(HOST_APP))
+    assert set(es) == NAMES
+
+
+def test_host_externalsecrets_live_in_the_vcluster_host_namespace():
+    for name, d in _externalsecrets(_kustomize(HOST_APP)).items():
+        assert (
+            d["metadata"]["namespace"] == "cnc-staging-vcluster"
+        ), f"{name} must be in the vcluster host ns cnc-staging-vcluster"
+
+
+def test_secret_keys_are_preserved():
+    es = _externalsecrets(_kustomize(HOST_APP))
+    assert es["cnc-secrets"]["spec"]["data"][0]["secretKey"] == "CNCD_SECRETS_MASTER_KEY"
+    assert es["cnc-runner-auth"]["spec"]["data"][0]["secretKey"] == "token"
+    assert (
+        ".dockerconfigjson"
+        in es["cnc-ghcr-pull"]["spec"]["target"]["template"]["data"]
+    )
+
+
+def test_ghcr_pull_keeps_dockerconfigjson_type():
+    es = _externalsecrets(_kustomize(HOST_APP))
+    assert (
+        es["cnc-ghcr-pull"]["spec"]["target"]["template"]["type"]
+        == "kubernetes.io/dockerconfigjson"
+    )
+
+
+def test_root_renders_host_app_with_host_destination_and_early_wave():
+    app = _application(_helm_template(ROOT_APP), "cnc-staging-host")
+    dest = app["spec"]["destination"]
+    # HOST destination (server), NOT a vCluster (which would use `name:`)
+    assert dest.get("server") == "https://kubernetes.default.svc"
+    assert dest["namespace"] == "cnc-staging-vcluster"
+    assert app["spec"]["source"]["path"] == "apps/cnc-staging-host/manifests"
+    # syncs before the in-vCluster staging workloads
+    assert app["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "-1"

--- a/scripts/tests/test_cnc_staging_host_secrets.py
+++ b/scripts/tests/test_cnc_staging_host_secrets.py
@@ -16,6 +16,7 @@ on-cluster spike, NOT here (helm/kustomize prove schema only; trusting that over
 runtime is exactly the #651 trap).
 """
 
+import base64
 import subprocess
 from pathlib import Path
 
@@ -24,8 +25,30 @@ import yaml  # hard dep (pyproject) — a missing yaml must ERROR, not skip
 REPO = Path(__file__).resolve().parents[2]
 HOST_APP = REPO / "apps/cnc-staging-host/manifests"
 ROOT_APP = REPO / "apps/root"
+CNC_STAGING = REPO / "apps/cnc-staging/manifests"
+CNC_PROD = REPO / "apps/cnc-prod/manifests"
+VC_TEMPLATE_VALUES = REPO / "apps/vclusters/template/values.yaml"
+VC_STAGING_VALUES = REPO / "apps/vclusters/cnc-staging/values.yaml"
+VCLUSTER_VERSION = "0.32.1"
 
 NAMES = {"cnc-secrets", "cnc-ghcr-pull", "cnc-runner-auth"}
+
+
+def _vcluster_config():
+    """Render the cnc-staging vCluster and decode its effective config.yaml."""
+    out = subprocess.run(
+        [
+            "helm", "template", "cnc-staging", "vcluster",
+            "--repo", "https://charts.loft.sh", "--version", VCLUSTER_VERSION,
+            "-f", str(VC_TEMPLATE_VALUES), "-f", str(VC_STAGING_VALUES),
+        ],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 0, f"helm template vcluster failed:\n{out.stderr}"
+    for d in yaml.safe_load_all(out.stdout):
+        if d and d.get("kind") == "Secret" and "config.yaml" in d.get("data", {}):
+            return yaml.safe_load(base64.b64decode(d["data"]["config.yaml"]))
+    raise AssertionError("vc-config Secret not rendered")
 
 
 def _helm_template(path: Path):
@@ -96,3 +119,38 @@ def test_root_renders_host_app_with_host_destination_and_early_wave():
     assert app["spec"]["source"]["path"] == "apps/cnc-staging-host/manifests"
     # syncs before the in-vCluster staging workloads
     assert app["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "-1"
+
+
+# --- Phase 2: staging in-vCluster exclusion + vCluster fromHost sync ---------
+
+
+def test_staging_overlay_excludes_the_three_externalsecrets():
+    """Staging must NOT create these inside the vCluster (they can't resolve
+    there); they arrive via fromHost sync instead."""
+    es = _externalsecrets(_kustomize(CNC_STAGING))
+    leaked = NAMES & set(es)
+    assert not leaked, f"staging overlay still creates in-vcluster ExternalSecrets: {leaked}"
+
+
+def test_prod_overlay_still_includes_the_three_externalsecrets():
+    """Prod resolves them directly in host ns cnc — unaffected by the staging
+    change (pins cnc-prod-secret-delivery-unaffected)."""
+    es = _externalsecrets(_kustomize(CNC_PROD))
+    missing = NAMES - set(es)
+    assert not missing, f"prod overlay lost ExternalSecrets: {missing}"
+
+
+def test_vcluster_fromhost_secret_mappings_present():
+    fh = _vcluster_config()["sync"]["fromHost"]["secrets"]
+    assert fh["enabled"] is True
+    mappings = fh["mappings"]["byName"]
+    for n in NAMES:
+        assert (
+            mappings.get(f"cnc-staging-vcluster/{n}") == f"cnc-staging/{n}"
+        ), f"missing/incorrect fromHost mapping for {n}: {mappings}"
+
+
+def test_vcluster_externalsecrets_integration_stays_disabled():
+    """Never re-enable the Pro-only integration that crashed OSS (#651)."""
+    cfg = _vcluster_config()
+    assert cfg["integrations"]["externalSecrets"]["enabled"] is False


### PR DESCRIPTION
## What

OSS-vCluster-compatible secret delivery for CNC **staging** (approach A). Resolve
the 3 CNC staging secrets **host-side** (host ESO + `infisical`) in the vCluster's
own host namespace, then sync them **into** the vCluster via OSS-native
`sync.fromHost.secrets`. Replaces the reverted Pro-only
`integrations.externalSecrets` (#651 → reverted by #652, which crashed the OSS
control-plane).

Spec: `docs/superpowers/specs/2026-07-19--secrets--cnc-staging-vcluster-secret-sync-design.md`
Plan: `docs/superpowers/plans/2026-07-19-cnc-staging-secret-sync/`

## Changes (agentic phases 1–2)

- **New host-side app** `apps/cnc-staging-host/` — the 3 ExternalSecrets
  (`cnc-secrets`/`cnc-ghcr-pull`/`cnc-runner-auth`, spec identical to `cnc-base`)
  in host ns `cnc-staging-vcluster` + root Application CR (host destination,
  `sync-wave: -1`, `ignoreDifferences` Secret `/data`).
- **`apps/vclusters/cnc-staging/values.yaml`** — `sync.fromHost.secrets.enabled`
  + 3 `byName` mappings (`cnc-staging-vcluster/<n>` → `cnc-staging/<n>`).
- **`apps/cnc-staging/manifests/kustomization.yaml`** — `$patch: delete` the 3
  ExternalSecrets from the in-vCluster staging overlay (they can't resolve
  there). `cnc-base` untouched → **prod unaffected**.
- **Guard test** `scripts/tests/test_cnc_staging_host_secrets.py` (9 tests, all
  green): host-app renders 3 ES with correct names/keys/`dockerconfigjson` type +
  host destination; staging overlay excludes them; prod still includes them;
  vCluster renders the 3 `fromHost` mappings; the Pro integration stays disabled.

## ⚠️ Phase 3 is MANUAL and back-loaded — ships unimplemented

The on-cluster verification spike cannot be automated and is **deliberately left
unimplemented** in this PR. After merge, the operator runs it and pushes to this
PR (`fr plan edit … --complete-phase 3 --note …`):

1. Confirm host ExternalSecrets resolve in ns `cnc-staging-vcluster`.
2. **PRIMARY RISK:** inside the vCluster, prove the 3 secrets land in ns
   `cnc-staging` with correct names/keys AND `cnc-ghcr-pull` is still type
   `kubernetes.io/dockerconfigjson` (NOT `Opaque` → would break image pulls).
   `helm template` proves schema only; this runtime fact is exactly the gap that
   caused the #651 incident, so it is verified on-cluster or not at all.
3. Confirm vCluster RBAC read of the host ns works.

**Separate prerequisite (not this PR):** register the vCluster as an ArgoCD
cluster `cnc-staging` (Blocker B) for full staging workload bring-up; the
`fromHost` secret sync itself does not require it.

## Acceptance debt (not ironed over)

3 rows remain `not-implemented`:
- `cnc-prod-secret-delivery-unaffected` — statically guarded by
  `test_prod_overlay_still_includes_the_three_externalsecrets` (prod kustomize
  build unchanged), but frank does **not** CI-run `scripts/tests/` (local guard),
  and full runtime confidence is part of Phase 3. Left honest.
- `cnc-staging-secrets-in-vcluster`, `cnc-staging-ghcr-pull-dockerconfigjson` —
  require the manual Phase-3 on-cluster spike.

## Code review (milestone) — findings + fixes

Read-only reviewer over spec + plan + diff; **all findings resolved** (10/10 guards green after fixes):

- **Important — `cnc-source-token` left in the vCluster overlay:** the ClusterGenerator-backed ExternalSecret (+ its consumer `reseed-job`) still rendered into the OSS vCluster where ESO can't resolve → would sit `SecretSyncError` and drag the app `Degraded`. **Fixed:** excluded both from the staging overlay for the first rollout (reseed skipped); the guard now asserts the staging build creates **zero** ExternalSecrets + no reseed Job.
- **Minor — misleading test name:** renamed the ghcr type test to make clear it checks the host *declaration*, not the synced copy (the runtime fact stays deferred to Phase 3).
- **Minor — test hermeticity:** documented that the guards are local (frank doesn't CI-run `scripts/tests/`) and network/toolchain-dependent, but fail-closed (no false-green).
- **Minor — sync-wave comment overstated:** softened — app-of-apps waves order CR *creation*, not content convergence; real ordering is health-gate + syncer reconcile.
- **Minor — "add explicit `prune: false`" — REFUTED:** the root `values.yaml` documents that explicit `prune: false` normalizes to absent and *caused permanent root-app drift*; the convention is to **omit** it. Manifest kept as-is (matches all sibling apps); spec prose aligned.

## Rollback

Revert the vCluster values + host-side app and drop the `$patch: delete`. No Pro
feature is enabled on the control-plane, so this cannot crash the vCluster the
way #651 did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
