### PR TITLE
docs(blog): back-link operating/30 from the four posts it cites

### DIFF
--- a/blog/content/_index.md
+++ b/blog/content/_index.md
@@ -25,13 +25,13 @@ layout: hextra-home
   {{< card
     link="docs/building/"
     title="Building Frank"
-    subtitle="29 posts — from bare metal to a fully operational AI-hybrid cluster."
+    subtitle="From bare metal to a fully operational AI-hybrid cluster."
     image="/images/tile-building.png"
   >}}
   {{< card
     link="docs/operating/"
     title="Operating on Frank"
-    subtitle="20 posts — day-to-day commands, health checks, and debugging guides."
+    subtitle="Day-to-day commands, health checks, and debugging guides."
     image="/images/tile-operating.png"
   >}}
   {{< card

--- a/blog/content/docs/building/35-gitea-actions-ci/index.md
+++ b/blog/content/docs/building/35-gitea-actions-ci/index.md
@@ -9,7 +9,7 @@ summary: "GitHub Actions burned its free tier in 19 days, so the workflows now r
 weight: 36
 reader_goal: "Run your GitHub Actions workflows unchanged on a self-hosted Gitea mirror — runner, status writeback, parallel-safety — and diagnose the three failure modes that bite."
 diataxis: [how-to, explanation]
-last_updated: 2026-07-20
+last_updated: 2026-07-27
 ---
 
 On July 19th at around noon, my GitHub Actions free tier died. Not "ran low" —
@@ -311,6 +311,35 @@ failing runs' logs show every *test* step green and only the artifact upload
 red, which is exactly the shape that tempts you to shrug and move on. Don't:
 on one repo the artifact step ran under `if: always()` with
 `if-no-files-found: error`, which failed every mirror run outright.
+
+**The fourth thing, a week later (added 2026-07-27).** Moving CI onto the
+cluster moved its *cost* onto the cluster too, in a currency nobody was
+watching: Kubernetes objects. At roughly 260 PipelineRuns a day against a
+7-day retention {{< abbr "TTL" >}}, the cluster accumulated ~1,800
+PipelineRuns — and **1,932 of Frank's 2,124 pods were completed Tekton
+pods**. Three of every four pods on the cluster were dead CI.
+
+Nothing was wrong with that, until it crossed a limit nobody had considered
+alongside it. `kube_pod_*` grew to 108,460 of ~120,000 kube-state-metrics
+series, pushing its `/metrics` payload to 21.6 MiB — past vmagent's default
+`-promscrape.maxScrapeSize` of 16 MiB. VictoriaMetrics discards an oversized
+response **whole**, so every `kube_*` series vanished and all 25 `kube_*`
+references in the Grafana alert rules evaluated against nothing. Ironically,
+two of them were `kube_cronjob_status_last_successful_time` — the rule that
+reports a CronJob no longer succeeding was among the blinded, while the
+PipelineRun {{< abbr "GC" >}} CronJob had itself started failing.
+
+The fix was two independent changes, deliberately: the scrape cap went to
+32MB, and retention went 7 days → 3. The first sweep at the new TTL removed
+1,369 of 1,820 PipelineRuns in 100 seconds and took the cluster from 2,124
+pods to 656, and the scrape payload from 21.6 MiB to 7.3 MiB. Either change
+alone would have cleared the blackout; keeping both means alerting does not
+depend on a CI hygiene setting, and CI hygiene is not load-bearing for
+observability.
+
+The lesson generalises past Tekton: **a migration that changes where work
+runs also changes what that work costs, in units the destination measures.**
+Full write-up in [Operating on Green]({{< relref "/docs/operating/30-silent-failure" >}}).
 
 **On parallel running.** GitHub Actions stays enabled through August; the
 free tier resets on the 1st and the parallel week costs a few hundred of the

--- a/blog/content/docs/operating/02-storage-backups/index.md
+++ b/blog/content/docs/operating/02-storage-backups/index.md
@@ -9,7 +9,7 @@ summary: "Day-to-day commands for managing Longhorn volumes, checking backup hea
 weight: 3
 reader_goal: "Check Longhorn volume health, manage R2 backups, expand a volume, restore from backup, and debug degraded volumes, failed backups, or stuck attachments — without relying on the Longhorn UI."
 diataxis: [how-to, reference]
-last_updated: 2026-07-15
+last_updated: 2026-07-27
 last_updated_commit: https://github.com/derio-net/frank/commit/a8bed9a1d358b7ad87bb6dcaa9b0162e5fb0e127
 ---
 
@@ -158,6 +158,33 @@ The underlying Longhorn volume and filesystem expand automatically. No pod resta
 ```bash
 xfs_growfs /
 ```
+
+**"Automatically" assumes Longhorn accepts the request — and it may not.** Longhorn's provisioning ceiling counts each replica's *declared* size, not bytes written, so a node can be half-empty and still refuse to grow a volume:
+
+```
+size + StorageScheduled <= (StorageMax - StorageReserved) * overProvisioningPercentage%
+```
+
+When that clause fails, the API server still accepts the patch and ArgoCD still reports `Synced` — `status.capacity.storage` simply never changes. Measured 2026-07-27 while growing a 20Gi volume: two of its three replicas sat on nodes with 5Gi and **−4Gi** of headroom, while those disks were roughly 55% physically written.
+
+So check headroom on the nodes hosting the replicas *before* expanding:
+
+```bash
+kubectl -n longhorn-system get nodes.longhorn.io -o json | jq -r '
+  .items[] | .metadata.name as $n |
+  (.status.diskStatus | to_entries[] |
+    "\($n) scheduled=\((.value.storageScheduled/1073741824)|floor)Gi " +
+    "max=\((.value.storageMaximum/1073741824)|floor)Gi")'
+```
+
+and verify afterwards against the artifact rather than the sync status:
+
+```bash
+kubectl -n <namespace> get pvc <pvc-name> -o jsonpath='{.status.capacity.storage}{"\n"}'
+kubectl -n <namespace> exec deploy/<app> -- df -h <mountpath>
+```
+
+Frank's ceiling was raised from the chart default of 100% to 150% (`apps/longhorn/values.yaml`); the physical guard, `storageMinimalAvailablePercentage: 15`, is untouched and remains what actually prevents filling a disk. Full treatment of this failure mode in [Operating on Green]({{< relref "/docs/operating/30-silent-failure" >}}).
 
 ### Trigger a Manual Backup
 

--- a/blog/content/docs/operating/23-argocd-drift-detective/index.md
+++ b/blog/content/docs/operating/23-argocd-drift-detective/index.md
@@ -9,7 +9,7 @@ summary: "How 20 of 52 ArgoCD apps were permanently OutOfSync, why it was seven 
 weight: 24
 reader_goal: "Diagnose and fix ArgoCD OutOfSync drift by classifying the root cause — CRD defaults, phantom diffs, orphan CRDs, zombie sub-charts, namespace fights, terminal hooks, and chart-operator disagreement."
 diataxis: [how-to, reference]
-last_updated: 2026-07-15
+last_updated: 2026-07-27
 last_updated_commit: https://github.com/derio-net/frank/commit/951c0c40
 ---
 
@@ -192,6 +192,33 @@ Symptom: apps where the chart or operator injects fields git doesn't specify —
 | infisical Deployment | `updatedAt: "2026-04-04 UTC 21:31:24"` (stamped every render) | `ignoreDifferences` |
 | infisical-postgresql {{< abbr "PDB" >}} | `maxUnavailable: ""` diverges from K8s default | `pdb.create: false` in values |
 
+### Class H: Stale Revision — the inverse failure (added 2026-07-27)
+
+Classes A–G are all the same shape: `OutOfSync` that means nothing. This one is the mirror image — **`Synced` that means nothing** — and it is worse, because the first kind is merely noisy while this kind is silent.
+
+Symptom: an Application reports `Synced/Healthy` minutes after a merge, while the live resource still holds pre-merge content. Seen twice in one session on 2026-07-27: `longhorn`'s rendered ConfigMap was missing a key the merged values add, and `hermes-agent-shell`'s PVC still requested the pre-merge size. `argocd.argoproj.io/refresh: hard` did **not** clear either.
+
+There is no `ignoreDifferences` fix here, because nothing is drifting. `Synced` is a claim about live matching *what ArgoCD fetched*, not about live matching `main`.
+
+Rule out your own manifest first — a chart silently dropping an unrecognised key looks identical from the cluster:
+
+```bash
+helm template <release> <chart> --version <ver> -f <values> | grep -A5 'name: <rendered-object>'
+```
+
+If the key renders locally and is absent live while the app claims `Synced`, force a real sync operation:
+
+```bash
+kubectl -n argocd patch application <app> --type=merge \
+  -p '{"operation":{"sync":{"revision":"HEAD","syncOptions":["ServerSideApply=true","RespectIgnoreDifferences=true"]}}}'
+```
+
+Both cleared within seconds. Multi-source apps (upstream chart + a `$values` ref into this repo) look the most exposed, though the underlying cause was never established — the recovery is known, the mechanism is not.
+
+Distinguish it from ordinary poll lag before acting: an Application that has simply not polled the newest commit yet converges on its own within a few minutes and was never wrong, only behind. Compare `.status.sync.revision` against the commit you merged and wait one poll interval before forcing anything.
+
+The wider pattern — four distinct ways a green tile diverges from reality, and the check for each — is [Operating on Green]({{< relref "/docs/operating/30-silent-failure" >}}).
+
 ## The Unmasked Bug
 
 The most important fix wasn't about any of the seven drift classes.
@@ -236,3 +263,4 @@ I had a `trafficRouterPlugins` entry in `values.yaml` pointing at a Cilium plugi
 - [Operating on GitOps]({{< relref "/docs/operating/03-gitops" >}})
 - [ArgoCD `ignoreDifferences`](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/)
 - [Kubernetes ServerSideApply](https://kubernetes.io/docs/reference/using-api/server-side-apply/)
+- [Operating on Green]({{< relref "/docs/operating/30-silent-failure" >}}) — four ways a green tile diverges from reality

--- a/blog/content/docs/operating/28-hermes-shell/index.md
+++ b/blog/content/docs/operating/28-hermes-shell/index.md
@@ -9,7 +9,7 @@ summary: "Checking the Hindsight memory sidecar's health, the two-tier memory ba
 weight: 29
 reader_goal: "Verify Hindsight memory health, back up and restore the memory database, diagnose retain-vs-recall failures, and connect via SSH/Mosh."
 diataxis: [how-to, reference]
-last_updated: 2026-07-15
+last_updated: 2026-07-27
 last_updated_commit: https://github.com/derio-net/frank/commit/4541ee68
 ---
 
@@ -148,6 +148,30 @@ kubectl -n hermes-agent-shell exec -c hindsight deploy/hermes-agent-shell -- \
 
 If not authenticated, log in: `kubectl exec -it -n hermes-agent-shell -c hindsight deploy/hermes-agent-shell -- claude` and complete the OAuth flow. Recall (local `BAAI/bge-small-en-v1.5` embeddings) is unaffected — it works without any {{< abbr "LLM" >}} auth.
 
+### The Tool-Home Volume Fills
+
+`hermes-agent-shell-home` is `$HOME` for every container, mounted at `/opt/data/home`. It reached 100% on 2026-07-27, which failed a fresh `fr` worktree checkout with `No space left on device`. Nothing alerted — there is still no PVC capacity rule.
+
+It is **not** a dotfile volume, which is how it came to be sized at 20Gi. Measured at 19G used:
+
+```
+.local/opt/hermes-agent   6.0G   the PVC-resident Hermes venv
+.vscode-server            3.3G
+.cache                    1.9G   playwright, uv, huggingface, pip, fr
+.local/{micromamba,share} 2.5G   mise, mamba, uv, claude
+worktrees                 1.3G   fr isolation checkouts
+```
+
+Growth is dominated by tool installs and caches — the worktrees that exposed it are ~7%. So prune caches before reaching for more capacity:
+
+```bash
+# -x matters: `repos` is a SEPARATE PVC mounted inside home, so du double-counts without it
+kubectl -n hermes-agent-shell exec -c ssh deploy/hermes-agent-shell -- \
+  du -xh -d 2 /opt/data/home | sort -h | tail -25
+```
+
+The volume was expanded 20Gi → 40Gi (`apps/hermes-agent-shell/manifests/pvc-home.yaml`, guarded by `scripts/tests/test_hermes_agent_shell_home_pvc.py`). If you expand it again, check Longhorn provisioning headroom first — the ceiling counts declared replica size, not bytes written, and refuses silently. See [Storage and Backups]({{< relref "/docs/operating/02-storage-backups" >}}) and [Operating on Green]({{< relref "/docs/operating/30-silent-failure" >}}).
+
 ## Missteps
 
 | What we assumed | Why it was wrong | What it cost |
@@ -174,3 +198,4 @@ If not authenticated, log in: `kubectl exec -it -n hermes-agent-shell -c hindsig
 - [willikins#285](https://github.com/derio-net/willikins/issues/285) — official-image migration
 - `docs/runbooks/frank-gotchas/agent-shells.md` — restore mechanic detail
 - [Operating on Local Inference]({{< relref "/docs/operating/07-inference" >}})
+- [Operating on Green]({{< relref "/docs/operating/30-silent-failure" >}}) — four ways a green tile diverges from reality


### PR DESCRIPTION
Follow-up to #726. That post links **out** to four earlier posts; none of them linked back, and each was missing the finding that belongs in it. This makes the cross-links reciprocal — and corrects one claim the incident actually disproved.

## The four

**`operating/23-argocd-drift-detective` — new Class H.** Classes A–G are all flavours of *`OutOfSync` meaning nothing*. This is the mirror image — ***`Synced` meaning nothing*** — and it's worse, because the first kind is merely noisy while this kind is silent. No `ignoreDifferences` fix applies, because nothing is drifting: `Synced` is a claim about live matching *what ArgoCD fetched*, not `main`.

Includes the `helm template` rule-out (a chart silently dropping an unrecognised key looks identical from the cluster) and — the part I'd have got wrong yesterday — **how to distinguish it from ordinary poll lag**. An Application that simply hasn't polled the newest commit converges on its own in a few minutes and was never wrong, only behind. I hit exactly that while verifying #726 and nearly wrote it up as a fifth incident.

**`operating/02-storage-backups` — a correction, not just an addition.** The post said *"the underlying Longhorn volume and filesystem expand automatically."* They do — **if Longhorn accepts the request**. The provisioning ceiling counts each replica's *declared* size, not bytes written, so a half-empty node can refuse; the API server still accepts the patch and ArgoCD still reports `Synced` while `status.capacity` never moves. Adds the headroom pre-check and the verify-the-artifact step.

**`operating/28-hermes-shell` — new "The Tool-Home Volume Fills" recovery section.** With the measured breakdown, because the volume was sized as if it held dotfiles and it holds 6.0G of PVC-resident venv, 3.3G of `.vscode-server` and 1.9G of caches. The fr worktrees that exposed it are ~7%. Notes the `du -x` trap: `repos` is a separate PVC mounted *inside* `home`, so it double-counts without it.

**`building/35-gitea-actions-ci` — the fourth thing the migration flushed out, a week later.** Moving CI onto the cluster moved its cost into a currency nobody was watching: **1,932 of 2,124 pods were completed Tekton pods**, which pushed kube-state-metrics past vmagent's scrape cap and blinded every `kube_*` alert rule. Retention 7 → 3 days took the cluster to 656 pods. The generalisable line: *a migration that changes where work runs also changes what that work costs, in units the destination measures.*

## Also: homepage post counts

Per operator request. The cards read `20 posts — day-to-day commands…` (Operating) and `29 posts — from bare metal…` (Building). Both hardcoded and both stale — Operating has 30, Building has 36. The Papers card already carried no count, so all three now match that shape and stop needing maintenance.

## Notes

`last_updated` bumped on all four. `last_updated_commit` deliberately left alone — it cannot name a commit that hasn't been written yet, and the field already lags on other posts rather than being backfilled.

## Verification

- educational gate: **passes on all four**
- glossary validator: **OK** — 142 entries, 554 markers blog-wide
- `hugo --buildDrafts`: **exit 0**, so every new `relref` resolves
- repo tripwires: **339 passed, 1 xfailed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)