### PR TITLE
fix(repo): blog build check verifies its own tolerate-list excuse; bump Hextra 0.12.3

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -1,15 +1,33 @@
 name: Deploy Blog
 
+# The blog's real gate lives in build-pages (hugo build, check_blog_build.py,
+# validate-mermaid.mjs, the paper/dossier validators). Until #719 this workflow
+# had NO pull_request trigger, so none of it ran until AFTER merge: a PR could go
+# fully green while shipping a blog that does not build, or one whose CSP-dropped
+# assets leave a feature silently dead. #718 came within a diff-read of exactly
+# that. Validation now runs on PRs too; only the two deploying jobs stay
+# push-only, so a PR proves the build without publishing anything.
 on:
   push:
     branches: [main]
     paths:
       - "blog/**"
+  pull_request:
+    paths:
+      - "blog/**"
+      # the checker and validator themselves — a change to a gate must run the gate
+      - "scripts/check_blog_build.py"
+      - "scripts/validate-mermaid.mjs"
+      - ".github/workflows/deploy-blog.yml"
   workflow_dispatch:
 
+# Push runs share one serialized group, as before ("blog-deploy" -> the same
+# single lane, renamed only to key off the event). Each PR gets its OWN group so
+# a validation run can never queue behind or cancel a deploy, and superseded runs
+# on the same PR are cancelled.
 concurrency:
-  group: "blog-deploy"
-  cancel-in-progress: false
+  group: blog-deploy-${{ github.event_name == 'pull_request' && github.ref || 'main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # GitHub Pages deployment
@@ -92,6 +110,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build-pages
+    # push-only: a PR validates the build, it never publishes it
+    if: github.event_name != 'pull_request'
     permissions:
       pages: write
       id-token: write
@@ -108,6 +128,10 @@ jobs:
   build-container:
     runs-on: ubuntu-latest
     needs: build-pages
+    # push-only: it pushes an image and commits a manifest tag update, neither of
+    # which a PR validation run should ever do (and a fork PR could not anyway —
+    # `pull_request` grants a read-only token with no secrets).
+    if: github.event_name != 'pull_request'
     permissions:
       contents: write
       packages: write

--- a/blog/go.mod
+++ b/blog/go.mod
@@ -2,4 +2,4 @@ module derio-net.github.io/frank
 
 go 1.24.2
 
-require github.com/imfing/hextra v0.12.1 // indirect
+require github.com/imfing/hextra v0.12.3 // indirect

--- a/blog/go.sum
+++ b/blog/go.sum
@@ -1,2 +1,4 @@
 github.com/imfing/hextra v0.12.1 h1:3t1n0bmJbDzSTVfht93UDcfF1BXMRjeFojA071ri2l8=
 github.com/imfing/hextra v0.12.1/go.mod h1:vi+yhpq8YPp/aghvJlNKVnJKcPJ/VyAEcfC1BSV9ARo=
+github.com/imfing/hextra v0.12.3 h1:DZHY2rUWYteyzjlHi9r4n7Bb5e2Q+6LXe4C1Dqn0ZjM=
+github.com/imfing/hextra v0.12.3/go.mod h1:vi+yhpq8YPp/aghvJlNKVnJKcPJ/VyAEcfC1BSV9ARo=

--- a/scripts/check_blog_build.py
+++ b/scripts/check_blog_build.py
@@ -51,10 +51,20 @@ ALLOWED_ORIGINS = {"counter.derio.net"}
 # substring that survives minification. Anything NOT listed here fails the build,
 # so a theme bump that changes this markup surfaces as a failure and gets
 # re-reviewed rather than silently regressing.
+#
+# The value is (why, superseder) and BOTH halves are enforced. Tolerating on the
+# `why` alone was a one-directional check: it forgave the inline block without
+# ever asserting the replacement is loaded, so removing the superseder's <script>
+# tag left the build green while the behaviour died. That is not hypothetical —
+# the blog-craft v0.16.0 resync (#718) all but dropped exactly this
+# mermaid-init.js load, and this file would have said OK. `superseder` is matched
+# against the page's external <script src> values, so the excuse for tolerating
+# the inline copy has to be true ON THE SAME PAGE.
 TOLERATED_INLINE_SCRIPTS = {
     "dataset.original": (
         "hextra _partials/scripts/mermaid.html — dropped by script-src; "
-        "superseded by blog/assets/js/mermaid-init.js"
+        "superseded by blog/assets/js/mermaid-init.js",
+        "mermaid-init",
     ),
 }
 
@@ -78,8 +88,21 @@ def external_host(url: str) -> str | None:
     return None
 
 
+def external_script_srcs(html: str) -> list[str]:
+    """Every `<script src=...>` on the page. Collected in a separate pass because
+    a superseder is loaded from <head> while the inline block it replaces can sit
+    anywhere later — the check must not depend on document order."""
+    out = []
+    for m in TAG_RE.finditer(html):
+        if m.group(1).lower() == "script":
+            if src := attrs(m.group(2)).get("src", ""):
+                out.append(src)
+    return out
+
+
 def check_page(path: Path, rel: str, problems: list[str], tolerated: Counter) -> None:
     html = path.read_text(encoding="utf-8", errors="replace")
+    ext_srcs = external_script_srcs(html)
 
     for m in TAG_RE.finditer(html):
         tag = m.group(1).lower()
@@ -91,11 +114,23 @@ def check_page(path: Path, rel: str, problems: list[str], tolerated: Counter) ->
                 # Inline script: shipped, parsed, and then dropped by script-src.
                 body = html[m.end() : m.end() + 400]
                 known = next(
-                    (why for mark, why in TOLERATED_INLINE_SCRIPTS.items() if mark in body),
+                    (v for mark, v in TOLERATED_INLINE_SCRIPTS.items() if mark in body),
                     None,
                 )
                 if known:
-                    tolerated[known] += 1
+                    why, superseder = known
+                    if any(superseder in s for s in ext_srcs):
+                        tolerated[why] += 1
+                        continue
+                    problems.append(
+                        f"{rel}: inline <script> is tolerated only because "
+                        f"{superseder!r} supersedes it, but this page loads no "
+                        f"<script src> matching that — so the inline copy is "
+                        f"dropped by the CSP and nothing replaces it. The "
+                        f"behaviour is silently dead; restore the external asset "
+                        f"(or drop the TOLERATED_INLINE_SCRIPTS entry if the "
+                        f"theme no longer needs superseding)"
+                    )
                     continue
                 snippet = body[:90].replace("\n", " ").strip()
                 problems.append(

--- a/scripts/tests/test_check_blog_build_supersession.py
+++ b/scripts/tests/test_check_blog_build_supersession.py
@@ -1,0 +1,75 @@
+"""check_blog_build.py must enforce BOTH halves of a tolerated inline script.
+
+An entry in TOLERATED_INLINE_SCRIPTS says "this inline block is inert because an
+external asset already does the work". Only the first half was ever checked: the
+block was forgiven on a keyword match, and nothing asserted the replacement was
+loaded. Removing the superseder's <script> tag therefore left the build GREEN
+while the behaviour died — which is very nearly what the blog-craft v0.16.0
+resync (#718) did to blog/assets/js/mermaid-init.js. It was caught by reading the
+diff, not by this checker.
+
+A tolerate-list that does not verify its own excuse is worse than no entry at
+all: it converts a loud failure into a silent one, and reads as coverage.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "scripts" / "check_blog_build.py"
+
+# The theme's inline mermaid init, keyed the way the checker keys it.
+INLINE_THEME_MERMAID = (
+    '<script>document.querySelectorAll(".mermaid").forEach((el)=>{'
+    'el.dataset.original=el.innerHTML;});</script>'
+)
+SUPERSEDER = '<script src=/frank/js/mermaid-init.min.abc123.js defer></script>'
+
+
+def _run(tmp_path, html, name="index.html"):
+    site = tmp_path / "public"
+    site.mkdir(exist_ok=True)
+    (site / name).write_text("<!DOCTYPE html><html><body>%s</body></html>" % html)
+    r = subprocess.run([sys.executable, str(CHECKER), str(site)],
+                       capture_output=True, text=True)
+    return r.returncode, r.stdout + r.stderr
+
+
+def test_tolerated_when_the_superseder_is_loaded(tmp_path):
+    """The normal case: theme block present, external replacement present."""
+    rc, out = _run(tmp_path, SUPERSEDER + INLINE_THEME_MERMAID)
+    assert rc == 0, out
+    assert "tolerated 1x" in out, out
+
+
+def test_fails_when_the_superseder_is_missing(tmp_path):
+    """The regression this test exists for. Same inline block, no replacement —
+    previously reported OK, which is how a dead feature ships unnoticed."""
+    rc, out = _run(tmp_path, INLINE_THEME_MERMAID)
+    assert rc != 0, "a tolerated inline script with NO superseder must FAIL:\n" + out
+    assert "supersedes it" in out or "silently dead" in out, out
+
+
+def test_an_unrelated_external_script_does_not_satisfy_the_excuse(tmp_path):
+    """The superseder is matched by name, not by 'some script exists'. Without
+    this, any page with any <script src> would satisfy every tolerate entry."""
+    rc, out = _run(
+        tmp_path,
+        '<script src=/frank/js/read-tracker.min.def456.js defer></script>'
+        + INLINE_THEME_MERMAID,
+    )
+    assert rc != 0, "an unrelated external script must not satisfy the excuse:\n" + out
+
+
+def test_order_does_not_matter(tmp_path):
+    """The superseder loads from <head>; the theme's block can appear anywhere
+    later. A single-pass check that only looked backwards would be order-fragile."""
+    rc, out = _run(tmp_path, INLINE_THEME_MERMAID + SUPERSEDER)
+    assert rc == 0, out
+
+
+def test_an_untolerated_inline_script_still_fails(tmp_path):
+    """The original invariant must survive the change."""
+    rc, out = _run(tmp_path, "<script>alert(1)</script>")
+    assert rc != 0, out
+    assert "inline <script>" in out, out


### PR DESCRIPTION
Two commits, ordered on purpose. Follow-up to #718.

## 1. `check_blog_build.py` only enforced half of its own rule

`TOLERATED_INLINE_SCRIPTS` says *"this inline block is inert because an external asset already does the work."* Only the first half was checked — the block was forgiven on a keyword match, and **nothing asserted the replacement was loaded**. Remove the superseder's `<script>` tag and the build stays green while the behaviour dies.

Not hypothetical: **#718 all but dropped this exact `mermaid-init.js` load.** Hextra initialises mermaid from an inline `<script>` that `script-src 'self'` discards; `mermaid.js` self-starts, so diagrams still *appear* — frozen in the light theme, across ~80 posts. `check_blog_build.py` would have printed `OK`. It was caught by reading the diff, which is not a control.

The value is now `(why, superseder)`, matched against the page's external `<script src>` values — so the excuse has to be true **on the same page**. Collected in a separate pass, because the superseder loads from `<head>` while the block it replaces sits later; an order-dependent check would be fragile in the one direction that matters.

**The checker had no test at all**, so a strengthened check could itself go vacuous. `scripts/tests/test_check_blog_build_supersession.py` pins five directions:

| | |
|---|---|
| superseder present | tolerated, exit 0 |
| superseder **absent** | **FAILS** ← the regression |
| unrelated external script | does **not** satisfy the excuse |
| block before/after superseder | order-independent |
| untolerated inline script | original invariant still fires |

That third one matters: without it, any page with any `<script src>` would satisfy every entry.

## 2. Hextra 0.12.1 → 0.12.3

Deliberate this time. #718 picked this up **by accident** — `hugo mod get` fetches *and* upgrades, and the theme is a Hugo module, so "get the modules" silently moved the pin. It was reverted there and the build re-verified on 0.12.1.

The guard lands **first** so it's in force for the bump. A theme bump is precisely what can invalidate a tolerate entry — by changing the markup the key matches, or by fixing it upstream so the entry is redundant. Bumping first and strengthening later would have verified nothing.

Checked rather than assumed: `layouts/_partials/scripts/mermaid.html` is **byte-identical** between the two versions, so the `dataset.original` key still matches and `mermaid-init.js` is still required. Real surface did move (`baseof.html`, footer, sidebar, toc, 404, giscus, several shortcodes, `flexsearch.js`, search-data schema) — not a no-op release.

## Verification (dev devcontainer, on 0.12.3)

- `hugo --minify` — 141 pages, no errors
- `check_blog_build.py` — OK, 112 pages; tolerates the inline mermaid init 80× **and** now confirms `mermaid-init.js` is loaded on each
- `validate-mermaid.mjs` — 198 blocks OK
- `pytest scripts/tests/` — **245 passed, 1 xfailed** (240 on this base + 5 new; the base moved from the 226 measured during #718 because `f1fa4580` added three kid-laptops test files)
- `mermaid-init.js` in the built output on 111 pages

No incidental artifacts: `git status` before staging showed only `go.mod`/`go.sum` — no `_vendor`, no lockfile churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)