### PR TITLE
fix(cnc): allow ArgoCD to reach the cnc-staging vCluster API (Blocker B pt3)

### DIFF
--- a/apps/cnc-staging-host/manifests/kustomization.yaml
+++ b/apps/cnc-staging-host/manifests/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: cnc-staging-vcluster
 resources:
   - externalsecrets.yaml
+  - networkpolicy-argocd.yaml

--- a/apps/cnc-staging-host/manifests/networkpolicy-argocd.yaml
+++ b/apps/cnc-staging-host/manifests/networkpolicy-argocd.yaml
@@ -1,0 +1,23 @@
+# Additive NetworkPolicy (Blocker B, part 3): allow the ArgoCD application-controller
+# to reach the cnc-staging vCluster API server (control-plane pod, port 8443) so
+# ArgoCD can sync the cnc-staging / cnc-staging-db apps INTO the vCluster. The
+# chart's vc-cp-* NetworkPolicy only permits in-vCluster pods + app=loft; ArgoCD
+# is neither. NetworkPolicies are additive (union), so this grants argocd->8443
+# without weakening the chart's isolation. Namespace is set by the kustomization
+# (cnc-staging-vcluster).
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-argocd-to-vcluster-api
+spec:
+  podSelector:
+    matchLabels:
+      release: cnc-staging
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: argocd
+      ports:
+        - {port: 8443, protocol: TCP}


### PR DESCRIPTION
Third and final part of **Blocker B** (making the cnc-staging vCluster a usable ArgoCD deploy target). After registering the cluster (part 1, out-of-band) and allowing the project destination (#655, part 2), `cnc-staging`/`cnc-staging-db` still fail:

> ComparisonError: Failed to get cluster info for `https://cnc-staging.cnc-staging-vcluster.svc:443`: … dial tcp 10.107.226.95:443: **i/o timeout**

The vcluster's chart NetworkPolicy (`vc-cp-cnc-staging`) only permits ingress from in-vcluster pods + `app=loft`. ArgoCD's application-controller (ns `argocd`) is neither, so its API probe is dropped.

**Fix:** an additive NetworkPolicy (deployed by the `cnc-staging-host` app into ns `cnc-staging-vcluster`) allowing the `argocd` namespace → the control-plane pod on `:8443`. NetworkPolicies are additive (union of allowed traffic), so the chart's isolation posture is preserved — this only *adds* ArgoCD as a permitted source.

Rendered + checked with `kustomize build`.

After merge: root syncs → `cnc-staging(-db)` leave ComparisonError and sync into the vCluster → postgres + migrate + cncd/node/fru come up, consuming the already-verified synced secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)