### PR TITLE
fix(cicd): map Gitea-only commit-status states to GitHub's vocabulary

### DIFF
--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -37,6 +37,7 @@ One-line reminders only. Each section header points at a per-topic file under `d
 - Gitea sends `X-Gitea-Event` (not `X-GitHub-Event`) — use `cel` interceptor, not `github`.
 - Gitea Actions runner DinD needs `DOCKER_TLS_CERTDIR=""` + explicit `--host=tcp://0.0.0.0:2375` — unset, dind serves TLS on 2376 and every job hangs "Running" against 2375.
 - act_runner registration is one-shot PVC state (`/data/.runner`) — rotating `STOA_GITEA_RUNNER_TOKEN` does NOT re-register; scale to 0, delete `/data/.runner`, scale up.
+- **Gitea's commit-status vocabulary is a SUPERSET of GitHub's** (`skipped`/`warning` beyond `pending|success|error|failure`) — `stoa-status-bridge` forwarded state verbatim, so a `skipped` job 422'd and the earlier `pending` stayed FOREVER (commit statuses have no lifecycle; nothing reconciles them). PR stuck `UNSTABLE`, the failure visible only as a Failed PipelineRun in `tekton-pipelines`. Fixed by the `gh_state` CEL overlay (skipped/warning→`success`, real state kept in the description). Fix MUST live in the EventListener, NOT the bridge Pipeline — Pipeline `.spec.tasks` is still frozen by array-item ignore rules. Skipping itself is CORRECT while `CI_AUTHORITY=github` — don't chase the guard. No backfill: statuses stranded pre-fix need a one-shot manual overwrite. Full prose: `tekton.md`.
 
 ### Argo Rollouts — `docs/runbooks/frank-gotchas/argo-rollouts.md`
 - Only `canary` / `blueGreen` strategies — stateful + RWO PVC apps stay as plain Deployments.

--- a/apps/tekton/triggers/eventlistener.yaml
+++ b/apps/tekton/triggers/eventlistener.yaml
@@ -50,9 +50,11 @@ spec:
     # forward (intentional: GitHub main commits get gitea-actions/* statuses
     # too). description/target_url are omitempty in Gitea's payload, hence
     # the has() overlays — a direct $(body.X) binding on a missing field
-    # drops the event. Gitea state values outside GitHub's vocabulary
-    # (e.g. 'warning') would 422 in github-status and fail the PipelineRun
-    # visibly — acceptable failure shape, revisit only if it fires.
+    # drops the event. Gitea state values outside GitHub's vocabulary were
+    # once left to 422 in github-status ("acceptable failure shape, revisit
+    # only if it fires") — it fired on 2026-07-22 and the failure shape was
+    # NOT acceptable, because the stranded status is invisible on the PR.
+    # They are narrowed in the gh_state overlay below.
     # ──────────────────────────────────────────────────────────────────
     - name: gitea-status-bridge
       interceptors:
@@ -67,8 +69,20 @@ spec:
                 !body.context.startsWith('tekton')
             - name: "overlays"
               value:
+                # Gitea's CommitStatusState is a SUPERSET of GitHub's
+                # (pending|success|error|failure): it also carries `skipped`
+                # and `warning`. Posting either verbatim 422s ("State is not
+                # included in the list"), github-status exits non-zero, and
+                # the GitHub status stays stuck on the `pending` written when
+                # the job was queued — permanently, because a commit status
+                # has no lifecycle of its own and nothing reconciles it.
+                # Both Gitea-only states mean "not a failure" → success.
+                - key: gh_state
+                  expression: "(body.state == 'skipped' || body.state == 'warning') ? 'success' : body.state"
+                # Keep the real Gitea state visible, or a skipped job reads
+                # as a genuine green check on the GitHub PR.
                 - key: description
-                  expression: "has(body.description) ? body.description : ''"
+                  expression: "(body.state == 'skipped' || body.state == 'warning') ? 'Gitea: ' + body.state : (has(body.description) ? body.description : '')"
                 - key: target_url
                   expression: "has(body.target_url) ? body.target_url : ''"
       bindings:
@@ -79,7 +93,7 @@ spec:
           value: $(body.sha)
           kind: TriggerBinding
         - name: state
-          value: $(body.state)
+          value: $(extensions.gh_state)
           kind: TriggerBinding
         - name: context
           value: $(body.context)

--- a/docs/runbooks/frank-gotchas/tekton.md
+++ b/docs/runbooks/frank-gotchas/tekton.md
@@ -26,6 +26,31 @@ Tekton `github` ClusterInterceptor silently drops Gitea webhooks because Gitea s
 
 The `docker:dind` sidecar in `apps/gitea-runner` defaults to generating TLS certs and listening on **2376** when `DOCKER_TLS_CERTDIR` is unset. act_runner is pointed at plain-TCP `tcp://localhost:2375`, so the pair comes up "Running" while every job hangs waiting for a docker daemon that is listening one port over, TLS-only. Set `DOCKER_TLS_CERTDIR: ""` and pass `--host=tcp://0.0.0.0:2375` explicitly (guarded by `scripts/tests/test_gitea_runner_app.py`).
 
+## Status bridge: Gitea's state vocabulary is a SUPERSET of GitHub's
+
+GitHub's commit-status API accepts exactly `pending | success | error | failure`. Gitea's `CommitStatusState` **also** has `skipped` and `warning`. The `stoa-status-bridge` originally forwarded `body.state` verbatim on the documented assumption that the vocabularies were identical — they are not.
+
+The failure is asymmetric and nastier than it looks, because a **commit status has no lifecycle of its own**: it is whatever the last *successful* POST said, with no timeout and nothing that reconciles it. So a skipped Gitea job produces:
+
+1. Gitea posts `pending` at queue time → bridge forwards it → GitHub shows pending.
+2. Gitea posts `skipped` when the job is gated out → bridge forwards it → GitHub **422s** (`"Validation failed: State is not included in the list"`) → `github-status` exits non-zero.
+3. The pending status is never superseded. **The PR stays `UNSTABLE` forever**, and no rerun or new push clears it.
+
+The PipelineRun failure *is* visible — but only in `tekton-pipelines`, with nothing linking it to the blocked PR. Diagnose with:
+
+```bash
+kubectl -n tekton-pipelines get pipelinerun | grep stoa-status-bridge   # Failed rows
+kubectl -n tekton-pipelines logs <pod> --all-containers | grep 'HTTP 4'
+```
+
+Fixed 2026-07-22 by narrowing the vocabulary in the `gitea-status-bridge` CEL overlays (`gh_state`: `skipped`/`warning` → `success`, everything else pass-through) and binding `state` to `$(extensions.gh_state)`. The real state is kept in the description (`Gitea: skipped`) so a gated-out job never reads as a genuine green check. Guarded by `scripts/tests/test_stoa_status_bridge.py::test_bridge_maps_gitea_only_states`.
+
+**Why the fix lives in the EventListener and not the Pipeline:** `apps/root/templates/tekton-extras.yaml` still carries array-item `jqPathExpressions` on `Pipeline` (`.spec.tasks[]?…`), which under `RespectIgnoreDifferences=true` freeze the whole `.spec.tasks` array — an edit to the bridge's task params would be silently discarded while ArgoCD reports Synced (see the ArgoCD section; frank#664). The `EventListener` rule was de-arrayed by that fix, so `spec.triggers` genuinely applies.
+
+**Trigger context:** the first mass `skipped` event came from the `CI_AUTHORITY` guard PRs. Skipping on the Gitea side is *correct* while the org variable is `CI_AUTHORITY=github` (the parallel-running default) — don't chase the guard, it isn't the bug. Incident writeup: `docs/superpowers/debugging/2026-07-22--cicd--gitea-skipped-status-stranded-on-github.md`.
+
+Note the bridge does **not** backfill: Gitea never re-sends a status for a job that already finished, so statuses stranded before the fix must be overwritten once by hand.
+
 ## Gitea Actions runner: registration is one-shot PVC state
 
 `act_runner` registers against Gitea once and persists its identity in `/data/.runner` on the PVC. Rotating `STOA_GITEA_RUNNER_TOKEN` (or re-minting the registration token) does **NOT** re-register an already-registered runner — the token is only read when `/data/.runner` is absent. To force a fresh registration: scale the Deployment to 0, delete `/data/.runner` (or the whole PVC — the tool cache is rebuildable), scale back up. Symptom of a half-dead registration: runner pod healthy but the Gitea admin runners page shows it Offline.

--- a/docs/superpowers/debugging/2026-07-22--cicd--gitea-skipped-status-stranded-on-github.md
+++ b/docs/superpowers/debugging/2026-07-22--cicd--gitea-skipped-status-stranded-on-github.md
@@ -1,0 +1,151 @@
+# Gitea `skipped` statuses strand GitHub PR checks on `pending` forever
+
+**Date:** 2026-07-22
+**Layer:** cicd
+**Fix:** `apps/tekton/triggers/eventlistener.yaml` (gitea-status-bridge `gh_state` overlay)
+**Guard:** `scripts/tests/test_stoa_status_bridge.py::test_bridge_maps_gitea_only_states`
+
+## Symptom & reproduction
+
+Four open PRs across the stoa mirrors — all titled `ci: gate automatic
+workflows on CI_AUTHORITY` — showed `gitea-actions/*` checks stuck **pending**
+on GitHub, while the corresponding Gitea Actions jobs had long since finished
+as **skipped**. No rerun, no new push, and no amount of waiting cleared them;
+`mergeStateStatus` sat at `UNSTABLE` indefinitely.
+
+Reproduce: push any commit to a mirrored repo while the Gitea org variable
+`CI_AUTHORITY=github`, so the `CI_AUTHORITY`-guarded jobs skip on the Gitea
+side. The bridge writes `pending` when the job is queued and never writes
+anything again.
+
+```bash
+gh pr view 39 --repo agentic-stoa/cnc-frd --json statusCheckRollup \
+  --jq '.statusCheckRollup[] | select(.context? // "" | startswith("gitea-actions/"))'
+# → every entry: "state": "PENDING", targetUrl → a finished Gitea run
+```
+
+## Evidence
+
+**1. The two halves are separate questions.** The skipping is correct; only
+the reporting is broken.
+
+The PRs add a job-level guard:
+
+```yaml
+if: (vars.CI_AUTHORITY || 'github') == (github.server_url == 'https://github.com' && 'github' || 'gitea')
+```
+
+On the Gitea side `github.server_url` is the Gitea instance, so the
+right-hand side is `'gitea'`, while the org variable is deliberately
+`CI_AUTHORITY=github` for the parallel-running window (manual op
+`cicd-stoa-gitea-org-actions-config`; cutover is the August flip). `'github'
+!= 'gitea'` → **every guarded job skips on Gitea, by design.**
+
+**2. The stranded status is a commit status, not a check run.** In the
+rollup, the `gitea-actions/*` entries are `StatusContext`, not `CheckRun` —
+plain `POST /repos/{o}/{r}/statuses/{sha}` writes from the
+`stoa-status-bridge` pipeline. A commit status has no lifecycle of its own:
+it is whatever the last *successful* POST said, with no timeout and nothing
+that reconciles it.
+
+**3. The bridge was failing, loudly, in a place nobody looks.**
+
+```
+$ kubectl -n tekton-pipelines get pipelinerun | grep stoa-status-bridge
+stoa-status-bridge-khp9s   False   Failed   ...     (× 30)
+
+$ kubectl -n tekton-pipelines logs <pod> --all-containers
+Reported status 'skipped' for aea1954d... (HTTP 422)
+{
+  "message": "Validation Failed",
+  "errors": "Validation failed: State is not included in the list",
+  ...
+}
+```
+
+All 30 failures, one state: `skipped`. (`warning` was not observed but is the
+same class.)
+
+## Root cause
+
+**Gitea's `CommitStatusState` vocabulary is a superset of GitHub's, and the
+bridge assumed the two were identical.** GitHub's status API accepts exactly
+`pending | success | error | failure`; Gitea additionally has `skipped` and
+`warning`. `stoa-status-bridge` forwards `body.state` verbatim — its own
+header says *"State vocabulary … is identical between the two APIs and passes
+through unmapped."* It is not.
+
+So a skipped job produces: Gitea posts `pending` at queue time → bridge
+forwards it → GitHub shows pending. Gitea then posts `skipped` → bridge
+forwards it → GitHub 422s → `github-status` exits non-zero → **the pending
+status is never superseded.** Permanently pending, because commit statuses
+never expire.
+
+The failure mode was anticipated and explicitly accepted in the trigger's own
+comment:
+
+> *Gitea state values outside GitHub's vocabulary (e.g. 'warning') would 422
+> in github-status and fail the PipelineRun visibly — acceptable failure
+> shape, revisit only if it fires.*
+
+It fired. The shape was **not** acceptable: the PipelineRun failure is visible
+only in the Tekton namespace, while the consequence — a permanently blocked
+PR — is what the operator actually sees, with no link between the two.
+
+## Fix
+
+Narrow Gitea's vocabulary to GitHub's in the `gitea-status-bridge` CEL
+overlays, before the value is ever bound:
+
+```yaml
+- key: gh_state
+  expression: "(body.state == 'skipped' || body.state == 'warning') ? 'success' : body.state"
+- key: description
+  expression: "(body.state == 'skipped' || body.state == 'warning') ? 'Gitea: ' + body.state : (has(body.description) ? body.description : '')"
+```
+
+…with the `state` binding moved from `$(body.state)` to
+`$(extensions.gh_state)`.
+
+Both Gitea-only states mean "not a failure", so both map to `success` — which
+also matches GitHub's own Checks semantics, where a skipped job is
+non-blocking. The real state survives in the description (`Gitea: skipped`),
+so a skipped job never masquerades as a genuine green check.
+
+**Why the CEL overlay and not the Pipeline's task params** — the natural place
+for a translation is `stoa-status-bridge`'s `state` param, but
+`apps/root/templates/tekton-extras.yaml` still carries array-item
+`jqPathExpressions` on `Pipeline` (`.spec.tasks[]?…`). Under
+`RespectIgnoreDifferences=true` those freeze the whole `.spec.tasks` array:
+ArgoCD carries the live array into every apply and silently discards the edit
+while reporting Synced (frank#664; `test_tekton_ignore_rules_no_arrays.py`
+documents `Pipeline`/`Task` as known, still-exempted debt). The
+`EventListener` rule was de-arrayed by that same fix, so `spec.triggers` does
+apply — it is the only surface where this fix actually reaches the cluster.
+
+Verified by evaluating both expressions with `cel-python` against real payload
+shapes: `skipped`/`warning` → `success`, and `pending`/`success`/`failure`
+pass through untouched with their original descriptions.
+
+## Rejected hypotheses
+
+- **Gitea never sent a terminal status.** Ruled out — the bridge logs show the
+  `skipped` status arriving and being forwarded.
+- **The CEL filter dropped the event.** Ruled out — the filter only excludes
+  non-`agentic-stoa` repos and `tekton/*` contexts; the PipelineRuns exist.
+- **The GitHub token lost `statuses: write`.** Ruled out — the 422 is a
+  validation error on the payload, and `tekton/ci` statuses posted `SUCCESS`
+  on the same shas at the same time with the same Secret.
+- **The `CI_AUTHORITY` guard is itself wrong.** Ruled out — skipping on the
+  Gitea side is exactly what `CI_AUTHORITY=github` is for during parallel
+  running. The guard PRs are correct and unrelated to the reporting bug; they
+  merely triggered the first mass `skipped` event.
+- **The GitHub-native checks failing (`FAILURE`) is part of this bug.** Ruled
+  out — those are the exhausted GitHub Actions minutes tier, a known
+  pre-existing condition on these repos.
+
+## Backfill (one-shot, operator)
+
+The fix only affects future webhook events; Gitea does not re-send statuses
+for jobs that already finished. The already-stranded contexts on the four open
+PRs must be overwritten once, by hand, after the fix is synced.

--- a/scripts/tests/test_stoa_status_bridge.py
+++ b/scripts/tests/test_stoa_status_bridge.py
@@ -71,7 +71,9 @@ def test_bridge_template_and_bindings():
     bindings = {b["name"]: b["value"] for b in trig.get("bindings", [])}
     assert bindings["repo-full-name"] == "$(body.repository.full_name)"
     assert bindings["revision"] == "$(body.sha)"
-    assert bindings["state"] == "$(body.state)"
+    # NOT $(body.state) — Gitea's vocabulary is a superset of GitHub's and
+    # must be narrowed first (see test_bridge_maps_gitea_only_states)
+    assert bindings["state"] == "$(extensions.gh_state)"
     assert bindings["context"] == "$(body.context)"
 
     # description/target_url are omitempty in Gitea's status payload — they
@@ -84,7 +86,6 @@ def test_bridge_template_and_bindings():
         for p in interceptor.get("params", []):
             if p["name"] == "overlays":
                 overlays.update({o["key"]: o["expression"] for o in p["value"]})
-    assert overlays["description"] == "has(body.description) ? body.description : ''"
     assert overlays["target_url"] == "has(body.target_url) ? body.target_url : ''"
 
     templates = [
@@ -100,6 +101,52 @@ def test_bridge_template_and_bindings():
     run = tmpl["spec"]["resourcetemplates"][0]
     assert run["kind"] == "PipelineRun"
     assert run["spec"]["pipelineRef"]["name"] == "stoa-status-bridge"
+
+
+def _bridge_overlays():
+    overlays = {}
+    for interceptor in _bridge_trigger().get("interceptors", []):
+        for p in interceptor.get("params", []):
+            if p["name"] == "overlays":
+                overlays.update({o["key"]: o["expression"] for o in p["value"]})
+    return overlays
+
+
+def test_bridge_maps_gitea_only_states():
+    """Gitea's CommitStatusState is a SUPERSET of GitHub's.
+
+    GitHub's status API accepts exactly pending|success|error|failure. Gitea
+    adds `skipped` and `warning`. Posting either verbatim returns 422
+    ("State is not included in the list"), github-status exits non-zero, and
+    — because a commit status has no lifecycle of its own — the GitHub status
+    stays stuck on the `pending` written when the job was queued. Forever.
+
+    Incident 2026-07-22: the CI_AUTHORITY guard PRs made every Gitea job skip
+    (correct: CI_AUTHORITY=github during parallel running), 30 bridge
+    PipelineRuns failed on `skipped`, and 4 PRs showed permanently pending
+    gitea-actions/* checks that no rerun could clear.
+
+    Both Gitea-only states mean "not a failure", so both map to `success`
+    with the real state preserved in the description. Everything already in
+    GitHub's vocabulary passes through untouched.
+    """
+    expr = _bridge_overlays().get("gh_state")
+    assert expr, "gh_state overlay missing — raw Gitea states would 422"
+
+    for gitea_only in ("skipped", "warning"):
+        assert f"'{gitea_only}'" in expr, (
+            f"Gitea-only state {gitea_only!r} not narrowed to GitHub's "
+            f"vocabulary — it would 422 and strand the status: {expr}"
+        )
+    assert "'success'" in expr
+    # non-Gitea-only states must still pass through unmapped
+    assert "body.state" in expr.split("?", 1)[1]
+
+    desc = _bridge_overlays().get("description")
+    assert desc and "body.state" in desc, (
+        "description must surface the real Gitea state, or a skipped job "
+        f"reads as a genuine green check on GitHub: {desc}"
+    )
 
 
 def test_bridge_pipeline_forwards_via_github_status():


### PR DESCRIPTION
## Symptom

Four open PRs on the stoa mirrors (all `ci: gate automatic workflows on CI_AUTHORITY`) showed `gitea-actions/*` checks stuck **pending** on GitHub while the corresponding Gitea jobs had finished as **skipped**. `mergeStateStatus: UNSTABLE`, indefinitely — no rerun or new push cleared it.

## Root cause

**Gitea's `CommitStatusState` vocabulary is a superset of GitHub's, and `stoa-status-bridge` assumed the two were identical** (its own header says so: *"State vocabulary … is identical between the two APIs and passes through unmapped"*).

GitHub accepts exactly `pending | success | error | failure`. Gitea additionally has `skipped` and `warning`. So for a gated-out job:

1. Gitea posts `pending` at queue time → bridge forwards → GitHub shows pending.
2. Gitea posts `skipped` → bridge forwards → GitHub **422** `"Validation failed: State is not included in the list"` → `github-status` exits non-zero.
3. The pending status is never superseded. **A commit status has no lifecycle of its own** — no timeout, nothing that reconciles it — so it stays pending forever.

Evidence: 30 Failed `stoa-status-bridge` PipelineRuns, all one state.

```
Reported status 'skipped' for aea1954d... (HTTP 422)
{"message": "Validation Failed", "errors": "Validation failed: State is not included in the list"}
```

The trigger comment had explicitly accepted this shape — *"would 422 in github-status and fail the PipelineRun visibly — acceptable failure shape, revisit only if it fires."* It fired, and the shape was not acceptable: the PipelineRun failure is visible only inside `tekton-pipelines`, while the consequence the operator sees is a permanently blocked PR, with nothing linking the two.

**The skipping itself is correct and not part of this bug.** `CI_AUTHORITY=github` is the deliberate parallel-running default, so `CI_AUTHORITY`-guarded jobs are *supposed* to skip on the Gitea side until the August cutover. Those PRs merely produced the first mass `skipped` event.

## Fix

Narrow the vocabulary in the `gitea-status-bridge` CEL overlays, before the value is ever bound:

```yaml
- key: gh_state
  expression: "(body.state == 'skipped' || body.state == 'warning') ? 'success' : body.state"
- key: description
  expression: "(body.state == 'skipped' || body.state == 'warning') ? 'Gitea: ' + body.state : (has(body.description) ? body.description : '')"
```

…with `state` bound to `$(extensions.gh_state)`.

Both Gitea-only states mean "not a failure" → `success`, matching GitHub's own Checks semantics where a skipped job is non-blocking. The real state survives in the description (`Gitea: skipped`) so a gated-out job never masquerades as a genuine green check.

**Why the EventListener and not the bridge Pipeline's task params** — the natural surface is the Pipeline, but `apps/root/templates/tekton-extras.yaml` still carries array-item `jqPathExpressions` on `Pipeline` (`.spec.tasks[]?…`). Under `RespectIgnoreDifferences=true` those freeze the whole array: ArgoCD carries the live array into every apply and silently discards the edit while reporting Synced (frank#664; `test_tekton_ignore_rules_no_arrays.py` documents `Pipeline`/`Task` as still-exempted debt). The `EventListener` rule was de-arrayed by that fix, so `spec.triggers` genuinely applies — it is the only surface where this reaches the cluster.

## Failing test first

`scripts/tests/test_stoa_status_bridge.py::test_bridge_maps_gitea_only_states` — added RED (`gh_state overlay missing — raw Gitea states would 422`), then green. The existing binding assertion that encoded the bug (`bindings["state"] == "$(body.state)"`) was updated to require the narrowing indirection.

Additionally verified behaviourally by evaluating both overlays with `cel-python` against real payload shapes — every output lands inside GitHub's vocabulary:

```
gitea=skipped  -> success  'Gitea: skipped'
gitea=warning  -> success  'Gitea: warning'
gitea=pending  -> pending  'Queued'
gitea=success  -> success  'All good'
gitea=failure  -> failure  ''
```

Full suite: `29 failed, 139 passed` on clean `main` → `29 failed, 140 passed` with this change. The 29 are pre-existing and untouched.

## Docs

- `docs/superpowers/debugging/2026-07-22--cicd--gitea-skipped-status-stranded-on-github.md` — full investigation incl. rejected hypotheses
- `agents/rules/frank-gotchas.md` (Tekton one-liner) + `docs/runbooks/frank-gotchas/tekton.md` (prose, diagnosis commands)

## Operator follow-up (not in this PR)

The fix only affects **future** webhook events — Gitea does not re-send statuses for jobs that already finished. The already-stranded contexts on the four open stoa PRs need a one-shot manual overwrite after this syncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)