### PR TITLE
chore(repo): resync the blog to blog-craft v0.18.1 (actionable-heading fix)

### DIFF
--- a/.blog-craft.sync.yaml
+++ b/.blog-craft.sync.yaml
@@ -12,7 +12,7 @@
 # COMMIT THIS FILE. Without it the updater falls back to the current config and
 # says so. Delete it only to deliberately forget what was last synced.
 version: 5
-blog_craft_version: "v0.17.0"   # blog-craft RELEASE frank is synced to (was v0.16.1).
+blog_craft_version: "v0.18.0"   # blog-craft RELEASE frank is synced to (was v0.17.0).
                                 # update.py re-renders AT this tag to recover the
                                 # 3-way merge base — a wrong value silently degrades
                                 # every `merged` path to a baseless conflict. Bump

--- a/.blog-craft.yaml
+++ b/.blog-craft.yaml
@@ -1,5 +1,5 @@
 version: 5
-blog_craft_version: "v0.18.0"   # blog-craft RELEASE frank is synced to (was v0.17.0).
+blog_craft_version: "v0.18.1"   # blog-craft RELEASE frank is synced to (was v0.18.0).
                                 # update.py re-renders AT this tag to recover the
                                 # 3-way merge base — a wrong value silently degrades
                                 # every `merged` path to a baseless conflict. Bump

--- a/blog/scripts/validate_educational.py
+++ b/blog/scripts/validate_educational.py
@@ -58,10 +58,23 @@ _DIATAXIS_ALIASES = {
 
 # Headings a reader in a hurry can act on. Matched case-insensitively against
 # the heading text (not the leading #s).
+#
+# Verb stems, NOT `\bword\b`. Writers inflect: real headings say "Verifying the
+# Bootstrap" and "Recovery Path", not "Verify" and "Recover". The anchored form
+# rejected exactly the sections this check exists to find — on one 83-post blog,
+# 27 of 34 gate failures already had such a heading. Trailing `\w*` handles
+# verify/verifying/verification and recover/recovery/recovering.
+#
+# Kept deliberately narrow at the other end: a pattern that matches any heading
+# is as useless as one that matches none. `\bsteps\b` stays anchored so
+# "Missteps" is not a hit, and narrative headings (Background, Architecture,
+# Data Flow) must keep failing — pinned by
+# test_narrative_headings_still_do_not_count_as_actionable.
 _ACTIONABLE = re.compile(
     r"(reproduce|try\s+it\s+yourself|run\s*book|step[\s-]*by[\s-]*step|"
-    r"\bsteps\b|\bprocedure\b|\bhow\s+to\b|\bverify\b|\brecover\b|"
-    r"\brollback\b|\bchecklist\b|\bwalkthrough\b|\brunbook\b)",
+    r"\bsteps\b|\bprocedure\b|\bhow\s+to\b|\bverif\w*|\brecover\w*|"
+    r"\brollback\b|\bchecklist\b|\bwalkthrough\b|\brunbook\b|"
+    r"\btroubleshoot\w*|\bdiagnos\w*|\bsmoke\s*test)",
     re.IGNORECASE,
 )
 


### PR DESCRIPTION
Pulls derio-net/blog-craft#70, found while preparing to enable the educational-writing gate here.

## What the upstream bug was

`_ACTIONABLE` anchored its verbs as `\bverify\b` / `\brecover\b`. Word boundaries can't match an inflected form, so the gate rejected the exact sections it exists to find:

```
MISS   Verifying the Bootstrap      MATCH  Verify
MISS   Recovery Path                MATCH  Recover
MISS   The Smoke Test
MISS   Troubleshooting / Diagnosis
```

## Measured on this blog, before and after

| | findings | posts |
|---|---|---|
| v0.18.0 | 39 | 34 |
| **v0.18.1** | **15** | **11** |

**23 of the 34 "failing" posts were never failing** — they already carried an actionable heading the matcher couldn't see. Had the gate been enabled on v0.18.0's reading, the work would have been renaming good prose (`## Recovery Path` → `## Recover`) to satisfy a regex — degrading the writing the gate exists to protect.

**No post is touched by this PR.** The entire 23-post reduction comes from fixing the measuring instrument.

## The remaining backlog is real

| Finding | Posts |
|---|---|
| no actionable section | building `00`, `01`, `03`, `05`, `06`, `08`, `10-local-inference`, `13-unified-auth`, `36-metrics-api`; operating `29-metrics-api` |
| too little evidence | building `00-overview`, `01-introduction` |
| missing diagram | building `30-frank-papers`, operating `29-metrics-api` |
| invalid `diataxis: explainer` | building `01-introduction` |
| lint FAIL `'seamless'` | operating `22-cicd-platform` |

## Not yet gated

`quality.enabled` stays unset, so CI does not gate on this. The flip comes **last**, after the backlog above is cleared — enabling it now would turn `main` red on every subsequent PR, since the gate runs over all posts and not just changed ones.

Plan was 1 replace / 5 noop, snapshot-backed, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)