### PR TITLE
chore(repo): resync the blog to blog-craft v0.18.0 (AI-tells lint layer)

### DIFF
--- a/.blog-craft.yaml
+++ b/.blog-craft.yaml
@@ -1,5 +1,5 @@
 version: 5
-blog_craft_version: "v0.17.0"   # blog-craft RELEASE frank is synced to (was v0.16.1).
+blog_craft_version: "v0.18.0"   # blog-craft RELEASE frank is synced to (was v0.17.0).
                                 # update.py re-renders AT this tag to recover the
                                 # 3-way merge base — a wrong value silently degrades
                                 # every `merged` path to a baseless conflict. Bump

--- a/blog/scripts/ai-tells.md
+++ b/blog/scripts/ai-tells.md
@@ -1,0 +1,177 @@
+# AI-tells catalog — patterns that make prose read machine-written
+
+Adapted from [@blader's humanizer skill](https://github.com/blader/humanizer)
+and Wikipedia's WikiProject AI Cleanup
+["Signs of AI writing"](https://en.wikipedia.org/wiki/Wikipedia:WikiProject_AI_Cleanup/Signs_of_AI_writing).
+
+Each family below has a one-line description, a bad → good example pair, and
+the fix rule. Apply this catalog as a **mandatory self-revision pass** on every
+draft: read the draft once looking only for these patterns, and rewrite each
+hit. The validator's lint layer derives its word lists and thresholds from the
+machine-readable block at the bottom of this file — the prose and the mechanics
+share one source and cannot drift apart.
+
+## AI vocabulary
+
+Words and stock phrases that LLMs reach for far more often than working
+engineers do; each one is a fingerprint.
+
+- Bad: "Let's delve into the ever-evolving realm of container networking."
+- Good: "Container networking has three moving parts; here's the one that bit us."
+- Fix: replace each flagged word with the plain word a colleague would say out
+  loud — dig into, changing, area — or delete the sentence if it says nothing.
+
+## Rule of three (triads)
+
+Grouping everything into rhythmic three-item lists ("fast, simple, and
+reliable") regardless of whether the content has three parts.
+
+- Bad: "The migration was quick, painless, and effective."
+- Good: "The migration took twenty minutes and nothing broke."
+- Fix: count the real items. If there are two, write two; if the list is
+  decorative, replace it with the one concrete fact you actually have.
+
+## Negative parallelisms
+
+The "not X, but Y" / "it isn't about X, it's about Y" seesaw — asserting by
+first denying a strawman.
+
+- Bad: "This isn't about saving disk space, it's about protecting your data."
+- Good: "Snapshots protect your data; the disk savings are incidental."
+- Fix: state the positive claim directly. If the contrast genuinely matters,
+  give the reader the evidence for it instead of the rhetorical shape.
+
+## Em-dash overuse
+
+Em dashes stitching together clauses that wanted a period, a comma, or a
+rewrite — several per paragraph is a tell.
+
+- Bad: "The cache was stale — not corrupted — which meant the fix — clearing it — was safe."
+- Good: "The cache was stale rather than corrupted, so clearing it was safe."
+- Fix: keep an em dash only where a deliberate interruption earns it; convert
+  the rest to periods or commas.
+
+## Inflated symbolism
+
+Framing routine work as emblematic: "a testament to," "underscores the
+importance of," "marks a pivotal moment."
+
+- Bad: "This bugfix is a testament to the power of systematic debugging."
+- Good: "Bisecting the config found the bad key in four steps."
+- Fix: delete the symbolism and report what happened. Significance the reader
+  can't derive from the facts wasn't there.
+
+## Promotional language
+
+Marketing adjectives welded onto technical nouns: seamless integration,
+game-changing performance, supercharged workflow.
+
+- Bad: "The seamless integration supercharges your deployment workflow."
+- Good: "Deploys now run in CI; nobody SSHes into the box anymore."
+- Fix: replace every claim of quality with the measurement or behavior change
+  that would justify it.
+
+## Superficial "-ing" analyses
+
+Trailing participial clauses that fake analysis: "..., highlighting the
+importance of testing," "..., showcasing the framework's flexibility."
+
+- Bad: "The service crashed under load, highlighting the importance of monitoring."
+- Good: "The service crashed under load. We had no alert on file descriptors; now we do."
+- Fix: cut the participial clause and, if the point matters, give it its own
+  sentence with its own evidence.
+
+## Vague attributions
+
+Ghost authorities: "industry experts say," "many developers believe," "it is
+widely considered."
+
+- Bad: "Many experts consider connection pooling a best practice."
+- Good: "Postgres caps connections at 100 by default; without pooling we hit it in a week."
+- Fix: name the source or own the claim yourself. If neither is possible, the
+  claim doesn't belong in the post.
+
+## Conjunctive-phrase excess
+
+Furthermore/Moreover/Additionally chains gluing paragraphs together instead of
+actual logical flow.
+
+- Bad: "Furthermore, the API is versioned. Moreover, it supports pagination. Additionally, it returns JSON."
+- Good: "The API is versioned, paginated, and returns JSON — table stakes; the interesting part is the cursor design."
+- Fix: delete the connective and check whether the paragraphs still follow. If
+  they don't, the problem is the ordering, not the missing glue word.
+
+## Cliché conclusions
+
+Endings that open with "In conclusion" / "Ultimately" / "At the end of the
+day" and then recap what the post already said.
+
+- Bad: "In conclusion, we learned that monitoring, testing, and documentation are essential."
+- Good: "The portable rule: alert on the resource you'll exhaust first, not the one that's easy to graph."
+- Fix: end with what transfers — the general rule or heuristic the reader
+  keeps — not a summary of the journey.
+
+## Machine-readable lint data
+
+The validator (`tools/validate_educational.py::load_lint_data`) parses this
+block. Edit the lists here; never in the tool.
+
+```yaml
+vocabulary:
+  - delve
+  - delves
+  - delving
+  - delved
+  - tapestry
+  - a testament to
+  - seamless
+  - seamlessly
+  - game-changer
+  - game-changing
+  - ever-evolving
+  - in today's fast-paced
+  - treasure trove
+  - supercharge
+  - supercharges
+  - supercharged
+  - supercharging
+  - revolutionize
+  - revolutionizes
+  - revolutionized
+  - revolutionizing
+  - harness the power
+  - embark
+  - embarks
+  - embarked
+  - embarking
+  - realm
+  - myriad
+  - plethora
+  - boasts
+  - boasting
+  - boasted
+conclusion_openers:
+  - in conclusion
+  - ultimately
+  - in the end
+  - at the end of the day
+  - all in all
+  - in summary
+patterns:
+  negative_parallelism: "\\bnot (?:just |only |merely |simply )?[^.;:]{3,40}[,;] but\\b|\\bisn'?t about [^.;:]{3,40}[,;.] it'?s about\\b"
+  triad: "\\b\\w+, \\w+, and \\w+\\b"
+thresholds:
+  em_dash_per_1000: 8
+  negative_parallelisms_per_1000: 2
+  triads_per_1000: 3
+transfer_headings:
+  - what transfers
+  - what you keep
+  - takeaway
+  - takeaways
+```
+
+Deliberately **excluded** from the fail list because they have legitimate
+technical uses: *underscore* (the character), *landscape* (this methodology's
+own term), *deep dive* (the repo's explainer vocabulary), *robust* / *crucial*
+/ *leverage* (common legit tech usage).

--- a/blog/scripts/validate_educational.py
+++ b/blog/scripts/validate_educational.py
@@ -17,6 +17,15 @@ Enforced (each toggle lives in `quality.gate`):
   - diagram          how-to / tutorial posts carry >= 1 ```mermaid block
                      (waive one post with `diagram_exempt: <reason>`)
 
+Lint layer (warnings-first; config block `quality.lint`, data from the fenced
+yaml block in skills/educational-writing/references/ai-tells.md — in a
+materialized blog, the sibling scripts/ai-tells.md):
+  - ai-vocabulary hits FAIL by default; em-dash / negative-parallelism / triad
+    densities, cliche conclusion openers, and a missing what-transfers section
+    on tutorial/explanation posts WARN. Per-check severity: fail | warn | off.
+    Lint failures exit nonzero alongside gate failures; warnings never do.
+    `quality.lint.enabled: false` skips the lint (gate-only run).
+
 Scope: only `content_type: posts` posts. Papers and explainers ship their own
 validators and their own structure, so a post whose series is a papers/explainers
 content-type is skipped. A post may opt out with `quality_exempt: <reason>` in
@@ -32,6 +41,7 @@ from __future__ import annotations
 
 import re
 import sys
+from pathlib import Path
 
 # Canonical Diataxis modes (see references/diataxis.md). Aliases normalize in.
 _DIATAXIS = {"tutorial", "how-to", "reference", "explanation"}
@@ -65,6 +75,53 @@ _DEFAULT_GATE = {
 
 # Diátaxis modes that teach a procedure — these must carry a diagram.
 _DIAGRAM_MODES = {"how-to", "tutorial"}
+
+# Lint layer (warnings-first, spec §5): built-in per-check severities. Only the
+# conservative vocabulary list fails by default — densities warn so prose is
+# never written to a regex. Overridable via `quality.lint.severities`
+# (fail | warn | off). Thresholds come from the ai-tells data block,
+# overridable via `quality.lint.thresholds`.
+_LINT_SEVERITIES = {
+    "vocabulary": "fail",
+    "em_dash": "warn",
+    "negative_parallelism": "warn",
+    "triad": "warn",
+    "conclusion": "warn",
+    "what_transfers": "warn",
+}
+
+
+def load_lint_data(path: str | None = None) -> dict:
+    """Parse the fenced yaml block in ai-tells.md (single source for lint data).
+
+    Resolution order: explicit `path` → the plugin checkout
+    (skills/educational-writing/references/ai-tells.md) → a sibling ai-tells.md
+    next to this script (how a materialized blog ships it — scripts/ has no
+    skills/ tree). Raises FileNotFoundError when no candidate exists; the CLI
+    turns that into a loud LINT SKIPPED, never a crash.
+    """
+    import yaml
+    here = Path(__file__).resolve().parent
+    candidates = (
+        [Path(path)]
+        if path
+        else [
+            here.parent / "skills/educational-writing/references/ai-tells.md",
+            here / "ai-tells.md",
+        ]
+    )
+    for p in candidates:
+        if not p.is_file():
+            continue
+        m = re.search(r"```yaml\n(.*?)```", p.read_text(encoding="utf-8"), re.DOTALL)
+        if not m:
+            raise ValueError(f"no fenced yaml block in {p}")
+        return yaml.safe_load(m.group(1))
+    raise FileNotFoundError(
+        "ai-tells.md not found (looked at: "
+        + ", ".join(str(p) for p in candidates)
+        + ")"
+    )
 
 
 def split_frontmatter(text: str) -> tuple[dict, str]:
@@ -211,6 +268,139 @@ def validate_post(fm: dict, body: str, gate: dict | None = None) -> list[str]:
     return fails
 
 
+# ------------------------------------------------------------------ lint layer
+
+def _prose_lines(body: str) -> list[str]:
+    """The lines of *body* outside fenced code blocks.
+
+    Fence tracking follows CommonMark's closing rule: a block opened by a
+    fence of N backticks/tildes closes only on a fence of the SAME character
+    at least N long — so a ````markdown block that itself contains ``` lines
+    stays one block, and its inner content never leaks into the prose scan.
+    """
+    out: list[str] = []
+    fence_char = ""
+    fence_len = 0
+    for line in body.splitlines():
+        m = re.match(r"^(`{3,}|~{3,})", line.strip())
+        if m:
+            marker = m.group(1)
+            if not fence_char:  # opening fence
+                fence_char = marker[0]
+                fence_len = len(marker)
+            elif marker[0] == fence_char and len(marker) >= fence_len:
+                fence_char = ""  # closing fence
+                fence_len = 0
+            # else: a shorter/other-char fence inside an open block is content
+            continue
+        if fence_char:
+            continue
+        out.append(line)
+    return out
+
+
+def _prose_only(body: str) -> str:
+    """Prose with fenced code blocks, inline code spans, and heading markup gone.
+
+    The lint must never fire on code — a command containing "delve" is not a
+    tell. Heading TEXT stays (it is prose); only the leading #s are stripped.
+    Typographic apostrophes normalize to ASCII so "isn’t" matches "isn't".
+    """
+    out = [re.sub(r"^#{1,6}\s+", "", line) for line in _prose_lines(body)]
+    text = re.sub(r"`[^`\n]+`", " ", "\n".join(out))
+    return text.replace("’", "'")
+
+
+def lint_post(
+    fm: dict, body: str, lint_cfg: dict | None = None, data: dict | None = None
+) -> tuple[list[str], list[str]]:
+    """AI-tells lint (warnings-first). Returns (failures, warnings).
+
+    `lint_cfg` is the config's `quality.lint` dict (may be None); `data` is the
+    parsed ai-tells block (defaults to load_lint_data()). Matching is
+    case-insensitive and runs over _prose_only(body) — code and frontmatter
+    never trip the lint.
+    """
+    if data is None:
+        data = load_lint_data()
+    cfg = lint_cfg or {}
+    severities = dict(_LINT_SEVERITIES)
+    severities.update(cfg.get("severities") or {})
+    thresholds = dict(data.get("thresholds") or {})
+    thresholds.update(cfg.get("thresholds") or {})
+
+    prose = _prose_only(body)
+    low = prose.lower()
+    words = max(len(prose.split()), 1)
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    def emit(check: str, msg: str) -> None:
+        sev = severities.get(check, "warn")
+        if sev == "fail":
+            failures.append(msg)
+        elif sev == "warn":
+            warnings.append(msg)
+        # "off" drops the message entirely
+
+    # vocabulary: word/phrase-boundary count per entry
+    for term in data.get("vocabulary") or []:
+        n = len(re.findall(r"\b" + re.escape(str(term).lower()) + r"\b", low))
+        if n:
+            emit("vocabulary", f"ai-vocabulary: '{term}' ({n}x)")
+
+    # em-dash density per 1000 words
+    t = thresholds.get("em_dash_per_1000")
+    if t is not None:
+        d = prose.count("—") * 1000.0 / words
+        if d > t:
+            emit("em_dash", f"em-dash density {d:.1f}/1000 words (threshold {t})")
+
+    # regex-pattern densities per 1000 words
+    patterns = data.get("patterns") or {}
+    for check, tkey, label in (
+        ("negative_parallelism", "negative_parallelisms_per_1000",
+         "negative-parallelism (not X, but Y)"),
+        ("triad", "triads_per_1000", "triad (rule of three)"),
+    ):
+        pat = patterns.get(check)
+        t = thresholds.get(tkey)
+        if pat and t is not None:
+            d = len(list(re.finditer(pat, low))) * 1000.0 / words
+            if d > t:
+                emit(check, f"{label} density {d:.1f}/1000 words (threshold {t})")
+
+    # what-transfers: tutorial/explanation posts end with what the reader KEEPS.
+    # Keys off the diataxis frontmatter ONLY — never series names.
+    if set(_normalize_modes(fm.get("diataxis"))) & {"tutorial", "explanation"}:
+        marks = [str(h).lower() for h in data.get("transfer_headings") or []]
+        # Headings are collected from prose lines only — a `# takeaway:`
+        # comment inside a fenced code block is code, not a heading.
+        heads = [
+            m.group(1).lower()
+            for m in (re.match(r"^#{1,6}\s+(.*)$", ln) for ln in _prose_lines(body))
+            if m
+        ]
+        if not any(mark in head for head in heads for mark in marks):
+            emit(
+                "what_transfers",
+                "no what-transfers closing section "
+                "(expected for tutorial/explanation posts)",
+            )
+
+    # cliche conclusion openers: any paragraph starting with one. Boundary-
+    # aware — "In the ending scene..." must not trip "in the end".
+    openers = [str(o).lower() for o in data.get("conclusion_openers") or []]
+    for para in re.split(r"\n\s*\n", low):
+        p = para.strip()
+        for opener in openers:
+            if re.match(re.escape(opener) + r"(?!\w)", p):
+                emit("conclusion", f"cliche conclusion opener: '{opener}'")
+                break
+
+    return failures, warnings
+
+
 # --------------------------------------------------------------------------- CLI
 
 def _non_posts_series_keys(cfg: dict) -> set[str]:
@@ -241,10 +431,25 @@ def _main(argv):
     a = ap.parse_args(argv)
 
     cfg = yaml.safe_load(open(a.config)) or {}
-    gate = ((cfg.get("quality") or {}).get("gate") or {})
+    quality = (cfg.get("quality") or {})
+    gate = (quality.get("gate") or {})
+    lint_cfg = (quality.get("lint") or {})
     skip_series = _non_posts_series_keys(cfg)
 
+    # Lint runs unless explicitly disabled; missing data skips it LOUDLY
+    # (a materialized blog whose scripts/ predates ai-tells.md stays gate-only).
+    lint_data = None
+    if lint_cfg.get("enabled") is not False:
+        try:
+            lint_data = load_lint_data()
+        except (FileNotFoundError, ValueError) as e:
+            print(
+                f"LINT SKIPPED: {e} — running the structural gate only",
+                file=sys.stderr,
+            )
+
     failed: dict[str, list[str]] = {}
+    lint_failed = False
     checked = 0
     skipped = 0
     for p in a.paths:
@@ -265,6 +470,14 @@ def _main(argv):
         checked += 1
         if fails:
             failed[p] = fails
+        if lint_data is not None:
+            lfails, lwarns = lint_post(fm, body, lint_cfg, lint_data)
+            for msg in lfails:
+                print(f"LINT FAIL: {p}: {msg}")
+            for msg in lwarns:
+                print(f"LINT WARN: {p}: {msg}")
+            if lfails:
+                lint_failed = True
 
     if failed:
         print("POST QUALITY GATE FAILED (educational-writing)", file=sys.stderr)
@@ -278,6 +491,13 @@ def _main(argv):
             "`diagram_exempt: <reason>` to waive just the diagram check.",
             file=sys.stderr,
         )
+    if lint_failed:
+        print(
+            "POST LINT FAILED (ai-tells): see LINT FAIL lines above — rewrite "
+            "the hits or tune severities under `quality.lint` (fail | warn | off)",
+            file=sys.stderr,
+        )
+    if failed or lint_failed:
         return 1
     print(f"POST QUALITY OK: {checked} post(s) checked, {skipped} skipped")
     return 0


### PR DESCRIPTION
Routine `/blog-craft:update`. Config schema was already at latest (v5) — no migration ladder. Only `blog_craft_version` moved: **v0.17.0 → v0.18.0**.

## The plan

```
NOOP     .github/workflows/blog-ci.yml [merged]
NOOP     blog/assets/css/custom.css [merged]
NOOP     blog/go.mod [merged]
NOOP     blog/go.sum [merged]
NOOP     blog/hugo.toml [merged]
ADD      blog/scripts/ai-tells.md [framework]
REPLACE  blog/scripts/validate_educational.py [framework]

1 add, 1 replace, 5 noop
```

No conflicts, and the run was **snapshot-backed** — `.blog-craft.sync.yaml` has been committed since #728, so the base is `render(exact recorded config, v0.17.0 templates)` rather than the approximate fallback. That distinction is the whole point of the snapshot: on a fallback run those five NOOPs would be indistinguishable from the silent-drop failure of blog-craft#60. Here they genuinely mean "frank's copy already wins".

## What landed

- **`blog/scripts/ai-tells.md`** (new) — vendored AI-tells catalog, with a fenced machine-readable block the validator parses for lint data.
- **`blog/scripts/validate_educational.py`** — a warnings-first lint layer on top of the existing structural gate. AI-vocabulary hits **fail**; em-dash density, parallelism runs, rule-of-three pileups, cliché conclusions and a missing what-transfers section **warn**. Code fences and frontmatter are excluded from scanning.

## Both are inert in CI today — deliberately

The shipped workflow gates its `validate_educational` step on `{{- with .quality }}{{- if .enabled }}`, and frank's config carries `quality: {mermaid_syntax: false}` with **no `enabled` key**. That is exactly why `blog-ci.yml` planned as NOOP instead of gaining a step — self-consistent, not drift.

Enabling the gate is a separate, deliberate decision, not a side effect of an update. **This PR does not enable it.**

## What enabling it would cost (measured, not assumed)

Running the new validator by hand over all 83 posts: | Layer | Result |
|---|---|
| Structural gate | 39 findings across 34 posts, exit 1 |
| Lint — FAIL | 1 (`'seamless'`, `operating/22-cicd-platform`) |
| Lint — WARN | 102 (66 em-dash density, 35 missing what-transfers, 1 triad) |

The structural half is **not** a v0.18.0 regression. Running the pre-update validator from `HEAD` over the same file set yields byte-identical findings — 39 across 34, same posts, same messages, nothing new and nothing dropped. That backlog predates this change and is simply unwired. The only genuinely new output is the lint layer.

## Verification

- `hugo --buildDrafts` — clean.
- Repo tripwire suite — **339 passed, 1 xfailed** (the pre-existing aspirational papers-layer-chip guard from #605).
- `blog/.github/` was **not** re-added by the update; `test_blog_ci_at_repo_root.py` passes.

One trap worth recording for anyone repeating this locally: `pytest` is not installed on the host python, and the rtk wrapper renders that hard failure as `Pytest: No tests collected` — which reads exactly like a green empty suite. The numbers above come from a real venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)