### PR TITLE
fix(cnc): allow cnc-staging vCluster as an infrastructure-project destination

### DIFF
--- a/apps/root/templates/project.yaml
+++ b/apps/root/templates/project.yaml
@@ -12,6 +12,10 @@ spec:
   destinations:
     - namespace: '*'
       server: {{ .Values.destination.server }}
+    # cnc-staging vCluster (registered out-of-band as ArgoCD cluster 'cnc-staging')
+    # so cnc-staging / cnc-staging-db can deploy INTO it.
+    - namespace: '*'
+      name: cnc-staging
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'


### PR DESCRIPTION
Part of **Blocker B** (making the cnc-staging vCluster a usable ArgoCD deploy target).

After registering the vCluster as ArgoCD cluster `cnc-staging`, the `cnc-staging` / `cnc-staging-db` apps still failed:

> application destination server 'cnc-staging' and namespace 'cnc-staging' do not match any of the allowed destinations in project 'infrastructure'

The `infrastructure` AppProject only allowed the in-cluster destination. This adds the `cnc-staging` cluster (by name) to the project's destination allowlist. The root app-of-apps templates this project, so it must be a git change (a live patch would be reverted by selfHeal).

Rendered + checked: `helm template root apps/root` emits the infrastructure project with both destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)