### PR TITLE
fix(cnc): let the vCluster's own pods reach its API — restores in-vCluster DNS

### DIFF
--- a/apps/cnc-staging-host/manifests/networkpolicy-argocd.yaml
+++ b/apps/cnc-staging-host/manifests/networkpolicy-argocd.yaml
@@ -1,10 +1,24 @@
-# Additive NetworkPolicy (Blocker B, part 3): allow the ArgoCD application-controller
-# to reach the cnc-staging vCluster API server (control-plane pod, port 8443) so
-# ArgoCD can sync the cnc-staging / cnc-staging-db apps INTO the vCluster. The
-# chart's vc-cp-* NetworkPolicy only permits in-vCluster pods + app=loft; ArgoCD
-# is neither. NetworkPolicies are additive (union), so this grants argocd->8443
-# without weakening the chart's isolation. Namespace is set by the kustomization
-# (cnc-staging-vcluster).
+# Ingress allow-list for the cnc-staging vCluster API server (control-plane pod,
+# port 8443). Namespace is set by the kustomization (cnc-staging-vcluster).
+#
+# This policy must grant BOTH consumers, because it is now the ONLY policy
+# selecting that pod — and a NetworkPolicy selecting a pod makes it default-deny
+# for every ingress it does not name:
+#
+#   1. ArgoCD  — so it can sync the cnc-staging / cnc-staging-db apps INTO the
+#      vCluster (Blocker B pt3, #656).
+#   2. The vCluster's OWN pods — CoreDNS watches Services/EndpointSlices/
+#      Namespaces on this API. Without it CoreDNS answers NOTHING and every
+#      in-vCluster name NXDOMAINs.
+#
+# HISTORY — do not "simplify" rule 2 away. #656 added only rule 1, reasoning that
+# NetworkPolicies are additive and the chart's own vc-cp-* policy already allowed
+# in-vCluster pods. That was true when written. #657 then DELETED the vc-* policies
+# (their egress excluded 10/8 and blocked the stack's ClusterIP traffic), so the
+# union collapsed to rule 1 alone and the vCluster's CoreDNS silently lost API
+# access: `Failed to watch: ... dial tcp 10.107.226.95:443: i/o timeout`, and
+# cncd's agent-session dispatch died at `lookup cnc-node ... no such host`.
+# Neither PR was wrong alone; the break lived in the seam between them.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -15,9 +29,18 @@ spec:
       release: cnc-staging
   policyTypes: [Ingress]
   ingress:
+    # 1. ArgoCD application-controller -> vCluster API
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: argocd
+      ports:
+        - {port: 8443, protocol: TCP}
+    # 2. The vCluster's own synced pods (CoreDNS, cncd, node, ...) -> vCluster API.
+    #    An empty podSelector in `from` means "every pod in THIS policy's
+    #    namespace" (cnc-staging-vcluster), which is exactly where they run.
+    #    Restores what the deleted vc-cp-* policy used to grant.
+    - from:
+        - podSelector: {}
       ports:
         - {port: 8443, protocol: TCP}

--- a/scripts/tests/test_cnc_staging_vcluster_api_netpol.py
+++ b/scripts/tests/test_cnc_staging_vcluster_api_netpol.py
@@ -1,0 +1,112 @@
+"""Guard that the cnc-staging vCluster API stays reachable by BOTH consumers.
+
+REGRESSION (2026-07-20): the vCluster's CoreDNS could not reach the vCluster API,
+so it had no Service/EndpointSlice data and answered NOTHING — every in-vCluster
+name NXDOMAINed. cncd's agent-session dispatch died at:
+
+    dial tcp: lookup cnc-node on <kube-dns>:53: no such host
+
+and the run failed instantly, before ever contacting the node.
+
+Cause was an interaction between two individually-correct changes:
+  - #656 added an ingress policy selecting the vCluster control-plane pod that
+    allowed ONLY the argocd namespace, reasoning (correctly, at the time) that
+    NetworkPolicies are additive and the chart's vc-cp-* policy already allowed
+    in-vCluster pods.
+  - #657 then DELETED the vc-* policies (their egress excluded 10/8 and blocked
+    the stack's ClusterIP traffic).
+
+The union collapsed to the argocd rule alone, and because ANY NetworkPolicy
+selecting a pod makes it default-deny for unnamed ingress, the vCluster's own
+pods lost API access. Neither PR was wrong alone — the break lived in the seam.
+
+So this guards the invariant that outlived both: whatever policy selects the
+vCluster control-plane pod must admit the vCluster's own namespace AND argocd.
+
+LOCAL guards (frank does not run scripts/tests/ in CI); fail-closed.
+"""
+
+import subprocess
+from pathlib import Path
+
+import yaml  # hard dep (pyproject) — a missing yaml must ERROR, not skip
+
+REPO = Path(__file__).resolve().parents[2]
+HOST_APP = REPO / "apps/cnc-staging-host/manifests"
+API_PORT = 8443
+
+
+def _netpols():
+    out = subprocess.run(
+        ["kustomize", "build", str(HOST_APP)], capture_output=True, text=True
+    )
+    assert out.returncode == 0, f"kustomize build failed:\n{out.stderr}"
+    return [
+        d for d in yaml.safe_load_all(out.stdout)
+        if d and d.get("kind") == "NetworkPolicy"
+    ]
+
+
+def _cp_policies():
+    """Policies that select the vCluster control-plane pod (release=cnc-staging)."""
+    hits = []
+    for np in _netpols():
+        sel = (np["spec"].get("podSelector") or {}).get("matchLabels") or {}
+        if sel.get("release") == "cnc-staging":
+            hits.append(np)
+    assert hits, "no NetworkPolicy selects the vCluster control-plane pod"
+    return hits
+
+
+def _rules_allowing(np, predicate):
+    for rule in np["spec"].get("ingress") or []:
+        ports = [p.get("port") for p in (rule.get("ports") or [])]
+        if API_PORT not in ports:
+            continue
+        for src in rule.get("from") or []:
+            if predicate(src):
+                return True
+    return False
+
+
+def test_argocd_can_reach_the_vcluster_api():
+    """Without this ArgoCD cannot sync the apps INTO the vCluster (#656)."""
+    ok = any(
+        _rules_allowing(
+            np,
+            lambda s: (s.get("namespaceSelector") or {})
+            .get("matchLabels", {})
+            .get("kubernetes.io/metadata.name") == "argocd",
+        )
+        for np in _cp_policies()
+    )
+    assert ok, f"no ingress rule admits the argocd namespace on {API_PORT}"
+
+
+def test_vcluster_own_pods_can_reach_the_vcluster_api():
+    """THE REGRESSION GUARD. An empty podSelector in `from` means every pod in the
+    policy's own namespace — where the vCluster's synced pods (CoreDNS!) run.
+
+    Without it CoreDNS cannot watch Services/EndpointSlices, so it answers no
+    in-vCluster name and cncd's dispatch dies on `no such host`.
+    """
+    ok = any(
+        _rules_allowing(np, lambda s: s.get("podSelector") == {})
+        for np in _cp_policies()
+    )
+    assert ok, (
+        f"no ingress rule admits the vCluster's own namespace on {API_PORT} — "
+        "CoreDNS will lose API access and every in-vCluster name will NXDOMAIN"
+    )
+
+
+def test_control_plane_policies_are_ingress_only():
+    """These policies must not add an egress policyType: doing so would flip the
+    control-plane pod to default-deny EGRESS too — the exact class of breakage
+    #657 had to undo on the chart's vc-* policies."""
+    for np in _cp_policies():
+        types = np["spec"].get("policyTypes") or []
+        assert "Egress" not in types, (
+            f"{np['metadata']['name']} adds an Egress policyType; that would "
+            "default-deny the control-plane pod's egress (see #657)"
+        )


### PR DESCRIPTION
Root cause of the staging acceptance walk's step-6 failure. **This is mine, not the product's** — and it's a regression from my own #656 + #657.

## The evidence

T1 was right that no API or log exposes the reason — it's only in `runs.stderr_excerpt`:

```
agent-session http://cnc-node:8765/v1/session/send:
Post "http://cnc-node:8765/v1/session/send": dial tcp:
lookup cnc-node on 10.97.126.137:53: no such host
```

So it *does* attempt the dial and fails at **DNS**. The vCluster's CoreDNS explains why:

```
[ERROR] plugin/kubernetes: Failed to watch: failed to list *v1.Service:
Get "https://10.107.226.95:443/api/v1/services": dial tcp 10.107.226.95:443: i/o timeout
```

CoreDNS cannot reach the vCluster API (`10.107.226.95` = the `cnc-staging` API Service), so it has **no** Service/EndpointSlice/Namespace data and answers *nothing*. Confirmed from a pod sharing that DNS view — `cnc-node`, `cncd`, and even full FQDNs all NXDOMAIN.

Proven read-only: a probe pod in `cnc-staging-vcluster` gets **curl exit 28 (timeout)** against `https://10.107.226.95:443`, matching CoreDNS's `i/o timeout` exactly.

## Cause — a seam between two correct changes

- **#656** added an ingress policy selecting the vCluster control-plane pod allowing **only** the `argocd` namespace. Correct as written: NetworkPolicies are additive, and the chart's `vc-cp-*` policy already admitted in-vCluster pods.
- **#657** then **deleted** the `vc-*` policies — their egress excluded `10/8` and blocked the stack's ClusterIP traffic to Postgres.

The union collapsed to the ArgoCD rule alone. Since **any** NetworkPolicy selecting a pod makes it default-deny for unnamed ingress, the vCluster's own pods lost API access. Neither PR was wrong in isolation; nothing tested the combination.

## Fix

Add a second ingress rule admitting `podSelector: {}` — every pod in the policy's **own** namespace, which is where the vCluster's synced pods (CoreDNS, cncd, node) run — to 8443. That restores exactly what the deleted `vc-cp-*` policy granted, while keeping the ArgoCD rule.

The file now carries the history inline so the rule can't be "simplified" away by someone reading only #656's reasoning.

## Guards

`scripts/tests/test_cnc_staging_vcluster_api_netpol.py`:
1. ArgoCD is admitted on 8443 (protects #656's fix).
2. **The vCluster's own namespace is admitted on 8443** — the regression guard; fails on the pre-fix manifest.
3. Control-plane policies stay **Ingress-only**, so they can never default-deny egress — the failure class #657 had to undo.

13 passed alongside the sibling host-secrets suite.

## After merge

ArgoCD syncs the policy → CoreDNS regains its watch → in-vCluster DNS resolves → I'll re-run the acceptance walk and post the result. Expect step 6 to reach the node for the first time.

Two observability gaps stand regardless (T1 is filing a cnc-frd issue): a failed run exposes **no reason** through the API (`/v1/runs/<id>` is 405, the runs list has no error field), and cncd logs **nothing** when it fails one. The reason is only in the DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
