### PR TITLE
fix(cnc): scope ArgoCD Pod-exclusion to unblock cnc-staging vCluster registration

### DIFF
--- a/apps/argocd/values.yaml
+++ b/apps/argocd/values.yaml
@@ -120,6 +120,79 @@ configs:
         - email
         - groups
         - offline_access
+    # resource.exclusions REPLACES the argo-cd chart default (Helm does not merge
+    # a multiline string value), so the chart's default exclusions are reproduced
+    # here VERBATIM (argo-cd chart 9.4.6) and the scoped Pod entry is appended.
+    # scripts/tests/test_argocd_vcluster_pod_exclusion.py guards that the defaults
+    # survive AND that the Pod exclusion stays cluster-scoped (never global).
+    resource.exclusions: |
+      ### Network resources created by the Kubernetes control plane (chart default)
+      - apiGroups:
+        - ''
+        - discovery.k8s.io
+        kinds:
+        - Endpoints
+        - EndpointSlice
+      ### Internal Kubernetes resources (chart default)
+      - apiGroups:
+        - coordination.k8s.io
+        kinds:
+        - Lease
+      ### Internal Kubernetes Authz/Authn resources (chart default)
+      - apiGroups:
+        - authentication.k8s.io
+        - authorization.k8s.io
+        kinds:
+        - SelfSubjectReview
+        - TokenReview
+        - LocalSubjectAccessReview
+        - SelfSubjectAccessReview
+        - SelfSubjectRulesReview
+        - SubjectAccessReview
+      ### Intermediate Certificate Requests (chart default)
+      - apiGroups:
+        - certificates.k8s.io
+        kinds:
+        - CertificateSigningRequest
+      - apiGroups:
+        - cert-manager.io
+        kinds:
+        - CertificateRequest
+      ### Cilium internal resources (chart default)
+      - apiGroups:
+        - cilium.io
+        kinds:
+        - CiliumIdentity
+        - CiliumEndpoint
+        - CiliumEndpointSlice
+      ### Kyverno intermediate and reporting resources (chart default)
+      - apiGroups:
+        - kyverno.io
+        - reports.kyverno.io
+        - wgpolicyk8s.io
+        kinds:
+        - PolicyReport
+        - ClusterPolicyReport
+        - EphemeralReport
+        - ClusterEphemeralReport
+        - AdmissionReport
+        - ClusterAdmissionReport
+        - BackgroundScanReport
+        - ClusterBackgroundScanReport
+        - UpdateRequest
+      ### fr-debugging 2026-07-19 — work around argo-cd#26529 / kubernetes#136533.
+      ### ArgoCD v3.3.2 (kubectl v0.34.0) panics `assignment to entry in nil map`
+      ### in populatePodInfo when caching a Pod from a remote vCluster that ships a
+      ### LimitRange, crashing the application-controller cluster-wide. Skip Pods on
+      ### the cnc-staging vCluster ONLY (scoped by `clusters`) so the main cluster
+      ### keeps full per-pod visibility. Remove when ArgoCD ships >= 3.5 (client-go
+      ### 1.36.1, the upstream fix).
+      - apiGroups:
+        - ''
+        kinds:
+        - Pod
+        clusters:
+        - https://cnc-staging.cnc-staging-vcluster.svc:443
   rbac:
     policy.csv: |
       g, root-admins, role:admin

--- a/docs/superpowers/debugging/2026-07-19-argocd-vcluster-cache-panic.md
+++ b/docs/superpowers/debugging/2026-07-19-argocd-vcluster-cache-panic.md
@@ -1,0 +1,144 @@
+# ArgoCD application-controller cluster-wide crash on registering the cnc-staging vCluster
+
+- **Date:** 2026-07-19
+- **Layer:** secrets / cnc (CNC permanent-deployment rollout, Blocker B)
+- **Branch:** `fix/argocd-vcluster-cache-panic`
+- **Status:** root cause confirmed; surgical fix landed; runtime re-verification is a back-loaded manual step (operator-gated)
+
+## Symptom & reproduction
+
+Registering the `cnc-staging` vCluster as an ArgoCD **cluster target** (out-of-band
+`cluster-cnc-staging` Secret, server `https://cnc-staging.cnc-staging-vcluster.svc:443`)
+makes the `argocd-application-controller-0` StatefulSet pod **panic and exit** while
+building that cluster's cache. On the next cold start it rebuilds *all* cluster caches,
+hits the same panic, and exits again → **CrashLoopBackOff cluster-wide**: all ~60
+Applications stop reconciling. Recovery was `kubectl delete secret cluster-cnc-staging -n
+argocd` + delete the controller pod; the controller then came up clean (61 Synced).
+
+Reproduction is destructive (cluster-wide outage), so it was NOT re-triggered. The panic
+was instead read from the already-captured controller logs in VictoriaLogs
+(`192.168.55.225:9428`), which is how the root cause was pinned without re-crashing the
+cluster.
+
+## Evidence
+
+Verbatim panic (VictoriaLogs, `kubernetes.pod_name:argocd-application-controller-0`,
+crash window ~20:12–20:23Z, two cold-start crashes at 20:12:24 and 20:17:26):
+
+```
+ArgoCD Application Controller is starting ... version=v3.3.2
+Start syncing cluster server="https://cnc-staging.cnc-staging-vcluster.svc:443"
+panic: assignment to entry in nil map
+goroutine 329 [running]:
+k8s.io/kubectl/pkg/util/resource.maxResourceList(...)        resource.go:179
+k8s.io/kubectl/pkg/util/resource.max(...)                    resource.go:157
+k8s.io/kubectl/pkg/util/resource.determineContainerReqs(...) resource.go:149
+k8s.io/kubectl/pkg/util/resource.podRequests(...)            resource.go:57
+k8s.io/kubectl/pkg/util/resource.PodRequestsAndLimits(...)   resource.go:36
+github.com/argoproj/argo-cd/v3/controller/cache.populatePodInfo(...)  controller/cache/info.go:462
+github.com/argoproj/argo-cd/v3/controller/cache.populateNodeInfo(...)
+github.com/argoproj/gitops-engine/pkg/cache.(*clusterCache).newResource(...)
+github.com/argoproj/gitops-engine/pkg/cache.(*clusterCache).sync ... listResources ... EachListItem
+created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 301
+```
+
+Key facts:
+- Panic fires 0.3s after `Start syncing cluster server=".../cnc-staging-vcluster..."` —
+  it is the **vCluster** cache sync, never the main cluster (which syncs fine repeatedly
+  in the same log).
+- ArgoCD **v3.3.2** (argo-cd Helm chart `9.4.6`), which vendors **kubectl v0.34.0**.
+- The assignment-to-nil-map is in kubectl's pod-resource helper (`maxResourceList`),
+  reached from ArgoCD `populatePodInfo` while caching a **Pod**.
+- Panic is uncaught in an `errgroup` goroutine → the whole process dies (not just that
+  cluster's cache), so it is latent (fine while a cache builds incrementally) and only
+  manifests on a full **cold** rebuild — i.e. on every controller restart.
+- Upstream: [argo-cd#26529](https://github.com/argoproj/argo-cd/issues/26529) →
+  [kubernetes#136533](https://github.com/kubernetes/kubernetes/issues/136533) (fixed in
+  [k8s#136534](https://github.com/kubernetes/kubernetes/pull/136534), milestone 1.36).
+  Maintainers confirm client-go was bumped to 1.36.1 in argo-cd master, **shipping in
+  ArgoCD 3.5** — explicitly **not** backported to 3.4. The named trigger is "a remote
+  vCluster that uses **LimitRanges**" — vClusters ship a default LimitRange, so any pod
+  cached from the vCluster hits the nil-map path.
+
+## Root cause
+
+**ArgoCD v3.3.2 crashes because kubectl v0.34.0's `resource.PodRequestsAndLimits` writes
+to a nil `ResourceList` map when computing the resource requests of a Pod that carries
+LimitRange-defaulted resources** (`argo-cd#26529` / `kubernetes#136533`). The
+`cnc-staging` vCluster ships a default LimitRange; registering it as an ArgoCD cluster
+target makes the controller cache the vCluster's Pods, invoking `populatePodInfo` →
+`PodRequestsAndLimits` → panic. Because the panic is unrecovered in a background cache-sync
+goroutine, it kills the entire controller process → cluster-wide CrashLoop on cold start.
+
+Stated as X because Y: *the controller crashes cluster-wide because a single vCluster Pod
+drives a version-pinned kubectl nil-map panic in an uncaught cache-sync goroutine.* It is a
+library-version regression, not a Frank manifest/config error.
+
+## Fix
+
+The permanent fix (ArgoCD 3.5 / client-go 1.36.1) is a major cross-version bump of the
+component that already crashed cluster-wide — too heavy and risky to chase now. Instead,
+apply the maintainer-endorsed workaround, **scoped so it stays surgical**: a
+`resource.exclusions` entry that skips **Pod** on the `cnc-staging` vCluster URL only.
+ArgoCD `resource.exclusions` matches on `apiGroups` + `kinds` + a `clusters` glob list, so
+the exclusion applies solely to `https://cnc-staging.cnc-staging-vcluster.svc:443`; the
+main cluster keeps full per-pod visibility for all other apps.
+
+Change: `apps/argocd/values.yaml` → `configs.cm.resource.exclusions`. Because setting this
+value **replaces** the argo-cd chart default (Helm does not merge a multiline string), the
+chart's default exclusions (Endpoints/EndpointSlice, Lease, Authz/Authn, CSR, Cilium
+identities, Kyverno reports) are reproduced verbatim and the scoped Pod entry appended.
+
+Cost: the CNC staging apps lose the per-pod tree/health in the ArgoCD UI (app health still
+rolls up from StatefulSet/Deployment/Rollout/Job status; sync/prune/self-heal of managed
+manifests is unaffected; direct `kubectl`/`exec` access is unaffected). Reversible — drop
+the Pod entry when ArgoCD ≥ 3.5 is deployed.
+
+Failing test that pins it: `scripts/tests/test_argocd_vcluster_pod_exclusion.py`
+(red → green). It renders the argo-cd chart with the repo values and asserts:
+1. a Pod exclusion scoped to the vCluster URL exists;
+2. **no Pod exclusion is ever global** (empty `clusters`) — the catastrophic silent
+   regression this fix must avoid;
+3. no Pod-exclusion glob matches the main cluster URL;
+4. every chart-default exclusion survives the value override (drift guard for chart bumps).
+
+The failing test proves *schema*. That the panic is **actually gone on re-registration** is
+a RUNTIME fact — proven by the manual on-cluster spike below, not by helm template.
+Trusting schema over runtime is exactly the #651 trap (Pro-only integration passed
+`helm template` and still crashed OSS at runtime).
+
+### Back-loaded manual step (operator-gated, cluster-wide risk)
+
+After merge and ArgoCD self-applies the argocd-cm change:
+1. Restart the application-controller so it reloads `resource.exclusions` (safe now — the
+   vCluster is currently unregistered, nothing to crash on).
+2. Re-register the `cnc-staging` vCluster (out-of-band `cluster-cnc-staging` Secret:
+   `tlsClientConfig.insecure: true`, NO caData, server
+   `https://cnc-staging.cnc-staging-vcluster.svc:443`; dry-run-proven registration script
+   in scratchpad).
+3. Verify: controller stays up (no panic in logs), the vCluster cluster goes to a healthy
+   cache, and the CNC staging Applications reconcile (cncd/node/fru/postgres come up).
+4. On failure: `kubectl delete secret cluster-cnc-staging -n argocd` + delete the
+   controller pod (the proven recovery), and STOP.
+
+## Rejected hypotheses
+
+- **gitops-engine `EachListItem` cache bug (the pre-debug paraphrase).** The frame is real
+  but incidental — it's the iteration harness. The panic is one frame deeper, in kubectl's
+  `maxResourceList`. Rejected once the full (unfiltered) goroutine dump was read.
+- **A malformed/nil-Object list from the vCluster's aggregated API.** The panic is not in
+  list *decoding*; it is in per-item pod-resource *computation* (`populatePodInfo`).
+  Rejected by the stack frames.
+- **A one-off bad Pod (e.g. the failed `cncd-migrate` Job pod) — delete it and move on.**
+  The trigger is structural (any LimitRange-defaulted Pod on the vCluster), not one pod;
+  cleanup would not prevent recurrence. Rejected.
+- **Global `resource.exclusions` Pod entry (the naive workaround).** Correct for the panic
+  but would strip pod tree/health from all ~60 main-cluster apps. Rejected in favour of the
+  `clusters`-scoped form.
+- **Bump ArgoCD to 3.5 now (the permanent fix).** Highest blast radius on the component
+  that just crashed cluster-wide; 3.5 maturity uncertain; not a "wrap up the rollout"
+  move. Deferred — the scoped exclusion carries a "remove when ≥ 3.5" note.
+- **Abandon the vCluster; run staging in a host namespace.** Viable and would kill the
+  panic class permanently, but it reworks the approach + #653–657 and changes the
+  deployment model (T1-owned). Operator chose to keep the vCluster with the surgical
+  exclusion.

--- a/scripts/tests/test_argocd_vcluster_pod_exclusion.py
+++ b/scripts/tests/test_argocd_vcluster_pod_exclusion.py
@@ -1,0 +1,153 @@
+"""Guard the surgical ArgoCD Pod-exclusion that lets the cnc-staging vCluster be
+registered as an ArgoCD cluster target WITHOUT crashing the application-controller.
+
+Root cause (fr-debugging 2026-07-19, docs/superpowers/debugging/): ArgoCD v3.3.2
+vendors kubectl v0.34.0, whose pod-resource helper panics
+`assignment to entry in nil map` in
+controller/cache.populatePodInfo -> kubectl resource.PodRequestsAndLimits ->
+maxResourceList when the cluster cache lists a Pod from a remote vCluster that
+ships a LimitRange (argo-cd#26529 / kubernetes#136533). The panic is UNCAUGHT in a
+cache-sync goroutine, so it kills the whole controller process -> cluster-wide
+CrashLoopBackOff on the next cold cache rebuild. The permanent fix ships in
+ArgoCD 3.5 (client-go bumped to 1.36.1); it is NOT backported to 3.4.
+
+Workaround (maintainer-endorsed in #26529): exclude Pod from the cluster cache,
+but SCOPED to the vCluster server URL only. `resource.exclusions` matches on
+apiGroups + kinds + `clusters` (a glob list of cluster URLs), so a scoped entry
+skips Pods ONLY on the vCluster while the main cluster keeps full per-pod
+visibility for all other apps.
+
+The load-bearing invariant these guards lock is that the exclusion stays
+SURGICAL. A GLOBAL Pod exclusion (empty/absent/over-broad `clusters`) would
+silently strip the pod tree + health rollup from ALL ~60 main-cluster apps — a
+catastrophic, quiet regression. That the panic is ACTUALLY gone on
+re-registration is a RUNTIME fact, proven by the manual on-cluster spike, NOT
+here (helm template proves schema only; trusting schema over runtime is exactly
+the #651 trap).
+
+LOCAL guards (frank does not run scripts/tests/ in CI); they shell out to
+`helm template --repo https://argoproj.github.io/argo-helm` and are fail-closed
+(non-zero return / missing render -> assertion error, never a false-green). In a
+runner without helm or without egress they go red on infra, not logic.
+"""
+
+import subprocess
+from fnmatch import fnmatch
+from pathlib import Path
+
+import yaml  # hard dep (pyproject) — a missing yaml must ERROR, not skip
+
+REPO = Path(__file__).resolve().parents[2]
+ARGOCD_VALUES = REPO / "apps/argocd/values.yaml"
+CHART_REPO = "https://argoproj.github.io/argo-helm"
+CHART_VERSION = "9.4.6"
+VCLUSTER_URL = "https://cnc-staging.cnc-staging-vcluster.svc:443"
+MAIN_CLUSTER_URL = "https://kubernetes.default.svc"
+
+
+def _render(*extra_args: str) -> str:
+    out = subprocess.run(
+        [
+            "helm", "template", "argocd", "argo-cd",
+            "--repo", CHART_REPO, "--version", CHART_VERSION,
+            *extra_args,
+        ],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 0, f"helm template argo-cd failed:\n{out.stderr}"
+    return out.stdout
+
+
+def _cm_from(rendered: str) -> dict:
+    for d in yaml.safe_load_all(rendered):
+        if (
+            d
+            and d.get("kind") == "ConfigMap"
+            and d.get("metadata", {}).get("name") == "argocd-cm"
+        ):
+            return d.get("data", {}) or {}
+    raise AssertionError("argocd-cm ConfigMap not rendered by the argo-cd chart")
+
+
+def _exclusions_of(data: dict) -> list:
+    raw = data.get("resource.exclusions")
+    assert raw, "argocd-cm has no resource.exclusions"
+    parsed = yaml.safe_load(raw)
+    assert isinstance(parsed, list), f"resource.exclusions must be a list, got {type(parsed)}"
+    return parsed
+
+
+def _exclusions() -> list:
+    """Our effective exclusions (chart rendered WITH the repo values)."""
+    return _exclusions_of(_cm_from(_render("-f", str(ARGOCD_VALUES))))
+
+
+def _default_exclusions() -> list:
+    """The chart's pristine default exclusions (rendered with NO overrides)."""
+    return _exclusions_of(_cm_from(_render()))
+
+
+def _pod_exclusion_entries(entries: list) -> list:
+    """Entries that would exclude core-group Pods (kinds ~ Pod/*, apiGroups ~ ''/*)."""
+    hits = []
+    for e in entries:
+        kinds = e.get("kinds") or []
+        groups = e.get("apiGroups") or []
+        if ("Pod" in kinds or "*" in kinds) and ("" in groups or "*" in groups):
+            hits.append(e)
+    return hits
+
+
+def test_argocd_excludes_vcluster_pods():
+    """A Pod exclusion scoped to the cnc-staging vCluster URL is present."""
+    pods = _pod_exclusion_entries(_exclusions())
+    assert pods, "no Pod exclusion entry found in resource.exclusions"
+    assert any(
+        any(fnmatch(VCLUSTER_URL, g) for g in (e.get("clusters") or []))
+        for e in pods
+    ), f"no Pod exclusion scoped to the vCluster URL {VCLUSTER_URL}"
+
+
+def test_pod_exclusion_is_never_global():
+    """CRITICAL: every Pod exclusion MUST carry a non-empty `clusters` scope.
+
+    A global Pod exclusion would strip pod tree + health from ALL ~60
+    main-cluster apps — the exact silent regression this fix must avoid.
+    """
+    for e in _pod_exclusion_entries(_exclusions()):
+        clusters = e.get("clusters") or []
+        assert clusters, f"Pod exclusion is GLOBAL (no `clusters` scope): {e}"
+
+
+def test_main_cluster_pods_are_never_excluded():
+    """No Pod-exclusion cluster glob may match the main cluster server URL."""
+    for e in _pod_exclusion_entries(_exclusions()):
+        for glob in (e.get("clusters") or []):
+            assert not fnmatch(MAIN_CLUSTER_URL, glob), (
+                f"Pod-exclusion glob {glob!r} matches the main cluster "
+                f"{MAIN_CLUSTER_URL} — would strip pod info from every "
+                f"main-cluster app: {e}"
+            )
+
+
+def _canon(entries: list) -> set:
+    """Order-insensitive signature of each exclusion entry (ignores comments)."""
+    return {
+        (
+            frozenset(e.get("apiGroups") or []),
+            frozenset(e.get("kinds") or []),
+            frozenset(e.get("clusters") or []),
+        )
+        for e in entries
+    }
+
+
+def test_chart_default_exclusions_are_preserved():
+    """Setting resource.exclusions REPLACES the chart default, so a stale copy (or
+    a chart bump) could silently drop the defaults (Endpoints, Lease, Cilium
+    identities, Kyverno reports, ...). Assert every default entry still renders."""
+    missing = _canon(_default_exclusions()) - _canon(_exclusions())
+    assert not missing, (
+        "our resource.exclusions dropped chart-default entries "
+        f"(re-sync from the argo-cd {CHART_VERSION} default): {missing}"
+    )


### PR DESCRIPTION
## Root cause

Registering the `cnc-staging` vCluster as an ArgoCD **cluster target** panics the
`argocd-application-controller` **cluster-wide**. Read verbatim from VictoriaLogs (the
crash was not re-triggered — reproduction is a cluster-wide outage):

```
version=v3.3.2
Start syncing cluster server="https://cnc-staging.cnc-staging-vcluster.svc:443"
panic: assignment to entry in nil map
  k8s.io/kubectl/pkg/util/resource.maxResourceList        resource.go:179
  ...PodRequestsAndLimits                                 resource.go:36
  argo-cd/v3/controller/cache.populatePodInfo             controller/cache/info.go:462
  ...gitops-engine clusterCache.sync → listResources → EachListItem
```

ArgoCD **v3.3.2** (chart `9.4.6`) vendors **kubectl v0.34.0**, whose `PodRequestsAndLimits`
writes to a **nil `ResourceList` map** when computing the requests of a Pod carrying
LimitRange-defaulted resources — and vClusters ship a default LimitRange. The panic is
uncaught in a cache-sync goroutine, so the whole controller process dies → CrashLoop on the
next cold cache rebuild (every restart) → all ~60 apps stop reconciling.

Upstream: [argo-cd#26529](https://github.com/argoproj/argo-cd/issues/26529) →
[kubernetes#136533](https://github.com/kubernetes/kubernetes/issues/136533). Permanent fix
ships in **ArgoCD 3.5** (client-go 1.36.1); **not** backported to 3.4.

Full investigation: `docs/superpowers/debugging/2026-07-19-argocd-vcluster-cache-panic.md`.

## Fix

Maintainer-endorsed workaround, kept **surgical**: a `resource.exclusions` entry that skips
**Pod** on the `cnc-staging` vCluster URL **only** (`resource.exclusions` matches
`apiGroups` + `kinds` + a `clusters` glob list). ArgoCD then never caches the vCluster's
Pods → `populatePodInfo` never runs there → no panic. The main cluster keeps full per-pod
visibility for every other app.

- `apps/argocd/values.yaml` → `configs.cm.resource.exclusions`. Setting this value
  **replaces** the argo-cd chart default (Helm does not merge a multiline string), so the
  chart's default exclusions (Endpoints, Lease, Cilium identities, Kyverno reports, …) are
  reproduced **verbatim** and the scoped Pod entry appended.
- **Cost:** CNC staging apps lose the per-pod tree/health in the ArgoCD UI. App health
  still rolls up from StatefulSet/Deployment/Rollout/Job; sync/prune/self-heal and direct
  `kubectl`/`exec` are unaffected.
- **Reversible:** remove the Pod entry when ArgoCD ≥ 3.5 is deployed.

## Failing test → fix (TDD)

`scripts/tests/test_argocd_vcluster_pod_exclusion.py` (red before the values change, green
after) renders the argo-cd chart with the repo values and asserts:
1. a Pod exclusion scoped to the vCluster URL exists;
2. **no Pod exclusion is ever global** — the catastrophic silent regression (would strip
   pod info from all ~60 main-cluster apps) this fix must avoid;
3. no Pod-exclusion glob matches the main cluster URL;
4. every chart-default exclusion survives the value override (drift guard for chart bumps).

These prove **schema**. That the panic is **actually gone on re-registration** is a runtime
fact — the manual spike below, not helm template (trusting schema over runtime is the #651
trap). Full suite: 4 passed. The other `scripts/tests/` failures in this environment are
pre-existing/infra (missing `kustomize` binary, a moved dossier script, the known
`test_cert_expiry_canary` drift) and independent of this diff.

## Back-loaded manual step — operator-gated (cluster-wide risk)

This PR is **inert until re-registration** (it only adds a cache exclusion). After merge +
ArgoCD self-applies the argocd-cm change:

1. Restart the application-controller so it reloads `resource.exclusions` (safe now — the
   vCluster is unregistered, nothing to crash on).
2. Re-register the `cnc-staging` vCluster (out-of-band `cluster-cnc-staging` Secret:
   `tlsClientConfig.insecure: true`, **no** caData, server
   `https://cnc-staging.cnc-staging-vcluster.svc:443`).
3. Verify: controller stays up (no panic), the vCluster cache goes healthy, and the CNC
   staging Applications reconcile (cncd/node/fru/postgres up).
4. On failure: `kubectl delete secret cluster-cnc-staging -n argocd` + delete the
   controller pod (the proven recovery), and stop.

Unblocks **Blocker B** of the CNC permanent-deployment rollout. Pairs with the shipped
secret-sync (#653/#654) and Blocker B pt2/3 (#655/#656/#657).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
