### PR TITLE
feat(cicd): full agentic-stoa mirror + Gitea Actions CI on Frank

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Enterprise-grade Kubernetes cluster on Talos Linux across heterogeneous hardware
 | VK Remote (self-hosted) | PostgreSQL 16 + ElectricSQL + Rust/Axum | Self-hosted VibeKanban kanban API server, local JWT auth, Authentik SSO via Traefik |
 | VK Relay | VK Relay Server (sidecar) | WebSocket relay tunneling browser API calls to local VK agent server via yamux multiplexing, SPAKE2 pairing |
 | In-Cluster Ingress | Traefik v3 | Wildcard TLS (`*.cluster.derio.net`) via ACME + Cloudflare DNS-01, Authentik forward-auth, raspi edge nodes |
-| CI/CD Platform | Gitea + Tekton + Zot | Self-hosted git forge (GitHub mirror), K8s-native pipelines, OCI registry with cosign signing — all on pc-1 |
+| CI/CD Platform | Gitea + Gitea Actions + Tekton + Zot | Self-hosted git forge (GitHub mirror), Actions-compatible CI on the mirrors (act_runner + DinD), K8s-native pipelines, OCI registry with cosign signing — all on pc-1 |
 | Cluster Dashboard | gethomepage.dev | Service catalog at `master.cluster.derio.net` with HTTP health indicators and custom bookmarks |
 | The Frank Papers | Third blog series (research) | Hugo section with dossier-gate pre-commit hook, Mermaid Frank theme, five `papers/` shortcodes, render-time cross-series backlinks (zero-retrofit) |
 | Ansible Automation | AWX | Operator-managed upstream Ansible controller (the `auto` layer) — the imperative counterweight reaching non-Talos home-lab hosts; native OIDC SSO via Authentik; Job Templates pull playbooks from a Gitea repo |
@@ -289,7 +289,8 @@ argocd app list
 | traefik | traefik-system | In-cluster ingress controller (192.168.55.220), ACME wildcard TLS for `*.cluster.derio.net` |
 | traefik-extras | traefik-system | Middleware CRDs (security headers, IP allowlist, Authentik forward-auth) + 16 IngressRoutes |
 | homepage | homepage | Cluster dashboard at `master.cluster.derio.net`, HTTP health indicators, service catalog |
-| gitea | gitea | Git forge with GitHub pull-mirror (192.168.55.209:3000), Authentik OIDC SSO |
+| gitea | gitea | Git forge with GitHub pull-mirror (192.168.55.209:3000), Authentik OIDC SSO, Gitea Actions enabled |
+| gitea-runner | gitea-runner | Gitea Actions runner (act_runner + DinD, pc-1) for agentic-stoa mirror CI |
 | gitea-extras | gitea | ExternalSecret for admin password, OIDC client secret, GitHub mirror token |
 | zot | zot | OCI container/artifact registry (192.168.55.210:5000), self-signed TLS via cert-manager |
 | zot-extras | zot | Certificate, ClusterIssuer, ExternalSecret for push password and OIDC |

--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -32,6 +32,8 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - PVC workspaces mount as root — set `fsGroup` on `taskRunTemplate.podTemplate.securityContext`.
 - `runAsUser: 65534` (nobody) → `HOME=/` (read-only); set `HOME=/tekton/home` env explicitly.
 - Gitea sends `X-Gitea-Event` (not `X-GitHub-Event`) — use `cel` interceptor, not `github`.
+- Gitea Actions runner DinD needs `DOCKER_TLS_CERTDIR=""` + explicit `--host=tcp://0.0.0.0:2375` — unset, dind serves TLS on 2376 and every job hangs "Running" against 2375.
+- act_runner registration is one-shot PVC state (`/data/.runner`) — rotating `STOA_GITEA_RUNNER_TOKEN` does NOT re-register; scale to 0, delete `/data/.runner`, scale up.
 
 ### Argo Rollouts — `docs/runbooks/frank-gotchas/argo-rollouts.md`
 - Only `canary` / `blueGreen` strategies — stateful + RWO PVC apps stay as plain Deployments.

--- a/apps/gitea-runner/manifests/config.yaml
+++ b/apps/gitea-runner/manifests/config.yaml
@@ -1,0 +1,27 @@
+# act_runner configuration. capacity 2 caps concurrent jobs so a Playwright
+# run plus a compose smoke can't starve pc-1 (32GB, shared with Gitea, Tekton
+# runs and Longhorn). Jobs run as containers against the DinD sidecar.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: act-runner-config
+  namespace: gitea-runner
+data:
+  config.yaml: |
+    log:
+      level: info
+    runner:
+      capacity: 2
+      timeout: 45m
+      fetch_timeout: 10s
+      fetch_interval: 5s
+      # ubuntu-latest maps to Gitea's runner image so `runs-on: ubuntu-latest`
+      # workflows run unmodified. node/go/python setup-actions install on top.
+      labels:
+        - "ubuntu-latest:docker://gitea/runner-images:ubuntu-latest"
+    cache:
+      enabled: true
+      dir: /data/cache
+    container:
+      docker_host: "tcp://localhost:2375"
+      force_pull: false

--- a/apps/gitea-runner/manifests/deployment.yaml
+++ b/apps/gitea-runner/manifests/deployment.yaml
@@ -1,0 +1,86 @@
+# Gitea Actions runner: act_runner + docker:dind sidecar.
+#
+# - The ONLY privileged workload we ship for CI; contained to this namespace
+#   and pinned to pc-1 (Edge zone) with no cluster credentials mounted.
+# - DinD serves plain TCP on localhost:2375 (DOCKER_TLS_CERTDIR="" — without
+#   it the daemon generates certs, listens on 2376, and the runner hangs
+#   waiting for a socket that never opens).
+# - strategy Recreate: RWO Longhorn PVC + RollingUpdate deadlocks (gotcha).
+# - /var/lib/docker is emptyDir on purpose: image cache is disposable; the
+#   PVC persists only runner identity (/data/.runner) and the tool cache.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: act-runner
+  namespace: gitea-runner
+  labels:
+    app.kubernetes.io/name: act-runner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: act-runner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: act-runner
+    spec:
+      nodeSelector:
+        kubernetes.io/hostname: pc-1
+      containers:
+        - name: runner
+          image: gitea/act_runner:0.2.13
+          env:
+            - name: GITEA_INSTANCE_URL
+              value: "http://gitea-http.gitea.svc.cluster.local:3000"
+            - name: GITEA_RUNNER_REGISTRATION_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: gitea-runner-token
+                  key: token
+            - name: CONFIG_FILE
+              value: /config/config.yaml
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2375"
+          volumeMounts:
+            - name: config
+              mountPath: /config
+              readOnly: true
+            - name: data
+              mountPath: /data
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              memory: 1Gi
+        - name: dind
+          image: docker:28.3.2-dind
+          securityContext:
+            privileged: true
+          args:
+            - "--host=tcp://0.0.0.0:2375"
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          volumeMounts:
+            - name: docker-lib
+              mountPath: /var/lib/docker
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              memory: 8Gi
+      volumes:
+        - name: config
+          configMap:
+            name: act-runner-config
+        - name: data
+          persistentVolumeClaim:
+            claimName: act-runner-data
+        - name: docker-lib
+          emptyDir:
+            sizeLimit: 40Gi

--- a/apps/gitea-runner/manifests/deployment.yaml
+++ b/apps/gitea-runner/manifests/deployment.yaml
@@ -27,6 +27,10 @@ spec:
       labels:
         app.kubernetes.io/name: act-runner
     spec:
+      # This pod runs semi-arbitrary mirrored-workflow code with a privileged
+      # DinD daemon — a job could bind-mount the SA token path through docker.
+      # No cluster credentials, enforced:
+      automountServiceAccountToken: false
       nodeSelector:
         kubernetes.io/hostname: pc-1
       containers:

--- a/apps/gitea-runner/manifests/externalsecret-runner-token.yaml
+++ b/apps/gitea-runner/manifests/externalsecret-runner-token.yaml
@@ -1,0 +1,25 @@
+# Runner registration token, minted inside Gitea and stored in Infisical
+# (manual op cicd-gitea-runner-registration-token). act_runner registers once
+# and persists its identity in /data/.runner on the PVC — rotating the token
+# does NOT re-register an already-registered runner.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: gitea-runner-token
+  namespace: gitea-runner
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: infisical
+    kind: ClusterSecretStore
+  target:
+    name: gitea-runner-token
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  data:
+    - secretKey: token
+      remoteRef:
+        key: STOA_GITEA_RUNNER_TOKEN
+        conversionStrategy: Default
+        decodingStrategy: None
+        metadataPolicy: None

--- a/apps/gitea-runner/manifests/namespace.yaml
+++ b/apps/gitea-runner/manifests/namespace.yaml
@@ -1,0 +1,12 @@
+# Dedicated namespace for the Gitea Actions runner. It exists so the
+# privileged DinD sidecar is contained here — the gitea namespace itself
+# stays at the default (restricted) PodSecurity level.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gitea-runner
+  labels:
+    app.kubernetes.io/name: gitea-runner
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/apps/gitea-runner/manifests/pvc.yaml
+++ b/apps/gitea-runner/manifests/pvc.yaml
@@ -1,0 +1,16 @@
+# Persistent runner state: /data/.runner (registration identity) and
+# /data/cache (actions tool/cache — Playwright, setup-go/node downloads).
+# The DinD image cache is deliberately an emptyDir in the Deployment: it is
+# rebuildable and would bloat a Longhorn volume.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: act-runner-data
+  namespace: gitea-runner
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn-cicd
+  resources:
+    requests:
+      storage: 20Gi

--- a/apps/gitea/values.yaml
+++ b/apps/gitea/values.yaml
@@ -44,6 +44,14 @@ gitea:
       ENABLED: true
       DEFAULT_INTERVAL: 10m
 
+    # Gitea Actions — GitHub-Actions-compatible CI on the agentic-stoa mirrors
+    # (2026-07-19 cicd plan). The runner ships separately in apps/gitea-runner
+    # (own privileged-labeled namespace; this one stays unprivileged).
+    # DEFAULT_ACTIONS_URL keeps its default (github) so actions/checkout etc.
+    # resolve from github.com.
+    actions:
+      ENABLED: true
+
     webhook:
       ALLOWED_HOST_LIST: "*.svc.cluster.local"
 

--- a/apps/root/templates/gitea-runner.yaml
+++ b/apps/root/templates/gitea-runner.yaml
@@ -1,0 +1,27 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: gitea-runner
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: infrastructure
+  source:
+    repoURL: {{ .Values.repoURL }}
+    targetRevision: {{ .Values.targetRevision }}
+    path: apps/gitea-runner/manifests
+  destination:
+    server: {{ .Values.destination.server }}
+    namespace: gitea-runner
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      # namespace ships as a manifest — it carries the PodSecurity labels
+      - CreateNamespace=false
+      - ServerSideApply=true
+  ignoreDifferences:
+    - kind: Secret
+      jsonPointers:
+        - /data

--- a/apps/tekton/pipelines/stoa-status-bridge.yaml
+++ b/apps/tekton/pipelines/stoa-status-bridge.yaml
@@ -1,0 +1,55 @@
+# Forwards a Gitea commit status (written by Gitea Actions on an
+# agentic-stoa mirror) to GitHub as a commit status on the same sha.
+#
+# The mirror is push-synced from GitHub, so the sha on the Gitea side IS the
+# GitHub PR head sha — no mapping. State vocabulary (pending/success/error/
+# failure) is identical between the two APIs and passes through unmapped.
+#
+# Context is prefixed `gitea-actions/` so Frank-side results are
+# distinguishable from native GitHub checks on the same PR. Tekton's own
+# dual-status writes never reach this pipeline (the gitea-status-bridge
+# trigger filters out context tekton/*).
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: stoa-status-bridge
+  namespace: tekton-pipelines
+spec:
+  description: Forward a Gitea Actions commit status to GitHub.
+  params:
+    - name: repo-full-name
+      type: string
+      description: "Repo full name, identical on both forges (e.g. agentic-stoa/hum)"
+    - name: revision
+      type: string
+      description: "Commit sha the status attaches to"
+    - name: state
+      type: string
+      description: "pending | success | error | failure (shared vocabulary)"
+    - name: context
+      type: string
+      description: "Gitea-side status context (workflow/job name)"
+    - name: description
+      type: string
+      default: ""
+    - name: target-url
+      type: string
+      default: ""
+      description: "Gitea Actions run URL — lands as the status link on GitHub"
+  tasks:
+    - name: forward
+      taskRef:
+        name: github-status
+      params:
+        - name: repo-full-name
+          value: $(params.repo-full-name)
+        - name: revision
+          value: $(params.revision)
+        - name: state
+          value: $(params.state)
+        - name: context
+          value: "gitea-actions/$(params.context)"
+        - name: description
+          value: $(params.description)
+        - name: target-url
+          value: $(params.target-url)

--- a/apps/tekton/triggers/eventlistener-github.yaml
+++ b/apps/tekton/triggers/eventlistener-github.yaml
@@ -107,11 +107,68 @@ spec:
         ref: stoa-blog-ci-github-template
 
     # ──────────────────────────────────────────────────────────────────
-    # Push-to-main trigger (Phase 5) — single trigger for all 4 repos.
-    # Fires github-pull-sync (just the pull-and-push, no CI) so Gitea's
-    # main branch catches up to GitHub's after a PR is merged.
+    # PR mirror-sync triggers for the Gitea-Actions repos (2026-07-19
+    # gitea-actions plan) — second-brain and hermes-brain have no bespoke
+    # Tekton CI body: the mirror push of sync-pr-<N> itself triggers their
+    # Gitea Actions workflows, so these bind straight to the shared
+    # main-sync template (github-pull-sync only, no test-image/command).
+    # flexible-health has no workflows → main-sync only, no PR trigger.
+    # ──────────────────────────────────────────────────────────────────
+    - name: agentic-stoa-second-brain-pr
+      interceptors:
+        - name: github
+          ref: {name: github, kind: ClusterInterceptor}
+          params:
+            - {name: secretRef, value: {secretName: stoa-github-webhook-secret, secretKey: secret}}
+            - {name: eventTypes, value: [pull_request]}
+        - name: cel
+          ref: {name: cel}
+          params:
+            - name: filter
+              value: body.repository.full_name == 'agentic-stoa/second-brain' && body.action in ['opened', 'synchronize', 'reopened']
+            - name: overlays
+              value:
+                - {key: sha, expression: "body.pull_request.head.sha"}
+                - {key: ref_to, expression: "'refs/heads/sync-pr-' + string(body.pull_request.number)"}
+      bindings:
+        - {name: github-repo, value: agentic-stoa/second-brain}
+        - {name: gitea-repo, value: agentic-stoa/second-brain}
+        - {name: sha, value: $(extensions.sha)}
+        - {name: ref-to, value: $(extensions.ref_to)}
+      template:
+        ref: agentic-stoa-main-sync-template
+    - name: agentic-stoa-hermes-brain-pr
+      interceptors:
+        - name: github
+          ref: {name: github, kind: ClusterInterceptor}
+          params:
+            - {name: secretRef, value: {secretName: stoa-github-webhook-secret, secretKey: secret}}
+            - {name: eventTypes, value: [pull_request]}
+        - name: cel
+          ref: {name: cel}
+          params:
+            - name: filter
+              value: body.repository.full_name == 'agentic-stoa/hermes-brain' && body.action in ['opened', 'synchronize', 'reopened']
+            - name: overlays
+              value:
+                - {key: sha, expression: "body.pull_request.head.sha"}
+                - {key: ref_to, expression: "'refs/heads/sync-pr-' + string(body.pull_request.number)"}
+      bindings:
+        - {name: github-repo, value: agentic-stoa/hermes-brain}
+        - {name: gitea-repo, value: agentic-stoa/hermes-brain}
+        - {name: sha, value: $(extensions.sha)}
+        - {name: ref-to, value: $(extensions.ref_to)}
+      template:
+        ref: agentic-stoa-main-sync-template
+
+    # ──────────────────────────────────────────────────────────────────
+    # Push-to-main trigger (Phase 5) — single trigger for all mirrored
+    # repos. Fires github-pull-sync (just the pull-and-push, no CI) so
+    # Gitea's main branch catches up to GitHub's after a PR is merged.
     # `companies` (added 2026-06-04, gh #444) has no CI pipeline — its mirror
     # feeds the live-mirror-sync EventListener (stoa-live-mirror-sync app).
+    # second-brain/hermes-brain/flexible-health (added 2026-07-19) run their
+    # CI as Gitea Actions on the mirror, not as Tekton pipelines.
     # ──────────────────────────────────────────────────────────────────
     - name: agentic-stoa-main-sync
       interceptors:
@@ -129,7 +186,7 @@ spec:
           params:
             - name: filter
               value: >-
-                body.repository.full_name in ['agentic-stoa/hum', 'agentic-stoa/content-factory', 'agentic-stoa/stoa-blog', 'agentic-stoa/companies', 'agentic-stoa/cnc-fr', 'agentic-stoa/cnc-frd', 'agentic-stoa/cnc-fru']
+                body.repository.full_name in ['agentic-stoa/hum', 'agentic-stoa/content-factory', 'agentic-stoa/stoa-blog', 'agentic-stoa/companies', 'agentic-stoa/cnc-fr', 'agentic-stoa/cnc-frd', 'agentic-stoa/cnc-fru', 'agentic-stoa/second-brain', 'agentic-stoa/hermes-brain', 'agentic-stoa/flexible-health']
                 && body.ref == 'refs/heads/main'
             - name: overlays
               value:

--- a/apps/tekton/triggers/eventlistener.yaml
+++ b/apps/tekton/triggers/eventlistener.yaml
@@ -43,6 +43,13 @@ spec:
     # gets those directly; forwarding would double-post every CI result.
     # Requires the org-level Gitea webhook (Status event) — manual op
     # cicd-stoa-gitea-org-actions-config.
+    # Notes: statuses attach to shas, not branches — mirror-main runs also
+    # forward (intentional: GitHub main commits get gitea-actions/* statuses
+    # too). description/target_url are omitempty in Gitea's payload, hence
+    # the has() overlays — a direct $(body.X) binding on a missing field
+    # drops the event. Gitea state values outside GitHub's vocabulary
+    # (e.g. 'warning') would 422 in github-status and fail the PipelineRun
+    # visibly — acceptable failure shape, revisit only if it fires.
     # ──────────────────────────────────────────────────────────────────
     - name: gitea-status-bridge
       interceptors:
@@ -54,6 +61,12 @@ spec:
                 header.match('X-Gitea-Event', 'status') &&
                 body.repository.full_name.startsWith('agentic-stoa/') &&
                 !body.context.startsWith('tekton')
+            - name: "overlays"
+              value:
+                - key: description
+                  expression: "has(body.description) ? body.description : ''"
+                - key: target_url
+                  expression: "has(body.target_url) ? body.target_url : ''"
       bindings:
         - name: repo-full-name
           value: $(body.repository.full_name)
@@ -64,9 +77,9 @@ spec:
         - name: context
           value: $(body.context)
         - name: description
-          value: $(body.description)
+          value: $(extensions.description)
         - name: target-url
-          value: $(body.target_url)
+          value: $(extensions.target_url)
       template:
         ref: stoa-status-bridge-template
     # NOTE 2026-05-13 (rework Phase 4): the per-repo agentic-stoa CI triggers

--- a/apps/tekton/triggers/eventlistener.yaml
+++ b/apps/tekton/triggers/eventlistener.yaml
@@ -34,6 +34,41 @@ spec:
         - ref: gitea-push-binding
       template:
         ref: gitea-pipeline-template
+    # ──────────────────────────────────────────────────────────────────
+    # Status bridge (2026-07-19 gitea-actions plan): Gitea Actions writes
+    # commit statuses on the agentic-stoa mirrors; this trigger forwards
+    # them to GitHub (same sha — the mirror is push-synced) via the
+    # stoa-status-bridge pipeline → github-status task. Tekton's own
+    # dual-status writes (context tekton/*) are excluded: GitHub already
+    # gets those directly; forwarding would double-post every CI result.
+    # Requires the org-level Gitea webhook (Status event) — manual op
+    # cicd-stoa-gitea-org-actions-config.
+    # ──────────────────────────────────────────────────────────────────
+    - name: gitea-status-bridge
+      interceptors:
+        - ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: >-
+                header.match('X-Gitea-Event', 'status') &&
+                body.repository.full_name.startsWith('agentic-stoa/') &&
+                !body.context.startsWith('tekton')
+      bindings:
+        - name: repo-full-name
+          value: $(body.repository.full_name)
+        - name: revision
+          value: $(body.sha)
+        - name: state
+          value: $(body.state)
+        - name: context
+          value: $(body.context)
+        - name: description
+          value: $(body.description)
+        - name: target-url
+          value: $(body.target_url)
+      template:
+        ref: stoa-status-bridge-template
     # NOTE 2026-05-13 (rework Phase 4): the per-repo agentic-stoa CI triggers
     # (agentic-stoa-hum-ci, agentic-stoa-content-factory-ci) moved out of this
     # gitea-listener to the new github-listener (apps/tekton/triggers/
@@ -55,3 +90,39 @@ spec:
 # template) were removed 2026-05-13 (rework Phase 4); replacement github-aware
 # versions ship in eventlistener-github.yaml. See the NOTE in the gitea-listener
 # triggers block above for context.
+---
+# Scaffolds the status-forward PipelineRun. No workspaces — the bridge is a
+# single curl-shaped task (github-status) with params only.
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: stoa-status-bridge-template
+  namespace: tekton-pipelines
+spec:
+  params:
+    - name: repo-full-name
+    - name: revision
+    - name: state
+    - name: context
+    - name: description
+    - name: target-url
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1
+      kind: PipelineRun
+      metadata:
+        generateName: stoa-status-bridge-
+        namespace: tekton-pipelines
+      spec:
+        pipelineRef:
+          name: stoa-status-bridge
+        params:
+          - {name: repo-full-name, value: $(tt.params.repo-full-name)}
+          - {name: revision,       value: $(tt.params.revision)}
+          - {name: state,          value: $(tt.params.state)}
+          - {name: context,        value: $(tt.params.context)}
+          - {name: description,    value: $(tt.params.description)}
+          - {name: target-url,     value: $(tt.params.target-url)}
+        taskRunTemplate:
+          podTemplate:
+            nodeSelector:
+              kubernetes.io/hostname: pc-1

--- a/blog/content/docs/building/27-cicd-platform/index.md
+++ b/blog/content/docs/building/27-cicd-platform/index.md
@@ -307,6 +307,20 @@ Inlined fetch+push (not the catalog `git-clone` Task — the catalog task does `
 
 One trap: `GIT_SSH_COMMAND` must point explicitly at `$HOME/.ssh/id_rsa` because the Tekton pod runs as UID 65534 (nobody), and OpenSSH's default key lookup walks `~/.ssh/id_*` against `/etc/passwd` HOME for that UID — which is `/`, where there is no readable `~/.ssh`.
 
+## Extension: Gitea Actions (2026-07)
+
+The mirror layer earned a second act. GitHub Actions on private repos bills by the minute, and one workflow in the mirrored fleet was firing **every 30 minutes** — roughly 1,500 runs a month before counting per-PR CI across five repos. The obvious question arrived: isn't Tekton's format compatible with Actions, so the workflows can just be reused?
+
+No. Tekton is Task/Pipeline CRDs — every per-repo pipeline above was a hand translation, and hand translations drift. What *is* compatible is **Gitea Actions**: same workflow YAML, `actions/checkout` resolved from github.com, service containers, artifacts, schedules. Gitea had been sitting on this capability the whole time, disabled by default.
+
+The division of labor is now:
+
+- **Tekton** stays the mirror/trigger layer — `github-pull-sync` pushes `sync-pr-N` branches, dual-status, promotion flows. Unchanged.
+- **Gitea Actions** runs the workflow-shaped CI on the mirrors, near-verbatim. A new `apps/gitea-runner/` app ships `act_runner` plus a `docker:dind` sidecar — the one privileged workload in the fleet, quarantined in its own namespace on pc-1 with capacity 2 so a Playwright run and a compose smoke can't jointly eat the node. Two traps baked into the manifests: DinD needs `DOCKER_TLS_CERTDIR=""` or it silently generates certs, listens on 2376, and the runner hangs waiting for 2375 forever; and act_runner registration is one-shot state on the PVC — rotating the token does not re-register an existing runner.
+- **A status bridge** closes the loop: Gitea's `status` webhook events feed a `gitea-status-bridge` trigger, which forwards each Gitea Actions result to GitHub as a commit status (context `gitea-actions/*`) on the same sha. Same sha because the mirror is push-synced — no mapping table, no state machine. Tekton's own `tekton/*` contexts are filtered out, or every Tekton CI result would double-post.
+
+The subtle part is **parallel running**. GitHub Actions stays enabled while Frank proves itself, and most workflows are harmless to run twice — tests failing twice is just emphasis. But PR-creating robots, auto-taggers, release image pushes and issue upserts must not run from both sides. Those jobs gate on a `CI_AUTHORITY` org variable (default `github`), compared against `github.server_url` — so cutover day is "flip one variable", not "edit five repos again".
+
 ## Missteps
 
 | What Happened | Why It Was Wrong | How We Fixed It | Commit |

--- a/blog/content/docs/operating/22-cicd-platform/index.md
+++ b/blog/content/docs/operating/22-cicd-platform/index.md
@@ -239,6 +239,30 @@ crane auth login 192.168.55.210:5000 -u tekton-push -p "$ZOT_PASS" --insecure
 
 If the password changed in Infisical, the ExternalSecret needs to re-sync. Check `kubectl get externalsecret -n zot`.
 
+## Gitea Actions Runner (2026-07 extension)
+
+The agentic-stoa mirrors now run their GitHub Actions workflows on Frank via Gitea Actions (`apps/gitea-runner/` — act_runner + DinD on pc-1).
+
+```bash
+# Is the runner alive and registered?
+kubectl -n gitea-runner get pods
+kubectl -n gitea-runner logs deploy/act-runner -c runner --tail=20
+# Gitea admin view: http://192.168.55.209:3000/-/admin/actions/runners (expect state Idle)
+
+# Watch a run's job containers appear inside DinD
+kubectl -n gitea-runner exec deploy/act-runner -c dind -- docker ps
+
+# Status bridge: did the result reach GitHub?
+kubectl -n tekton-pipelines get pipelinerun | grep stoa-status-bridge
+```
+
+Operational notes:
+
+- **Capacity** lives in `apps/gitea-runner/manifests/config.yaml` (`runner.capacity: 2`). Drop to 1 if pc-1 strains before considering a node move.
+- **DinD's image cache is an emptyDir** — wiped on pod restart, by design. The PVC keeps only the runner identity (`/data/.runner`) and the actions tool cache.
+- **Registration is one-shot.** The runner registers once and persists identity on the PVC; rotating `STOA_GITEA_RUNNER_TOKEN` does NOT re-register. To force a fresh registration: scale to 0, delete `/data/.runner` (or the PVC), scale up.
+- **Mutation authority**: the `CI_AUTHORITY` org variable in Gitea (org agentic-stoa → Settings → Actions → Variables) decides which side's mutating jobs run. `github` = parallel-safe default; flip to `gitea` at cutover.
+
 ## Missteps
 
 | What we assumed | Why it was wrong | What it cost |

--- a/docs/acceptance/matrix.yaml
+++ b/docs/acceptance/matrix.yaml
@@ -243,3 +243,40 @@ rows:
       (prod overlay still renders all 3 ExternalSecrets; cnc-base byte-unchanged —
       the staging change is a staging-scoped $patch:delete). Local guard (frank does
       not CI-run scripts/tests/); prod runtime path untouched by this PR.'
+  - id: stoa-mirror-all-private
+    capability: stoa CI on Frank
+    acceptance: Every private agentic-stoa repo has a Gitea mirror on Frank whose main
+      branch tracks GitHub automatically.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
+    levels: {}
+    status: not-implemented
+    notes: Adds second-brain, hermes-brain, flexible-health to the existing 7.
+  - id: stoa-ci-runs-on-frank
+    capability: stoa CI on Frank
+    acceptance: The Actions workflows of the five CI-bearing agentic-stoa repos execute
+      on Frank via Gitea Actions, on PR sync branches, main pushes, and their schedules.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''
+  - id: stoa-ci-github-status-writeback
+    capability: stoa CI on Frank
+    acceptance: A Frank-side CI run reports its result as a commit status on the originating
+      GitHub PR sha, keeping branch protection meaningful.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''
+  - id: stoa-ci-no-double-mutation
+    capability: stoa CI on Frank
+    acceptance: While GitHub Actions and Frank CI run in parallel, mutating jobs (PR
+      robots, tags, releases, issue upserts) execute from exactly one operator-selectable
+      authority side.
+    origin:
+    - frank:docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
+    levels: {}
+    status: not-implemented
+    notes: ''

--- a/docs/runbooks/frank-gotchas/tekton.md
+++ b/docs/runbooks/frank-gotchas/tekton.md
@@ -21,3 +21,11 @@ Tekton tasks with `runAsUser: 65534` get `HOME=/` from `/etc/passwd`. Since `/` 
 ## Gitea sends `X-Gitea-Event`, not `X-GitHub-Event`
 
 Tekton `github` ClusterInterceptor silently drops Gitea webhooks because Gitea sends `X-Gitea-Event` header instead. Use `cel` interceptor with `header.match('X-Gitea-Event', 'push')` instead.
+
+## Gitea Actions runner: DinD needs `DOCKER_TLS_CERTDIR=""`
+
+The `docker:dind` sidecar in `apps/gitea-runner` defaults to generating TLS certs and listening on **2376** when `DOCKER_TLS_CERTDIR` is unset. act_runner is pointed at plain-TCP `tcp://localhost:2375`, so the pair comes up "Running" while every job hangs waiting for a docker daemon that is listening one port over, TLS-only. Set `DOCKER_TLS_CERTDIR: ""` and pass `--host=tcp://0.0.0.0:2375` explicitly (guarded by `scripts/tests/test_gitea_runner_app.py`).
+
+## Gitea Actions runner: registration is one-shot PVC state
+
+`act_runner` registers against Gitea once and persists its identity in `/data/.runner` on the PVC. Rotating `STOA_GITEA_RUNNER_TOKEN` (or re-minting the registration token) does **NOT** re-register an already-registered runner — the token is only read when `/data/.runner` is absent. To force a fresh registration: scale the Deployment to 0, delete `/data/.runner` (or the whole PVC — the tool cache is rebuildable), scale back up. Symptom of a half-dead registration: runner pod healthy but the Gitea admin runners page shows it Offline.

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -1831,6 +1831,60 @@ operations:
   verify:
   - Webhook test-delivery from the Gitea UI returns 2xx
   status: done
+- id: cicd-gitea-runner-registration-token
+  layer: cicd
+  app: gitea-runner
+  plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+  when: After Phase 2 merges and the gitea Application syncs (Actions enabled); before the act-runner Deployment can register.
+  why_manual: Runner registration tokens are minted inside the running Gitea instance and stored in Infisical — bootstrap secret path.
+  commands:
+  - kubectl -n gitea exec deploy/gitea -- gitea actions generate-runner-token
+  - 'Infisical UI: add STOA_GITEA_RUNNER_TOKEN with the printed value, same project/path as the existing gitea secrets (see cicd-infisical-gitea-secrets)'
+  - kubectl -n gitea-runner annotate externalsecret gitea-runner-token force-sync=$(date +%s) --overwrite
+  verify:
+  - kubectl -n gitea-runner get secret gitea-runner-token
+  - kubectl -n gitea-runner logs deploy/act-runner -c runner | grep -i 'runner registered'
+  - Gitea UI http://192.168.55.209:3000/-/admin/actions/runners shows the runner Idle
+  status: pending
+- id: cicd-stoa-mirror-remaining-repos
+  layer: cicd
+  app: gitea
+  plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+  when: After Phase 1 merges (triggers live); before the GitHub webhooks are added.
+  why_manual: Repo creation + history backfill uses stoa-bot credentials; one-time per repo (pattern of cicd-stoa-companies-gitea-mirror/-backfill).
+  commands:
+  - 'For each of second-brain, hermes-brain, flexible-health:'
+  - 'curl -s -X POST http://192.168.55.209:3000/api/v1/orgs/agentic-stoa/repos -H ''Authorization: token <stoa-bot token from Infisical>'' -H ''Content-Type: application/json'' -d ''{"name": "<repo>", "private": true, "default_branch": "main"}'''
+  - git clone --mirror git@github.com:agentic-stoa/<repo>.git /tmp/<repo>.git && cd /tmp/<repo>.git && git push --mirror ssh://git@192.168.55.209:2222/agentic-stoa/<repo>.git (stoa-bot key)
+  verify:
+  - 'Gitea UI: agentic-stoa/<repo> exists, main matches GitHub main HEAD sha'
+  status: pending
+- id: cicd-stoa-github-webhook-remaining-repos
+  layer: cicd
+  app: tekton
+  plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+  when: After the Gitea mirror repos exist (previous op).
+  why_manual: GitHub webhook config is per-repo UI work; no IaC for this in our setup (same as cicd-stoa-github-webhook-hum et al).
+  commands:
+  - 'GitHub UI, for each of agentic-stoa/{second-brain, hermes-brain, flexible-health}: Settings → Webhooks → Add webhook'
+  - 'Payload URL: https://webhooks.hop.derio.net/  | Content type: application/json | Secret: STOA_GITHUB_WEBHOOK_SECRET from Infisical | SSL verify: enabled | Events: pull_request, push | Active: yes'
+  verify:
+  - Recent Deliveries shows 200 on the ping event
+  - kubectl -n tekton-pipelines logs -l eventlistener=github-listener --tail=20
+  status: pending
+- id: cicd-stoa-gitea-org-actions-config
+  layer: cicd
+  app: gitea
+  plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+  when: After Phase 2 merges (Actions enabled); before any Gitea Actions run needs GitHub credentials.
+  why_manual: Org-level Actions secrets/variables and org webhooks are Gitea UI/API state, not chart values.
+  commands:
+  - 'Gitea UI → org agentic-stoa → Settings → Actions → Secrets: add STOA_APP_PRIVATE_KEY (the stoa-fr-automation App PEM, from Infisical), STOA_CI_GH_TOKEN (GHCR-capable GitHub token for ghcr.io login + gh CLI where workflows fall back from GITHUB_TOKEN)'
+  - 'Gitea UI → org agentic-stoa → Settings → Actions → Variables: add CI_AUTHORITY=github (mutating jobs stay GitHub-authoritative during parallel running; flip to gitea at cutover — no workflow edits needed)'
+  - 'Gitea UI → org agentic-stoa → Settings → Webhooks → Add webhook: target http://el-gitea-listener.tekton-pipelines.svc.cluster.local:8080 (confirm svc name: kubectl -n tekton-pipelines get svc | grep el-gitea), content application/json, trigger on: Status only'
+  verify:
+  - Push any commit to a mirrored repo's sync branch → Gitea Actions run starts → gitea-listener logs show a received status event → matching commit status appears on GitHub sha with context gitea-actions/*
+  status: pending
 - id: obs-alert-agent-claude-login
   layer: obs
   app: alert-agent

--- a/docs/runbooks/manual-operations.yaml
+++ b/docs/runbooks/manual-operations.yaml
@@ -1879,10 +1879,12 @@ operations:
   when: After Phase 2 merges (Actions enabled); before any Gitea Actions run needs GitHub credentials.
   why_manual: Org-level Actions secrets/variables and org webhooks are Gitea UI/API state, not chart values.
   commands:
+  - 'Enable the Actions unit on every workflow-bearing mirror — instance-level actions.ENABLED does NOT switch it on for EXISTING repos (silent no-run otherwise): for r in second-brain hermes-brain cnc-fr cnc-frd cnc-fru; do curl -s -X PATCH http://192.168.55.209:3000/api/v1/repos/agentic-stoa/$r -H ''Authorization: token <gitea admin/stoa-bot token>'' -H ''Content-Type: application/json'' -d ''{"has_actions": true}''; done  (idempotent; covers the three new mirrors too in case DEFAULT_REPO_UNITS excludes repo.actions)'
   - 'Gitea UI → org agentic-stoa → Settings → Actions → Secrets: add STOA_APP_PRIVATE_KEY (the stoa-fr-automation App PEM, from Infisical), STOA_CI_GH_TOKEN (GHCR-capable GitHub token for ghcr.io login + gh CLI where workflows fall back from GITHUB_TOKEN)'
   - 'Gitea UI → org agentic-stoa → Settings → Actions → Variables: add CI_AUTHORITY=github (mutating jobs stay GitHub-authoritative during parallel running; flip to gitea at cutover — no workflow edits needed)'
   - 'Gitea UI → org agentic-stoa → Settings → Webhooks → Add webhook: target http://el-gitea-listener.tekton-pipelines.svc.cluster.local:8080 (confirm svc name: kubectl -n tekton-pipelines get svc | grep el-gitea), content application/json, trigger on: Status only'
   verify:
+  - Each of the 5 repos shows an Actions tab in the Gitea UI (unit enabled)
   - Push any commit to a mirrored repo's sync branch → Gitea Actions run starts → gitea-listener logs show a received status event → matching commit status appears on GitHub sha with context gitea-actions/*
   status: pending
 - id: obs-alert-agent-claude-login

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/01.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/01.yaml
@@ -48,14 +48,14 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T21:56:21+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T21:56:23+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-07-19T21:56:25+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/01.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/01.yaml
@@ -1,0 +1,61 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Complete the mirror trigger set (second-brain, hermes-brain, flexible-health)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+  acceptance:
+  - stoa-mirror-all-private
+tasks:
+- number: 1
+  title: Guard test + EventListener extension
+  steps:
+  - id: P1.T1.S1
+    text: |
+      RED: Write scripts/tests/test_stoa_mirror_triggers.py (pytest, repo-local guard
+      convention). Parse apps/tekton/triggers/eventlistener-github.yaml with
+      yaml.safe_load_all; locate the EventListener named github-listener. Assert:
+      (a) the agentic-stoa-main-sync trigger's CEL filter string contains all 10
+      private repos: hum, content-factory, stoa-blog, companies, cnc-fr, cnc-frd,
+      cnc-fru, second-brain, hermes-brain, flexible-health (each as
+      'agentic-stoa/<name>');
+      (b) triggers agentic-stoa-second-brain-pr and agentic-stoa-hermes-brain-pr
+      exist, use eventTypes ["pull_request"], carry a CEL overlay ref_to of the
+      form 'refs/heads/sync-pr-' + PR number, and reference template
+      agentic-stoa-main-sync-template (mirror-only sync; Gitea Actions runs the CI
+      body, unlike the Phase-4 repos' bespoke <repo>-ci templates).
+      Run: python3 -m pytest scripts/tests/test_stoa_mirror_triggers.py -q
+      Expect: FAIL (three repos missing from filter; triggers absent).
+  - id: P1.T1.S2
+    text: |
+      GREEN: Edit apps/tekton/triggers/eventlistener-github.yaml:
+      (1) extend the agentic-stoa-main-sync CEL filter list with
+      'agentic-stoa/second-brain', 'agentic-stoa/hermes-brain',
+      'agentic-stoa/flexible-health';
+      (2) add triggers agentic-stoa-second-brain-pr and agentic-stoa-hermes-brain-pr,
+      copying the agentic-stoa-hum-pr interceptor shape (github ClusterInterceptor
+      with stoa-github-webhook-secret + cel filter on full_name and action in
+      opened/synchronize/reopened, overlays sha=body.pull_request.head.sha and
+      ref_to='refs/heads/sync-pr-'+string(body.pull_request.number)) but bind to
+      template agentic-stoa-main-sync-template with params github-repo/gitea-repo/
+      sha/ref-to only (no test-image/test-command — these repos have no Tekton CI
+      body; Gitea Actions fires on the sync-pr push). flexible-health gets NO PR
+      trigger (no workflows) — main-sync only. Update the trigger-block comment to
+      name the new repos.
+      Run: python3 -m pytest scripts/tests/test_stoa_mirror_triggers.py -q
+      Expect: PASS.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/02.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/02.yaml
@@ -94,26 +94,27 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T21:59:01+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T21:59:06+00:00'
       note: null
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T21:59:10+00:00'
       note: null
     P2.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T21:59:14+00:00'
       note: null
     P2.T2.S4:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-07-19T21:59:18+00:00'
+      note: no kustomization in app dir; raw manifests stay plain per step's own skip
+        clause
   completion:
-    at: null
+    at: '2026-07-19T21:59:22+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/02.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/02.yaml
@@ -1,0 +1,119 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Enable Gitea Actions + deploy act_runner (apps/gitea-runner)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+  acceptance:
+  - stoa-ci-runs-on-frank
+tasks:
+- number: 1
+  title: Guard test for the runner app (RED)
+  steps:
+  - id: P2.T1.S1
+    text: |
+      RED: Write scripts/tests/test_gitea_runner_app.py asserting:
+      (a) apps/gitea/values.yaml: gitea.config.actions.ENABLED is true;
+      (b) apps/gitea-runner/manifests/namespace.yaml: namespace gitea-runner labeled
+      pod-security.kubernetes.io/enforce: privileged (DinD lives here, NOT in the
+      gitea namespace — Gitea itself stays unprivileged);
+      (c) apps/gitea-runner/manifests/deployment.yaml: containers 'runner' (image
+      gitea/act_runner, pinned tag, not :latest) and 'dind' (image docker:dind,
+      pinned, privileged: true), spec.strategy.type == Recreate (RWO PVC gotcha),
+      nodeSelector kubernetes.io/hostname: pc-1, runner env GITEA_INSTANCE_URL
+      pointing at http://gitea-http.gitea.svc.cluster.local:3000, DOCKER_HOST
+      tcp://localhost:2375 and DOCKER_TLS_CERTDIR "" on dind, runner envFrom/env
+      referencing Secret gitea-runner-token for GITEA_RUNNER_REGISTRATION_TOKEN,
+      and memory limits present on BOTH containers;
+      (d) apps/gitea-runner/manifests/config.yaml ConfigMap: runner.capacity == 2
+      and a labels entry mapping 'ubuntu-latest' to a docker:// image;
+      (e) apps/gitea-runner/manifests/externalsecret-runner-token.yaml:
+      ExternalSecret producing Secret gitea-runner-token from remote key
+      STOA_GITEA_RUNNER_TOKEN, same secretStoreRef as
+      apps/gitea/manifests/externalsecret-gitea.yaml (read that file for the store
+      name in the test, don't hardcode);
+      (f) apps/gitea-runner/manifests/pvc.yaml: storageClassName longhorn-cicd;
+      (g) apps/root/templates/gitea-runner.yaml: Application with path
+      apps/gitea-runner/manifests, destination namespace gitea-runner, syncOptions
+      containing ServerSideApply=true and CreateNamespace=true, prune absent/false.
+      Run: python3 -m pytest scripts/tests/test_gitea_runner_app.py -q
+      Expect: FAIL (nothing exists yet).
+- number: 2
+  title: Implement values + manifests + Application CR (GREEN)
+  steps:
+  - id: P2.T2.S1
+    text: |
+      Edit apps/gitea/values.yaml: under gitea.config add
+        actions:
+          ENABLED: true
+      (Gitea 1.25.4 live; DEFAULT_ACTIONS_URL default 'github' is correct — actions/*
+      resolve from github.com.)
+  - id: P2.T2.S2
+    text: |
+      Create apps/gitea-runner/manifests/:
+      - namespace.yaml — Namespace gitea-runner, labels pod-security enforce
+        privileged (+ audit/warn), plus the standard app labels.
+      - externalsecret-runner-token.yaml — ExternalSecret gitea-runner-token,
+        refreshInterval 1h, target Secret gitea-runner-token key token, remoteRef
+        STOA_GITEA_RUNNER_TOKEN; copy secretStoreRef from
+        apps/gitea/manifests/externalsecret-gitea.yaml.
+      - config.yaml — ConfigMap act-runner-config with config.yaml:
+          log: {level: info}
+          runner: {capacity: 2, timeout: 45m, fetch_timeout: 10s, fetch_interval: 5s,
+                   labels: ["ubuntu-latest:docker://gitea/runner-images:ubuntu-latest"]}
+          cache: {enabled: true, dir: /data/cache}
+          container: {docker_host: "tcp://localhost:2375", force_pull: false}
+      - pvc.yaml — PVC act-runner-data, 20Gi, longhorn-cicd, RWO.
+      - deployment.yaml — Deployment act-runner, replicas 1, strategy Recreate,
+        nodeSelector pc-1; container runner: image gitea/act_runner:0.2.13,
+        env GITEA_INSTANCE_URL=http://gitea-http.gitea.svc.cluster.local:3000,
+        GITEA_RUNNER_REGISTRATION_TOKEN from Secret gitea-runner-token/token,
+        CONFIG_FILE=/config/config.yaml, DOCKER_HOST=tcp://localhost:2375;
+        volumeMounts: /config (ConfigMap), /data (PVC); requests 100m/256Mi,
+        limits memory 1Gi. Container dind: image docker:28-dind, privileged true,
+        env DOCKER_TLS_CERTDIR="", args ["--host=tcp://0.0.0.0:2375"];
+        requests 500m/1Gi, limits memory 8Gi (Playwright/compose headroom;
+        pc-1 has 32GB). emptyDir /var/lib/docker (image cache is disposable;
+        PVC holds only act_runner state + tool cache).
+  - id: P2.T2.S3
+    text: |
+      Create apps/root/templates/gitea-runner.yaml Application CR: copy an existing
+      raw-manifests app template (e.g. apps/root/templates/pushgateway.yaml shape),
+      project infrastructure, source path apps/gitea-runner/manifests, destination
+      namespace gitea-runner, syncPolicy automated selfHeal + CreateNamespace=true,
+      ServerSideApply=true.
+      Run: python3 -m pytest scripts/tests/test_gitea_runner_app.py -q
+      Expect: PASS.
+  - id: P2.T2.S4
+    text: |
+      OPTIONAL REFACTOR: deduplicate any literal repeated across manifests (e.g.
+      the gitea-runner namespace string) only if kustomization is already in use in
+      this app dir; otherwise skip — raw manifests stay plain. Re-run the guard →
+      stays green.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S4:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/03.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/03.yaml
@@ -1,0 +1,70 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Status bridge — Gitea Actions results → GitHub commit statuses
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+  acceptance:
+  - stoa-ci-github-status-writeback
+tasks:
+- number: 1
+  title: Guard test + bridge trigger/pipeline
+  steps:
+  - id: P3.T1.S1
+    text: |
+      RED: Write scripts/tests/test_stoa_status_bridge.py asserting:
+      (a) apps/tekton/triggers/eventlistener.yaml gitea-listener has a trigger
+      gitea-status-bridge whose CEL filter matches header X-Gitea-Event == 'status',
+      requires body.repository.full_name.startsWith('agentic-stoa/'), and excludes
+      contexts written by Tekton's own dual-status (filter contains
+      !body.context.startsWith('tekton')) — Tekton results already reach GitHub
+      directly via github-status; forwarding them again would double-post;
+      (b) a TriggerTemplate stoa-status-bridge-template exists creating a
+      PipelineRun of pipeline stoa-status-bridge with params repo-full-name,
+      revision, state, context, description, target-url;
+      (c) apps/tekton/pipelines/stoa-status-bridge.yaml exists, single task
+      referencing Task github-status, passing context as
+      'gitea-actions/' + forwarded context and repo-full-name/revision/state
+      through, target-url pointing at the Gitea run URL from the webhook body.
+      Run: python3 -m pytest scripts/tests/test_stoa_status_bridge.py -q
+      Expect: FAIL.
+  - id: P3.T1.S2
+    text: |
+      GREEN: Implement:
+      (1) apps/tekton/pipelines/stoa-status-bridge.yaml — Pipeline
+      stoa-status-bridge, params repo-full-name/revision/state/context/description/
+      target-url, one task 'forward' with taskRef github-status, context param
+      value "gitea-actions/$(params.context)". No workspaces.
+      (2) In apps/tekton/triggers/eventlistener.yaml add trigger
+      gitea-status-bridge: cel interceptor filter
+        header.match('X-Gitea-Event', 'status') &&
+        body.repository.full_name.startsWith('agentic-stoa/') &&
+        !body.context.startsWith('tekton')
+      overlays: none needed — bind directly. TriggerBinding (inline bindings):
+      repo-full-name=body.repository.full_name, revision=body.sha,
+      state=body.state, context=body.context, description=body.description,
+      target-url=body.target_url. Add TriggerTemplate stoa-status-bridge-template
+      (PipelineRun, generateName stoa-status-bridge-, nodeSelector pc-1, no
+      workspaces).
+      NOTE: Gitea state vocabulary (pending/success/error/failure) is identical to
+      GitHub's — pass through unmapped. The webhook body field names (sha, state,
+      context, description, target_url) are verified live in the Test Plan; if the
+      1.25 payload nests them differently, fix the bindings here (this is the one
+      spec-flagged live-verification risk).
+      Run: python3 -m pytest scripts/tests/test_stoa_status_bridge.py -q
+      Expect: PASS.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/03.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/03.yaml
@@ -57,14 +57,14 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T22:03:34+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T22:03:36+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-07-19T22:03:39+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/04.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/04.yaml
@@ -47,22 +47,22 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T22:09:16+00:00'
       note: null
     P4.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T22:09:19+00:00'
       note: null
     P4.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T22:09:22+00:00'
       note: null
     P4.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-07-19T22:09:26+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-07-19T22:09:29+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/04.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/04.yaml
@@ -1,0 +1,68 @@
+schema_version: 2
+phase:
+  number: 4
+  title: Docs — retro blog updates, gotchas, runbook sync
+  tag: agentic
+  depends_on:
+  - 1
+  - 2
+  - 3
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Retro-update the cicd layer posts
+  steps:
+  - id: P4.T1.S1
+    text: |
+      Locate the cicd layer's building and operating posts (grep 'layer: cicd'
+      blog/content/docs/*/*/index.md). Building post: add a section on the Gitea
+      Actions extension — why (private-repo Actions cost; pins-update */30min),
+      the engine decision (Tekton not Actions-compatible; Gitea Actions is), the
+      act_runner+DinD architecture, the CI_AUTHORITY parallel-running guard, and
+      the status bridge. Operating post: add runner operations — check runner:
+      Gitea UI /admin/actions/runners; logs: kubectl -n gitea-runner logs deploy/
+      act-runner -c runner; capacity tuning in apps/gitea-runner/manifests/
+      config.yaml; DinD disk: emptyDir wiped on pod restart (by design).
+      This is the fix/extension workflow — extend existing posts, no new post.
+  - id: P4.T1.S2
+    text: |
+      Add gotcha one-liners to agents/rules/frank-gotchas.md (+ full prose in
+      docs/runbooks/frank-gotchas/tekton.md or a new gitea-actions section) for any
+      non-obvious trap surfaced in phases 1-3 (candidates: DinD needs
+      DOCKER_TLS_CERTDIR="" or the daemon silently waits for certs; act_runner
+      registration is one-shot state on the PVC — token rotation does NOT
+      re-register without wiping /data/.runner). Skip cleanly if nothing surfaced.
+- number: 2
+  title: Runbook + README sync
+  steps:
+  - id: P4.T2.S1
+    text: |
+      Run the /sync-runbook skill so the manual-operation blocks in this plan's
+      05.yaml merge into docs/runbooks/manual-operations.yaml (dedup by id,
+      status pending).
+  - id: P4.T2.S2
+    text: |
+      Run /update-readme if the Technology Stack / Current Status sections should
+      name Gitea Actions as the stoa CI engine (they should — one-line addition).
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
@@ -86,10 +86,12 @@ tasks:
       when: After Phase 2 merges (Actions enabled); before any Gitea Actions run needs GitHub credentials.
       why_manual: Org-level Actions secrets/variables and org webhooks are Gitea UI/API state, not chart values.
       commands:
+        - "Enable the Actions unit on every workflow-bearing mirror — instance-level actions.ENABLED does NOT switch it on for EXISTING repos (silent no-run otherwise): for r in second-brain hermes-brain cnc-fr cnc-frd cnc-fru; do curl -s -X PATCH http://192.168.55.209:3000/api/v1/repos/agentic-stoa/$r -H 'Authorization: token <gitea admin/stoa-bot token>' -H 'Content-Type: application/json' -d '{\"has_actions\": true}'; done  (idempotent; covers the three new mirrors too in case DEFAULT_REPO_UNITS excludes repo.actions)"
         - "Gitea UI → org agentic-stoa → Settings → Actions → Secrets: add STOA_APP_PRIVATE_KEY (the stoa-fr-automation App PEM, from Infisical), STOA_CI_GH_TOKEN (GHCR-capable GitHub token for ghcr.io login + gh CLI where workflows fall back from GITHUB_TOKEN)"
         - "Gitea UI → org agentic-stoa → Settings → Actions → Variables: add CI_AUTHORITY=github (mutating jobs stay GitHub-authoritative during parallel running; flip to gitea at cutover — no workflow edits needed)"
         - "Gitea UI → org agentic-stoa → Settings → Webhooks → Add webhook: target http://el-gitea-listener.tekton-pipelines.svc.cluster.local:8080 (confirm svc name: kubectl -n tekton-pipelines get svc | grep el-gitea), content application/json, trigger on: Status only"
       verify:
+        - "Each of the 5 repos shows an Actions tab in the Gitea UI (unit enabled)"
         - "Push any commit to a mirrored repo's sync branch → Gitea Actions run starts → gitea-listener logs show a received status event → matching commit status appears on GitHub sha with context gitea-actions/*"
       status: pending
 - number: 5

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
@@ -1,0 +1,131 @@
+schema_version: 2
+phase:
+  number: 5
+  title: '[manual] Secrets, Gitea repos, webhooks, org config, first-run verification'
+  tag: manual
+  depends_on:
+  - 1
+  - 2
+  - 3
+  - 4
+  tracking_issue: null
+  acceptance:
+  - stoa-mirror-all-private
+  - stoa-ci-runs-on-frank
+  - stoa-ci-no-double-mutation
+tasks:
+- number: 1
+  title: Mint the act_runner registration token
+  steps:
+  - id: P5.T1.S1
+    text: |
+      # manual-operation
+      id: cicd-gitea-runner-registration-token
+      layer: cicd
+      app: gitea-runner
+      plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+      when: After Phase 2 merges and the gitea Application syncs (Actions enabled); before the act-runner Deployment can register.
+      why_manual: Runner registration tokens are minted inside the running Gitea instance and stored in Infisical — bootstrap secret path.
+      commands:
+        - kubectl -n gitea exec deploy/gitea -- gitea actions generate-runner-token
+        - "Infisical UI: add STOA_GITEA_RUNNER_TOKEN with the printed value, same project/path as the existing gitea secrets (see cicd-infisical-gitea-secrets)"
+        - kubectl -n gitea-runner annotate externalsecret gitea-runner-token force-sync=$(date +%s) --overwrite
+      verify:
+        - kubectl -n gitea-runner get secret gitea-runner-token
+        - "kubectl -n gitea-runner logs deploy/act-runner -c runner | grep -i 'runner registered'"
+        - "Gitea UI http://192.168.55.209:3000/-/admin/actions/runners shows the runner Idle"
+      status: pending
+- number: 2
+  title: Create + backfill the three Gitea mirror repos
+  steps:
+  - id: P5.T2.S1
+    text: |
+      # manual-operation
+      id: cicd-stoa-mirror-remaining-repos
+      layer: cicd
+      app: gitea
+      plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+      when: After Phase 1 merges (triggers live); before the GitHub webhooks are added.
+      why_manual: Repo creation + history backfill uses stoa-bot credentials; one-time per repo (pattern of cicd-stoa-companies-gitea-mirror/-backfill).
+      commands:
+        - "For each of second-brain, hermes-brain, flexible-health:"
+        - "curl -s -X POST http://192.168.55.209:3000/api/v1/orgs/agentic-stoa/repos -H 'Authorization: token <stoa-bot token from Infisical>' -H 'Content-Type: application/json' -d '{\"name\": \"<repo>\", \"private\": true, \"default_branch\": \"main\"}'"
+        - "git clone --mirror git@github.com:agentic-stoa/<repo>.git /tmp/<repo>.git && cd /tmp/<repo>.git && git push --mirror ssh://git@192.168.55.209:2222/agentic-stoa/<repo>.git (stoa-bot key)"
+      verify:
+        - "Gitea UI: agentic-stoa/<repo> exists, main matches GitHub main HEAD sha"
+      status: pending
+- number: 3
+  title: GitHub webhooks for the three new mirrors
+  steps:
+  - id: P5.T3.S1
+    text: |
+      # manual-operation
+      id: cicd-stoa-github-webhook-remaining-repos
+      layer: cicd
+      app: tekton
+      plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+      when: After the Gitea mirror repos exist (previous op).
+      why_manual: GitHub webhook config is per-repo UI work; no IaC for this in our setup (same as cicd-stoa-github-webhook-hum et al).
+      commands:
+        - "GitHub UI, for each of agentic-stoa/{second-brain, hermes-brain, flexible-health}: Settings → Webhooks → Add webhook"
+        - "Payload URL: https://webhooks.hop.derio.net/  | Content type: application/json | Secret: STOA_GITHUB_WEBHOOK_SECRET from Infisical | SSL verify: enabled | Events: pull_request, push | Active: yes"
+      verify:
+        - "Recent Deliveries shows 200 on the ping event"
+        - kubectl -n tekton-pipelines logs -l eventlistener=github-listener --tail=20
+      status: pending
+- number: 4
+  title: Gitea org Actions secrets + CI_AUTHORITY variable + status webhook
+  steps:
+  - id: P5.T4.S1
+    text: |
+      # manual-operation
+      id: cicd-stoa-gitea-org-actions-config
+      layer: cicd
+      app: gitea
+      plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/05.yaml
+      when: After Phase 2 merges (Actions enabled); before any Gitea Actions run needs GitHub credentials.
+      why_manual: Org-level Actions secrets/variables and org webhooks are Gitea UI/API state, not chart values.
+      commands:
+        - "Gitea UI → org agentic-stoa → Settings → Actions → Secrets: add STOA_APP_PRIVATE_KEY (the stoa-fr-automation App PEM, from Infisical), STOA_CI_GH_TOKEN (GHCR-capable GitHub token for ghcr.io login + gh CLI where workflows fall back from GITHUB_TOKEN)"
+        - "Gitea UI → org agentic-stoa → Settings → Actions → Variables: add CI_AUTHORITY=github (mutating jobs stay GitHub-authoritative during parallel running; flip to gitea at cutover — no workflow edits needed)"
+        - "Gitea UI → org agentic-stoa → Settings → Webhooks → Add webhook: target http://el-gitea-listener.tekton-pipelines.svc.cluster.local:8080 (confirm svc name: kubectl -n tekton-pipelines get svc | grep el-gitea), content application/json, trigger on: Status only"
+      verify:
+        - "Push any commit to a mirrored repo's sync branch → Gitea Actions run starts → gitea-listener logs show a received status event → matching commit status appears on GitHub sha with context gitea-actions/*"
+      status: pending
+- number: 5
+  title: First-run verification (pre-Test-Plan smoke)
+  steps:
+  - id: P5.T5.S1
+    text: |
+      Smoke only (the full one-repo-per-class Test Plan runs post-merge, spec
+      §Test Plan): confirm the runner shows Idle in Gitea admin, then re-deliver a
+      recent pull_request webhook from GitHub (Recent Deliveries → Redeliver) on
+      second-brain and watch: sync-pr-N branch updates on Gitea → Actions run
+      starts → status lands on the GitHub PR sha. Record outcomes in this plan's
+      Deviations section of _prose.md.
+state:
+  steps:
+    P5.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T5.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/_meta.yaml
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-07-19-cicd-stoa-mirror-gitea-actions
+spec: docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.7.0,<4.0.0'
+created: '2026-07-19'

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/_prose.md
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/_prose.md
@@ -72,3 +72,11 @@ flip one org variable, no workflow edits. This is acceptance row
 ## Deviations
 
 (recorded during execution)
+
+- 2026-07-20 P4.T2.S1: runbook merge done surgically (4 new cicd entries
+  inserted after the last cicd entry, formatting preserved) rather than the
+  skill's full-rewrite-and-sort — the live file's tail is append-ordered, and
+  a full resort would have produced a large unrelated diff in this PR.
+- 2026-07-20 P4.T2.S2: README updated by targeted edits (CI/CD Platform row,
+  gitea row, new gitea-runner row) instead of a full /update-readme run; the
+  full sync remains a post-merge post-deploy-checklist item.

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/_prose.md
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/_prose.md
@@ -1,0 +1,74 @@
+# Full agentic-stoa Mirror + Gitea Actions CI on Frank
+
+**Spec:** `docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md`
+**Status:** In progress
+
+## Why
+
+GitHub Actions minutes on private agentic-stoa repos are too expensive —
+`cnc-fr/pins-update.yml` alone fires every 30 minutes (~1,500 runs/month), plus
+per-PR CI across five repos (13 workflows total). The operator's engine
+question ("isn't Tekton's format Actions-compatible?") is answered in the spec:
+it is not — Gitea Actions is, and Gitea already runs on Frank. So: complete the
+mirror set (3 repos missing), enable Gitea Actions, deploy an act_runner, and
+bridge run results back to GitHub commit statuses.
+
+## Shape of the work
+
+- **Phase 1** extends the existing webhook-driven mirror (github-listener →
+  `github-pull-sync`) to second-brain, hermes-brain (main + PR sync) and
+  flexible-health (main only — no workflows). Unlike the Phase-4-era repos,
+  these get NO bespoke Tekton CI pipeline: the mirror push itself triggers
+  Gitea Actions.
+- **Phase 2** enables `actions.ENABLED` in the gitea chart values and adds
+  `apps/gitea-runner/` — act_runner + DinD sidecar in a new privileged-labeled
+  `gitea-runner` namespace on pc-1, capacity 2, tool cache on a longhorn-cicd
+  PVC, registration token via ESO from Infisical.
+- **Phase 3** adds the status bridge: Gitea `status` webhook events (Gitea
+  1.25.4 live) → `gitea-listener` trigger → new `stoa-status-bridge` pipeline →
+  existing `github-status` task, context-prefixed `gitea-actions/`. Tekton's
+  own dual-status contexts are filtered out to avoid double-posting.
+- **Phase 4** does the extension-workflow docs: retro-updates to the cicd
+  building/operating posts, gotcha capture, runbook + README sync.
+- **Phase 5 [manual]** is deliberately back-loaded (fr-goal placement policy):
+  runner token mint, Gitea repo creation + backfill ×3, GitHub webhooks ×3,
+  Gitea org Actions secrets (`STOA_APP_PRIVATE_KEY`, `STOA_CI_GH_TOKEN`) +
+  `CI_AUTHORITY=github` variable + org status webhook, and a smoke check.
+  The PR ships with this phase unimplemented; the operator executes and pushes
+  evidence to the same PR.
+
+## Cross-repo coordination (not phases of this plan)
+
+The five workflow-bearing repos (second-brain, cnc-fr, cnc-frd, cnc-fru,
+hermes-brain) each need one small PR — `sync-pr-**` push triggers,
+`${{ secrets.STOA_CI_GH_TOKEN || secrets.GITHUB_TOKEN }}` fallbacks, and
+`CI_AUTHORITY` guards on mutating jobs. Per fr-goal's multi-repo rule those are
+dispatched one agent per repo (worktree isolation) against this spec; they are
+sequenced AFTER this plan's phases 1–3 merge and BEFORE the Test Plan runs.
+All edits are no-ops on the GitHub side, so ordering risk is low. Repo names
+and workflow filenames only in frank artifacts (third-party privacy rule).
+
+## Parallel-running safety (the load-bearing guard)
+
+The operator chose to keep GitHub Actions enabled. Non-mutating jobs running
+twice is waste, not damage. Mutating jobs (pins-update PR robot, auto-tag,
+release image pushes, acceptance-report issue upsert, fixtures-recapture) must
+run from exactly one side: they gate on `vars.CI_AUTHORITY` (default `github`),
+compared against the side derived from `github.server_url`. Cutover later =
+flip one org variable, no workflow edits. This is acceptance row
+`stoa-ci-no-double-mutation`.
+
+## Test Plan (post-merge, operator-driven — from the spec)
+
+1. PR class: test PR in cnc-frd → postgres service container run on Frank →
+   status on the GitHub PR sha (`gitea-actions/…`).
+2. Schedule class: pins-update fires on Frank's next half-hour tick,
+   check-only under `CI_AUTHORITY=github`.
+3. Artifact class: workflow_dispatch acceptance-report on second-brain's
+   mirror → artifact downloadable from Gitea.
+4. Steady state: a week of parallel green before the operator flips authority /
+   disables GH Actions per repo (out of scope here).
+
+## Deviations
+
+(recorded during execution)

--- a/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/_prose.md
+++ b/docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/_prose.md
@@ -80,3 +80,19 @@ flip one org variable, no workflow edits. This is acceptance row
 - 2026-07-20 P4.T2.S2: README updated by targeted edits (CI/CD Platform row,
   gitea row, new gitea-runner row) instead of a full /update-readme run; the
   full sync remains a post-merge post-deploy-checklist item.
+- 2026-07-20 P2 deviation (flagged in review): plan 02.yaml said
+  `CreateNamespace=true`; implemented as `CreateNamespace=false` + a Namespace
+  manifest carrying the PodSecurity labels (declarative labels; ArgoCD's
+  kind-priority ordering applies Namespaces first). Guard test asserts the
+  implemented shape.
+- 2026-07-20 code review (fr-goal step 7) — all findings fixed on-branch:
+  (1) per-repo Actions unit enablement added to cicd-stoa-gitea-org-actions-config
+  (instance ENABLED does not activate the unit on existing repos — would have
+  silently no-opped the Test Plan on the cnc mirrors); (2)
+  automountServiceAccountToken: false on the runner pod + guard assertion;
+  (3) rebased onto origin/main (#658); (4) bridge description/target_url moved
+  to has()-guarded CEL overlays (omitempty payload fields would drop events);
+  (5) main-branch status forwarding documented as intentional in the trigger
+  comment. Reviewer note for cutover (repo-side, out of scope here): auto-tag's
+  `git push origin <tag>` on a Gitea runner pushes to the mirror, not GitHub —
+  needs a checkout-token override when CI_AUTHORITY flips.

--- a/docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
+++ b/docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
@@ -51,8 +51,9 @@ layer (github-pull-sync, dual-status, cnc promotion) — those flows are untouch
     release.yml (image → GHCR), fixtures-recapture.yml (weekly; postgres;
     App token)
   - `hermes-brain`: backup-restore-tests.yml (BDD suite, push main/feat/fix/chore + PR)
-- **Gitea:** chart 12.5.0 (Gitea 1.24.x), Actions **not** enabled, runs on pc-1,
-  sqlite, LB 192.168.55.209.
+- **Gitea:** chart 12.5.0, live image `docker.gitea.com/gitea:1.25.4-rootless`
+  (verified on-cluster) — Actions, schedules, and the `status` webhook event all
+  available; Actions **not** enabled yet. Runs on pc-1, sqlite, LB 192.168.55.209.
 - **Webhook path:** GitHub → `https://webhooks.hop.derio.net/` → mesh →
   el-github-listener-lb (192.168.55.223). Per-repo webhook creation is an
   established manual op (`cicd-stoa-github-webhook-*`).
@@ -186,6 +187,12 @@ The Frank-side capacity cost is bounded by runner capacity 2 on pc-1.
 - **agentic-stoa ×5 (dispatched, one small PR each):** trigger additions,
   secret fallback swaps, `CI_AUTHORITY` guards. Repo names and workflow
   filenames only in this spec — no business logic detail (third-party privacy).
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|-------------|------|--------|
+| 2026-07-19-cicd-stoa-mirror-gitea-actions | `derio-net/frank` | `2026-07-19-cicd-stoa-mirror-gitea-actions` | — |
 
 ## Test Plan (post-merge, operator-driven — one repo per class)
 

--- a/docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
+++ b/docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md
@@ -1,0 +1,216 @@
+# Full agentic-stoa Mirror + Gitea Actions CI on Frank — Design
+
+**Date:** 2026-07-19
+**Layer:** cicd (extension of the stoa-gitea-primary rework)
+**Status:** Draft
+**Driver:** GitHub Actions minutes on private agentic-stoa repos are too expensive.
+
+## Goal
+
+Every private agentic-stoa repo mirrors to Frank's Gitea, and the CI that today
+burns GitHub Actions minutes runs on Frank instead — with results written back
+to the originating GitHub PRs so branch protection stays meaningful.
+
+## Operator decisions (batched Q&A, 2026-07-19)
+
+| Decision | Answer |
+|---|---|
+| CI engine | **Gitea Actions (act_runner)** — near-verbatim workflow reuse; Tekton keeps its current jobs |
+| Scope | **Mirror all private repos; keep GitHub Actions enabled** (parallel operation; operator disables GH side later, manually) |
+| PR gating | **Status writeback to GitHub** commit statuses |
+| Test Plan | **One repo per class** (detailed below) |
+
+### The compatibility question, answered
+
+Tekton's format (Task/Pipeline CRDs) is **not** compatible with GitHub Actions
+workflow YAML — every existing per-repo Tekton pipeline in `apps/tekton/` was a
+hand translation. **Gitea Actions** is the Actions-compatible engine: same
+workflow syntax, `actions/*` resolved from github.com, service containers,
+artifacts, and schedules. Direct reuse therefore means Gitea Actions runners on
+Frank, not Tekton. Tekton remains what it already is here: the mirror/trigger
+layer (github-pull-sync, dual-status, cnc promotion) — those flows are untouched.
+
+## Current state (verified 2026-07-19)
+
+- **Mirrored already (7/11):** hum, content-factory, stoa-blog, companies,
+  cnc-fr, cnc-frd, cnc-fru — webhook-driven via `github-pull-sync`
+  (GitHub PR → `sync-pr-<N>` branch on Gitea; push-to-main → main sync).
+- **Not mirrored:** second-brain, hermes-brain, flexible-health
+  (+ paperclip, public — Actions free, stays out of scope).
+- **Actions estate (5 repos, 13 workflows):**
+  - `second-brain`: tests.yml (python unittest ×2 jobs, push main + PR),
+    acceptance-report.yml (fr toolchain; artifact upload; weekly issue upsert)
+  - `cnc-fr`: compose-smoke.yml (docker compose + GHCR pulls),
+    parity.yml (cross-repo checkout via stoa-fr-automation App token),
+    acceptance-report.yml, **pins-update.yml — every 30 min** (~1,500 runs/mo;
+    the single largest cost driver; creates PRs via App token)
+  - `cnc-frd`: ci.yml (go vet/build/test + postgres service container +
+    golangci-lint + docker image-smoke), release.yml (image → GHCR on tag),
+    auto-tag.yml (tag + release + image on VERSION change)
+  - `cnc-fru`: ci.yml (npm checks + Playwright e2e + docker smoke),
+    release.yml (image → GHCR), fixtures-recapture.yml (weekly; postgres;
+    App token)
+  - `hermes-brain`: backup-restore-tests.yml (BDD suite, push main/feat/fix/chore + PR)
+- **Gitea:** chart 12.5.0 (Gitea 1.24.x), Actions **not** enabled, runs on pc-1,
+  sqlite, LB 192.168.55.209.
+- **Webhook path:** GitHub → `https://webhooks.hop.derio.net/` → mesh →
+  el-github-listener-lb (192.168.55.223). Per-repo webhook creation is an
+  established manual op (`cicd-stoa-github-webhook-*`).
+- **App token machinery:** `clustergenerator-stoa-github-app.yaml` (ESO
+  GithubAccessToken generator for stoa-fr-automation, app-id 3994156) already
+  on-cluster; the same App key backs `STOA_APP_PRIVATE_KEY` in the workflows.
+
+## Design
+
+### 1. Complete the mirror set (frank-side, declarative)
+
+Extend `apps/tekton/triggers/eventlistener-github.yaml`:
+
+- Add `second-brain`, `hermes-brain`, `flexible-health` to the
+  `agentic-stoa-main-sync` CEL filter (main catch-up sync).
+- Add PR-sync triggers (pull_request → `sync-pr-<N>` push) for `second-brain`
+  and `hermes-brain` — both have PR-triggered CI. These reuse
+  `agentic-stoa-main-sync-template`-style plumbing bound to `github-pull-sync`
+  (mirror-only; the CI itself fires Gitea-side on the branch push — no
+  per-repo Tekton CI pipeline for these, unlike the Phase-4 repos).
+- `flexible-health` has no workflows → main sync only.
+
+Manual ops (per established patterns):
+- Gitea repo creation + backfill for the 3 repos (pattern:
+  `cicd-stoa-companies-gitea-mirror` / `-backfill`).
+- GitHub per-repo webhook for the 3 repos (pattern:
+  `cicd-stoa-github-webhook-<repo>`; payload URL `https://webhooks.hop.derio.net/`,
+  events: pull_request, push).
+
+### 2. Enable Gitea Actions
+
+`apps/gitea/values.yaml`:
+
+```yaml
+config:
+  actions:
+    ENABLED: true
+```
+
+Schedules note: Gitea runs `on: schedule` workflows against the default branch —
+after mirroring, that is a synced `main`, so pins-update and the weekly robots
+fire on Frank per their cron.
+
+### 3. New app: `apps/gitea-runner/` (act_runner + DinD)
+
+- Deployment on pc-1: `gitea/act_runner` container + `docker:dind` sidecar
+  (privileged; DOCKER_HOST over localhost). DinD is required because the
+  workflows use docker builds, docker compose, and service containers.
+- Namespace `gitea` gains `pod-security.kubernetes.io/enforce: privileged`
+  label (or the runner gets its own namespace with that label — decide at
+  implementation; own namespace preferred to keep Gitea itself unprivileged).
+- Runner config ConfigMap: label map `ubuntu-latest` →
+  `gitea/runner-images:ubuntu-latest` (or catthehacker equivalent), capacity 2
+  (pc-1 is 32GB and shared with Gitea + Tekton runs + Longhorn).
+- Cache PVC (longhorn-cicd) for act_runner's action/tool cache — Playwright
+  and setup-go/node downloads are heavy; without cache every run re-downloads.
+- Registration: ExternalSecret delivering a runner registration token from
+  Infisical (`STOA_GITEA_RUNNER_TOKEN`); minting the token is a manual op
+  (`gitea actions generate-runner-token` in the Gitea pod, store in Infisical).
+- Resource limits sized so two concurrent jobs cannot starve pc-1
+  (requests/limits on both runner and DinD; DinD memory limit is the one that
+  matters for compose/Playwright).
+
+### 4. Workflow adaptations (repo-side, 5 repos — small PRs, parallel-safe)
+
+Each of the 5 repos gets one small PR. All changes are no-ops on the GitHub
+side so parallel operation is safe:
+
+1. **Trigger:** add `push: branches: ["sync-pr-**"]` to PR-triggered workflows
+   (those branches exist only on the Gitea mirror; GitHub never fires them).
+2. **Registry/API secrets:** where `secrets.GITHUB_TOKEN` is used against
+   github.com/ghcr.io (GHCR login, `gh` CLI), switch to the fallback pattern
+   `${{ secrets.STOA_CI_GH_TOKEN || secrets.GITHUB_TOKEN }}` — unset on
+   GitHub (falls back to the native token, unchanged behavior), set as a Gitea
+   org secret on Frank. Workflows already using `STOA_APP_PRIVATE_KEY` +
+   `create-github-app-token` work as-is once the key is a Gitea org secret.
+3. **Double-mutation guard:** mutating jobs (pins-update PR creation, auto-tag,
+   release image pushes, acceptance-report issue upsert, fixtures-recapture)
+   gate on a repo/org **variable** `CI_AUTHORITY` (`github` | `gitea`):
+   `if: (vars.CI_AUTHORITY || 'github') == <this side>`, where "this side" is
+   derived from `github.server_url`. Default authority stays `github`; the
+   operator later flips the variable to move mutation to Frank — no workflow
+   edit needed at cutover. Non-mutating test/lint jobs run on both sides.
+
+Gitea org-level secrets/variables (manual op): `STOA_APP_PRIVATE_KEY`,
+`STOA_CI_GH_TOKEN` (GHCR-capable GitHub token), `CI_AUTHORITY=github`.
+
+### 5. Status writeback to GitHub
+
+Primary: **central bridge, zero per-workflow steps.** Gitea Actions sets commit
+statuses on the mirror; Gitea (1.23+) emits a `status` webhook event. A new
+trigger on an EventListener receives it and runs the existing
+`github-status` task to post the same sha/state/context to GitHub — the sha is
+identical on both sides by construction, so mapping is trivial. Context prefix
+`gitea-actions/<workflow>` distinguishes Frank results from native GH checks.
+
+Fallback (if 1.24's status webhook proves unusable at implementation time): a
+final writeback step appended per workflow, using the App token. The spec
+prefers the bridge; the plan must verify the webhook event early and pick.
+
+Bridge filters: restrict to the agentic-stoa org, and drop statuses written by
+Tekton's own `gitea-status` task (the Phase-4 dual-status pipelines post to
+Gitea too) so Tekton results aren't re-forwarded to GitHub, which already gets
+them directly from `github-status`. There is no feedback loop by construction:
+the bridge listens on Gitea and posts only to GitHub.
+
+### 6. What does NOT change
+
+- GitHub Actions stays enabled everywhere (operator's call; parallel running).
+- Existing per-repo Tekton CI pipelines (hum, content-factory, stoa-blog,
+  cnc-*) keep running — retiring them in favor of Gitea Actions is a separate,
+  later decision.
+- cnc promotion (`repository_dispatch` → Tekton) stays GitHub-authoritative
+  until `CI_AUTHORITY` flips.
+- paperclip stays unmirrored (public).
+
+## Cost model
+
+pins-update alone is ~1,500 private-repo runs/month on GitHub. With
+`CI_AUTHORITY=github` nothing is saved yet by design (operator chose parallel
+first); the savings materialize when the operator disables Actions per repo /
+flips authority — at that point all 13 workflows' minutes go to zero on GitHub.
+The Frank-side capacity cost is bounded by runner capacity 2 on pc-1.
+
+## Deliverables
+
+- **frank (this repo, one PR):** eventlistener triggers for 3 new mirrors,
+  `apps/gitea/values.yaml` Actions enable, `apps/gitea-runner/` app +
+  root Application CR, status-bridge trigger + task wiring, manual-op blocks,
+  runbook sync.
+- **agentic-stoa ×5 (dispatched, one small PR each):** trigger additions,
+  secret fallback swaps, `CI_AUTHORITY` guards. Repo names and workflow
+  filenames only in this spec — no business logic detail (third-party privacy).
+
+## Test Plan (post-merge, operator-driven — one repo per class)
+
+1. **PR class (Go + service container):** open a test PR in cnc-frd → watch the
+   run on Frank's Gitea (`sync-pr-<N>`), postgres service comes up, tests pass →
+   commit status appears on the GitHub PR sha with `gitea-actions/` context.
+2. **Schedule class:** observe pins-update fire on Frank at its next half-hour
+   tick; with `CI_AUTHORITY=github` confirm it runs check-only (no PR created
+   from Frank).
+3. **Artifact class:** trigger acceptance-report (workflow_dispatch) on
+   second-brain's mirror → artifact uploaded and downloadable from Gitea.
+4. **Steady state:** after a week of parallel green, operator decides per-repo
+   GH Actions disable / authority flip (out of this plan's scope).
+
+## Risks
+
+- **DinD privileged pod** on pc-1: contained to a dedicated namespace, pinned
+  to the Edge node, no cluster credentials mounted; accepted for a homelab CI.
+- **Parallel mutation:** guarded by `CI_AUTHORITY` (default github). The guard
+  is the load-bearing piece — reviewed per workflow in the repo-side PRs.
+- **pc-1 capacity:** capacity 2 + limits; Playwright/compose are the heavy
+  cases. If pc-1 strains, capacity drops to 1 before any node move.
+- **Gitea 1.24 feature reality** (schedule semantics, status webhook event,
+  artifact API): verified as the plan's first implementation step; status
+  writeback has a designed fallback.
+- **second-brain acceptance-report installs fr from derio-net/super-fr** —
+  if that repo is private to the runner's network position, the job needs a
+  token; checked during implementation.

--- a/scripts/tests/test_gitea_runner_app.py
+++ b/scripts/tests/test_gitea_runner_app.py
@@ -1,0 +1,136 @@
+"""Guard: the Gitea Actions runner app (apps/gitea-runner) is shaped safely.
+
+The act_runner + DinD pair is the only privileged workload we ship for CI —
+these assertions pin the containment decisions: dedicated privileged-labeled
+namespace (Gitea itself stays unprivileged), pc-1 pinning, Recreate strategy
+(RWO PVC gotcha), pinned images, memory limits on both containers, and the
+ESO-delivered registration token.
+
+Plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER_DIR = REPO_ROOT / "apps/gitea-runner/manifests"
+
+
+def _load(name):
+    docs = [
+        d
+        for d in yaml.safe_load_all((RUNNER_DIR / name).read_text())
+        if d is not None
+    ]
+    assert docs, f"{name} is empty"
+    return docs
+
+
+def test_gitea_actions_enabled():
+    values = yaml.safe_load(
+        (REPO_ROOT / "apps/gitea/values.yaml").read_text()
+    )
+    assert values["gitea"]["config"]["actions"]["ENABLED"] is True
+
+
+def test_namespace_is_privileged_and_dedicated():
+    ns = _load("namespace.yaml")[0]
+    assert ns["kind"] == "Namespace"
+    assert ns["metadata"]["name"] == "gitea-runner"
+    labels = ns["metadata"]["labels"]
+    assert labels["pod-security.kubernetes.io/enforce"] == "privileged"
+
+
+def test_deployment_shape():
+    deploys = [d for d in _load("deployment.yaml") if d["kind"] == "Deployment"]
+    assert len(deploys) == 1
+    spec = deploys[0]["spec"]
+
+    # RWO PVC + RollingUpdate deadlocks (frank gotcha) — must be Recreate
+    assert spec["strategy"]["type"] == "Recreate"
+    assert spec["replicas"] == 1
+
+    pod = spec["template"]["spec"]
+    assert pod["nodeSelector"]["kubernetes.io/hostname"] == "pc-1"
+
+    containers = {c["name"]: c for c in pod["containers"]}
+    assert set(containers) == {"runner", "dind"}
+
+    runner, dind = containers["runner"], containers["dind"]
+
+    # pinned images, never :latest
+    for c in (runner, dind):
+        image = c["image"]
+        assert ":" in image and not image.endswith(":latest"), image
+        assert c["resources"]["limits"]["memory"], f"{c['name']} needs a memory limit"
+
+    assert "act_runner" in runner["image"]
+    assert dind["image"].startswith("docker:") and "dind" in dind["image"]
+    assert dind["securityContext"]["privileged"] is True
+
+    env = {e["name"]: e for e in runner["env"]}
+    assert (
+        env["GITEA_INSTANCE_URL"]["value"]
+        == "http://gitea-http.gitea.svc.cluster.local:3000"
+    )
+    assert (
+        env["GITEA_RUNNER_REGISTRATION_TOKEN"]["valueFrom"]["secretKeyRef"]["name"]
+        == "gitea-runner-token"
+    )
+    assert env["DOCKER_HOST"]["value"] == "tcp://localhost:2375"
+
+    dind_env = {e["name"]: e.get("value") for e in dind["env"]}
+    # empty TLS certdir = plain-TCP daemon on localhost; without this dind
+    # silently generates certs and listens on 2376, and the runner hangs
+    assert dind_env["DOCKER_TLS_CERTDIR"] == ""
+
+
+def test_runner_config():
+    cms = [d for d in _load("config.yaml") if d["kind"] == "ConfigMap"]
+    config = yaml.safe_load(cms[0]["data"]["config.yaml"])
+    assert config["runner"]["capacity"] == 2
+    labels = config["runner"]["labels"]
+    assert any(
+        label.startswith("ubuntu-latest:docker://") for label in labels
+    ), labels
+    assert config["container"]["docker_host"] == "tcp://localhost:2375"
+
+
+def test_registration_token_externalsecret():
+    es = _load("externalsecret-runner-token.yaml")[0]
+    assert es["kind"] == "ExternalSecret"
+    assert es["metadata"]["namespace"] == "gitea-runner"
+
+    # same store as the existing gitea secrets — read it, don't hardcode
+    gitea_es = yaml.safe_load(
+        (REPO_ROOT / "apps/gitea/manifests/externalsecret-gitea.yaml").read_text()
+    )
+    assert es["spec"]["secretStoreRef"] == gitea_es["spec"]["secretStoreRef"]
+
+    assert es["spec"]["target"]["name"] == "gitea-runner-token"
+    remote_keys = {d["remoteRef"]["key"] for d in es["spec"]["data"]}
+    assert remote_keys == {"STOA_GITEA_RUNNER_TOKEN"}
+
+
+def test_cache_pvc():
+    pvc = _load("pvc.yaml")[0]
+    assert pvc["kind"] == "PersistentVolumeClaim"
+    assert pvc["spec"]["storageClassName"] == "longhorn-cicd"
+    assert pvc["spec"]["accessModes"] == ["ReadWriteOnce"]
+
+
+def test_root_application():
+    app = yaml.safe_load(
+        (REPO_ROOT / "apps/root/templates/gitea-runner.yaml")
+        .read_text()
+        .replace("{{ .Values.repoURL }}", "REPO")
+        .replace("{{ .Values.targetRevision }}", "REV")
+        .replace("{{ .Values.destination.server }}", "SERVER")
+    )
+    assert app["spec"]["source"]["path"] == "apps/gitea-runner/manifests"
+    assert app["spec"]["destination"]["namespace"] == "gitea-runner"
+    opts = app["spec"]["syncPolicy"]["syncOptions"]
+    assert "ServerSideApply=true" in opts
+    # namespace ships as a manifest (it carries the PSS labels)
+    assert "CreateNamespace=false" in opts

--- a/scripts/tests/test_gitea_runner_app.py
+++ b/scripts/tests/test_gitea_runner_app.py
@@ -53,6 +53,9 @@ def test_deployment_shape():
 
     pod = spec["template"]["spec"]
     assert pod["nodeSelector"]["kubernetes.io/hostname"] == "pc-1"
+    # privileged DinD + arbitrary workflow code: the SA token must not be
+    # reachable (a job can bind-mount host paths through the docker daemon)
+    assert pod["automountServiceAccountToken"] is False
 
     containers = {c["name"]: c for c in pod["containers"]}
     assert set(containers) == {"runner", "dind"}

--- a/scripts/tests/test_stoa_mirror_triggers.py
+++ b/scripts/tests/test_stoa_mirror_triggers.py
@@ -1,0 +1,109 @@
+"""Guard: the agentic-stoa mirror trigger set is complete.
+
+All 10 private agentic-stoa repos must be in the main-sync CEL filter, and the
+two workflow-bearing repos added by the 2026-07-19 Gitea Actions plan
+(second-brain, hermes-brain) must have PR-time mirror-sync triggers so Gitea
+Actions can fire on sync-pr-N branches. flexible-health has no workflows and
+deliberately gets main-sync only.
+
+Plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EL_GITHUB = REPO_ROOT / "apps/tekton/triggers/eventlistener-github.yaml"
+
+ALL_PRIVATE_REPOS = [
+    "hum",
+    "content-factory",
+    "stoa-blog",
+    "companies",
+    "cnc-fr",
+    "cnc-frd",
+    "cnc-fru",
+    "second-brain",
+    "hermes-brain",
+    "flexible-health",
+]
+
+# repos whose PR CI runs as Gitea Actions on the mirror (mirror-sync trigger
+# only — no bespoke Tekton CI template, unlike the Phase-4-era repos)
+GITEA_ACTIONS_PR_REPOS = ["second-brain", "hermes-brain"]
+
+
+def _docs():
+    return list(yaml.safe_load_all(EL_GITHUB.read_text()))
+
+
+def _github_listener():
+    for doc in _docs():
+        if (
+            doc
+            and doc.get("kind") == "EventListener"
+            and doc["metadata"]["name"] == "github-listener"
+        ):
+            return doc
+    raise AssertionError("github-listener EventListener not found")
+
+
+def _trigger(name):
+    for trig in _github_listener()["spec"]["triggers"]:
+        if trig.get("name") == name:
+            return trig
+    return None
+
+
+def _cel_params(trig):
+    params = {}
+    for interceptor in trig.get("interceptors", []):
+        if interceptor.get("ref", {}).get("name") == "cel":
+            for p in interceptor.get("params", []):
+                params[p["name"]] = p["value"]
+    return params
+
+
+def test_main_sync_covers_all_private_repos():
+    trig = _trigger("agentic-stoa-main-sync")
+    assert trig is not None, "agentic-stoa-main-sync trigger missing"
+    filt = _cel_params(trig)["filter"]
+    for repo in ALL_PRIVATE_REPOS:
+        assert f"agentic-stoa/{repo}" in filt, (
+            f"main-sync filter missing agentic-stoa/{repo}"
+        )
+
+
+def test_pr_mirror_sync_triggers_for_gitea_actions_repos():
+    for repo in GITEA_ACTIONS_PR_REPOS:
+        trig = _trigger(f"agentic-stoa-{repo}-pr")
+        assert trig is not None, f"PR trigger for {repo} missing"
+
+        # fires on pull_request events, filtered to the repo + PR lifecycle
+        cel = _cel_params(trig)
+        assert f"agentic-stoa/{repo}" in cel["filter"]
+        assert "'opened', 'synchronize', 'reopened'" in cel["filter"]
+
+        # overlays produce the synthetic sync-pr-N destination branch
+        overlays = {o["key"]: o["expression"] for o in cel["overlays"]}
+        assert overlays["sha"] == "body.pull_request.head.sha"
+        assert "'refs/heads/sync-pr-' + string(body.pull_request.number)" in (
+            overlays["ref_to"]
+        )
+
+        # mirror-only sync: bound to the shared main-sync template (which runs
+        # github-pull-sync), NOT a bespoke <repo>-ci template — Gitea Actions
+        # provides the CI body for these repos.
+        assert trig["template"]["ref"] == "agentic-stoa-main-sync-template"
+
+        # no Tekton test body params
+        binding_names = {b["name"] for b in trig.get("bindings", [])}
+        assert "test-image" not in binding_names
+        assert "test-command" not in binding_names
+
+
+def test_flexible_health_has_no_pr_trigger():
+    assert _trigger("agentic-stoa-flexible-health-pr") is None, (
+        "flexible-health has no workflows — main-sync only by design"
+    )

--- a/scripts/tests/test_stoa_status_bridge.py
+++ b/scripts/tests/test_stoa_status_bridge.py
@@ -1,0 +1,110 @@
+"""Guard: the Gitea→GitHub status bridge is wired and filtered correctly.
+
+Gitea Actions writes commit statuses on the mirror; Gitea's `status` webhook
+event carries them to the gitea-listener, and the stoa-status-bridge pipeline
+forwards them to GitHub via the existing github-status Task. The sha is
+identical on both sides by construction (mirror), so no mapping is needed.
+
+The filters are the load-bearing part:
+- only agentic-stoa mirrors are forwarded;
+- Tekton's own dual-status writes (context tekton/*) are dropped — GitHub
+  already receives those directly from github-status; forwarding them again
+  would double-post every Tekton CI result.
+
+Plan: docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EL_GITEA = REPO_ROOT / "apps/tekton/triggers/eventlistener.yaml"
+BRIDGE_PIPELINE = REPO_ROOT / "apps/tekton/pipelines/stoa-status-bridge.yaml"
+
+BRIDGE_PARAMS = {
+    "repo-full-name",
+    "revision",
+    "state",
+    "context",
+    "description",
+    "target-url",
+}
+
+
+def _gitea_docs():
+    return [d for d in yaml.safe_load_all(EL_GITEA.read_text()) if d]
+
+
+def _bridge_trigger():
+    for doc in _gitea_docs():
+        if doc.get("kind") == "EventListener":
+            for trig in doc["spec"]["triggers"]:
+                if trig.get("name") == "gitea-status-bridge":
+                    return trig
+    return None
+
+
+def test_bridge_trigger_filter():
+    trig = _bridge_trigger()
+    assert trig is not None, "gitea-status-bridge trigger missing"
+
+    filters = []
+    for interceptor in trig.get("interceptors", []):
+        if interceptor.get("ref", {}).get("name") == "cel":
+            for p in interceptor.get("params", []):
+                if p["name"] == "filter":
+                    filters.append(p["value"])
+    filt = " && ".join(filters)
+
+    assert "X-Gitea-Event" in filt and "'status'" in filt
+    assert "body.repository.full_name.startsWith('agentic-stoa/')" in filt
+    assert "!body.context.startsWith('tekton')" in filt
+
+    assert trig["template"]["ref"] == "stoa-status-bridge-template"
+
+
+def test_bridge_template_and_bindings():
+    trig = _bridge_trigger()
+    assert trig is not None
+
+    bindings = {b["name"]: b["value"] for b in trig.get("bindings", [])}
+    assert bindings["repo-full-name"] == "$(body.repository.full_name)"
+    assert bindings["revision"] == "$(body.sha)"
+    assert bindings["state"] == "$(body.state)"
+    assert bindings["context"] == "$(body.context)"
+
+    templates = [
+        d
+        for d in _gitea_docs()
+        if d.get("kind") == "TriggerTemplate"
+        and d["metadata"]["name"] == "stoa-status-bridge-template"
+    ]
+    assert templates, "stoa-status-bridge-template missing"
+    tmpl = templates[0]
+    assert {p["name"] for p in tmpl["spec"]["params"]} == BRIDGE_PARAMS
+
+    run = tmpl["spec"]["resourcetemplates"][0]
+    assert run["kind"] == "PipelineRun"
+    assert run["spec"]["pipelineRef"]["name"] == "stoa-status-bridge"
+
+
+def test_bridge_pipeline_forwards_via_github_status():
+    docs = [d for d in yaml.safe_load_all(BRIDGE_PIPELINE.read_text()) if d]
+    pipelines = [d for d in docs if d["kind"] == "Pipeline"]
+    assert len(pipelines) == 1
+    spec = pipelines[0]["spec"]
+
+    assert {p["name"] for p in spec["params"]} == BRIDGE_PARAMS
+
+    tasks = spec["tasks"]
+    assert len(tasks) == 1
+    forward = tasks[0]
+    assert forward["taskRef"]["name"] == "github-status"
+
+    params = {p["name"]: p["value"] for p in forward["params"]}
+    # gitea-actions/ prefix distinguishes Frank results from native GH checks
+    assert params["context"] == "gitea-actions/$(params.context)"
+    assert params["revision"] == "$(params.revision)"
+    assert params["state"] == "$(params.state)"
+    assert params["repo-full-name"] == "$(params.repo-full-name)"

--- a/scripts/tests/test_stoa_status_bridge.py
+++ b/scripts/tests/test_stoa_status_bridge.py
@@ -74,6 +74,19 @@ def test_bridge_template_and_bindings():
     assert bindings["state"] == "$(body.state)"
     assert bindings["context"] == "$(body.context)"
 
+    # description/target_url are omitempty in Gitea's status payload — they
+    # must come through has()-guarded overlays, not direct body bindings
+    # (a missing field in a direct binding silently drops the event)
+    assert bindings["description"] == "$(extensions.description)"
+    assert bindings["target-url"] == "$(extensions.target_url)"
+    overlays = {}
+    for interceptor in trig.get("interceptors", []):
+        for p in interceptor.get("params", []):
+            if p["name"] == "overlays":
+                overlays.update({o["key"]: o["expression"] for o in p["value"]})
+    assert overlays["description"] == "has(body.description) ? body.description : ''"
+    assert overlays["target_url"] == "has(body.target_url) ? body.target_url : ''"
+
     templates = [
         d
         for d in _gitea_docs()


### PR DESCRIPTION
GitHub Actions minutes on private agentic-stoa repos are too expensive (`cnc-fr/pins-update.yml` alone: every 30 min ≈ 1,500 runs/month). This PR completes the Gitea mirror set and stands up **Gitea Actions** CI on Frank — the honest answer to "isn't Tekton compatible with Actions?" is no (Tekton = CRDs, every existing pipeline was a hand translation); Gitea Actions runs the workflow files near-verbatim.

- **Spec:** `docs/superpowers/specs/2026-07-19--cicd--stoa-full-mirror-gitea-actions-design.md`
- **Plan:** `docs/superpowers/plans/2026-07-19-cicd-stoa-mirror-gitea-actions/`

## What's in this PR (phases 1–4, agentic — done)

1. **Mirror completion** — main-sync now covers all 10 private repos; PR mirror-sync triggers for second-brain + hermes-brain (their CI body is Gitea Actions, no bespoke Tekton pipeline); flexible-health main-only.
2. **Gitea Actions enabled** + new `apps/gitea-runner/` app: act_runner 0.2.13 + docker:28.3.2-dind in a dedicated privileged-labeled namespace on pc-1, capacity 2, ESO registration token, longhorn-cicd cache PVC, `automountServiceAccountToken: false`, Recreate strategy.
3. **Status bridge** — Gitea `status` webhook → `stoa-status-bridge` pipeline → existing `github-status` task; context `gitea-actions/*` on the identical sha; Tekton's own `tekton/*` contexts filtered (no double-post); `has()`-guarded overlays for omitempty payload fields.
4. **Docs** — building/operating cicd post extensions, 2 gotchas, runbook merge (4 ops), README rows.

Guards (local, all green): `test_stoa_mirror_triggers.py`, `test_gitea_runner_app.py`, `test_stoa_status_bridge.py` — 13 passed. Full `scripts/tests/` run: 147 passed; 6 pre-existing failures on main (cert-expiry canary drift, moved dossier script) — unrelated.

## Phase 5 [manual] — deliberately UNIMPLEMENTED; operator pushes to this PR

Back-loaded per fr-goal placement policy (`05.yaml` + `manual-operations.yaml`, all `status: pending`):
- `cicd-gitea-runner-registration-token` — mint + Infisical `STOA_GITEA_RUNNER_TOKEN`
- `cicd-stoa-mirror-remaining-repos` — create + backfill second-brain/hermes-brain/flexible-health on Gitea
- `cicd-stoa-github-webhook-remaining-repos` — 3 GitHub webhooks → webhooks.hop.derio.net
- `cicd-stoa-gitea-org-actions-config` — **per-repo Actions unit enablement** (instance ENABLED ≠ existing-repo unit ON — silent no-run trap caught in review), org secrets `STOA_APP_PRIVATE_KEY` + `STOA_CI_GH_TOKEN`, variable `CI_AUTHORITY=github`, org Status webhook → gitea-listener

## Companion repo-side PRs (all no-ops on GitHub until cutover)

second-brain#8 · cnc-fr#92 · cnc-frd#37 · cnc-fru#34 · hermes-brain#13 — sync-pr-** triggers, `STOA_CI_GH_TOKEN || GITHUB_TOKEN` fallbacks, `CI_AUTHORITY` guards on all mutating jobs (pins-update, auto-tag ×2, fixtures-recapture, issue upserts). Merge order: any time; they're inert until the Phase-5 ops run.

## Code review (fr-goal step 7) — verdict "with fixes", all findings fixed here

- Per-repo Actions **unit** enablement added to the manual ops (would have silently no-opped the Test Plan on the pre-existing cnc mirrors)
- `automountServiceAccountToken: false` + guard assertion (makes "no cluster credentials" true against DinD bind-mount reach)
- Rebased onto origin/main (#658)
- Bridge `description`/`target_url` moved to `has()`-guarded overlays; main-branch status forwarding documented as intentional
- **Cutover flag (repo-side, deferred):** on a Gitea runner, auto-tag's `git push origin <tag>` pushes to the *mirror*, not GitHub — the tag flow needs a checkout-token override when `CI_AUTHORITY` flips to `gitea`

Also surfaced: second-brain's GitHub Actions are already dormant (credits exhausted) — the mirror *revives* its CI; its `repair-is-idempotent` job will fail there until `repair-delete-artifacts.py --write` runs on main (pre-existing, noted in second-brain#8).

## Test Plan (post-merge — operator-driven, one repo per class)

1. **PR class:** test PR in cnc-frd → run on Frank (`sync-pr-<N>`, postgres service container) → status lands on the GitHub PR sha with `gitea-actions/*` context.
2. **Schedule class:** pins-update fires on Frank at its next half-hour tick; with `CI_AUTHORITY=github` it must be check-only (no PR created from Frank).
3. **Artifact class:** workflow_dispatch acceptance-report on second-brain's mirror → artifact downloadable from Gitea.
4. **Steady state:** a week of parallel green, then operator decides per-repo GH Actions disable / authority flip (out of scope).

## Acceptance

Rows added since origin/main (all `not-implemented` — they pin live behavior that only Phase 5 + the Test Plan can prove; flipping them pre-merge would be fiction):
- `stoa-mirror-all-private` — every private repo auto-tracks on Gitea; the "mirror all" half of the goal, engine-independent
- `stoa-ci-runs-on-frank` — the 5 repos' workflows execute on Frank; the cost-motivated core, verifiable only by a watched run
- `stoa-ci-github-status-writeback` — results land on the GitHub PR sha; without it, moving CI un-gates merges
- `stoa-ci-no-double-mutation` — mutating jobs run from exactly one operator-selectable side; what makes parallel running safe

Pre-existing repo acceptance debt (gpu-1 NIC rows etc.) unchanged — see `fr acceptance status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
