### PR TITLE
fix(repo): pass an image entry's `references:` anchors to the model again

### DIFF
--- a/blog/scripts/generate-images.py
+++ b/blog/scripts/generate-images.py
@@ -144,7 +144,29 @@ def post_process(output: Path, steps: list) -> None:
             Image.open(output).save(str(s["target"]), sizes=[(s.get("size", 32), s.get("size", 32))])
 
 
-def _gen_bytes(prompt: str, ref: Path | None, model: str, image_cfg: dict, entry: dict) -> bytes | None:
+def entry_reference_paths(entry: dict, root: Path) -> list[Path]:
+    """Resolve an entry's `references:` clothing/pose anchors against the repo root.
+
+    These are the ADDITIONAL reference images the composed `reference_guidance`
+    prose describes ("clothing/pose anchors"). The master character sheet is
+    selected separately and MUST stay first in the payload — that prose tells the
+    model the FIRST image is canonical for the face.
+
+    A missing anchor is skipped with a warning rather than failing the run: a
+    stale path in one entry should not block generating its cover.
+    """
+    out: list[Path] = []
+    for rel in entry.get("references") or []:
+        p = (root / str(rel)).expanduser()
+        if p.is_file():
+            out.append(p)
+        else:
+            print(f"  WARN: reference not found, skipping: {rel}", file=sys.stderr)
+    return out
+
+
+def _gen_bytes(prompt: str, ref: Path | None, model: str, image_cfg: dict, entry: dict,
+               root: Path) -> bytes | None:
     if TEST_MODE:
         return _ONE_PX_PNG
     from google import genai
@@ -153,6 +175,12 @@ def _gen_bytes(prompt: str, ref: Path | None, model: str, image_cfg: dict, entry
     contents: list = [prompt]
     if ref:
         contents.append(Image.open(ref))
+    # Entry-level anchors follow the master sheet, in declared order.
+    for p in entry_reference_paths(entry, root):
+        try:
+            contents.append(Image.open(p))
+        except OSError as exc:
+            print(f"  WARN: reference unreadable, skipping: {p} ({exc})", file=sys.stderr)
     cfg_kwargs: dict = {}
     if entry.get("aspect_ratio") or entry.get("image_size"):
         ic = {}
@@ -222,11 +250,21 @@ def main(argv: list[str]) -> int:
         out = root / e.get("output", f"{image_cfg.get('output_dir', 'static/images')}/{key}.png")
         ref = select_reference(e, image_cfg, root, override)
         if a.dry_run:
-            print(f"[dry-run] {key} -> {out}  (ref={ref}, {len(prompt)} chars)")
+            extra = entry_reference_paths(e, root)
+            refs_used = ([ref] if ref else []) + extra
+            print(f"[dry-run] {key} -> {out}  (ref={ref}, {len(prompt)} chars, "
+                  f"{len(refs_used)} image(s) to model)")
+            for i, p in enumerate(refs_used, 1):
+                kind = "master" if (ref and p == ref and i == 1) else "entry"
+                try:
+                    rel = p.relative_to(root)
+                except ValueError:
+                    rel = p
+                print(f"           ref {i} ({kind}): {rel}")
             continue
         variants = []
         for i in range(max(1, count)):
-            b = _gen_bytes(prompt, ref, model, image_cfg, e)
+            b = _gen_bytes(prompt, ref, model, image_cfg, e, root)
             if not b:
                 print(f"  {key}: no image returned", file=sys.stderr)
                 rc = 1

--- a/scripts/tests/test_generate_images_entry_references.py
+++ b/scripts/tests/test_generate_images_entry_references.py
@@ -1,0 +1,99 @@
+"""Guard that an image entry's `references:` anchors actually reach the model.
+
+REGRESSION HISTORY — this is why the test exists. frank's original
+`scripts/generate-all-images.py` passed the entry's `references:` images to the
+model after the master character sheet:
+
+    contents = [full_prompt, reference_image]
+    contents.extend(explicit_images)   # from the entry's `references:` field
+
+The P7 blog-craft cutover (42916bf9, #600) replaced it with
+`blog/scripts/generate-images.py`, whose `_gen_bytes` appended ONLY the master
+reference. The `references:` field silently became decorative on all 84 entries.
+
+It went unnoticed because the cutover proved "image-compose parity" on the
+composed PROMPT TEXT (smoke-image-compose) — the one thing that had not
+regressed. Nothing asserted which IMAGES were sent. Covers then drifted off the
+declared clothing/torso variant, because only the text layer carried it.
+
+So these guards pin the payload, not the prose:
+  - entry references resolve relative to the repo root (where .blog-craft.yaml
+    and .reference-pool/ live), matching every entry's `output:` convention;
+  - a missing anchor is SKIPPED, not fatal (a stale path must not block a cover);
+  - ORDER is load-bearing: the master character sheet stays FIRST, because the
+    composed `reference_guidance` prose tells the model the first image is
+    canonical for the face and later ones are clothing/pose anchors only.
+
+LOCAL guards (frank does not run scripts/tests/ in CI). Pure — no network, no
+API key, no PIL decode.
+"""
+
+import importlib.util
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+GEN = REPO / "blog/scripts/generate-images.py"
+
+
+def _mod():
+    """Import the hyphenated script by path (not importable as a module name)."""
+    spec = importlib.util.spec_from_file_location("generate_images", GEN)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_entry_references_resolve_against_repo_root(tmp_path):
+    m = _mod()
+    (tmp_path / ".reference-pool/building/subjects").mkdir(parents=True)
+    a = tmp_path / ".reference-pool/building/subjects/a.png"
+    a.write_bytes(b"x")
+    entry = {"references": [".reference-pool/building/subjects/a.png"]}
+    assert m.entry_reference_paths(entry, tmp_path) == [a]
+
+
+def test_missing_reference_is_skipped_not_fatal(tmp_path):
+    """A stale path in one entry must not block generating its cover."""
+    m = _mod()
+    (tmp_path / "refs").mkdir()
+    good = tmp_path / "refs/good.png"
+    good.write_bytes(b"x")
+    entry = {"references": ["refs/missing.png", "refs/good.png"]}
+    assert m.entry_reference_paths(entry, tmp_path) == [good]
+
+
+def test_declared_order_is_preserved(tmp_path):
+    m = _mod()
+    (tmp_path / "refs").mkdir()
+    for n in ("one", "two", "three"):
+        (tmp_path / f"refs/{n}.png").write_bytes(b"x")
+    entry = {"references": ["refs/two.png", "refs/one.png", "refs/three.png"]}
+    got = [p.name for p in m.entry_reference_paths(entry, tmp_path)]
+    assert got == ["two.png", "one.png", "three.png"]
+
+
+def test_absent_or_empty_references_yields_nothing(tmp_path):
+    m = _mod()
+    assert m.entry_reference_paths({}, tmp_path) == []
+    assert m.entry_reference_paths({"references": []}, tmp_path) == []
+    assert m.entry_reference_paths({"references": None}, tmp_path) == []
+
+
+def test_gen_bytes_takes_root_so_entry_refs_can_resolve():
+    """The regression was structural: _gen_bytes had no way to resolve the
+    entry's repo-root-relative reference paths, so it could not pass them."""
+    import inspect
+    m = _mod()
+    params = list(inspect.signature(m._gen_bytes).parameters)
+    assert "entry" in params and "root" in params, params
+
+
+def test_master_reference_stays_first_in_the_payload():
+    """ORDER guard: reference_guidance declares the FIRST image canonical for the
+    face; entry anchors must be appended AFTER it, never before."""
+    import inspect
+    m = _mod()
+    src = inspect.getsource(m._gen_bytes)
+    master_at = src.index("contents.append(Image.open(ref))")
+    entry_at = src.index("entry_reference_paths(entry, root)")
+    assert master_at < entry_at, "entry references must be appended after the master sheet"


### PR DESCRIPTION
## The regression

frank's original `scripts/generate-all-images.py` passed an entry's `references:` images to the model, after the master character sheet:

```python
contents: list = [full_prompt, reference_image]   # master sheet FIRST
contents.extend(explicit_images)                  # entry `references:`
contents.extend(pool_images)
```

The P7 blog-craft cutover (`42916bf9`, #600) replaced it with `blog/scripts/generate-images.py`, whose `_gen_bytes` appended **only** the master reference:

```python
contents: list = [prompt]
if ref:
    contents.append(Image.open(ref))
# entry["references"] never read
```

So `references:` has been **decorative on all 84 entries** since the cutover. Symptom: covers drift off the declared clothing/torso variant, because only the text layer (`torso_variant`) carries it — the actual anchor images never reach the model.

**Why it hid for so long:** the cutover proved *"image-compose parity"* — but parity was verified on the composed **prompt text** (`smoke-image-compose`), which is exactly the thing that had *not* regressed. Nothing asserted which **images** were sent.

## The fix

- **`entry_reference_paths(entry, root)`** — new pure helper resolving an entry's references against the repo root (where `.blog-craft.yaml` and `.reference-pool/` live, matching every entry's repo-root-relative `output:`). A missing anchor **warns and skips** rather than failing: a stale path in one entry must not block generating its cover.
- **`_gen_bytes(..., root)`** appends those images **after** the master sheet. Order is load-bearing — the composed `reference_guidance` prose tells the model the *first* image is canonical for the face and later ones are clothing/pose anchors only. Putting an anchor first would corrupt the character.
- **`--dry-run` now lists every image in payload order.** This is the missing check that let the regression through, and it makes the behaviour verifiable with no API spend.

## Verification

```
$ python3 blog/scripts/generate-images.py --only building-34-first-vcluster-tenant --dry-run
[dry-run] building-34-first-vcluster-tenant -> .../cover.png  (ref=..., 3963 chars, 3 image(s) to model)
           ref 1 (master): .reference-pool/building/reference-building.png
           ref 2 (entry): .reference-pool/building/subjects/frank-server-torso-shirt-construction-vest.png
           ref 3 (entry): .reference-pool/building/subjects/frank-dirty-clothes.png
```

1 image before → 3 after.

`scripts/tests/test_generate_images_entry_references.py` — **6 passed**: root-relative resolution, missing-anchor skip, declared-order preservation, absent/empty/None handling, a signature guard (`_gen_bytes` must take `root`, since the regression was structural — it had no way to resolve the paths), and an **ordering guard** asserting the master sheet is appended before entry anchors.

## Upstream

`blog-craft` 0.8.0's `templates/hugo-hextra/scripts/generate-images.py` has the byte-identical bug — tracked as [derio-net/blog-craft#39](https://github.com/derio-net/blog-craft/issues/39) (item 5). Worth porting this patch there so new blogs don't inherit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
