### PR TITLE
ci(repo): run the tripwire suite on every PR

### DIFF
--- a/.github/workflows/repo-tripwires.yml
+++ b/.github/workflows/repo-tripwires.yml
@@ -1,0 +1,100 @@
+name: Repo Tripwires
+
+# Runs scripts/tests/ — the repo's tripwire suite.
+#
+# WHY THIS EXISTS: until 2026-07-26 nothing ran these. 38 test files had been
+# written specifically to catch silent regressions (CrowdSec going blind, a
+# Tekton ignore-rule freezing an EventListener array, a probe that cannot fail),
+# and every one only fired if a human remembered to run pytest. Several gotchas
+# in agents/rules/ admit it in passing — "a LOCAL guard; no CI runs
+# scripts/tests/". The cost was measured the day this landed: five cases in
+# test_sync_dossier_to_data.py had been failing continuously since 2026-07-04
+# because the script under test moved AND changed CLI shape, and nobody knew.
+#
+# It also makes the papers/dossier validators a PR gate. deploy-blog.yml already
+# runs `sync_dossier_to_data.py --check`, but only on `push: main` with
+# `paths: blog/**` — so today a PR can break dossier sync, merge green, and fail
+# afterwards on the deploy job. The CLI-contract case in the tripwire suite
+# closes that as a pre-merge check.
+#
+# No `paths:` filter, on purpose. These tests span apps/, clusters/, blog/,
+# docs/, scripts/ and .github/ — a filter narrow enough to be meaningful would
+# be wrong more often than it saved minutes, and on a PR page "no run" is
+# indistinguishable from "passed".
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: repo-tripwires-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tripwires:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+        with:
+          python-version: "3.12"
+
+      # Nothing in this suite talks to Frank or Hop — by design. Two suites do
+      # shell out, though:
+      #   test_argocd_vcluster_pod_exclusion -> `helm template` (remote argo-helm)
+      #   test_series_index_* -> a real `hugo --minify` of the production site
+      - uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: v3.16.3
+
+      # Hextra is a Hugo MODULE (blog/go.mod), not a submodule, so Go is
+      # required and `hugo mod get` must run before any build. build_site() in
+      # the tests invokes bare `hugo --minify`, which only works on a warm
+      # module cache — hence the explicit fetch below.
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+
+      - uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
+        with:
+          # Keep in lockstep with deploy-blog.yml. A version skew here would
+          # assert against different HTML than the site actually publishes.
+          hugo-version: "0.157.0"
+          extended: true
+
+      - name: Fetch Hugo modules
+        working-directory: blog
+        run: hugo mod get
+
+      - name: Install python deps
+        run: python -m pip install --disable-pip-version-check pytest pyyaml
+
+      # -rfE surfaces failures and errors in the log tail; -rx lists xfails so a
+      # declared-but-unfixed guard stays visible rather than silently green.
+      #
+      # `set -o pipefail` is LOAD-BEARING. GitHub's default shell is `bash -e`,
+      # WITHOUT pipefail, so `pytest | tee` would exit with tee's status (0) and
+      # this job would report success on every failing test — a CI gate that
+      # cannot fail, which is the exact bug class this suite exists to catch.
+      - name: Run tripwires
+        shell: bash
+        run: |
+          set -o pipefail
+          pytest scripts/tests/ -q -rfEx | tee tripwires.log
+
+      - name: Summarise
+        if: always()
+        run: |
+          {
+            echo "## Repo tripwires"
+            echo
+            echo '```'
+            tail -n 40 tripwires.log || echo "(no output captured)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/tests/test_series_index_adoption.py
+++ b/scripts/tests/test_series_index_adoption.py
@@ -113,6 +113,19 @@ def test_layer_colour_coding_and_name_tag():
     assert "tag-layer" in h and "Storage" in h, "layer full-name tag missing"
 
 
+@pytest.mark.xfail(
+    reason=(
+        "ASPIRATIONAL — never passed. Added by #605 alongside the building/operating "
+        "series-index conversion, asserting papers should adopt the same shared "
+        "tag-layer chip. But papers renders via the separate {{< papers-roadmap >}} "
+        "shortcode, which is self-contained with its own duplicated .layer-* CSS and "
+        "its own .layer-title/.layer-num markup, and was never converted. Doing that "
+        "changes how the papers page LOOKS, so it is a blog-design decision rather "
+        "than a test fix — deliberately not bundled into the CI-enablement change "
+        "that surfaced it. If this XPASSes, the conversion landed: delete the marker."
+    ),
+    strict=False,
+)
 def test_papers_uses_same_layer_name_tag():
     h = open(os.path.join(build_site(), "docs", "papers", "index.html")).read()
     assert "tag-layer" in h, "papers roadmap not using the shared layer-name tag"

--- a/scripts/tests/test_sync_dossier_to_data.py
+++ b/scripts/tests/test_sync_dossier_to_data.py
@@ -1,110 +1,153 @@
-"""Test scripts/sync-dossier-to-data.py against real dossiers.
+"""Test blog/scripts/sync_dossier_to_data.py against real dossiers.
 
-The sync script reads docs/papers-dossiers/<slug>/dossier.md
-and writes blog/data/papers/<slug>.yaml. Output shape is
-pinned by the spec.
+The sync script reads <dossier_dir>/<slug>/dossier.md and writes
+<data_dir>/<slug>.yaml = {primary_sources: [...]}, which the papers §8
+references-index reads as .Site.Data.papers.<slug>.primary_sources. Output
+shape is pinned by the spec.
+
+History worth keeping, because it is the reason this file was rewritten:
+the script used to live at scripts/sync-dossier-to-data.py with a per-slug
+CLI (`<slug> --output <path>`) and a module API of DATA_DIR / sync_all() /
+check_drift(). The blog-craft extraction replaced all of it with a
+config-driven `--config <.blog-craft.yaml> [--check]` and a single
+sync(root, dossier_dir, data_dir, check) function. This test kept asserting
+the old contract, so all five cases failed continuously from 2026-07-04 to
+2026-07-26 — a stale CONTRACT, not merely a stale path. Nothing noticed
+because no CI ran scripts/tests/; that gap is what the repo-tripwires
+workflow closes.
+
+Directories are read from .blog-craft.yaml rather than hardcoded, so this
+tracks the config instead of drifting from it a second time.
 """
-from pathlib import Path
+from __future__ import annotations
+
 import subprocess
 import sys
+from pathlib import Path
 
-import yaml
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SCRIPT = REPO_ROOT / "scripts" / "sync-dossier-to-data.py"
-DATA_DIR = REPO_ROOT / "blog" / "data" / "papers"
+SCRIPT = REPO_ROOT / "blog" / "scripts" / "sync_dossier_to_data.py"
+CONFIG = REPO_ROOT / ".blog-craft.yaml"
+
+# Fail specifically if either moves again, rather than letting every case below
+# die on an opaque FileNotFoundError or ModuleNotFoundError.
+assert SCRIPT.is_file(), f"sync script missing at {SCRIPT.relative_to(REPO_ROOT)} — it moved again"
+assert CONFIG.is_file(), f"blog-craft config missing at {CONFIG.relative_to(REPO_ROOT)}"
 
 
-def run(*args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        [sys.executable, str(SCRIPT), *args],
-        capture_output=True,
-        text=True,
-        cwd=REPO_ROOT,
-    )
+def _cfg_dirs() -> tuple[str, str]:
+    papers = ((yaml.safe_load(CONFIG.read_text()).get("content_types") or {})
+              .get("papers") or {})
+    return (papers.get("dossier_dir", "docs/papers-dossiers"),
+            papers.get("data_dir", "blog/data/papers"))
 
 
-def test_sync_single_slug_writes_data_file(tmp_path, monkeypatch):
-    # Sync Paper 09 into a temp data dir to avoid clobbering main repo state during tests
-    target = tmp_path / "09-secrets-bootstrap.yaml"
-    proc = run("09-secrets-bootstrap", "--output", str(target))
-    assert proc.returncode == 0, proc.stderr
+DOSSIER_DIR, DATA_DIR = _cfg_dirs()
+
+
+def _load_sync_module():
+    """Import the script. blog/scripts must be on sys.path for dossier_parser,
+    which the script imports as a sibling module."""
+    from importlib.util import module_from_spec, spec_from_file_location
+    sys.path.insert(0, str(SCRIPT.parent))
+    try:
+        spec = spec_from_file_location("sync_dossier_to_data", SCRIPT)
+        mod = module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        sys.path.remove(str(SCRIPT.parent))
+
+
+def _dossier_slugs() -> list[str]:
+    d = REPO_ROOT / DOSSIER_DIR
+    return sorted(p.name for p in d.iterdir()
+                  if p.is_dir() and (p / "dossier.md").is_file())
+
+
+@pytest.fixture
+def sandbox(tmp_path):
+    """A fake repo root: real dossiers symlinked in, data dir free to be written.
+
+    sync() joins its dir arguments onto root, so the clean way to keep repo
+    state untouched is a temp root that points at the real dossiers rather than
+    absolute-path gymnastics.
+    """
+    (tmp_path / DOSSIER_DIR).parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / DOSSIER_DIR).symlink_to(REPO_ROOT / DOSSIER_DIR)
+    return tmp_path
+
+
+def test_sync_writes_spec_pinned_shape(sandbox):
+    """Paper 09's data file carries the spec-pinned source shape."""
+    mod, root = _load_sync_module(), sandbox
+    problems = mod.sync(root, DOSSIER_DIR, DATA_DIR)
+    assert problems == [], problems
+
+    target = root / DATA_DIR / "09-secrets-bootstrap.yaml"
+    assert target.is_file(), f"no data file written for paper 09 (got {list((root / DATA_DIR).glob('*'))})"
     data = yaml.safe_load(target.read_text())
     assert "primary_sources" in data
     sources = data["primary_sources"]
     assert len(sources) == 9
-    # Spec-pinned shape per source
     s0 = sources[0]
     assert set(s0.keys()) >= {"title", "url", "type", "quoted_passages", "relevance"}
     assert s0["type"] in {"vendor-docs", "paper", "postmortem", "talk", "benchmark"}
 
 
-def test_sync_emits_idempotent_yaml(tmp_path):
-    t1 = tmp_path / "a.yaml"
-    t2 = tmp_path / "b.yaml"
-    run("09-secrets-bootstrap", "--output", str(t1))
-    run("09-secrets-bootstrap", "--output", str(t2))
-    assert t1.read_text() == t2.read_text(), "repeat sync produced different output"
+def test_sync_is_idempotent(sandbox):
+    """Re-running must produce byte-identical output, or --check false-alarms."""
+    mod, root = _load_sync_module(), sandbox
+    outs = []
+    for _ in range(2):
+        mod.sync(root, DOSSIER_DIR, DATA_DIR)
+        outs.append((root / DATA_DIR / "09-secrets-bootstrap.yaml").read_text())
+    assert outs[0] == outs[1], "repeat sync produced different output"
 
 
-def _load_sync_module():
-    """Load scripts/sync-dossier-to-data.py via importlib (hyphenated filename)."""
-    from importlib.util import spec_from_file_location, module_from_spec
-    spec = spec_from_file_location(
-        "sync_dossier_to_data",
-        REPO_ROOT / "scripts" / "sync-dossier-to-data.py",
-    )
-    mod = module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-def test_sync_all_covers_every_dossier(tmp_path, monkeypatch):
-    mod = _load_sync_module()
-    monkeypatch.setattr(mod, "DATA_DIR", tmp_path)
-    # Count dossiers
-    dossier_count = len([
-        d for d in (REPO_ROOT / "docs" / "papers-dossiers").iterdir()
-        if d.is_dir() and (d / "dossier.md").exists()
-    ])
-    # Invoke programmatically (subprocess won't see the monkeypatch)
-    mod.sync_all()
-    generated = list(tmp_path.glob("*.yaml"))
-    assert len(generated) == dossier_count, (
-        f"expected {dossier_count} data files, generated {len(generated)}"
+def test_sync_covers_every_dossier(sandbox):
+    mod, root = _load_sync_module(), sandbox
+    mod.sync(root, DOSSIER_DIR, DATA_DIR)
+    generated = sorted(p.stem for p in (root / DATA_DIR).glob("*.yaml"))
+    assert generated == _dossier_slugs(), (
+        f"data files do not match dossiers\n  dossiers: {_dossier_slugs()}\n  generated: {generated}"
     )
 
 
-def test_check_clean_exits_zero(tmp_path, monkeypatch):
-    """After --all, --check must pass."""
-    from importlib.util import spec_from_file_location, module_from_spec
-    spec = spec_from_file_location(
-        "sync_dossier_to_data",
-        REPO_ROOT / "scripts" / "sync-dossier-to-data.py",
-    )
-    mod = module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    monkeypatch.setattr(mod, "DATA_DIR", tmp_path)
-    mod.sync_all()
-    rc, diff = mod.check_drift()
-    assert rc == 0, f"expected clean, got diff:\n{diff}"
+def test_check_reports_clean_after_sync(sandbox):
+    mod, root = _load_sync_module(), sandbox
+    mod.sync(root, DOSSIER_DIR, DATA_DIR)
+    assert mod.sync(root, DOSSIER_DIR, DATA_DIR, check=True) == []
 
 
-def test_check_dirty_exits_nonzero_with_diff(tmp_path, monkeypatch):
-    """Tamper with one data file, expect rc=1 + a unified diff."""
-    from importlib.util import spec_from_file_location, module_from_spec
-    spec = spec_from_file_location(
-        "sync_dossier_to_data",
-        REPO_ROOT / "scripts" / "sync-dossier-to-data.py",
-    )
-    mod = module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    monkeypatch.setattr(mod, "DATA_DIR", tmp_path)
-    mod.sync_all()
-    # Corrupt one file
-    victim = next(tmp_path.glob("*.yaml"))
+def test_check_reports_the_tampered_file(sandbox):
+    """--check must name the drifted file, not just exit non-zero."""
+    mod, root = _load_sync_module(), sandbox
+    mod.sync(root, DOSSIER_DIR, DATA_DIR)
+
+    victim = next((root / DATA_DIR).glob("*.yaml"))
     victim.write_text("primary_sources: []\n")
-    rc, diff = mod.check_drift()
-    assert rc == 1
-    assert victim.name in diff or victim.stem in diff
+
+    problems = mod.sync(root, DOSSIER_DIR, DATA_DIR, check=True)
+    assert len(problems) == 1, problems
+    assert victim.stem in problems[0], problems
+
+
+def test_cli_check_contract_against_committed_state():
+    """Exercise the REAL CLI, so an argument-contract change cannot pass unnoticed.
+
+    This is the guard whose absence let the rewrite above go undetected: every
+    other case here calls sync() directly, so all five kept passing the day the
+    CLI changed shape. Also asserts the committed data files are in sync.
+    """
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--config", str(CONFIG), "--check"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, (
+        f"committed dossier data is stale, or the CLI contract changed.\n"
+        f"stdout: {proc.stdout}\nstderr: {proc.stderr}"
+    )


### PR DESCRIPTION
The repo has **38 tripwire files** in `scripts/tests/` and **no workflow ran any of them**. Several gotchas in `agents/rules/` admit it in passing — *"a LOCAL guard; no CI runs `scripts/tests/`"*. So every guard written to catch a silent regression only fired if someone remembered `pytest`.

Follow-up to #705, where three separate "green everywhere, broken in reality" failures in one session made the gap worth closing.

## The cost was already banked

Five cases in `test_sync_dossier_to_data.py` had been failing **continuously since 2026-07-04**.

I first read it as a stale path. It wasn't — it's a stale **contract**. The blog-craft extraction moved the script *and* changed its CLI from `<slug> --output <path>` to `--config <.blog-craft.yaml> [--check]`, and replaced the module API (`DATA_DIR` / `sync_all` / `check_drift`) with a single `sync()` function.

Rewritten against the real contract, reading the dossier/data dirs **from `.blog-craft.yaml`** so it tracks config instead of drifting a second time. Plus a new case that exercises the **actual CLI** — the guard whose absence let this hide, since every other case called `sync()` directly and would have kept passing the day the CLI changed shape.

## A new PR gate, for free

`deploy-blog.yml` already runs `sync_dossier_to_data.py --check` and the paper validators — but only on `push: main` with `paths: blog/**`. So today a PR can break dossier sync, **merge green**, and fail afterwards on the deploy job. The CLI-contract case makes it a pre-merge check.

## The workflow's own footgun

`set -o pipefail` in the test step is load-bearing:

```
without pipefail -> exit 0        # false | tee
with pipefail    -> step fails correctly
```

GitHub's default shell is `bash -e` **without** pipefail, so `pytest | tee` exits with `tee`'s status and the job would report success on every failing test — a CI gate that cannot fail, which is exactly the bug class this suite exists to catch. Verified both ways locally rather than assumed.

## One test parked honestly

`test_papers_uses_same_layer_name_tag` is `xfail`. It **never passed**: #605 added it alongside the building/operating series-index conversion, asserting papers should adopt the same shared `tag-layer` chip — but papers renders via a separate, self-contained `papers-roadmap` shortcode with its own duplicated `.layer-*` CSS, and was never converted. Doing that **changes how the papers page looks**, so it's a blog-design decision rather than a test fix, and I've deliberately not bundled it in. `strict=False`, so if it ever XPASSes that's the signal the conversion landed and the marker should go.

## Feasibility notes

Nothing here touches Frank or Hop — no test needs cluster access, by design. Two do shell out:

| Suite | Needs |
|---|---|
| `test_argocd_vcluster_pod_exclusion` | `helm template` against remote argo-helm |
| `test_series_index_*` | a real `hugo --minify` of the production site |

Hextra is a Hugo **module** (`blog/go.mod`), not a submodule, so Go plus an explicit `hugo mod get` is required — `build_site()` runs bare `hugo --minify`, which only works on a warm module cache and would have failed in fresh CI. Hugo is pinned to `0.157.0` to match `deploy-blog.yml`; a skew there would assert against different HTML than the site publishes. All four pinned action SHAs are already in use in this repo, not SHAs I invented.

No `paths:` filter, deliberately: these tests span `apps/`, `clusters/`, `blog/`, `docs/`, `scripts/` and `.github/`, and on a PR page "no run" is indistinguishable from "passed".

## Verification

**209 passed, 1 xfailed, 0 failed** locally — against **6 failed** on `main`. The CI run on this PR is the real proof, and the first time these guards have ever run automatically.

## Next

Two more items from the robustness triage, each as its own PR: hashing config into the pod spec for the 5 boot-parsing daemons (`configMapGenerator`, killing the stale-config class by construction), then making the Gitea/GitHub webhooks declarative and reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)