### PR TITLE
feat(obs): alert on a wedged VK executor pool (health-bridge only, no page)

### DIFF
--- a/apps/grafana-alerting/manifests/alert-rules-cm.yaml
+++ b/apps/grafana-alerting/manifests/alert-rules-cm.yaml
@@ -406,6 +406,64 @@ data:
             annotations:
               summary: "Secure agent pod {{ $labels.pod }} not in Running phase"
 
+      # --- VK executor pool wedged (eval every 5m) ---
+      # Detects the leaked-permit wedge (2026-07-24 incident, frank#692): a
+      # 30s-timeout MCP client abandons a spawn, vk-local's Child::wait() is
+      # cancelled, the child dies unreaped, and its concurrency permit is never
+      # released. Leaks accumulate to VK_MAX_CONCURRENT_EXECUTIONS and every
+      # later dispatch queues forever — pod 2/2 Running, ArgoCD green, agents
+      # silently hang. Signature: active pinned at max with a non-draining
+      # queue. `for: 1h` clears the worst legitimate case (a mass dispatch of
+      # long coding runs saturating 8 slots drains its queue well inside an
+      # hour); a wedge holds the state indefinitely. The bool-product expr
+      # always returns 0/1 while the scrape is alive, so NoData really means
+      # "scrape dead" → noDataState: Alerting surfaces it as DatasourceNoData,
+      # which health-bridge caps at degraded (blindness ≠ death). Routed via
+      # health_bridge_only="true": severity=critical drives the dead→bug-issue
+      # lifecycle but never pages Telegram. Root-cause fix: super-fr#404.
+      # Recovery + full prose: docs/runbooks/frank-gotchas/agent-shells.md.
+      - orgId: 1
+        name: vk-executor-pool
+        folder: feature-health
+        interval: 5m
+        rules:
+          - uid: vk-executor-pool-wedged
+            title: VK Executor Pool Wedged
+            condition: C
+            data:
+              - refId: A
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: P4169E866C3094E38
+                model:
+                  refId: A
+                  expr: '(vibekanban_active_executions >= bool vibekanban_max_executions) * (vibekanban_queued_executions >= bool 1)'
+                  instant: true
+                  intervalMs: 1000
+                  maxDataPoints: 43200
+              - refId: B
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model: { refId: B, type: reduce, expression: A, reducer: last, settings: { mode: dropNN } }
+              - refId: C
+                relativeTimeRange: { from: 600, to: 0 }
+                datasourceUid: __expr__
+                model:
+                  refId: C
+                  type: threshold
+                  expression: B
+                  conditions:
+                    - evaluator: { type: gt, params: [0.5] }
+            noDataState: Alerting
+            execErrState: Error
+            for: 1h
+            labels:
+              severity: critical
+              health_bridge_only: "true"
+              github_issue: "frank-ops#18"
+            annotations:
+              summary: "VK executor pool wedged: active executions pinned at the cap with a non-draining queue for 1h - leaked permits from dead executors likely hold every slot; newly dispatched agents hang silently"
+              runbook: "Recovery: kubectl -n secure-agent-pod exec deploy/secure-agent-pod -c vk-local -- kill -TERM 1 (restart runs orphan-cleanup, frees permits). Check vibekanban_active/queued/max_executions in VMUI and defunct sh children in the container. Full prose: docs/runbooks/frank-gotchas/agent-shells.md"
+
       # =====================================================================
       # LAYER TRACKERS (Derio Ops board, derio-net/frank-ops — private)
       # Labels: severity + github_issue=frank-ops#<LAYER>

--- a/apps/grafana-alerting/manifests/notification-policy-cm.yaml
+++ b/apps/grafana-alerting/manifests/notification-policy-cm.yaml
@@ -76,6 +76,14 @@ data:
             matchers:
               - gpu_timeshare="true"
             continue: false
+          # Generic "critical for health-bridge, but do not page" escape hatch
+          # (same trick as canary_watchdog above: severity=critical drives the
+          # dead→bug-issue lifecycle, this route keeps it off Telegram). MUST
+          # precede the severity routes. First user: vk-executor-pool-wedged.
+          - receiver: "Health Bridge Webhook"
+            matchers:
+              - health_bridge_only="true"
+            continue: false
           - receiver: "Telegram - Willikins"
             matchers:
               - severity=critical

--- a/docs/runbooks/frank-gotchas/agent-shells.md
+++ b/docs/runbooks/frank-gotchas/agent-shells.md
@@ -114,6 +114,13 @@ setupscripts, and more 30 s-timeout leaks until the client fix ships).
 
 **Detection signals** (any one is sufficient):
 
+- **Automated**: Grafana rule `vk-executor-pool-wedged` (feature-health,
+  `health_bridge_only="true"` → Health Bridge bug-issue only, no Telegram)
+  fires when `active >= max` AND `queued > 0` hold for 1 h. The vk-local
+  `/metrics` endpoint is scraped via the existing `VMPodScrape` (vk-http :8081,
+  30 s); the rule's bool-product expr returns 0/1 while the scrape is alive, so
+  NoData strictly means "scrape dead" (surfaced as DatasourceNoData → degraded).
+  Guard: `scripts/tests/test_vk_wedge_alert.py`.
 - `/metrics` on vk-local :8081 — `vibekanban_active_executions` pinned at
   `vibekanban_max_executions` with `vibekanban_queued_executions` > 0 and not
   draining.

--- a/scripts/tests/test_cert_expiry_canary.py
+++ b/scripts/tests/test_cert_expiry_canary.py
@@ -135,14 +135,19 @@ def test_canary_mute_route_is_second():
 def test_existing_routes_preserved_in_order():
     # pin the total so a stray route inserted between the canary pair and the
     # tail can't hide in the [2:] slice
-    assert len(_routes()) == 7
+    assert len(_routes()) == 9
     tail = _routes()[2:]
     expected = [
+        # Dead-man's-switch direct page — must precede blog-edge (see policy comment)
+        ("Telegram - Willikins", ['telegram_direct="true"'], False),
         ("AI Helper Webhook", ['grafana_folder="blog-edge"'], False),
         # GPU-timeshare feature-health: early continue:false to Health Bridge only
         # (degraded tile, no Telegram) — must precede the severity routes so a
         # gpu_timeshare alert never pages. See frank-gotchas "gpu_timeshare".
         ("Health Bridge Webhook", ['gpu_timeshare="true"'], False),
+        # Generic critical-without-paging escape hatch — must also precede the
+        # severity routes. First user: vk-executor-pool-wedged.
+        ("Health Bridge Webhook", ['health_bridge_only="true"'], False),
         ("Telegram - Willikins", ["severity=critical"], True),
         ("Telegram - Willikins", ["severity=warning"], True),
         ("Health Bridge Webhook", ['grafana_folder="feature-health"'], False),

--- a/scripts/tests/test_vk_wedge_alert.py
+++ b/scripts/tests/test_vk_wedge_alert.py
@@ -1,0 +1,81 @@
+"""Guard the VK executor-pool wedge alert (frank#692 follow-up).
+
+Locks the load-bearing shape of the leaked-permit wedge detector. The two
+easiest regressions to ship silently:
+
+1. Rewriting the expr as a plain `and`-filter — healthy then becomes an EMPTY
+   result (NoData), which collides with `noDataState: Alerting` and fires the
+   wedge alert on every quiet day. The bool-product form always returns 0/1
+   while the scrape is alive, so NoData is reserved for "scrape dead".
+2. Losing the health_bridge_only route (or letting it drift BELOW the severity
+   routes) — severity=critical would then page Telegram on every evaluation
+   window, which this rule must never do (route order is load-bearing, see
+   the canary_watchdog comment in the notification policy).
+"""
+
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+RULES_CM = REPO / "apps/grafana-alerting/manifests/alert-rules-cm.yaml"
+POLICY_CM = REPO / "apps/grafana-alerting/manifests/notification-policy-cm.yaml"
+UID = "vk-executor-pool-wedged"
+
+
+def _find_rule():
+    cm = yaml.safe_load(RULES_CM.read_text())
+    for blob in cm["data"].values():
+        doc = yaml.safe_load(blob)
+        for grp in doc.get("groups", []):
+            for rule in grp.get("rules", []):
+                if rule.get("uid") == UID:
+                    return rule
+    raise AssertionError(f"rule {UID} not found in {RULES_CM}")
+
+
+def _routes():
+    cm = yaml.safe_load(POLICY_CM.read_text())
+    doc = yaml.safe_load(cm["data"]["notification-policy.yaml"])
+    return doc["policies"][0]["routes"]
+
+
+def test_expr_is_bool_product_not_and_filter():
+    expr = next(d for d in _find_rule()["data"] if d["refId"] == "A")["model"]["expr"]
+    assert ">= bool vibekanban_max_executions" in expr
+    assert "vibekanban_queued_executions >= bool 1" in expr
+    assert ") * (" in expr, "must be a 0/1 product so healthy != NoData"
+    assert " and " not in expr, "an and-filter makes healthy == NoData == Alerting"
+
+
+def test_nodata_means_scrape_dead_and_fires():
+    rule = _find_rule()
+    assert rule["noDataState"] == "Alerting", "scrape death must surface, not go silent"
+    assert rule["execErrState"] == "Error"
+    c = next(d for d in rule["data"] if d["refId"] == "C")
+    cond = c["model"]["conditions"][0]["evaluator"]
+    assert cond["type"] == "gt" and cond["params"] == [0.5]
+
+
+def test_flap_window_outlasts_a_legitimate_dispatch_storm():
+    assert _find_rule()["for"] == "1h"
+
+
+def test_critical_for_health_bridge_but_never_pages():
+    labels = _find_rule()["labels"]
+    assert labels["severity"] == "critical"        # dead→bug-issue lifecycle
+    assert labels["health_bridge_only"] == "true"  # ...without paging Telegram
+    assert labels["github_issue"] == "frank-ops#18"
+
+
+def test_health_bridge_only_route_precedes_severity_routes():
+    routes = _routes()
+
+    def idx(pred):
+        return next(i for i, r in enumerate(routes) if pred(r))
+
+    hbo = idx(lambda r: 'health_bridge_only="true"' in r.get("matchers", []))
+    sev = idx(lambda r: "severity=critical" in r.get("matchers", []))
+    assert hbo < sev, "route order is load-bearing: severity=critical pages Telegram"
+    assert routes[hbo]["receiver"] == "Health Bridge Webhook"
+    assert routes[hbo]["continue"] is False


### PR DESCRIPTION
## What

Detection follow-up to #692 — the leaked-permit wedge was completely silent (pod 2/2 Running, ArgoCD green) until dispatched agents visibly hung. This closes that gap:

- **New Grafana rule `vk-executor-pool-wedged`** (folder `feature-health`, group eval 5m, `for: 1h`): fires when `vibekanban_active_executions >= vibekanban_max_executions` AND `vibekanban_queued_executions > 0` hold for an hour. A legitimate mass dispatch saturating 8 slots drains its queue well inside an hour; a wedge holds the state forever.
- **Expr is a bool-product, not an `and`-filter**: `(active >= bool max) * (queued >= bool 1)` returns 0/1 whenever the scrape is alive, so healthy ≠ NoData. `noDataState: Alerting` then strictly means "scrape dead" → DatasourceNoData, which health-bridge caps at degraded (blindness ≠ death).
- **New generic notification route `health_bridge_only="true"`** (canary_watchdog pattern, placed before the severity routes): `severity: critical` drives health-bridge's dead→bug-issue lifecycle (`github_issue: frank-ops#18`, same feature as pod-not-running) without ever paging Telegram.
- **No scrape changes needed**: vk-local `/metrics` was already covered by the existing `VMPodScrape` (vk-http :8081, 30s).

## Verified live before shipping

- All three `vibekanban_*` gauges present in VictoriaMetrics (max=8 from the post-#692 pod).
- The exact rule expression evaluated against live VM returns `0` on the current healthy pool (not empty).

## Tests

- New guard `scripts/tests/test_vk_wedge_alert.py`: pins the bool-product expr (an `and`-filter would make healthy == NoData == Alerting → fires every quiet day), the NoData semantics, the 1h flap window, the critical+health_bridge_only labels, and that the new route precedes `severity=critical`.
- Repairs the stale route-order pin in `test_cert_expiry_canary.py` — **pre-existing failure on main** (it predated the `telegram_direct` route; expected 7 routes, main has 8, now 9).
- `21 passed` across the three alerting guard tests.

## Post-merge

Grafana reads provisioning files at boot — after ArgoCD syncs the ConfigMaps, restart the Grafana pod (`kubectl -n monitoring rollout restart deploy/victoria-metrics-victoria-metrics-k8s-stack-grafana`) and confirm the rule shows Normal. Cannot be end-to-end fired without wedging the pool; the live-evaluated expr + guard tests are the verification.

Root-cause fix remains super-fr#404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)