### PR TITLE
fix(cnc): disable vCluster-level NetworkPolicy for cnc-staging (unblock workload comms)

### DIFF
--- a/apps/vclusters/cnc-staging/values.yaml
+++ b/apps/vclusters/cnc-staging/values.yaml
@@ -13,6 +13,13 @@ controlPlane:
         size: 20Gi
         storageClass: longhorn
 policies:
+  # Disable the vCluster-level (host-side vc-*) NetworkPolicies for staging. Their
+  # default egress excludes 10.0.0.0/8, so the CNC stack's ClusterIP-based comms
+  # (migrate/cncd -> postgres, cncd <-> node :8765, etc.) are denied on Frank's
+  # Cilium (EPERM). The CNC stack ships its OWN networkpolicy.yaml (cnc-base) which
+  # governs workload isolation INSIDE the vCluster. Staging is internal-by-default.
+  networkPolicy:
+    enabled: false
   resourceQuota:
     enabled: true
     quota:


### PR DESCRIPTION
Blocker-B follow-on. After the vCluster became a working ArgoCD target and workloads started syncing in, the migrate job failed:

> migrate: dial tcp 10.105.107.78:5432 (cnc-staging-db-postgresql): connect: **operation not permitted**

The vcluster's default host-side NetworkPolicies (`vc-work`/`vc-cp`) have an egress allowlist of `0.0.0.0/0 EXCEPT [..., 10.0.0.0/8, ...]` plus pod-identity selectors. The CNC stack talks over **ClusterIP VIPs in `10/8`** (migrate/cncd → postgres, cncd ↔ node `:8765`), which those policies exclude — denied on Frank's Cilium (EPERM). This is the 2nd time the vc-* NPs fought the stack (1st: argocd→API, #656).

**Fix:** disable the redundant vCluster-level NetworkPolicy for cnc-staging. The CNC stack ships its **own** `networkpolicy.yaml` (in `cnc-base`) that governs workload isolation *inside* the vCluster. Staging is internal-by-default (operator decision, consistent with the earlier `insecure` cluster-registration call).

Rendered check: `helm template` of the cnc-staging vcluster now emits **0** `vc-*` NetworkPolicies.

**Post-merge (manual, one-time):** the app runs `prune: false`, so the 4 existing `vc-*` NetworkPolicies must be deleted once (they won't be recreated after this merge). I'll do that as part of driving the staging bring-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)