### PR TITLE
docs(repo): preserve frank's persona notes before the blog-craft v0.14.0 resync

### DIFF
--- a/.reference-pool/PERSONA.md
+++ b/.reference-pool/PERSONA.md
@@ -1,0 +1,65 @@
+# Frank's persona invariants — reference-pool notes
+
+**Why this file exists.** `.reference-pool/README.md` is **blog-craft-owned**
+(`framework`-classified in blog-craft's manifest), so `/blog-craft:update`
+replaces it wholesale. It documents the *generic* v5 reference contract. This
+file holds the parts that are specific to **Frank** and would otherwise be lost
+on the next update. blog-craft materializes only `README.md` and
+`generic/subjects/.gitkeep` in this directory and never deletes unknown paths,
+so `PERSONA.md` survives every update.
+
+Read `README.md` for the mechanism (one `primary` per entry, `clothing:`
+anchors, order is load-bearing). Read this for what Frank must look like.
+
+## The eye design is the invariant
+
+Frank has **large solid-black eyes with a small white pupil highlight**. There
+is **never any white sclera**. This is the single most load-bearing detail of
+the character: get it wrong and the figure stops reading as Frank even when the
+costume, proportions and line work are all correct.
+
+Every sheet under `<series>/reference/` encodes it. When generating a new sheet,
+review **every face on the sheet** before promoting it — a sheet with one
+off-model face will drag every cover generated from it off-model too.
+
+### The startled-expression trap
+
+A *startled / surprised* expression pulls the image model toward generic
+cartoon eyes — white sclera, small dark iris. It is the reliable way to break
+the invariant, and it does so silently: the rest of the sheet looks fine.
+
+**Pin the expression row to steady expressions** — neutral / grin / angry /
+worried. Do not ask for startled, surprised, shocked, or wide-eyed.
+
+Measured on Gemini; treat it as a property of image models generally rather
+than of one vendor, and re-check it after any generator change. Anchoring on
+2–3 already-approved sheets is the other half of the defence.
+
+## Pool layout as Frank actually uses it
+
+```
+.reference-pool/
+  <series>/reference/          # the v5 anchors — one sheet per outfit variant
+  <series>/reference-<series>.png   # legacy v4 master ref; unused by v5 entries
+  generic/reference/           # entries with no series
+    frank-favicon.png          # HEAD-ONLY icon sheet — favicon/tile work only,
+                               #   not a full turnaround; don't point a cover at it
+```
+
+Series in use: `building`, `operating`, `papers`, plus `generic`.
+
+Filenames are descriptive of the **outfit**, because that is the selection key:
+an entry's `clothing:` modifier and its `reference_images.primary` must agree.
+Pointing a `papers[white_lab_coat]` entry at a `building/` gear-shirt sheet
+produces a technically on-model Frank in the wrong costume, and nothing warns
+you — verify with `scripts/generate-images.py --dry-run`.
+
+## Related
+
+- `blog/prompt_for_images.yaml` — the entries that consume these sheets.
+- `.blog-craft.yaml` → `image.layers` — the shared character/atmosphere/clothing
+  prose; `image.character_sheet.layers` — the sheet-generation prompt.
+- `docs/runbooks/banner-generation-handoff/README.md` — banner generation
+  (a different pipeline: Codex three-stripe, not character sheets).
+- `docs/runbooks/blog-craft-resync.md` — which paths blog-craft owns and how
+  frank pulls updates.

--- a/docs/runbooks/blog-craft-resync.md
+++ b/docs/runbooks/blog-craft-resync.md
@@ -6,8 +6,17 @@ scaffolding under `blog/` are produced from the blog-craft templates
 blog-craft revision, pinned in `.blog-craft.yaml`:
 
 ```yaml
-blog_craft_version: "a7f2f7f"   # blog-craft main SHA frank is synced to
+blog_craft_version: "v0.10.0"   # blog-craft RELEASE frank is synced to
 ```
+
+Keep this accurate: `update.py` recovers the 3-way-merge base by **re-rendering
+at the recorded release**, so a stale or wrong value silently degrades every
+`merged` path to a baseless conflict. It is a release tag, not a main SHA (older
+revisions of this note showed a SHA). Bump it *after* an apply, not before.
+
+Two axes move independently — the config **schema** (`version:`, migrated by
+`tools/migrate_config.py`) and the blog-craft **release** (`blog_craft_version`).
+`migrate_config.py --check` reports the first; the release gap is the usual one.
 
 This note records how frank pulls blog-craft updates, and — importantly — which
 paths frank **owns** despite blog-craft classifying them otherwise. A blanket
@@ -34,24 +43,70 @@ committed palette + registry↔palette name consistency).
 From a blog-craft checkout, dry-run the plan against frank's blog:
 
 ```bash
-python tools/update.py --config <frank>/.blog-craft.yaml --blog <frank>/blog
+python tools/update.py --config "$(pwd)/.blog-craft.yaml" --blog .
 ```
+
+**Pass `--config` as an ABSOLUTE path.** `update.py` hands the value straight to
+`bootstrap-render.sh` in a subprocess that runs from a different cwd, so a
+relative path dies in a `CalledProcessError` traceback whose real cause —
+`load answers: open .blog-craft.yaml: no such file or directory` — is swallowed
+in the captured output and never printed. `--blog` points at the **config root**
+(the repo root, which is where `.blog-craft.yaml` lives), *not* at `blog/`;
+`site_dir: blog` in the config already maps the Hugo paths under `blog/`.
 
 `update.py` only touches paths blog-craft **materializes** (`layouts/`, `hugo.toml`,
 CI, …); frank's authored content (`content/**`, `data/**`, images,
 `.blog-craft.yaml`) is `content`-class and left alone. `data/layer_palette.yaml`
 is content-class too — regenerate it explicitly (above), it is not auto-updated.
 
+## A reverted `framework` path is usually an UPSTREAM bug — fix it there
+
+Before adding anything to the table below, apply this test:
+
+> Does this path encode a fact about **frank's repo**, or a gap in
+> **blog-craft**?
+
+`framework` means "blog-craft owns this — overwrite unconditionally". There is
+no merge and no conflict detection, so a local patch to such a file is invisible
+upstream and silently reverted on **every** update, drifting further each
+release while every other blog-craft blog keeps the bug. The exclusion table is
+for the first case only. **The second case gets an issue/PR against
+`derio-net/blog-craft`, then a clean re-run of `/update`** — never a local patch
+plus a table row.
+
+Worked example (2026-07-26, blog-craft #53 / #54). Updating v0.10.0 → v0.13.1
+returned three `framework` paths as *reverts*; all three were upstream gaps, not
+frank customizations, and all three were fixed upstream in v0.14.0:
+
+| Path | The upstream gap |
+|------|------------------|
+| `blog/layouts/docs/single.html` | Rendered the post cover as a raw `<img>` while `list.html` (the cover *thumbnail*), `render-image.html`, `screenshot.html` and `site-banner.html` all used `opt-image.html` — so the largest image on the page skipped WebP, `maxWidth` capping and `srcset`. This is frank PR #710's fix; a blanket apply would have reverted it. |
+| `blog/scripts/generate-images.py` | `post_process()`'s `resize` step could not write to a `target` (`crop_resize` and `ico` already could), so a one-master-to-many-derivatives pass — the favicon set — was inexpressible. |
+| `.reference-pool/README.md` | Documented the v4 reference precedence chain that v5 removed in 0.10.0, contradicting blog-craft's own `docs/CONFIG.md`. |
+
+After v0.14.0 these render identically to frank's copies and drop out of the
+update plan. Frank's *persona-specific* reference notes — the eye-design
+invariant, the startled-expression trap, the head-only favicon sheet — moved to
+**`.reference-pool/PERSONA.md`**, which blog-craft never materializes (its
+manifest names `.reference-pool/README.md` explicitly, not a `**` glob) and
+`update.py` never deletes.
+
 ## Frank-owned paths — DO NOT let an update overwrite these
 
 blog-craft's manifest classifies these `framework`/`merged` (overwrite/merge),
-but frank owns them. Exclude them from any `update.py --apply`:
+but frank genuinely owns them — each encodes a fact about frank's repo that has
+no upstream meaning. Exclude them from any `update.py --apply`:
 
 | Path | Why frank owns it |
 |------|-------------------|
 | `blog/layouts/shortcodes/papers-roadmap.html` | Frank-customized (papers roster + Published/deferred status). blog-craft ships a generic one via the papers content-type; frank's is bespoke and **not** generalized upstream. |
 | `.github/workflows/blog-ci.yml` | Frank has its own blog CI + GitHub Pages deploy; blog-craft's generic workflow does not apply. |
 | `blog/README.md` | Frank's blog has no standalone README (frank's README is repo-root). |
+
+`blog/hugo.toml` is `merged`, not excluded, but a v0.14.0 update proposes only a
+re-ordering of the `[params.seriesIndex]` / `[params.imageOptimize]` blocks —
+semantically identical TOML that would drop frank's explanatory comments for no
+gain. Skip it unless a later release changes it substantively.
 
 ## Deferred (harmless) framework adds
 


### PR DESCRIPTION
Prep for the `/blog-craft:update` to v0.14.0. blog-craft
[#54](https://github.com/derio-net/blog-craft/pull/54) fixed the three upstream gaps
frank had been patching locally in `framework`-classified files, so the next update
**converges** instead of reverting — including frank PR #710's cover-`srcset` fix, which
a blanket apply would have reverted. One consequence needs handling before that runs.

## The problem this solves

`.reference-pool/README.md` is blog-craft-owned, so the update replaces it with the
generic v5 contract. Frank's copy carries persona-specific prose that would go with it:

- the **eye-design invariant** — large solid-black eyes with a small white pupil
  highlight, never white sclera
- the **startled-expression trap** that silently breaks it (the rest of the sheet still
  looks fine, so it passes a casual review)
- the head-only `generic/reference/frank-favicon.png` sheet

## Where it went, and why there

`.reference-pool/PERSONA.md` — which survives every update, by construction:

- blog-craft's manifest names `.reference-pool/README.md` **explicitly**, not a `**`
  glob, so a sibling file is unclassified and never materialized;
- `update.py` only ever writes rendered paths — it contains no `unlink`/`rmtree`/delete.

It also sits where someone actually looks — next to the sheets — rather than in
`docs/runbooks/banner-generation-handoff/README.md`, which is scoped to a different
pipeline (Codex three-stripe banners, not character sheets).

## The policy correction

`docs/runbooks/blog-craft-resync.md` gains the rule this round established:

> A reverted `framework` path is **usually an upstream bug**. It gets an issue/PR
> against blog-craft — not a local patch plus an exclusion-table row.

The test is whether the path encodes a fact about **frank's repo** or a gap in
**blog-craft**. `blog-ci.yml` and `blog/README.md` are the former and stay in the table;
all three of this round's reverts were the latter. Recorded as the worked example, with
what each upstream gap actually was.

This matters because `framework` means "overwrite unconditionally" — no merge, no
conflict detection. A local patch there is invisible upstream and reverted on *every*
update, drifting further each release while every other blog-craft blog keeps the bug.

## Two corrections to the same runbook

- **`blog_craft_version` was documented as a main SHA.** It's a release tag, and
  `update.py` re-renders at it to recover the 3-way merge base — so a wrong value
  silently degrades every `merged` path to a baseless conflict.
- **`--config` must be an absolute path.** `update.py` hands it to
  `bootstrap-render.sh` in a subprocess with a different cwd; the real cause
  (`load answers: open .blog-craft.yaml: no such file or directory`) is swallowed by
  `capture_output` and surfaces only as a bare `CalledProcessError` traceback. Also
  clarified `--blog` points at the config root, not `blog/`.

## Verification

Docs only — two files, no code. Full tripwire suite green **on the host**: 216 passed,
1 xfailed.

Worth flagging separately: `pytest scripts/tests/` **inside fr isolation** reports 17
failures on a pristine tree, because the `dev` devcontainer profile has no `kustomize`
while the host does. It's exactly the three kustomize-dependent files
(`test_cnc_staging_host_secrets.py`, `test_cnc_staging_vcluster_api_netpol.py`,
`test_gitea_runner_app.py` — 13 + 4 = 17), all 23 of which pass on the host against this
branch. The failures name assertion targets rather than the missing binary, so they read
as a real regression. Not fixed here (unrelated to this change) — happy to add
`kustomize` to the `dev` profile as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
