### PR TITLE
test(cicd): probe whether guarded array-item ignore rules freeze .spec.tasks

### DIFF
--- a/apps/tekton/pipelines/hum-ci.yaml
+++ b/apps/tekton/pipelines/hum-ci.yaml
@@ -59,7 +59,23 @@ spec:
     - name: shared-workspace
     - name: ssh-creds
   tasks:
+    # FREEZE PROBE (2026-07-26, temporary — remove once the result is recorded).
+    #
+    # Settles whether `select(...)`-guarded array-item jqPathExpressions in
+    # tekton-extras' ignoreDifferences actually freeze `.spec.tasks`, as the
+    # #664 EventListener incident concluded. Nothing in the repo's history
+    # discriminates: the only prior .spec.tasks change since those rules landed
+    # was adding `kind: Task`, whose value equals the server default, so live
+    # matches git whether or not updates apply. A live-patch attempt was
+    # confounded because tekton-extras sits permanently OutOfSync (ArgoCD tracks
+    # ~1680 ephemeral PipelineRuns) and selfHeal has backed off.
+    #
+    # `timeout` is inert here — hum-ci is dormant, zero retained runs — and is
+    # covered by NO ignore rule. So if the array is not frozen, this value must
+    # appear live after an explicit sync. If it does not, the freeze is real and
+    # stoa-live-mirror-sync's identical rules are a genuine hazard.
     - name: pull-and-push
+      timeout: "59m0s"
       workspaces:
         - name: source
           workspace: shared-workspace


### PR DESCRIPTION
**Temporary, one-line probe.** Merge it, I'll sync and read the result, then a follow-up removes it.

## Why this can't be answered offline

The #664 incident concluded that array-item `jqPathExpressions` freeze the array under `RespectIgnoreDifferences`. Two tripwires and the `stoa-live-mirror-sync` exemption now rest on that conclusion — but I couldn't confirm it, and I'd rather not leave three artifacts standing on an unverified belief.

**History doesn't discriminate.** The only `.spec.tasks` change since those rules landed (2026-07-06) was adding `kind: Task` — a value *identical to the server default*. Live matches git whether or not updates apply. Every other edit touched `params`/`finally`, different arrays.

**A live-patch test was confounded.** I injected a field into `.spec.tasks[0]` and it survived 230s — but so did the control label outside the array. The reason is worth knowing independently: **`tekton-extras` is permanently `OutOfSync/Degraded` because ArgoCD tracks ~1680 ephemeral PipelineRuns.** Its last sync succeeded; in that state selfHeal has backed off, so drift isn't corrected either way. Both probes were fully reverted.

## The probe

An inert `timeout: "59m0s"` inside `.spec.tasks[0]` of `hum-ci` — dormant (zero retained runs), and covered by **no** ignore rule.

| Result after an explicit sync | Meaning |
|---|---|
| `timeout` **present** live | array is NOT frozen → the `stoa-live-mirror-sync` exemption is a documented ghost, and #1 drops off the list |
| `timeout` **absent** live | freeze is real → the cross-repo fix is worth the dance, and the Pipeline/Task debt is a live hazard |

I'll sync explicitly rather than wait for selfHeal, since selfHeal demonstrably isn't acting on this app.

## Risk

Effectively nil. `hum-ci` hasn't run at all in the retained window, `timeout` is valid Tekton schema, and the follow-up removes it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)