### PR TITLE
fix(edge,repo): un-break the blog — per-site CSP, class-based highlighting, reachable srcset

### DIFF
--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -4,7 +4,10 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {},
-    "ghcr.io/devcontainers/features/node:1": {}
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.24"
+    }
   },
   "postCreateCommand": "uv tool install --python 3.13 'git+https://github.com/derio-net/super-fr#subdirectory=packages/fr'; ARCH=$(dpkg --print-architecture); HUGO_V=0.157.0; case \"$ARCH\" in amd64) HUGO_SHA=5b2fdfe4646a48ee98107035024fd6640299bff31c4486c259eeeb9f4c822492;; arm64) HUGO_SHA=398efd55428589b928afc65df2410f97efc83608f7a3324d1435196f17adaa0a;; *) echo \"unsupported arch $ARCH\" >&2; exit 1;; esac; curl -fsSL \"https://github.com/gohugoio/hugo/releases/download/v${HUGO_V}/hugo_extended_${HUGO_V}_linux-${ARCH}.tar.gz\" -o /tmp/hugo.tgz; echo \"${HUGO_SHA}  /tmp/hugo.tgz\" | sha256sum -c -; sudo tar -xz -C /usr/local/bin -f /tmp/hugo.tgz hugo; rm /tmp/hugo.tgz",
   "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
@@ -16,7 +19,7 @@
   "customizations": {
     "fr": {
       "profile": "dev",
-      "purpose": "day-to-day docs/skills/blog/plan work — checks: cd blog && hugo --minify; scripts/validate-plans.sh; uv run scripts/validate-papers.py; uv run scripts/validate-dossier.py; pytest scripts/tests/; node scripts/validate-mermaid.mjs"
+      "purpose": "day-to-day docs/skills/blog/plan work — checks: cd blog && hugo mod get && hugo --minify; python3 scripts/check_blog_build.py blog/public; scripts/validate-plans.sh; uv run scripts/validate-papers.py; uv run scripts/validate-dossier.py; pytest scripts/tests/; node scripts/validate-mermaid.mjs. The go feature is required, not optional: the Hextra theme is a Hugo MODULE, so a container without the go toolchain fails at 'binary with name go not found in PATH' before Hugo renders a single page."
     }
   }
 }

--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -59,6 +59,14 @@ jobs:
           hugo mod get
           hugo --minify
 
+      # The check the Caddy CSP comment assumes exists. blog.derio.net drops
+      # inline scripts and off-origin assets browser-side, and an image whose
+      # srcset cannot reach its own full resolution renders upscaled — all three
+      # are invisible server-side (200 OK, ArgoCD green). Only the built output
+      # shows them, so this runs here rather than in scripts/tests/.
+      - name: Check built output (CSP compatibility + responsive images)
+        run: python3 scripts/check_blog_build.py blog/public
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/blog/assets/css/custom.css
+++ b/blog/assets/css/custom.css
@@ -612,3 +612,11 @@
   list-style: none;
   padding-left: 1rem;
 }
+
+/* Footer "clear read history" link. Was an inline style attribute in
+   layouts/partials/custom/footer.html; moved here when blog.derio.net gained a
+   CSP so the whole footer control is external and cacheable. */
+.clear-read-history {
+  font-size: 0.75rem;
+  opacity: 0.5;
+}

--- a/blog/assets/js/asciinema-init.js
+++ b/blog/assets/js/asciinema-init.js
@@ -1,0 +1,43 @@
+/* asciinema player bootstrap.
+ *
+ * The {{< asciinema >}} shortcode used to emit a per-instance inline <script>
+ * calling AsciinemaPlayer.create(). blog.derio.net serves `script-src 'self'`
+ * with no 'unsafe-inline', so every such block would be dropped and the player
+ * would never appear. The shortcode now emits configuration as data-* attributes
+ * and this external script consumes them.
+ *
+ * NOTE: the player library itself is still loaded from unpkg.com by
+ * custom/head-end.html, which the CSP also blocks. Vendor it into
+ * blog/assets/ (or widen the CSP) before using the shortcode — see the comment
+ * there. scripts/check_blog_build.py fails the build if an off-origin asset is
+ * ever emitted, so this cannot ship silently broken.
+ */
+(function () {
+  "use strict";
+
+  function num(value, fallback) {
+    var n = parseFloat(value);
+    return isNaN(n) ? fallback : n;
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var containers = document.querySelectorAll(".asciinema-container[data-cast-src]");
+    if (!containers.length || typeof window.AsciinemaPlayer === "undefined") return;
+
+    var theme = document.documentElement.classList.contains("dark")
+      ? "asciinema"
+      : "solarized-light";
+
+    containers.forEach(function (el) {
+      window.AsciinemaPlayer.create(el.dataset.castSrc, el, {
+        cols: num(el.dataset.cols, 120),
+        rows: num(el.dataset.rows, 30),
+        speed: num(el.dataset.speed, 1),
+        idleTimeLimit: num(el.dataset.idleTimeLimit, 2),
+        poster: el.dataset.poster || "npt:0:3",
+        theme: theme,
+        fit: "width",
+      });
+    });
+  });
+})();

--- a/blog/assets/js/mermaid-init.js
+++ b/blog/assets/js/mermaid-init.js
@@ -1,0 +1,57 @@
+/* Mermaid initialisation — external replacement for Hextra's inline init.
+ *
+ * The theme's `_partials/scripts/mermaid.html` ends in an inline <script> that
+ * calls mermaid.initialize() and installs a MutationObserver to re-render on
+ * dark/light toggle. blog.derio.net serves `script-src 'self'` with no
+ * 'unsafe-inline', so that block is dropped by the browser. Diagrams still
+ * appeared — mermaid.js self-starts — but always in the light theme, and they
+ * stopped following the theme toggle across all 80 posts that use mermaid.
+ *
+ * Rather than fork the theme partial (whose loader does a build-time remote
+ * fetch we do not want to duplicate), this file re-implements the same two
+ * behaviours from an external asset. The theme's inline block stays in the
+ * markup, inert; this one does the work.
+ *
+ * Load order matters: head-end.html loads this with `defer`, and the theme's
+ * mermaid.min.js is also deferred but later in the document. Deferred scripts
+ * run in document order, all before DOMContentLoaded — so registering on
+ * DOMContentLoaded guarantees window.mermaid exists by the time we run.
+ */
+(function () {
+  "use strict";
+
+  function currentTheme() {
+    return document.documentElement.classList.contains("dark") ? "dark" : "default";
+  }
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var nodes = document.querySelectorAll(".mermaid");
+    if (!nodes.length || typeof window.mermaid === "undefined") return;
+
+    // Keep the original source: re-rendering needs the markup, not the SVG
+    // mermaid replaced it with. This round-trips the page's OWN build-time
+    // content through dataset and back — there is no user-supplied input in
+    // this path, and it mirrors upstream Hextra's behaviour exactly.
+    nodes.forEach(function (el) {
+      el.dataset.original = el.innerHTML;
+    });
+
+    window.mermaid.initialize({ startOnLoad: true, theme: currentTheme() });
+
+    var timeout;
+    new MutationObserver(function () {
+      clearTimeout(timeout);
+      timeout = setTimeout(function () {
+        document.querySelectorAll(".mermaid").forEach(function (el) {
+          el.innerHTML = el.dataset.original;
+          el.removeAttribute("data-processed");
+        });
+        window.mermaid.initialize({ startOnLoad: true, theme: currentTheme() });
+        window.mermaid.init();
+      }, 150);
+    }).observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+  });
+})();

--- a/blog/assets/js/read-history-clear.js
+++ b/blog/assets/js/read-history-clear.js
@@ -1,0 +1,24 @@
+/* "Clear read history" footer link.
+ *
+ * Was an inline <script> in layouts/partials/custom/footer.html until
+ * blog.derio.net gained `script-src 'self'` (no 'unsafe-inline'), which dropped
+ * it on every page — the link rendered but did nothing. Externalised so the
+ * browser will actually run it.
+ *
+ * The link is emitted on every page, so guard on its presence rather than
+ * assuming it.
+ */
+(function () {
+  "use strict";
+
+  document.addEventListener("DOMContentLoaded", function () {
+    var link = document.getElementById("clear-read-history");
+    if (!link) return;
+
+    link.addEventListener("click", function (e) {
+      e.preventDefault();
+      localStorage.removeItem("frank-read-posts");
+      window.location.reload();
+    });
+  });
+})();

--- a/blog/hugo.toml
+++ b/blog/hugo.toml
@@ -82,7 +82,22 @@ title = "Frank, the Talos Cluster"
   [markup.highlight]
     codeFences = true
     lineNos = false
+    # `style` is inert while noClasses = false (below): it only seeds
+    # `hugo gen chromastyles`, and we emit no generated palette. Kept as the
+    # record of the previous look; the live palette comes from the theme.
     style = "monokai"
+    # Chroma defaults noClasses=true, stamping the palette onto every token as
+    # `<span style="color:#f92672">` — ~9,300 inline style attributes site-wide.
+    # blog.derio.net serves a CSP, a browser drops inline styles while the page
+    # still returns 200, and on 2026-07-26 that silently cost EVERY code block
+    # its highlighting with nothing failing server-side.
+    #
+    # Class-based output is also what Hextra expects: it ships
+    # assets/css/chroma/{light,dark}.css at `.highlight .chroma .<token>`
+    # specificity, so highlighting now follows the light/dark toggle instead of
+    # being monokai in both. Do NOT add a generated chroma stylesheet alongside
+    # it — one was tried and lost on specificity every time, silently.
+    noClasses = false
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]

--- a/blog/layouts/partials/custom/footer.html
+++ b/blog/layouts/partials/custom/footer.html
@@ -1,10 +1,8 @@
-<a href="#" id="clear-read-history" style="font-size: 0.75rem; opacity: 0.5;">
+{{- /* Styling lives in assets/css/custom.css, the click handler in
+       assets/js/read-history-clear.js (loaded by custom/head-end.html). Both
+       were inline here until blog.derio.net gained a CSP: `script-src 'self'`
+       dropped the handler on every page, so this link rendered but never
+       cleared anything. Keep them external. */ -}}
+<a href="#" id="clear-read-history" class="clear-read-history">
   Clear read history
 </a>
-<script>
-document.getElementById('clear-read-history').addEventListener('click', function(e) {
-  e.preventDefault();
-  localStorage.removeItem('frank-read-posts');
-  window.location.reload();
-});
-</script>

--- a/blog/layouts/partials/custom/head-end.html
+++ b/blog/layouts/partials/custom/head-end.html
@@ -8,9 +8,34 @@
 */ -}}
 {{ $customCSS := resources.Get "css/custom.css" | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $customCSS.RelPermalink }}">
+{{- /* No chroma stylesheet is loaded here on purpose: Hextra already ships
+       assets/css/chroma/{light,dark}.css, compiled into main.css at
+       `.highlight .chroma .<token>` specificity. Adding our own only produced a
+       redundant, permanently-losing second copy. See markup.highlight in
+       hugo.toml. */}}
+{{- /* Mermaid: external replacement for the theme's inline init, which
+       blog.derio.net's `script-src 'self'` drops. Unconditional and tiny — it
+       no-ops when a page has no .mermaid nodes. Deferred so it runs after the
+       theme's own (later, also deferred) mermaid.min.js. */}}
+{{- with resources.Get "js/mermaid-init.js" }}
+<script src="{{ (. | minify | fingerprint).RelPermalink }}" defer></script>
+{{- end }}
 {{- if .HasShortcode "asciinema" }}
+{{- /* WARNING: these two load from unpkg.com, which blog.derio.net's CSP
+       (script-src 'self' https://counter.derio.net) BLOCKS. The shortcode is
+       currently unused so nothing is broken today — but vendor them into
+       blog/assets/ (or widen the CSP in
+       clusters/hop/apps/caddy/manifests/files/Caddyfile) BEFORE using it.
+       scripts/check_blog_build.py fails the build if they are ever emitted. */}}
 <link rel="stylesheet" href="https://unpkg.com/asciinema-player@3.9.0/dist/bundle/asciinema-player.css" />
 <script src="https://unpkg.com/asciinema-player@3.9.0/dist/bundle/asciinema-player.min.js"></script>
+{{- with resources.Get "js/asciinema-init.js" }}
+<script src="{{ (. | minify | fingerprint).RelPermalink }}" defer></script>
+{{- end }}
+{{- end }}
+{{- /* read-history-clear.js — powers the footer link in custom/footer.html */}}
+{{- with resources.Get "js/read-history-clear.js" }}
+<script src="{{ (. | minify | fingerprint).RelPermalink }}" defer></script>
 {{- end }}
 {{- /* read-tracker.js — present only when features.read_tracker materialized it */}}
 {{- with resources.Get "js/read-tracker.js" }}

--- a/blog/layouts/partials/opt-image.html
+++ b/blog/layouts/partials/opt-image.html
@@ -30,11 +30,24 @@
     {{- $pt := cond (gt $srcW $maxW) (try ($r.Resize (printf "%dx %s q%d" $maxW $fmt $q))) (try ($r.Process (printf "%s q%d" $fmt $q))) -}}
     {{- if not $pt.Err -}}
       {{- $primary = $pt.Value -}}
-      {{- range $w := (slice 480 960 $maxW) -}}
-        {{- /* clamp to BOTH the source width and the cap (matters when maxWidth < 960) */ -}}
-        {{- if and (le $w $srcW) (le $w $maxW) -}}
+      {{- /* The top candidate must be the PRIMARY's own width, never the cap.
+             When the source is narrower than the cap — banners 2169 < 2560,
+             covers 1424 < 1600 — a cap-derived candidate fails the clamp and is
+             dropped, leaving NOTHING in the srcset that matches the primary.
+             That is not merely a missing size: per the HTML spec, a srcset
+             carrying `w` descriptors removes `src` from the candidate list
+             entirely, so the full-resolution file this partial just generated
+             becomes unreachable and every banner renders upscaled from 960w.
+             Pinned by scripts/check_blog_build.py. */ -}}
+      {{- $topW := $primary.Width -}}
+      {{- range $w := (slice 480 960 $topW) -}}
+        {{- if lt $w $topW -}}
           {{- $dt := try ($r.Resize (printf "%dx %s q%d" $w $fmt $q)) -}}
           {{- if not $dt.Err -}}{{- $srcset = $srcset | append (printf "%s %dw" $dt.Value.RelPermalink $dt.Value.Width) -}}{{- end -}}
+        {{- else if eq $w $topW -}}
+          {{- /* reuse the primary itself — re-Resizing to its own width would
+                 emit a byte-identical second file under a different hash */ -}}
+          {{- $srcset = $srcset | append (printf "%s %dw" $primary.RelPermalink $primary.Width) -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}

--- a/blog/layouts/shortcodes/asciinema.html
+++ b/blog/layouts/shortcodes/asciinema.html
@@ -8,18 +8,13 @@
 {{- $res := .Page.Resources.GetMatch $src -}}
 {{- $url := $src -}}
 {{- with $res }}{{ $url = .RelPermalink }}{{ end -}}
-<div id="{{ $id }}" class="asciinema-container"></div>
-<script>
-(function() {
-  var theme = document.documentElement.classList.contains('dark') ? 'asciinema' : 'solarized-light';
-  AsciinemaPlayer.create('{{ $url }}', document.getElementById('{{ $id }}'), {
-    cols: {{ $cols }},
-    rows: {{ $rows }},
-    speed: {{ $speed }},
-    idleTimeLimit: {{ $idleTimeLimit }},
-    poster: '{{ $poster }}',
-    theme: theme,
-    fit: 'width'
-  });
-})();
-</script>
+{{- /* Config travels as data-* attributes; assets/js/asciinema-init.js consumes
+       them. This was a per-instance inline <script> until blog.derio.net gained
+       `script-src 'self'`, which drops inline blocks silently. */ -}}
+<div id="{{ $id }}" class="asciinema-container"
+     data-cast-src="{{ $url }}"
+     data-cols="{{ $cols }}"
+     data-rows="{{ $rows }}"
+     data-speed="{{ $speed }}"
+     data-idle-time-limit="{{ $idleTimeLimit }}"
+     data-poster="{{ $poster }}"></div>

--- a/clusters/hop/apps/caddy/manifests/files/Caddyfile
+++ b/clusters/hop/apps/caddy/manifests/files/Caddyfile
@@ -32,23 +32,52 @@
 # in the same change: the browser blocks it while the page still returns
 # 200, so no server-side check catches the breakage.
 #
-# style-src is 'self' with no 'unsafe-inline', which means the site images
-# must emit external stylesheets rather than inline <style> blocks.
-# agentic-stoa/site pins that with its own build check.
-#
 # HSTS intentionally omits `preload`. Preload applies to every
 # *.derio.net name a browser has seen and is hard to walk back; promoting
 # to it is a separate, deliberate decision.
+#
+# The CSP is NOT in this snippet: www and the blog need different style-src
+# values, and the difference is load-bearing enough to be stated per-site
+# rather than hidden behind a shared default. See csp_strict / csp_blog.
 (security_headers) {
   header {
     Strict-Transport-Security "max-age=31536000; includeSubDomains"
     X-Content-Type-Options "nosniff"
     Referrer-Policy "strict-origin-when-cross-origin"
     Permissions-Policy "geolocation=(), camera=(), microphone=(), browsing-topics=()"
-    Content-Security-Policy "default-src 'self'; script-src 'self' https://counter.derio.net; connect-src 'self' https://counter.derio.net; style-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; object-src 'none'"
     # Caddy advertises itself by default; no reason to help fingerprinting.
     -Server
   }
+}
+
+# CSP for www (agentic-stoa/site) — fully strict: style-src 'self' with no
+# 'unsafe-inline'. That site emits external stylesheets only and pins the
+# constraint with its own build check, so it can hold this line.
+(csp_strict) {
+  header Content-Security-Policy "default-src 'self'; script-src 'self' https://counter.derio.net; connect-src 'self' https://counter.derio.net; style-src 'self'; img-src 'self' data:; font-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; object-src 'none'"
+}
+
+# CSP for the blog — identical EXCEPT style-src carries 'unsafe-inline'.
+#
+# This is a deliberate, measured concession, not drift. The blog is Hugo +
+# the Hextra theme, and Hextra emits inline style attributes structurally,
+# not sloppily: `cards.html` renders style="--hextra-cards-grid-cols: {N}"
+# and `card.html` renders a templated style="{{ $imageStyle | safeCSS }}".
+# Those are per-invocation computed values; no external stylesheet can carry
+# them. Verified against v0.12.3 (latest, 2026-07-26) — identical to the
+# pinned v0.12.1, so this is not a "wait for the next release" situation.
+#
+# Applying the strict snippet here on 2026-07-26 (#704, for www-parity) took
+# the blog down visually while every server-side check stayed green: all
+# three card lists rendered as bare text and EVERY syntax-highlighted code
+# block lost its colours. A CSP violation is a browser-side drop — 200 OK,
+# ArgoCD Synced, nothing paged.
+#
+# script-src stays strict, with no 'unsafe-inline'. That is the half that
+# actually stops XSS, and the blog build now holds it: scripts/check_blog_build.py
+# fails the build on any inline <script> or off-origin asset.
+(csp_blog) {
+  header Content-Security-Policy "default-src 'self'; script-src 'self' https://counter.derio.net; connect-src 'self' https://counter.derio.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; base-uri 'none'; form-action 'self'; frame-ancestors 'none'; object-src 'none'"
 }
 
 # --- Public routes ---
@@ -68,6 +97,7 @@ blog.derio.net {
   # client IP is currently in an active decision.
   crowdsec
   import security_headers
+  import csp_blog
   handle /frank* {
     reverse_proxy blog.blog-system.svc:8080
   }
@@ -90,6 +120,7 @@ www.derio.net {
   log
   crowdsec
   import security_headers
+  import csp_strict
   reverse_proxy www.www-system.svc:8080
   handle_errors {
     # The site-level `import security_headers` above does NOT reach here.
@@ -99,6 +130,7 @@ www.derio.net {
     # mutations are not applied to it. Re-importing keeps the hardening
     # promise true during an outage, which is exactly when it matters.
     import security_headers
+    import csp_strict
     respond "Coming soon." 200
   }
 }

--- a/docs/superpowers/journals/debug/2026-07-26-blog-render-regression.md
+++ b/docs/superpowers/journals/debug/2026-07-26-blog-render-regression.md
@@ -1,0 +1,223 @@
+# Journal: 2026-07-26-blog-render-regression
+
+<!-- fr:journal kind=repro scope=debug id=repro-banner created=2026-07-26T14:21:02 -->
+### repro-banner · repro · Banners and covers render upscaled from a 960w variant on every section
+
+Operator report: banners very low res; list elements on /frank/docs/papers/ look like plain HTML.
+
+Repro (no browser needed): fetch any section page and read the <img> markup.
+  curl -sS https://blog.derio.net/frank/docs/papers/ | grep -o "<img[^>]*banner[^>]*>"
+
+Observed on ALL four sections (/frank/, building, operating, papers):
+  banner: src=...banner-papers_hu_*.webp width=2169 srcset="480w, 960w" (no sizes)
+  cover : src=...cover_hu_*.webp        width=1424 srcset="480w, 960w" (no sizes)
+
+The full-resolution primary (2169w banner / 1424w cover) is served and 200s, but
+appears ONLY in src. Per the HTML spec, once srcset carries w descriptors, src is
+not a selection candidate — so the browser can only pick 480w or 960w. With no
+sizes attribute it assumes 100vw, so a full-bleed banner on a 1512px Retina
+viewport wants ~3024px and gets 960px: a ~3.15x upscale.
+
+<!-- fr:journal kind=ruled-out scope=debug id=ro-sri created=2026-07-26T14:21:02 -->
+### ro-sri · ruled-out · RULED OUT: stylesheet blocked by Subresource-Integrity mismatch
+
+Hypothesis: main.min.<sha>.css carries integrity=sha256-...; if the served bytes
+differed the browser would silently refuse the stylesheet while curl still saw 200 —
+which would explain BOTH an unstyled list and a banner rendered at natural size.
+
+Test: sha256 the served file, identity and --compressed.
+  expected bcf3db04...3849 (filename hash == integrity)
+  identity 122419 bytes -> bcf3db04...3849  MATCH
+  gzip/br  122419 bytes -> bcf3db04...3849  MATCH
+Both stylesheets and all JS return 200 with correct hashes. Not SRI.
+
+<!-- fr:journal kind=ruled-out scope=debug id=ro-cache created=2026-07-26T14:21:03 -->
+### ro-cache · ruled-out · RULED OUT (as the current cause): stale cached HTML pointing at 404 fingerprinted assets
+
+Hypothesis: Hugo fingerprints asset filenames; if HTML outlives a deploy the browser
+requests asset names that no longer exist -> 404 -> fully unstyled page.
+
+Real but bounded: HTML and assets both send cache-control: public, max-age=3600, so the
+mismatch window is <=1h and self-heals. Deploy last-modified 2026-07-25 22:47 GMT (~17h
+before this report), so it cannot explain what the operator is seeing now. Noting it as a
+latent hazard, not this bug.
+
+<!-- fr:journal kind=root-cause scope=debug id=rc-csp created=2026-07-26T14:25:38 -->
+### rc-csp · root-cause · Unstyled lists: blog.derio.net inherited a CSP with style-src self, but the Hugo build emits its card CSS inline
+
+CONFIRMED. Caddy sends on blog.derio.net:
+  content-security-policy: ... style-src 'self'; ...   (no 'unsafe-inline')
+
+The papers/roadmap cards ship their entire stylesheet as a single inline <style>
+block inside the rendered content. The browser refuses to instantiate it:
+  document.querySelectorAll('style').length          -> 1   (element present)
+  thatStyleElement.sheet                              -> null (BLOCKED)
+  [...document.styleSheets]                           -> only the 2 external files
+  getComputedStyle('.roadmap-card')  -> border 0px, background transparent, padding 0px
+24 cards, zero styling => the operator's "simple html". Page still returns 200 and the
+external stylesheets still apply, which is why nav/sidebar/headings look fine.
+
+Origin: clusters/hop/apps/caddy/manifests/configmap.yaml — the blog vhost gained
+ in f1ea946e (#704, "blog-parity hardening"), touched again by
+5fa500e2 (#705). The snippet was written for agentic-stoa/site, and its own comment
+(lines 42-44) states the constraint and predicts the failure mode verbatim:
+  "style-src is 'self' with no 'unsafe-inline', which means the site images must emit
+   external stylesheets rather than inline <style> blocks. agentic-stoa/site pins that
+   with its own build check."
+www has that build check. The blog does not, and the blog does emit inline <style>.
+The CSP was applied to the blog for parity without the parity constraint being met.
+
+Collateral from the same header: the one inline <script> (the clear-read-history
+button handler) is blocked by script-src 'self' and is therefore dead.
+
+<!-- fr:journal kind=root-cause scope=debug id=rc-srcset created=2026-07-26T14:25:38 -->
+### rc-srcset · root-cause · Low-res banners: opt-image.html drops the top srcset candidate whenever the source is narrower than the cap
+
+CONFIRMED. blog/layouts/partials/opt-image.html:33-38 builds candidates from
+  range $w := (slice 480 960 $maxW)
+gated by
+  if and (le $w $srcW) (le $w $maxW)
+
+The cap is compared against itself, not against the primary that was actually emitted.
+When the SOURCE is narrower than the cap the top candidate fails  and is
+dropped, so nothing in the srcset matches the primary's real width:
+
+  banners  src 2169w, bannerMaxWidth 2560 -> 2560 > 2169 -> srcset = 480w, 960w
+  covers   src 1424w, maxWidth       1600 -> 1600 > 1424 -> srcset = 480w, 960w
+
+Per the HTML spec, once a srcset carries w descriptors the src attribute stops being a
+selection candidate — so the full-resolution file Hugo generated and Caddy serves (200 OK)
+is unreachable. There is also no sizes attribute, so the browser assumes 100vw.
+
+Measured live (browser, DPR 2, 849px viewport):
+  banner: currentSrc = banner-papers_hu_9ce0a7f02b95736b.webp  (the 960w one)
+          displayed 849 CSS px, needs 1698 device px  ->  upscale_factor 2.0
+          while a 2169w variant exists at the src URL. has_sizes: false
+Wider viewports are worse. Independent of the CSP bug — arithmetic + spec + currentSrc.
+
+<!-- fr:journal kind=finding scope=debug id=f-scope created=2026-07-26T14:38:29 state=open -->
+### f-scope · finding [open] · Scope is far wider than reported: the CSP also kills ALL syntax highlighting (9366 inline style attrs from Chroma)
+
+The reported "simple html" lists are the smallest part. A full build (hugo v0.157.0
+extended, theme hextra v0.12.1) into /tmp/blogbuild, scanned for CSP-incompatible output:
+
+  <style> blocks   : 7     across 6   files
+  inline <script>  : 191   across 111 files
+  style= attributes: 9366  across 112 files
+
+The 9366 style attributes are Hugo's Chroma syntax highlighter. hugo.toml has
+[markup.highlight] style="monokai" but never sets noClasses=false, and noClasses
+defaults to TRUE, so every code token ships as <span style="color:#f92672">.
+
+Live proof on /frank/docs/building/04-gpu-compute/ (24 code blocks, 357 token spans):
+
+  pre.getAttribute("style")   -> "color:#f8f8f2;background-color:#272822;..."
+  getComputedStyle(pre).color -> rgb(0, 0, 0)          NOT APPLIED
+  token span style="color:#f92672" -> computed rgb(0, 0, 0)
+
+So every code block on a technical blog renders as flat black text with no Monokai
+background and no highlighting at all. This was not in the operator report ("perhaps
+there are other errors") but is the largest surface by far.
+
+Mermaid survives: .mermaid svg count = 1, because the theme renders diagrams from an
+EXTERNAL script; only the inline config script is blocked, so diagrams draw but lose
+their theme wiring.
+
+OWNERSHIP (decides what is fixable in this repo):
+
+  OURS   markup.highlight noClasses default             -> 9366 style attrs
+  OURS   shortcodes roadmap/papers-roadmap/series-index -> 3 style blocks
+  OURS   partials/custom/footer.html                    -> 1 inline script + 1 style attr
+  OURS   shortcodes/asciinema.html                      -> 1 inline script
+  THEME  _partials/theme-toggle.html:33                 -> style="position: fixed; ..."
+  THEME  _partials/language-switch.html:32              -> style="position: fixed; ..."
+  THEME  _partials/search.html:26                       -> style="transition: max-height ..."
+  THEME  _partials/scripts/mermaid.html                 -> inline mermaid config script
+
+Fixing everything that is ours removes ~99.6% of the inline content, but the pinned
+upstream theme still emits ~3 style attributes and 1 script per page. A strict
+style-src self therefore cannot be fully satisfied without forking the theme or
+hash-allowlisting its residue.
+
+<!-- fr:journal kind=finding scope=debug id=fix-all created=2026-07-26T16:12:18 state=fixed -->
+### fix-all · finding [fixed] · Fixed: per-site CSP for the blog, class-based highlighting, externalised scripts, and a reachable srcset top candidate
+
+Two independent root causes, fixed independently.
+
+CSP (clusters/hop/apps/caddy/manifests/configmap.yaml)
+  The CSP moved out of the shared (security_headers) snippet into two explicit
+  per-site snippets, because www and the blog genuinely need different values and
+  hiding that behind a shared default is what caused the incident:
+
+    (csp_strict)  style-src 'self'                     -> www.derio.net
+    (csp_blog)    style-src 'self' 'unsafe-inline'     -> blog.derio.net
+
+  script-src stays strict on BOTH. Hextra can never satisfy a strict style-src:
+  cards.html renders style="--hextra-cards-grid-cols: {N}" and card.html a
+  templated style="{{ $imageStyle | safeCSS }}" — per-invocation computed values
+  no external stylesheet can carry. Verified identical in v0.12.3 (latest), so
+  waiting for an upstream release was not an option.
+
+  www's handle_errors re-imports both snippets: it runs its own handler chain and
+  does not inherit site-level header mutations.
+
+Syntax highlighting (blog/hugo.toml)
+  markup.highlight.noClasses = false. Chroma defaulted to true, stamping the
+  palette onto ~9,300 token spans as inline style attributes. Class-based output
+  is also what Hextra expects — it ships assets/css/chroma/{light,dark}.css at
+  `.highlight .chroma .<token>` specificity, so highlighting now follows the
+  light/dark toggle instead of being monokai in both.
+  A generated chroma.css was tried first and REMOVED: it duplicated the theme's
+  stylesheet and lost on specificity every time, silently.
+
+Inline scripts (script-src stays strict, so these had to be externalised)
+  blog/assets/js/read-history-clear.js  <- was inline in custom/footer.html; the
+      "Clear read history" link had been rendering but doing nothing.
+  blog/assets/js/mermaid-init.js        <- external replacement for the theme's
+      inline init. Diagrams still drew (mermaid self-starts) but were stuck in
+      the light theme and ignored the toggle across all 80 mermaid posts.
+  blog/assets/js/asciinema-init.js      <- shortcode now passes config as data-*
+      attributes. Latent, not live: 0 posts currently use the shortcode.
+  The footer link's inline style attribute became a .clear-read-history class.
+
+srcset (blog/layouts/partials/opt-image.html)
+  The top candidate is now $primary.Width instead of $maxW, so the primary is
+  always reachable. 179 unreachable-full-resolution images -> 0. The browser now
+  selects the 2169w banner and the 1424w cover; it previously could only reach
+  960w.
+
+Guards
+  scripts/check_blog_build.py — new build-output gate, wired into deploy-blog.yml
+  after `hugo --minify`. Asserts no inline <script>, no off-origin assets, and
+  that every w-descriptor srcset can reach its own primary. It does NOT police
+  inline STYLES: style-src permits them, and policing them would only generate
+  busywork against upstream templates frank tracks verbatim. It tolerates exactly
+  one documented theme-owned inline script (mermaid), so a theme bump that
+  changes that markup surfaces as a failure.
+
+  test_caddy_security_headers.py — previously read only the FIRST CSP line in the
+  file, so it never distinguished the two sites and passed straight through the
+  regression. Now asserts each vhost imports its own snippet, script-src is
+  strict on both, www's style-src is strict AND the blog's is not, and that the
+  www fallback re-imports both. Verified non-vacuous by reintroducing the #704
+  policy: the suite fails.
+
+  test_image_optimization_adoption.py — the opt-image fix is a divergence from
+  blog-craft@5dc31f8, which a byte-equality guard forbids. Rather than overwrite
+  the fixture (which would erase the drift signal), the divergence is pinned to
+  exactly that hunk: the emit block and preamble must still match byte-for-byte.
+  The fix is an UPSTREAM defect and belongs in blog-craft.
+
+Deliberately reverted mid-flight
+  The three list shortcodes' <style> blocks were externalised, then put back.
+  scripts/tests/test_series_index_resync.py exists specifically so "frank no
+  longer carries a divergent copy" of series-index.html and roadmap.html; with
+  style-src now permitting inline, that externalisation bought nothing functional
+  and re-introduced drift a prior project had removed.
+
+Verification
+  hugo build + scripts/check_blog_build.py: OK, 112 pages.
+  Full suite: 17 failed / 195 passed — the same 17 that fail on origin/main, and
+  zero new failures (baseline captured from `git archive origin/main`).
+  Browser: 24 cards styled, banner currentSrc = the 2169w variant, code blocks
+  highlighted with 0 inline style attributes in <pre>, mermaid renders.

--- a/scripts/check_blog_build.py
+++ b/scripts/check_blog_build.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Build-output gate for the blog — the check Caddy's CSP comment assumes exists.
+
+`clusters/hop/apps/caddy/manifests/files/Caddyfile` hardens blog.derio.net with a
+CSP. Its own comment says the constraint "is pinned by the site's own build
+check" — agentic-stoa/site has one, the blog did not, and on 2026-07-26 that gap
+cost the blog every syntax-highlighted code block, all three card lists, and the
+dark-mode wiring on 80 mermaid diagrams. Nothing alerted: a CSP violation is a
+browser-side drop, so the page still returns 200 and ArgoCD stays green.
+
+This script closes that gap by asserting invariants against the BUILT site, which
+is the only place these defects are observable.
+
+Invariant 1 — nothing the CSP will silently drop.
+    script-src is 'self' plus the analytics origin, with NO 'unsafe-inline'.
+    An inline <script> is therefore dead code that ships and never runs, and an
+    external asset from an origin outside the allowlist never loads at all.
+
+    Inline STYLES are deliberately not policed. style-src carries
+    'unsafe-inline' for the blog because Hextra's templated CSS custom
+    properties make a strict style-src unsatisfiable, so inline styles render
+    correctly and are not a defect. This script asserts what the browser
+    actually enforces — nothing more, or it would just generate busywork
+    against upstream templates frank is supposed to track verbatim.
+
+Invariant 2 — responsive images must be able to reach their own full resolution.
+    Once a srcset carries `w` descriptors, the HTML spec drops `src` from the
+    candidate list. So if every candidate is narrower than the primary named in
+    `src`, the browser CANNOT select the full-resolution file the build just
+    generated, and renders an upscaled one instead. That is invisible server-side:
+    every variant returns 200.
+
+Usage:  python3 scripts/check_blog_build.py blog/public
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+from urllib.parse import urlparse
+
+# Origins the CSP permits for scripts/styles. Keep in sync with the csp_blog
+# snippet in clusters/hop/apps/caddy/manifests/files/Caddyfile.
+ALLOWED_ORIGINS = {"counter.derio.net"}
+
+# Inline scripts emitted by the PINNED upstream theme, which we cannot remove
+# without forking it. Each is tolerated only because an external equivalent
+# already does the work — the inline copy is inert, not load-bearing. Keyed by a
+# substring that survives minification. Anything NOT listed here fails the build,
+# so a theme bump that changes this markup surfaces as a failure and gets
+# re-reviewed rather than silently regressing.
+TOLERATED_INLINE_SCRIPTS = {
+    "dataset.original": (
+        "hextra _partials/scripts/mermaid.html — dropped by script-src; "
+        "superseded by blog/assets/js/mermaid-init.js"
+    ),
+}
+
+TAG_RE = re.compile(r"<(script|style|img|link)\b([^>]*)>", re.I | re.S)
+ATTR_RE = re.compile(r"""([-\w:]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]*))""")
+CANDIDATE_RE = re.compile(r"(\S+)\s+(\d+)w")
+
+
+def attrs(raw: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for m in ATTR_RE.finditer(raw):
+        out[m.group(1).lower()] = m.group(2) or m.group(3) or m.group(4) or ""
+    return out
+
+
+def external_host(url: str) -> str | None:
+    """Return the host if `url` points off-origin, else None."""
+    if url.startswith(("//", "http://", "https://")):
+        host = urlparse(url if "//" in url[:8] else "https:" + url).netloc
+        return host or None
+    return None
+
+
+def check_page(path: Path, rel: str, problems: list[str], tolerated: Counter) -> None:
+    html = path.read_text(encoding="utf-8", errors="replace")
+
+    for m in TAG_RE.finditer(html):
+        tag = m.group(1).lower()
+        a = attrs(m.group(2))
+
+        if tag == "script":
+            src = a.get("src", "")
+            if not src:
+                # Inline script: shipped, parsed, and then dropped by script-src.
+                body = html[m.end() : m.end() + 400]
+                known = next(
+                    (why for mark, why in TOLERATED_INLINE_SCRIPTS.items() if mark in body),
+                    None,
+                )
+                if known:
+                    tolerated[known] += 1
+                    continue
+                snippet = body[:90].replace("\n", " ").strip()
+                problems.append(
+                    f"{rel}: inline <script> is blocked by script-src 'self' "
+                    f"(externalise it into blog/assets/js/) :: {snippet[:70]}"
+                )
+            elif (host := external_host(src)) and host not in ALLOWED_ORIGINS:
+                problems.append(
+                    f"{rel}: <script src> from off-origin host {host!r} is blocked by "
+                    f"script-src (vendor it into blog/assets/, or widen the CSP)"
+                )
+
+        elif tag == "link" and "stylesheet" in a.get("rel", "").lower():
+            if (host := external_host(a.get("href", ""))) and host not in ALLOWED_ORIGINS:
+                problems.append(
+                    f"{rel}: stylesheet from off-origin host {host!r} is blocked by "
+                    f"style-src (vendor it into blog/assets/css/)"
+                )
+
+        elif tag == "img":
+            srcset, width = a.get("srcset", ""), a.get("width", "")
+            if not srcset or not width.isdigit():
+                continue
+            cands = [int(w) for _, w in CANDIDATE_RE.findall(srcset)]
+            if not cands:
+                continue  # density descriptors: src stays a candidate, fine
+            primary = int(width)
+            if max(cands) < primary:
+                problems.append(
+                    f"{rel}: <img> srcset tops out at {max(cands)}w but src is "
+                    f"{primary}w — once a srcset uses w descriptors the browser "
+                    f"cannot fall back to src, so the full-resolution image is "
+                    f"unreachable and it renders upscaled "
+                    f"({a.get('src', '?').rsplit('/', 1)[-1]})"
+                )
+
+
+def main(argv: list[str]) -> int:
+    root = Path(argv[1] if len(argv) > 1 else "blog/public")
+    if not root.is_dir():
+        print(f"error: built site not found at {root} — run `hugo --minify` first")
+        return 2
+
+    pages = sorted(root.rglob("*.html"))
+    if not pages:
+        print(f"error: no HTML under {root} — did the build produce output?")
+        return 2
+
+    problems: list[str] = []
+    tolerated: Counter = Counter()
+    for p in pages:
+        check_page(p, str(p.relative_to(root)), problems, tolerated)
+
+    for why, n in tolerated.most_common():
+        print(f"note: tolerated {n}x — {why}")
+
+    if not problems:
+        print(f"OK: {len(pages)} pages — no CSP-dropped assets, no unreachable image variants")
+        return 0
+
+    # Collapse per-page repeats; the same defect on 111 pages is one defect.
+    kinds = Counter(re.sub(r"^[^:]+: ", "", p).split(" ::")[0] for p in problems)
+    print(f"FAIL: {len(problems)} problem(s) across {len(pages)} pages\n")
+    for kind, n in kinds.most_common():
+        print(f"  [{n:5d}x] {kind}")
+    print("\nfirst 10 occurrences:")
+    for p in problems[:10]:
+        print(f"  - {p}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/tests/test_caddy_security_headers.py
+++ b/scripts/tests/test_caddy_security_headers.py
@@ -83,34 +83,108 @@ def test_baseline_headers_present() -> None:
         assert expected in matching[0], f"{header} does not contain {expected!r}"
 
 
+def _snippet(name: str) -> str:
+    """Return the body of the named Caddy snippet `(name) { ... }`."""
+    text = caddyfile()
+    start = text.index(f"({name}) {{")
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    raise AssertionError(f"unbalanced snippet ({name})")
+
+
+def _policy(snippet: str) -> str:
+    """Return the Content-Security-Policy line from a named CSP snippet."""
+    csp = [ln for ln in _snippet(snippet).splitlines() if "Content-Security-Policy" in ln]
+    assert csp, f"({snippet}) defines no Content-Security-Policy"
+    return csp[0]
+
+
+def _directive(policy: str, name: str) -> str:
+    """Return one directive's full text from a CSP header line."""
+    for part in policy.split('"')[1].split(";"):
+        part = part.strip()
+        if part.split(" ")[0] == name:
+            return part
+    raise AssertionError(f"no {name!r} directive in {policy!r}")
+
+
 def test_csp_admits_analytics_and_forbids_framing() -> None:
+    for snippet in ("csp_strict", "csp_blog"):
+        policy = _policy(snippet)
+        assert "default-src 'self'" in policy, f"{snippet}: no default-src"
+        assert "frame-ancestors 'none'" in policy, (
+            f"{snippet}: frame-ancestors 'none' replaces X-Frame-Options; "
+            "without it the site is clickjackable"
+        )
+        # GoatCounter serves the script and receives the beacon.
+        assert f"script-src 'self' {ANALYTICS_ORIGIN}" in policy, (
+            f"{snippet}: CSP must allow the GoatCounter script, or analytics "
+            "dies silently"
+        )
+        assert ANALYTICS_ORIGIN in _directive(policy, "connect-src"), (
+            f"{snippet}: CSP must allow the GoatCounter beacon in connect-src"
+        )
+
+
+def test_script_src_stays_strict_on_both_sites() -> None:
+    """script-src is the half that actually stops XSS, so it stays strict.
+
+    The blog's build gate (scripts/check_blog_build.py) fails on any inline
+    <script> precisely so this line can keep holding.
+    """
+    for snippet in ("csp_strict", "csp_blog"):
+        script_src = _directive(_policy(snippet), "script-src")
+        assert "'unsafe-inline'" not in script_src, (
+            f"{snippet}: no 'unsafe-inline' in script-src — externalise the "
+            "script into blog/assets/js/ instead of widening the policy"
+        )
+
+
+def test_www_style_src_is_strict_but_the_blog_is_not() -> None:
+    """The asymmetry is deliberate and load-bearing, so assert BOTH halves.
+
+    www (agentic-stoa/site) emits external stylesheets only and pins that with
+    its own build check, so it holds style-src 'self'.
+
+    The blog is Hugo + Hextra, and Hextra emits inline style attributes
+    structurally, not sloppily: `cards.html` renders
+    style="--hextra-cards-grid-cols: {N}" and `card.html` a templated
+    style="{{ $imageStyle | safeCSS }}". Those are per-invocation computed
+    values no external stylesheet can carry — identical in v0.12.3, the latest
+    release as of 2026-07-26, so this is not a "wait for the next version"
+    situation. Applying the strict policy to the blog on 2026-07-26 (#704)
+    blanked every card list and every syntax-highlighted code block while the
+    server still returned 200 and ArgoCD stayed green.
+
+    Dropping 'unsafe-inline' from the blog therefore requires forking the theme
+    first. Delete this assertion only together with that work.
+    """
+    assert "'unsafe-inline'" not in _directive(_policy("csp_strict"), "style-src"), (
+        "www must keep style-src 'self' — it emits external stylesheets only"
+    )
+    assert "'unsafe-inline'" in _directive(_policy("csp_blog"), "style-src"), (
+        "the blog needs style-src 'unsafe-inline' until Hextra stops emitting "
+        "templated inline style attributes — see this test's docstring"
+    )
+
+
+def test_each_public_site_imports_headers_and_its_own_csp() -> None:
     text = caddyfile()
-    csp = [ln for ln in text.splitlines() if "Content-Security-Policy" in ln]
-    assert csp, "no Content-Security-Policy"
-    policy = csp[0]
-
-    assert "default-src 'self'" in policy
-    assert "frame-ancestors 'none'" in policy, (
-        "frame-ancestors 'none' replaces X-Frame-Options; without it the sites "
-        "are clickjackable"
-    )
-    # GoatCounter serves the script and receives the beacon.
-    assert f"script-src 'self' {ANALYTICS_ORIGIN}" in policy, (
-        "CSP must allow the GoatCounter script, or analytics dies silently"
-    )
-    assert ANALYTICS_ORIGIN in policy.split("connect-src")[1].split(";")[0], (
-        "CSP must allow the GoatCounter beacon in connect-src"
-    )
-    assert "'unsafe-inline'" not in policy.split("script-src")[1].split(";")[0], (
-        "no 'unsafe-inline' in script-src — the sites ship no inline scripts"
-    )
-
-
-def test_both_public_sites_import_the_snippet() -> None:
-    text = caddyfile()
-    for host in ("www.derio.net", "blog.derio.net"):
-        assert "import security_headers" in _block(text, host), (
+    for host, csp in (("www.derio.net", "csp_strict"), ("blog.derio.net", "csp_blog")):
+        block = _block(text, host)
+        assert "import security_headers" in block, (
             f"{host} does not import security_headers"
+        )
+        assert f"import {csp}" in block, f"{host} does not import {csp}"
+        other = "csp_blog" if csp == "csp_strict" else "csp_strict"
+        assert f"import {other}" not in block, (
+            f"{host} imports {other} — the two policies are not interchangeable"
         )
 
 
@@ -132,3 +206,13 @@ def test_www_degrades_to_the_holding_page() -> None:
     )
     errors = block[block.index("handle_errors") :]
     assert "Coming soon." in errors and "200" in errors
+    # handle_errors runs its own handler chain: the site-level header mutations
+    # do NOT reach it (verified live 2026-07-26, when the fallback served 200
+    # with no HSTS/CSP and leaked `Server: Caddy`). Both imports must be repeated
+    # inside the block or the hardening lapses exactly during an outage.
+    assert "import security_headers" in errors, (
+        "www's handle_errors fallback does not re-import security_headers"
+    )
+    assert "import csp_strict" in errors, (
+        "www's handle_errors fallback does not re-import csp_strict"
+    )

--- a/scripts/tests/test_image_optimization_adoption.py
+++ b/scripts/tests/test_image_optimization_adoption.py
@@ -31,12 +31,59 @@ def test_config_opts_into_optimization():
 
 
 def test_mechanism_templates_match_blog_craft():
-    """opt-image + render-image track blog-craft@5dc31f8 (no frank divergence)."""
-    for name, dest in (("opt-image.html", "partials/opt-image.html"),
-                       ("render-image.html", "_markup/render-image.html")):
+    """render-image tracks blog-craft@5dc31f8 (no frank divergence).
+
+    opt-image.html is a RECORDED divergence — pinned by the next test.
+    """
+    for name, dest in (("render-image.html", "_markup/render-image.html"),):
         live = open(os.path.join(BLOG, "layouts", dest), "rb").read()
         ref = open(os.path.join(FIX, name), "rb").read()
         assert live == ref, f"blog/layouts/{dest} diverges from blog-craft@5dc31f8"
+
+
+def test_opt_image_diverges_from_blog_craft_only_in_the_srcset_clamp():
+    """opt-image.html carries ONE deliberate fix ahead of blog-craft@5dc31f8.
+
+    Upstream builds the srcset from `slice 480 960 $maxW` and clamps each
+    candidate with `le $w $maxW` — comparing the cap against itself instead of
+    against the primary actually emitted. Whenever the SOURCE is narrower than
+    the cap (frank's banners are 2169w against a 2560 cap, covers 1424w against
+    1600) the top candidate is dropped and nothing in the srcset matches the
+    primary. Since the HTML spec removes `src` from the candidate list as soon
+    as a srcset uses `w` descriptors, the full-resolution file becomes
+    unreachable and every banner renders upscaled from 960w — measured at 2.0x
+    on a 1512px Retina viewport, and worse on wider screens.
+
+    That is an upstream defect, not a frank preference, so it belongs in
+    blog-craft. Until it lands there and frank re-syncs, this test pins the
+    divergence to exactly that hunk, so no OTHER drift can hide behind it.
+    """
+    live = open(os.path.join(BLOG, "layouts", "partials", "opt-image.html")).read()
+    ref = open(os.path.join(FIX, "opt-image.html")).read()
+
+    assert "(slice 480 960 $maxW)" in ref, (
+        "fixture is no longer the upstream copy this divergence was recorded "
+        "against — re-check whether blog-craft has fixed it upstream"
+    )
+    assert "(slice 480 960 $maxW)" not in live, (
+        "opt-image.html regressed to the upstream srcset clamp — banners will "
+        "silently render upscaled from 960w again"
+    )
+    assert "$topW := $primary.Width" in live, (
+        "the srcset's top candidate must be the primary's real width"
+    )
+
+    # Nothing outside the srcset loop may differ. Compare the parts either side
+    # of it: a change anywhere else is unrecorded drift, not this fix.
+    marker = "{{- if $primary -}}"
+    assert live.split(marker)[1] == ref.split(marker)[1], (
+        "opt-image.html diverges from blog-craft@5dc31f8 in its EMIT block — "
+        "that drift is not recorded anywhere"
+    )
+    preamble = "{{- /* decode the source width defensively"
+    assert live.split(preamble)[0] == ref.split(preamble)[0], (
+        "opt-image.html diverges from blog-craft@5dc31f8 in its preamble"
+    )
 
 
 def test_banners_relocated_to_assets():


### PR DESCRIPTION
## What was broken

The operator reported the banners looked very low-res and that the list on
`/frank/docs/papers/` had turned into "simple html". Both were real, plus a third
defect nobody had spotted: **every code block on the blog had lost its syntax
highlighting.**

Two independent root causes.

### 1. The blog inherited a CSP it cannot satisfy

#704 added `import security_headers` to the `blog.derio.net` vhost for www-parity.
That snippet sets `style-src 'self'` with no `'unsafe-inline'`, so the browser
dropped every inline `<style>` block and style attribute — while the page still
returned `200`. ArgoCD stayed green and nothing paged.

The snippet's own comment predicted this exact failure mode, and noted that
agentic-stoa/site "pins that with its own build check". The blog was given the
policy without the check.

Measured on the live site before the fix:

```
document.querySelectorAll('style').length   -> 1     (element present)
thatStyleElement.sheet                      -> null  (BLOCKED)
getComputedStyle('.roadmap-card')           -> border 0px, background transparent
pre.getAttribute('style')                   -> "color:#f8f8f2;background-color:#272822"
getComputedStyle(pre).color                 -> rgb(0, 0, 0)   NOT APPLIED
```

A full build showed the blast radius: **9,366 inline style attributes across 112
pages**, 9,350 of them Chroma syntax-highlighting tokens.

**Hextra can never satisfy a strict `style-src`.** Its inline styles are
structural, not sloppiness:

```
cards.html:  style="--hextra-cards-grid-cols: {{ $cols }};"
card.html:   {{ with $imageStyle }}style="{{ . | safeCSS }}"{{ end }}
```

Those are per-invocation computed values; no external stylesheet can carry them.
Verified identical in **v0.12.3** (latest as of 2026-07-26), so "wait for the next
release" was not an option.

So the CSP splits into two explicit per-site snippets that differ only in
`style-src`:

| snippet | site | style-src | script-src |
|---|---|---|---|
| `csp_strict` | www.derio.net | `'self'` | strict |
| `csp_blog` | blog.derio.net | `'self' 'unsafe-inline'` | strict |

**`script-src` stays strict on both** — that is the half that actually stops XSS,
and the new build gate is what lets it keep holding.

Two more casualties of the same header, also fixed:

- The **"Clear read history"** footer link had been rendering but doing nothing.
- **Mermaid diagrams** were stuck in the light theme and ignored the dark-mode
  toggle across all **80** posts that use them (they still drew, because
  mermaid.js self-starts — only the theme wiring was dead).

### 2. Banners could not reach their own full resolution

`opt-image.html` built its srcset from `slice 480 960 $maxW` and clamped each
candidate with `le $w $maxW` — comparing the cap against itself instead of against
the primary actually emitted. Whenever the source is narrower than the cap:

```
banners  src 2169w, bannerMaxWidth 2560  ->  2560 > 2169  ->  srcset = 480w, 960w
covers   src 1424w, maxWidth       1600  ->  1600 > 1424  ->  srcset = 480w, 960w
```

Per the HTML spec, once a srcset carries `w` descriptors, `src` stops being a
selection candidate — so the full-resolution file Hugo generated and Caddy served
(200 OK) was simply unreachable. Measured in-browser at DPR 2:

```
banner currentSrc = banner-papers_hu_9ce0a7f02b95736b.webp   (the 960w variant)
       displayed 849 CSS px, needs 1698 device px  ->  upscale_factor 2.0
```

**179 affected images -> 0.** The browser now selects the 2169w banner and the
1424w cover.

## Also

`markup.highlight.noClasses = false`, which is what Hextra expects — it ships
`chroma/light.css` and `chroma/dark.css`, so highlighting now **follows the theme
toggle** instead of being monokai in both modes. ~9,300 inline style attributes
removed from the HTML.

> Heads-up on appearance: code blocks in light mode are now light (theme-native)
> rather than always-dark monokai. That is a visible change. Reverting is a
> one-line `noClasses = true` if you prefer the old look.

A generated `chroma.css` was tried first and **removed** — it duplicated the
theme's stylesheet and lost on specificity every time, silently.

The dev devcontainer gains the **go toolchain**: the Hextra theme is a Hugo
module, so without go the blog build dies at `binary with name "go" not found in
PATH` before rendering a single page.

## Guards

All three defects are invisible server-side, so each gets a tripwire.

- **`scripts/check_blog_build.py`** (new), wired into `deploy-blog.yml` after
  `hugo --minify`: no inline `<script>`, no off-origin assets, and every
  w-descriptor srcset must reach its own primary. It deliberately does **not**
  police inline styles — `style-src` permits them, and policing them would only
  generate busywork against upstream templates frank tracks verbatim. It tolerates
  exactly one documented theme-owned inline script, so a theme bump that changes
  that markup surfaces as a failure.

- **`test_caddy_security_headers.py`** read only the *first* CSP line in the file,
  so it never distinguished the two sites and passed straight through #704. It now
  pins both policies per-vhost, asserts `script-src` is strict on both, asserts
  www's `style-src` is strict **and** the blog's is not, and that the www
  `handle_errors` fallback re-imports both. Verified non-vacuous by reintroducing
  the #704 policy — the suite fails.

- **`test_image_optimization_adoption.py`**: the opt-image fix is an **upstream**
  defect and diverges from `blog-craft@5dc31f8`, which a byte-equality guard
  forbids. Rather than overwrite the fixture and erase the drift signal, the
  divergence is pinned to exactly that hunk — the emit block and preamble must
  still match byte-for-byte.

## Reverted mid-flight

The three list shortcodes' `<style>` blocks were externalised into the asset
pipeline, then deliberately put back. `test_series_index_resync.py` exists
specifically so that "frank no longer carries a divergent copy" of
`series-index.html` and `roadmap.html`; with `style-src` now permitting inline,
that externalisation bought nothing functional and re-introduced drift a prior
project had removed.

## Follow-ups (not in this PR)

- Upstream the `opt-image.html` srcset fix to **blog-craft**, then re-sync frank
  and drop the recorded divergence.
- The asciinema shortcode still loads its player from **unpkg.com**, which the CSP
  blocks. It is used by 0 posts today, so nothing is broken — but it must be
  vendored before use. The build gate fails loudly if it is ever emitted.
- `opt-image.html` emits no `sizes` attribute, so the browser assumes `100vw` and
  over-fetches on narrow layouts. Correct-but-heavy; a separate optimisation.

## Verification

- `hugo --minify` + the gate: **OK, 112 pages** — no CSP-dropped assets, no
  unreachable image variants.
- Full tripwire suite: **17 failed / 195 passed**, the same 17 that fail on
  `origin/main` (baseline captured via `git archive origin/main`) — **zero new
  failures**.
- In-browser against a local build: 24 paper cards styled, banner `currentSrc`
  resolves to the 2169w variant, code blocks highlighted with **0** inline style
  attributes left in `<pre>`, mermaid renders.

Root-cause trail, including the two hypotheses ruled out along the way (SRI
mismatch; stale-HTML/404-asset), is in
`docs/superpowers/journals/debug/2026-07-26-blog-render-regression.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
