### PR TITLE
docs(repo): spec + plan for enabling the blog educational-writing gate

### DIFF
--- a/docs/superpowers/journals/plans/2026-07-28-blog-quality-gate.md
+++ b/docs/superpowers/journals/plans/2026-07-28-blog-quality-gate.md
@@ -1,0 +1,1 @@
+# Journal: 2026-07-28-blog-quality-gate

--- a/docs/superpowers/plans/2026-07-28-blog-quality-gate/01.yaml
+++ b/docs/superpowers/plans/2026-07-28-blog-quality-gate/01.yaml
@@ -1,0 +1,64 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Quick structural fixes (diataxis value, ai-vocabulary lint)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Fix the invalid diataxis mode on building/01-introduction
+  steps:
+  - id: P1.T1.S1
+    text: |
+      Run the gate on the one post and record the red baseline:
+      `uv run --frozen python blog/scripts/validate_educational.py --config .blog-craft.yaml blog/content/docs/building/01-introduction/index.md`.
+      Expect `invalid 'diataxis' value(s) ['explainer']: allowed are ['explanation', 'how-to', 'reference', 'tutorial']`.
+  - id: P1.T1.S2
+    text: |
+      Edit `blog/content/docs/building/01-introduction/index.md` frontmatter: replace the `diataxis` value `explainer` with `explanation`. Do NOT add an alias upstream — `explainer` is a blog-craft *content type*, not a Diataxis mode, and conflating them is what produced the typo. Re-run the command from S1 and confirm the diataxis line is gone (the evidence/actionable findings remain, they are Phase 2).
+- number: 2
+  title: Clear the ai-vocabulary lint failure on operating/22-cicd-platform
+  steps:
+  - id: P1.T2.S1
+    text: |
+      Locate the hit: `rtk proxy grep -n seamless blog/content/docs/operating/22-cicd-platform/index.md`. Read the surrounding sentence — the fix is a rewrite that says what actually happens, not a synonym swap ("seamless" almost always means the sentence never said anything).
+  - id: P1.T2.S2
+    text: |
+      Rewrite the sentence so it names the concrete behaviour. Re-run
+      `uv run --frozen python blog/scripts/validate_educational.py --config .blog-craft.yaml blog/content/docs/operating/22-cicd-platform/index.md`
+      and confirm no `LINT FAIL` line. Em-dash / what-transfers WARN lines are expected and are not gating.
+- number: 3
+  title: Confirm the corpus count dropped and nothing else moved
+  steps:
+  - id: P1.T3.S1
+    text: |
+      Run the gate over all posts and confirm the total is now 13 findings across 11 posts (down from 15/11 — two structural findings cleared, the lint FAIL cleared). Command:
+      `uv run --frozen python blog/scripts/validate_educational.py --config .blog-craft.yaml blog/content/docs/*/*/index.md`.
+      Also run `uv run --frozen pytest` and confirm 354 passed, 1 xfailed.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-28-blog-quality-gate/02.yaml
+++ b/docs/superpowers/plans/2026-07-28-blog-quality-gate/02.yaml
@@ -1,0 +1,67 @@
+schema_version: 2
+phase:
+  number: 2
+  title: building/00-overview and building/01-introduction — evidence plus actionable
+    sections
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Gather real evidence for both posts
+  steps:
+  - id: P2.T1.S1
+    text: |
+      Dispatch the `blog-craft:post-researcher` agent once per post (00-overview, 01-introduction) with the source tree as its scope. Ask specifically for: commands a reader could actually run to inspect the cluster's shape (node list, ArgoCD app list, layer inventory), with file:line citations for anything asserted. These two posts are the only ones failing `too little evidence`, so they need a command/output block regardless of the actionable section.
+  - id: P2.T1.S2
+    text: |
+      RUN the candidate commands and capture real output. Do not paste a command whose output you have not seen — both posts are entry points, so a wrong command here is the first thing a new reader hits.
+- number: 2
+  title: Add the section to building/00-overview
+  steps:
+  - id: P2.T2.S1
+    text: |
+      Add a `## Verify the cluster is what this post describes` section (or similar) carrying at least one fenced command block with the captured output from P2.T1.S2. It must satisfy BOTH the evidence check and the actionable check — one real block does both.
+  - id: P2.T2.S2
+    text: |
+      Re-run the gate on the post; expect zero findings. Then read the section back as a first-time reader: if it does not let someone confirm their own cluster matches, it is a hollow section that happens to pass — rewrite it.
+- number: 3
+  title: Add the section to building/01-introduction
+  steps:
+  - id: P2.T3.S1
+    text: |
+      Same shape as P2.T2 for `01-introduction`, using its own captured evidence. Do not copy 00-overview's block; two entry-point posts with identical commands is a signal the section was written for the validator.
+  - id: P2.T3.S2
+    text: |
+      Re-run the gate on the post and confirm zero findings, then `uv run --frozen pytest` stays green.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-28-blog-quality-gate/03.yaml
+++ b/docs/superpowers/plans/2026-07-28-blog-quality-gate/03.yaml
@@ -1,0 +1,49 @@
+schema_version: 2
+phase:
+  number: 3
+  title: building/03-storage, 05-gitops, 06-fun-stuff, 08-backup — actionable sections
+  tag: agentic
+  depends_on:
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Gather evidence for the four posts
+  steps:
+  - id: P3.T1.S1
+    text: |
+      Dispatch `blog-craft:post-researcher` per post. These four already pass the evidence check, so they HAVE command blocks — the research question is narrower: what would a reader do to verify or recover this layer today? Prefer commands already proven elsewhere in the repo (`docs/runbooks/`, `agents/rules/frank-commands.md`) over inventing new ones.
+  - id: P3.T1.S2
+    text: |
+      Run each candidate command and capture output. For 06-fun-stuff (OpenRGB), check whether the layer has genuine day-to-day operations at all — if it does not, `quality_exempt: novelty layer, no operational surface` is the honest answer and is explicitly allowed. Decide per post, and say which you chose and why.
+- number: 2
+  title: Write the sections
+  steps:
+  - id: P3.T2.S1
+    text: |
+      Add a real actionable section to each of the four (or the exemption decided in P3.T1.S2). Each section: one purpose, real commands, real output, and what the reader should see if it is healthy.
+  - id: P3.T2.S2
+    text: |
+      Run the gate over all posts and confirm these four no longer appear. Run `uv run --frozen pytest` and `cd blog && hugo --buildDrafts` clean.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-28-blog-quality-gate/04.yaml
+++ b/docs/superpowers/plans/2026-07-28-blog-quality-gate/04.yaml
@@ -1,0 +1,50 @@
+schema_version: 2
+phase:
+  number: 4
+  title: building/10-local-inference, 13-unified-auth, 36-metrics-api — actionable
+    sections
+  tag: agentic
+  depends_on:
+  - 3
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Gather evidence for the three posts
+  steps:
+  - id: P4.T1.S1
+    text: |
+      Dispatch `blog-craft:post-researcher` per post. All three are live-service layers with existing operating companions — check `blog/content/docs/operating/` first: the companion post may already contain the verification commands, in which case the building post's section should point at it rather than duplicate it (duplicated runbooks drift).
+  - id: P4.T1.S2
+    text: |
+      Run the candidates. `10-local-inference` and `36-metrics-api` touch GPU-timeshared services — a command that only works when the GPU node is up should say so, rather than appearing to be unconditional.
+- number: 2
+  title: Write the sections
+  steps:
+  - id: P4.T2.S1
+    text: |
+      Add the three sections. Where the operating companion owns the runbook, the building post's section should be a short verify-it-worked block plus a link, not a copy.
+  - id: P4.T2.S2
+    text: |
+      Re-run the gate over all posts; only `building/30-frank-papers` and `operating/29-metrics-api` should remain. `uv run --frozen pytest` green.
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-28-blog-quality-gate/05.yaml
+++ b/docs/superpowers/plans/2026-07-28-blog-quality-gate/05.yaml
@@ -1,0 +1,49 @@
+schema_version: 2
+phase:
+  number: 5
+  title: The two diagram gaps — building/30-frank-papers and operating/29-metrics-api
+  tag: agentic
+  depends_on:
+  - 4
+  tracking_issue: null
+tasks:
+- number: 1
+  title: operating/29-metrics-api — actionable section and diagram
+  steps:
+  - id: P5.T1.S1
+    text: |
+      This post needs both an actionable section and a mermaid diagram (its diataxis mode is how-to/tutorial, which the gate requires to carry one). Gather evidence via `post-researcher`, including the metrics-server / `kubectl top` verification path and the `--kubelet-insecure-tls` gotcha already recorded in `agents/rules/frank-gotchas.md`.
+  - id: P5.T1.S2
+    text: |
+      Add the section plus a `flowchart` showing scrape path: kubelet -> metrics-server -> metrics.k8s.io -> `kubectl top` / HPA. Confirm the mermaid renders (`cd blog && hugo --buildDrafts`) and the gate reports zero findings for the post.
+- number: 2
+  title: building/30-frank-papers — diagram
+  steps:
+  - id: P5.T2.S1
+    text: |
+      This post fails ONLY `missing diagram`. Decide honestly first: does a papers-series post teach a procedure? If its diataxis mode is wrong (it may be `explanation`, which is not gated for diagrams), fixing the mode is the correct fix and adding a decorative diagram is not.
+  - id: P5.T2.S2
+    text: |
+      Apply whichever of the two is correct — a real diagram of the paper lifecycle (dossier -> gate -> draft -> media -> publish), or a corrected diataxis mode with a one-line note in the PR saying why. Re-run the gate: the whole corpus must now report zero findings.
+state:
+  steps:
+    P5.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-28-blog-quality-gate/06.yaml
+++ b/docs/superpowers/plans/2026-07-28-blog-quality-gate/06.yaml
@@ -1,0 +1,59 @@
+schema_version: 2
+phase:
+  number: 6
+  title: Enable the gate and guard against hollow sections
+  tag: agentic
+  depends_on:
+  - 5
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Add the anti-gaming tripwire
+  steps:
+  - id: P6.T1.S1
+    text: |
+      Write `scripts/tests/test_actionable_sections_carry_commands.py` (RED first). For every `content_type: posts` post, each heading matching blog-craft's `_ACTIONABLE` vocabulary must be followed by at least one fenced code block before the next heading of the same-or-higher level. Rationale in the module docstring: the gate is a heading regex, so it passes a section containing nothing; this raises the floor above "a heading with the right word in it". Include a self-test that the detector can actually fail (a fixture heading with no block must be flagged), mirroring `test_python_toolchain_single_source.py`.
+  - id: P6.T1.S2
+    text: |
+      Run it against the corpus. Every section written in Phases 2-5 must pass. If any fails, the section is hollow — fix the prose, do not relax the guard.
+- number: 2
+  title: Flip quality.enabled and verify CI gates
+  steps:
+  - id: P6.T2.S1
+    text: |
+      Set `quality.enabled: true` in `.blog-craft.yaml` under the existing `quality:` block (which currently holds only `mermaid_syntax: false`). Re-render CI: `uv run --frozen python <blog-craft>/tools/update.py --config .blog-craft.yaml --blog . ` — the dry-run should now plan a MERGE on `.github/workflows/blog-ci.yml` adding the `Validate post quality (educational-writing)` step. Apply it.
+  - id: P6.T2.S2
+    text: |
+      Confirm the rendered workflow carries the new step and that frank's documented CI-superset customizations survived the merge (`scripts/tests/test_blog_ci_at_repo_root.py` must stay green). Run the full local suite and push; the PR's own CI is the real proof that the gate now runs and passes.
+- number: 3
+  title: Record the lesson where it will be found
+  steps:
+  - id: P6.T3.S1
+    text: |
+      Add a one-liner to `agents/rules/frank-gotchas.md` under a Process/practice bullet: a gate reporting a large backlog must be checked before the backlog is worked — blog-craft's `_ACTIONABLE` produced 34 failures of which 23 were its own false negatives, and acting on that output would have meant renaming good prose to satisfy a regex. Point at this spec for the full prose.
+state:
+  steps:
+    P6.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P6.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-07-28-blog-quality-gate/_meta.yaml
+++ b/docs/superpowers/plans/2026-07-28-blog-quality-gate/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-07-28-blog-quality-gate
+spec: docs/superpowers/specs/2026-07-28--repo--blog-quality-gate-design.md
+target_repo: derio-net/frank
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-07-28'

--- a/docs/superpowers/plans/2026-07-28-blog-quality-gate/_prose.md
+++ b/docs/superpowers/plans/2026-07-28-blog-quality-gate/_prose.md
@@ -1,0 +1,68 @@
+# Blog Quality Gate — turning on the educational-writing gate
+
+blog-craft ships a structural gate for teaching posts and frank has it vendored
+but unwired: `quality.enabled` is unset, so the CI step is never rendered. The
+validator exists and gates nothing. This plan turns it on.
+
+## The part that is easy to get wrong
+
+The obvious sequence — run the validator, fix what it names, flip the flag —
+would have produced a large amount of damaging work.
+
+At blog-craft v0.18.0 the gate reported **39 findings across 34 posts**, 34 of
+them "no actionable section". But most of those posts already had one:
+blog-craft's `_ACTIONABLE` pattern anchored its verbs as `\bverify\b` and
+`\brecover\b`, and a word boundary cannot match an inflected form. So the check
+that asks *"is there a heading a reader under pressure can follow?"* was
+rejecting `## Verifying the Bootstrap`, `## Recovery Path` and `## The Smoke
+Test`.
+
+Fixed upstream (blog-craft#70, v0.18.1) and resynced (frank#731). The same
+measurement afterwards: **15 findings across 11 posts**. Twenty-three of the
+thirty-four were never failing. Nothing in that reduction touched a post.
+
+Had the gate been believed, the work would have been renaming `## Recovery Path`
+to `## Recover` across two dozen posts — mutilating good writing to satisfy a
+regex, and calling it a quality improvement.
+
+**So the standing instruction for this plan: when a gate reports a large
+backlog, check the gate before working the backlog.**
+
+## What is actually left
+
+Eleven posts. Ten need a genuine actionable section, two of those also lack any
+command/output block, two need a diagram, one has an invalid Diátaxis mode, and
+one trips the ai-vocabulary lint on "seamless".
+
+## The constraint that shapes every phase
+
+`_has_actionable_heading` is a regex over heading text. Any H2 containing
+`verify`, `runbook`, `steps`, `recover` and friends satisfies it — **including
+one with nothing underneath**. A green run therefore proves nothing about
+whether a reader can act.
+
+Every section this plan adds must carry real commands that were actually run,
+with their real output. Where a post has no operational surface (06-fun-stuff /
+OpenRGB is the likely case), `quality_exempt: <reason>` is the honest answer and
+is explicitly allowed — a hollow section is worse than a declared exemption,
+because the exemption is visible and the hollow section looks like coverage.
+
+Phase 6 adds a mechanical floor: a tripwire requiring a fenced command block
+under every actionable heading. It cannot judge whether a section is *good*, but
+it makes an empty one fail — and, like the toolchain guard it mirrors, it
+carries a self-test proving the detector can actually fire.
+
+## Ordering
+
+The gate runs over the whole corpus, not the changed files. Flipping
+`quality.enabled` before the backlog clears turns `main` red on every unrelated
+PR. So the flip is Phase 6 and every earlier phase leaves `main` green — each
+phase is independently mergeable and independently useless-to-revert.
+
+## Evidence gathering
+
+Ten posts need commands that genuinely work. Use `blog-craft:post-researcher`
+per post to gather file:line-cited evidence, run the candidates, and paste real
+output. Where an operating companion post already owns the runbook, link it
+rather than duplicating it — two copies of a runbook drift, and the drift
+surfaces during an incident.

--- a/docs/superpowers/specs/2026-07-28--repo--blog-quality-gate-design.md
+++ b/docs/superpowers/specs/2026-07-28--repo--blog-quality-gate-design.md
@@ -1,0 +1,113 @@
+# Blog Quality Gate — enabling the educational-writing gate in CI
+
+**Date:** 2026-07-28
+**Layer:** `repo` — meta / blog infrastructure
+**Status:** Designed — backlog partially cleared upstream; implementation is this spec's plan.
+**Prompted by:** the blog-craft v0.18.0 resync (#729), which shipped
+`validate_educational.py` but left it ungated.
+
+## What this is
+
+blog-craft ships an educational-writing gate: a structural check that every
+`content_type: posts` post declares a `reader_goal`, names a Diátaxis mode,
+carries at least one command/output block, and offers a heading a reader under
+pressure can follow. It ships a warnings-first AI-tells lint on top.
+
+frank has the validator vendored at `blog/scripts/validate_educational.py` but
+`quality.enabled` is unset, so the shipped CI step is never rendered. The gate
+exists and does nothing. This spec covers turning it on.
+
+## Why the backlog is smaller than it first looked
+
+The obvious approach — read the validator's output, fix what it names — would
+have been wrong, and expensively so.
+
+Measured across all 83 posts at blog-craft v0.18.0, the gate reported **39
+findings across 34 posts**, 34 of them "no actionable section". Inspecting the
+posts rather than the report showed most of those posts already had exactly such
+a section:
+
+```
+MISS   Verifying the Bootstrap      MATCH  Verify
+MISS   Recovery Path                MATCH  Recover
+MISS   The Smoke Test
+MISS   Troubleshooting / Diagnosis
+```
+
+`_ACTIONABLE` anchored its verbs as `\bverify\b` / `\brecover\b`, and a word
+boundary cannot match an inflected form. The check asking *"is there a heading a
+reader can act on?"* was rejecting `## Verifying the Bootstrap`.
+
+Fixed upstream (derio-net/blog-craft#70, released v0.18.1) and resynced here
+(#731). The same measurement afterwards:
+
+| | findings | posts |
+|---|---|---|
+| v0.18.0 | 39 | 34 |
+| **v0.18.1** | **15** | **11** |
+
+**23 of the 34 "failures" were never failures.** Acting on the v0.18.0 output
+would have meant renaming good prose (`## Recovery Path` → `## Recover`) to
+satisfy a regex — degrading the writing the gate exists to protect. No post was
+edited to achieve that reduction.
+
+The lesson generalises and belongs in the plan: **when a gate reports a large
+backlog, check the gate before working the backlog.**
+
+## The remaining backlog
+
+| Finding | Posts |
+|---|---|
+| no actionable section | building `00-overview`, `01-introduction`, `03-storage`, `05-gitops`, `06-fun-stuff`, `08-backup`, `10-local-inference`, `13-unified-auth`, `36-metrics-api`; operating `29-metrics-api` |
+| too little evidence | building `00-overview`, `01-introduction` |
+| missing diagram | building `30-frank-papers`, operating `29-metrics-api` |
+| invalid `diataxis: explainer` | building `01-introduction` |
+| lint FAIL `'seamless'` | operating `22-cicd-platform` |
+
+## Design constraints
+
+### 1. The gate is trivially gameable — green is not the goal
+
+`_has_actionable_heading` is a regex over H2–H6 text. Any heading containing
+`reproduce|runbook|steps|verify|recover|rollback|checklist|walkthrough|
+procedure|how to|try it yourself|troubleshoot|diagnos|smoke test` satisfies it,
+regardless of what follows.
+
+So a passing run proves nothing about whether a reader can act. **Every section
+added by this plan must carry at least one fenced command block with real,
+verified commands from this repo** — not invented ones, and not a heading with
+the right word in it. Where a post genuinely has nothing operational to offer,
+the honest move is `quality_exempt: <reason>` in frontmatter, not a hollow
+section.
+
+Phase 6 adds a mechanical floor for this: a tripwire asserting every
+actionable-matching heading is followed by a fenced command block before the
+next H2. That does not make a section *good*, but it makes an empty one fail.
+
+### 2. Ordering — the flip comes last
+
+The gate runs over **all** posts, not just changed ones. Setting
+`quality.enabled: true` before the backlog is cleared turns `main` red on every
+subsequent PR, unrelated to its contents. Every phase before the last leaves
+`main` green.
+
+### 3. Evidence gathering is per-post and belongs in a subagent
+
+Ten posts each need commands that actually work against this cluster or repo.
+Use blog-craft's `post-researcher` agent to gather file:line-cited evidence per
+post rather than improvising commands into a draft; use `cold-reader` on the
+result. Improvised commands in a published runbook are worse than no runbook.
+
+## Verification
+
+- `uv run --frozen python blog/scripts/validate_educational.py --config .blog-craft.yaml blog/content/docs/*/*/index.md`
+  exits 0 over the whole corpus, with the gate enabled.
+- `uv run --frozen pytest` stays green (currently 354 passed, 1 xfailed).
+- `hugo --buildDrafts` clean.
+- Each added section's commands are run and their output pasted, not paraphrased.
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-07-28-blog-quality-gate | `derio-net/frank` | `2026-07-28-blog-quality-gate` | — |


### PR DESCRIPTION
Plans the work approved after #731: clear the remaining educational-writing backlog, then turn the gate on.

## Why the spec leads with a bug report

At blog-craft v0.18.0 the gate reported **39 findings across 34 posts**. Twenty-three of those posts were not failing at all — `_ACTIONABLE` anchored its verbs as `\bverify\b` / `\brecover\b`, which cannot match an inflected form, so it rejected `## Verifying the Bootstrap` and `## Recovery Path`: exactly the sections it exists to find.

Fixed upstream (blog-craft#70 → v0.18.1) and resynced (#731). Same measurement after: **15 findings across 11 posts**, with **no post edited**.

Believing the first number would have meant renaming good prose to satisfy a regex. So the plan carries the generalised instruction: *when a gate reports a large backlog, check the gate before working the backlog.*

## Two constraints that shape every phase

**The gate is trivially gameable.** `_has_actionable_heading` is a regex over heading text — it passes a section containing nothing. Every section this plan adds must carry real commands that were actually run, with real output. Where a post has no operational surface (`06-fun-stuff`/OpenRGB is the likely case), `quality_exempt: <reason>` is the honest answer: an exemption is visible, a hollow section looks like coverage.

Phase 6 adds a mechanical floor — a tripwire requiring a fenced command block under every actionable heading, with a self-test proving the detector can actually fire (mirroring `test_python_toolchain_single_source.py` from #730).

**The flip comes last.** The gate runs over the whole corpus, not the changed files, so enabling it early turns `main` red on every unrelated PR. Phases 1–5 each leave `main` green and are independently mergeable.

## Phases

| # | Scope |
|---|---|
| 1 | Quick fixes — `diataxis: explainer` → `explanation`, drop `'seamless'` |
| 2 | `building/00-overview` + `01-introduction` — evidence blocks **and** sections |
| 3 | `building/03-storage`, `05-gitops`, `06-fun-stuff`, `08-backup` |
| 4 | `building/10-local-inference`, `13-unified-auth`, `36-metrics-api` |
| 5 | The two diagram gaps — `operating/29-metrics-api`, `building/30-frank-papers` |
| 6 | Flip `quality.enabled: true` + anti-gaming tripwire + gotcha one-liner |

Phase 5 explicitly asks whether `building/30-frank-papers` should get a diagram at all, or whether its Diátaxis mode is simply wrong — adding a decorative diagram to pass a check aimed at how-to posts would be the same mistake one level down.

## Verification

`fr plan self-review` passes. Suite: **354 passed, 1 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)