### PR TITLE
fix(obs): cred-expiry check reads nested claudeAiOauth field

### DIFF
--- a/apps/alert-agent/handlers/handlers/cred_expiry.py
+++ b/apps/alert-agent/handlers/handlers/cred_expiry.py
@@ -81,7 +81,14 @@ def evaluate_expiry(creds_text: str | None, now_ms: int) -> Verdict:
     exp_ms = None
     if creds_text is not None:
         try:
-            exp_ms = json.loads(creds_text).get("refreshTokenExpiresAt")
+            doc = json.loads(creds_text)
+            # The real claude credentials.json nests the field under `claudeAiOauth`
+            # (confirmed live 2026-07-22); accept a top-level field too, defensively.
+            oauth = doc.get("claudeAiOauth") if isinstance(doc, dict) else None
+            if isinstance(oauth, dict) and "refreshTokenExpiresAt" in oauth:
+                exp_ms = oauth.get("refreshTokenExpiresAt")
+            else:
+                exp_ms = doc.get("refreshTokenExpiresAt")
         except (ValueError, TypeError, AttributeError):
             exp_ms = None
     # Reject non-numbers, bools (isinstance(True, int) is True), and non-finite

--- a/apps/alert-agent/handlers/tests/test_cred_expiry.py
+++ b/apps/alert-agent/handlers/tests/test_cred_expiry.py
@@ -11,7 +11,21 @@ DAY_MS = 86_400_000
 
 
 def _creds(days_out: float) -> str:
+    # The REAL claude credentials.json nests the field under `claudeAiOauth`
+    # (confirmed live 2026-07-22) — NOT top-level.
+    return json.dumps({"claudeAiOauth": {
+        "refreshToken": "", "expiresAt": 0,
+        "refreshTokenExpiresAt": int(NOW_MS + days_out * DAY_MS)}})
+
+
+def _creds_flat(days_out: float) -> str:
+    # Defensive fallback: a top-level field must also work (format may vary).
     return json.dumps({"refreshTokenExpiresAt": int(NOW_MS + days_out * DAY_MS), "expiresAt": 0})
+
+
+def test_reads_nested_and_flat_field():
+    assert ce.evaluate_expiry(_creds(5), NOW_MS).days_left == 5        # nested claudeAiOauth
+    assert ce.evaluate_expiry(_creds_flat(5), NOW_MS).days_left == 5   # top-level fallback
 
 
 # --- evaluate_expiry: arithmetic + tiers -------------------------------------

--- a/docs/runbooks/frank-gotchas/obs-digest.md
+++ b/docs/runbooks/frank-gotchas/obs-digest.md
@@ -390,7 +390,12 @@ for 3 days with no signal: the pod stayed `3/3 Running`, ArgoCD stayed green, an
 the failure (`Login expired · Please run /login`) lived inside a tmux pane —
 invisible to every existing probe. The token is a hard ~30-day clock
 (`refreshTokenExpiresAt`, epoch-ms, in `/home/agent/.claude/.credentials.json` on
-the `alert-agent-home` PVC; `expiresAt` is `0`).
+the `alert-agent-home` PVC; `expiresAt` is `0`). **The field is nested under a
+`claudeAiOauth` wrapper** (`{"claudeAiOauth": {"refreshTokenExpiresAt": …}}`), NOT
+top-level — the v1 check read it flat and reported `tier=error` (a daily false
+"credential check FAILED" warning), caught only at live verification; a substring
+grep matches the field regardless of nesting, so confirm the *shape*, not just the
+name. Fixed to descend the wrapper (top-level fallback retained).
 
 **Design — dual signal, fails independently.** A standalone canary pod is
 impossible: the credential lives on an RWO PVC held by the agent pod, and the pod

--- a/docs/superpowers/specs/2026-07-22--obs--cred-expiry-alert-design.md
+++ b/docs/superpowers/specs/2026-07-22--obs--cred-expiry-alert-design.md
@@ -20,8 +20,10 @@ warner itself dies.
 - **Credential**: `/home/agent/.claude/.credentials.json` on PVC `alert-agent-home`
   (RWO, `apps/alert-agent/manifests/pvc.yaml:4-10`), mounted at `/home/agent`
   **only on the `agent` container** (`deployment.yaml:65`). Field
-  `refreshTokenExpiresAt` (epoch-ms int); confirmed live 2026-07-22
-  (`=2026-08-19`, `expiresAt=0`). Path per `agent-shells.md:567-568`.
+  `refreshTokenExpiresAt` (epoch-ms int) is **nested under `claudeAiOauth`**
+  (`{"claudeAiOauth": {"refreshTokenExpiresAt": …}}`) — confirmed live 2026-07-22
+  (`=2026-08-19`); NOT top-level (the reader must descend the wrapper, with a
+  top-level fallback). Path per `agent-shells.md:567-568`.
 - **RWO + no-RBAC posture** (`automountServiceAccountToken: false`,
   `deployment.yaml:22-25`) → a standalone CronJob can neither co-mount the PVC
   nor `kubectl exec`. A separate canary pod is **out**.


### PR DESCRIPTION
## Bug

The credential-expiry check shipped in #671 read `refreshTokenExpiresAt` at the **top level** of `~/.claude/.credentials.json`. The real file nests it under a `claudeAiOauth` wrapper:

```json
{ "claudeAiOauth": { "refreshToken": "", "expiresAt": 0, "refreshTokenExpiresAt": 1787107246868 } }
```

So the check found no field → `tier=error` → it would have sent a **daily false 'credential check FAILED' Telegram warning** (and did, once, during post-merge verification).

## Why it slipped through

Unit fixtures were flat, and the pre-merge 'confirmation' was a substring `grep` that matches `refreshTokenExpiresAt` regardless of nesting — the field *name* was confirmed, the *shape* was not. Only live verification against the deployed pod (the repo's 'observe end-to-end' rule) surfaced it — the reviewer checked logic, not the real file.

## Fix

`evaluate_expiry` now descends the `claudeAiOauth` wrapper, with a top-level fallback (format may vary). The test fixture is updated to the **real nested shape**, plus a flat-fallback case. All broken-input cases still route to `tier=error`.

## Verification

- 50 unit tests pass; `cred_expiry.py` ruff-clean.
- **Live, against the real deployed credential**: the fixed module returns `tier=ok days_left=27 should_warn=False`, `refresh_expires=2026-08-19` — no more false warning.
- Spec constraint + obs-digest gotcha corrected to document the nested shape and the confirm-the-shape-not-the-name lesson.

Follow-up to #671 (obs layer, same feature). Once merged, ArgoCD rolls the pod and the daily 09:00 check reports `tier=ok` until the token nears 7 days (~Aug 12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)