### PR TITLE
fix(orch): expand Hermes home PVC

### DIFF
--- a/apps/hermes-agent-shell/manifests/pvc-home.yaml
+++ b/apps/hermes-agent-shell/manifests/pvc-home.yaml
@@ -15,5 +15,6 @@ spec:
       # .ssh, .gitconfig, .config/gh, and the compat .hermes.md. Its
       # pre-migration contents are seeded into the new /opt/data layout in
       # Phase 2 before it is re-pointed. Keeping the name preserves the bound
-      # Longhorn volume (no reprovision). 20Gi unchanged.
-      storage: 20Gi
+      # Longhorn volume (no reprovision). Resize it in place to provide enough
+      # headroom for Hermes, developer tooling, and transient fr worktrees.
+      storage: 40Gi

--- a/scripts/tests/test_hermes_agent_shell_home_pvc.py
+++ b/scripts/tests/test_hermes_agent_shell_home_pvc.py
@@ -1,0 +1,22 @@
+"""Guard the Hermes tool-home PVC against the worktree-exhaustion regression."""
+
+from pathlib import Path
+import re
+
+import yaml  # hard dependency declared in pyproject
+
+
+REPO = Path(__file__).resolve().parents[2]
+PVC = REPO / "apps/hermes-agent-shell/manifests/pvc-home.yaml"
+
+
+def test_hermes_tool_home_pvc_has_worktree_headroom() -> None:
+    manifest = yaml.safe_load(PVC.read_text())
+    storage = manifest["spec"]["resources"]["requests"]["storage"]
+    match = re.fullmatch(r"(\d+)Gi", storage)
+
+    assert match, "Hermes tool-home PVC must declare a GiB storage request"
+    assert int(match.group(1)) >= 40, (
+        "Hermes tool-home must request at least 40Gi: the previous 20Gi PVC "
+        "filled during fr worktree creation and blocked scheduled bookmark drains"
+    )


### PR DESCRIPTION
## Summary
- expand the bound `hermes-agent-shell-home` Longhorn PVC from 20Gi to 40Gi in place
- add a regression tripwire requiring at least 40Gi of Hermes tool-home capacity

## Incident evidence
`/opt/data/home` is this PVC and reached 100% capacity, causing fresh `fr` worktree checkout to fail with `No space left on device` before the scheduled bookmark drain could begin. Immediate recovery removed 23 clean historical checkout directories while retaining their branches/reports.

## Verification
- targeted PVC tripwire: passed
- PVC YAML parse and semantic assertions: passed
- agent configuration validation: passed
- full repository tripwire suite: **220 passed, 8 skipped**
- fresh bookmark-drain isolation worktree: created successfully and removed cleanly

## Deployment note
Longhorn should expand this existing bound volume in place after ArgoCD applies the updated PVC request; this PR does not recreate or replace the PVC.
