### PR TITLE
chore(repo): blog-craft v0.19.0 — mermaid natural-size rendering + all 35 diagrams under the width gate

### DIFF
--- a/.blog-craft.sync.yaml
+++ b/.blog-craft.sync.yaml
@@ -11,8 +11,8 @@
 #
 # COMMIT THIS FILE. Without it the updater falls back to the current config and
 # says so. Delete it only to deliberately forget what was last synced.
-version: 5
-blog_craft_version: "v0.18.0"   # blog-craft RELEASE frank is synced to (was v0.17.0).
+version: 6
+blog_craft_version: "v0.19.0"   # blog-craft RELEASE frank is synced to (was v0.18.1).
                                 # update.py re-renders AT this tag to recover the
                                 # 3-way merge base — a wrong value silently degrades
                                 # every `merged` path to a baseless conflict. Bump
@@ -244,6 +244,14 @@ features:
   # blog without one (the theme's block would still run, racing two observers).
   # blog-craft #58 / CONFIG.md §10; frank first shipped this locally in #710.
   mermaid_csp_init: true
+  # Render diagrams at their AUTHORED size inside a framed horizontal scroller,
+  # instead of letting mermaid's `useMaxWidth` shrink every SVG into Hextra's
+  # 672px content column (a 2139px diagram painted 14px labels at 4.4px — the
+  # same 31% scale on a 4K panel as on a laptop, so it was never a wide-screen
+  # problem). Pure CSS, plus a `render-codeblock-mermaid.html` override making
+  # the scroller keyboard-focusable (WCAG 2.1 SC 2.1.1). Set false to restore
+  # pre-v0.19.0 rendering. blog-craft CHANGELOG 0.19.0 / CONFIG.md §12.
+  mermaid_view: true
   # Mermaid palette is in custom.css (.content scoping = all docs posts).
   # css.mermaid_palette is not used because frank's theme applies global
   # SVG overrides via CSS nesting; the papers quadrant-chart selectors

--- a/.blog-craft.yaml
+++ b/.blog-craft.yaml
@@ -1,5 +1,5 @@
-version: 5
-blog_craft_version: "v0.18.1"   # blog-craft RELEASE frank is synced to (was v0.18.0).
+version: 6
+blog_craft_version: "v0.19.0"   # blog-craft RELEASE frank is synced to (was v0.18.1).
                                 # update.py re-renders AT this tag to recover the
                                 # 3-way merge base — a wrong value silently degrades
                                 # every `merged` path to a baseless conflict. Bump
@@ -231,6 +231,14 @@ features:
   # blog without one (the theme's block would still run, racing two observers).
   # blog-craft #58 / CONFIG.md §10; frank first shipped this locally in #710.
   mermaid_csp_init: true
+  # Render diagrams at their AUTHORED size inside a framed horizontal scroller,
+  # instead of letting mermaid's `useMaxWidth` shrink every SVG into Hextra's
+  # 672px content column (a 2139px diagram painted 14px labels at 4.4px — the
+  # same 31% scale on a 4K panel as on a laptop, so it was never a wide-screen
+  # problem). Pure CSS, plus a `render-codeblock-mermaid.html` override making
+  # the scroller keyboard-focusable (WCAG 2.1 SC 2.1.1). Set false to restore
+  # pre-v0.19.0 rendering. blog-craft CHANGELOG 0.19.0 / CONFIG.md §12.
+  mermaid_view: true
   # Mermaid palette is in custom.css (.content scoping = all docs posts).
   # css.mermaid_palette is not used because frank's theme applies global
   # SVG overrides via CSS nesting; the papers quadrant-chart selectors

--- a/.github/workflows/blog-ci.yml
+++ b/.github/workflows/blog-ci.yml
@@ -130,3 +130,21 @@ jobs:
       - name: Hugo build
         working-directory: blog
         run: hugo --minify
+
+      # Mermaid width gate: a diagram measuring wider than 1400px fails
+      # CI (waive one with a `%% blog-craft: wide-ok — …` comment inside the
+      # fence). Needs public/ to exist, so it runs after the Hugo build step
+      # above — but from the REPOSITORY ROOT cwd like every other validator,
+      # with no per-step cwd override: this workflow file only executes there
+      # in the first place (GitHub Actions reads .github/workflows/ from the
+      # repo root only — a copy materialized under site_dir is inert and
+      # gates nothing while looking like it does; blog-craft#61).
+      # Zero npm dependencies, so no actions/setup-node / npm install: the
+      # tool needs only the Node >= 22 that ubuntu-latest already preinstalls.
+      # Disable with `quality.mermaid_max_width: 0` — loud at the script level
+      # (still scans every diagram, reports how many it would have blocked,
+      # never launches a browser) and, at render time, loud in a different
+      # sense: the step is omitted from the workflow entirely, so an opted-out
+      # blog invokes no browser and pays no CI cost for a gate it turned off.
+      - name: Validate mermaid layout
+        run: node blog/scripts/validate_mermaid_layout.mjs --public blog/public --max-width 1400

--- a/blog/assets/css/mermaid-view.css
+++ b/blog/assets/css/mermaid-view.css
@@ -1,0 +1,159 @@
+/* ===================================================================
+   features.mermaid_view — diagrams at their authored size, in a framed
+   horizontal scroller.
+
+   THE MECHANISM (read this before editing anything below).
+
+   Mermaid's `useMaxWidth` shrinks every SVG to fit Hextra's 672px
+   content column — measured ~31% scale on frank's wider diagrams, i.e.
+   unreadable. But mermaid also writes
+
+       style="max-width: <natural>px"
+
+   INLINE on each rendered SVG, where <natural> is the diagram's
+   authored width. Inline author declarations beat stylesheet ones, and
+   `max-width` beats `width` regardless of origin. So the single rule
+
+       .content .mermaid svg { width: 200rem }
+
+   resolves to min(200rem, natural): a 428px diagram stays 428px and
+   never scrolls; a 2139px diagram renders full size inside the
+   scroller; nothing is ever enlarged past its authored size. One rule,
+   self-scaling across every diagram in the blog, no per-diagram tuning.
+
+   DO NOT add a `max-width` to the SVG here. It would compete with the
+   value the whole feature depends on. (It also would not help: the
+   inline declaration wins anyway — which is why the `max-width: 100%`
+   already shipped at custom.css.tmpl:143 is inert once mermaid has
+   rendered, and why removing it is neither needed nor sufficient.)
+   tests/unit/test_mermaid_view.py asserts its ABSENCE for this reason.
+
+   WHY CSS AND NOT JS. templates/features/mermaid-csp/assets/js/
+   mermaid-init.js:48-61 re-renders every diagram on the dark/light
+   toggle by resetting innerHTML. Any JS-attached wrapper, handler or
+   measured width would be destroyed at that moment; CSS re-applies for
+   free.
+
+   LOAD ORDER. head-end.html loads this sheet BEFORE custom.css, so a
+   blog can still override the frame from its own stylesheet (frank has
+   already rewritten its `.content .mermaid` block). That is deliberate:
+   everything here is a default, not a lock.
+=================================================================== */
+
+.content .mermaid {
+  /* The diagram is now free to be wider than the column, so the block
+     has to become a scroller — otherwise the page clips it, which is
+     strictly worse than the 31% shrink this replaces. */
+  overflow-x: auto;
+
+  /* Frame. All colours derived with color-mix(in srgb, currentColor …)
+     so ONE rule serves light and dark: currentColor is already the
+     theme's body text colour, so the border and tint track the theme
+     without a second `.dark` rule to keep in sync. */
+  border: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, currentColor 4%, transparent);
+  padding: 1rem 1.25rem;
+  margin: 1.75rem 0;
+
+  /* --- scroll affordance 2 of 2: shadows ---------------------------
+     Two cover gradients in the frame's own colour, attached `local` so
+     they travel WITH the content, sitting on top of two edge shadows
+     attached `scroll` so they stay pinned to the scroller. At the left
+     end the left cover hides the left shadow; scroll right and the
+     cover slides away, uncovering it. Self-cancelling at both ends,
+     no JS, and therefore untouched by mermaid-init.js's re-render.
+
+     The colours are custom properties because they must INVERT with the
+     theme: a black shadow is invisible against a #111 frame, so the cue
+     would silently disappear in dark mode — the same failure mode as
+     the overlay scrollbar, by a second route. #fff / #111 are Hextra's
+     measured light and dark body backgrounds (getComputedStyle on a
+     built site), and the covers must match the page behind the frame,
+     not merely be "light" or "dark".
+
+     ORDER IS LOAD-BEARING: the four background-attachment values index
+     the four background-image layers positionally. Reorder one list and
+     the covers become pinned and the shadows scroll away, permanently
+     hiding both cues. The `background` shorthand above also RESETS
+     these longhands, so it must stay above them. */
+  --frame-bg: #fff;
+  --frame-shadow: rgba(0, 0, 0, 0.28);
+  background-image:
+    linear-gradient(to right, var(--frame-bg), rgba(255, 255, 255, 0)),
+    linear-gradient(to left,  var(--frame-bg), rgba(255, 255, 255, 0)),
+    linear-gradient(to right, var(--frame-shadow), rgba(0, 0, 0, 0)),
+    linear-gradient(to left,  var(--frame-shadow), rgba(0, 0, 0, 0));
+  background-position: left center, right center, left center, right center;
+  background-size: 32px 100%, 32px 100%, 16px 100%, 16px 100%;
+  background-repeat: no-repeat;
+  background-attachment: local, local, scroll, scroll;
+}
+
+.dark .content .mermaid {
+  /* Only the two colours flip; every other frame value is already
+     currentColor-derived and needs no dark counterpart. The shadow is a
+     pale blue-white here because a dark frame can only be shaded by
+     LIGHT — inverting the cue, not merely re-tinting it. */
+  --frame-bg: #111;
+  --frame-shadow: rgba(190, 215, 255, 0.22);
+}
+
+/* --- scroll affordance 1 of 2: a scrollbar that is actually painted ---
+   macOS (and iPadOS, and Chrome with overlay scrollbars) defaults to an
+   overlay scrollbar that paints NOTHING at rest. Measured on the
+   prototype: offsetHeight - clientHeight == 0 with the naive version,
+   9px once -webkit-appearance: none is set. Without it the diagram is
+   SILENTLY TRUNCATED — it looks complete and the reader never learns
+   the right-hand third exists. Sizing the pseudo-element alone does not
+   opt out; -webkit-appearance is the only lever. */
+.content .mermaid::-webkit-scrollbar {
+  -webkit-appearance: none;
+  height: 9px;
+}
+
+.content .mermaid::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.content .mermaid::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, currentColor 28%, transparent);
+  border-radius: 5px;
+}
+
+.content .mermaid::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, currentColor 45%, transparent);
+}
+
+/* THE TRAP, and the reason for this feature query.
+   Firefox has no ::-webkit-scrollbar and needs the standard properties.
+   But in Chrome/Safari `scrollbar-width` / `scrollbar-color` WIN over
+   the pseudo-elements above and disable them — restoring the invisible
+   overlay bar with no warning, no error, nothing in devtools. Measured
+   and confirmed. The two mechanisms are mutually exclusive, so the gate
+   is load-bearing: it must stay, and these properties must never be
+   hoisted out of it "for tidiness". */
+@supports not selector(::-webkit-scrollbar) {
+  .content .mermaid {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, currentColor 35%, transparent) transparent;
+  }
+}
+
+.content .mermaid svg {
+  /* The load-bearing line. See the header comment. NOT a literal size —
+     an upper bound that mermaid's inline max-width always clamps. */
+  width: 200rem;
+
+  /* Block-level, and NOT because of aesthetics. custom.css.tmpl:142
+     ships `.content .mermaid { text-align: center }`. A centred INLINE
+     child wider than its scroll container overflows on BOTH sides, and
+     left overflow is outside the scrollable overflow region — the left
+     edge of a wide diagram would be permanently unreachable. As a block
+     the SVG is out of the line box, so text-align cannot touch it:
+     `margin-inline: auto` centres it while it fits, and once it does not
+     the over-constrained block resolves both auto margins to 0, sending
+     all overflow right where all of it can be scrolled to. */
+  display: block;
+  margin-inline: auto;
+}

--- a/blog/content/docs/building/05-gitops/index.md
+++ b/blog/content/docs/building/05-gitops/index.md
@@ -21,7 +21,7 @@ GitOps means the Git repo is the single source of truth for everything running o
 This post covers the migration from Flux CD to ArgoCD, the Pulumi detour that did not work out, and building an App-of-Apps Helm chart to manage all workloads via GitOps — adopting Cilium and Longhorn in place without a single pod restart.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Git[Git Repo]
     Chart[apps/root/ — App-of-Apps chart]
     Apps[apps/cilium/, apps/longhorn/...]

--- a/blog/content/docs/building/06-fun-stuff/index.md
+++ b/blog/content/docs/building/06-fun-stuff/index.md
@@ -17,7 +17,7 @@ Every serious infrastructure project needs a completely unnecessary feature. Thi
 It does not work. We know exactly why, we know what it would take to fix it, and we have not fixed it yet. This is the honest version of that story.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Hardware[gpu-1 Hardware]
     Fans[6x ARGB Fans]
     Hub[Fan Hub<br/>button does nothing]

--- a/blog/content/docs/building/08-backup/index.md
+++ b/blog/content/docs/building/08-backup/index.md
@@ -19,7 +19,7 @@ Frank is fully GitOps-managed. If the cluster evaporates tonight, ArgoCD restore
 But three Longhorn 1.11 bugs and limitations turned what should have been a simple BackupTarget + RecurringJob config into a week of workarounds. {{< abbr "SOPS" >}}-encrypted secrets cannot live in ArgoCD manifest paths. RecurringJobs have no `backupTargetName` field — you cannot route jobs to specific targets. And the {{< abbr "NFS" >}} backup target is broken by a mount-path formatting bug that will not be fixed until Longhorn 1.13.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Sources[Data Sources]
     VM[VictoriaMetrics<br/>20Gi PVC]
     Grafana[Grafana<br/>1Gi PVC]

--- a/blog/content/docs/building/09-secrets/index.md
+++ b/blog/content/docs/building/09-secrets/index.md
@@ -19,7 +19,7 @@ Layer 9 replaces the runtime half. The goal: secrets live in a versioned, audite
 But deploying Infisical's standalone chart surfaced three bugs in quick succession — duplicate environment variables, hardcoded Redis password paths, and Bitnami image registry issues — that forced splitting one ArgoCD application into three.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Infisical[Infisical — Secret Store]
     PG[PostgreSQL<br/>separate ArgoCD app]
     Redis[C<br/>separate ArgoCD app]

--- a/blog/content/docs/building/10-local-inference/index.md
+++ b/blog/content/docs/building/10-local-inference/index.md
@@ -17,7 +17,7 @@ The cluster has a GPU. Layer 4 installed the NVIDIA operator. Layer 5 gave the m
 Layer 10 wires up a unified {{< abbr "LLM" >}} gateway. Any tool on the network — agentic frameworks, document processors, coding assistants — talks to one OpenAI-compatible endpoint at `192.168.55.206:4000`. Behind that endpoint, requests route to either a local model on gpu-1's RTX 5070 Ti or a free cloud model via OpenRouter. The consumer never needs to know which.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Consumers[Consumers]
     AGI[AnythingLLM]
     Agent[Agent frameworks]

--- a/blog/content/docs/building/12-gpu-talos-fix/index.md
+++ b/blog/content/docs/building/12-gpu-talos-fix/index.md
@@ -15,7 +15,7 @@ last_updated: 2026-07-15
 Layer 4 deployed the NVIDIA GPU Operator. Layer 10 deployed Ollama. Between those two milestones lay four distinct issues that kept every GPU container stuck — first at `Init:0/1`, then `ContainerCreating`, then crashing in a 3-second loop. Each issue was specific to the Talos Linux intersection with the NVIDIA stack, and each had to be solved in sequence before a single model ran.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Talos[Talos Linux — Immutable OS]
     SE[System Extensions<br/>driver + toolkit]
     MP[Machine Config Patches<br/>via Omni]

--- a/blog/content/docs/building/13-unified-auth/index.md
+++ b/blog/content/docs/building/13-unified-auth/index.md
@@ -19,7 +19,7 @@ That is fine for one person. It is not fine the moment you add a second person, 
 Layer 13 fixes this with Authentik — one identity provider for the entire cluster.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph IdP[Authentik — 192.168.55.211]
     Server[Server + Worker]
     Outpost[Embedded Proxy Outpost]

--- a/blog/content/docs/building/18-persistent-agent/index.md
+++ b/blog/content/docs/building/18-persistent-agent/index.md
@@ -15,7 +15,7 @@ last_updated: 2026-07-15
 My laptop is not always online. The Claude mobile app is useful but cannot run terminal commands, install tools, or maintain a persistent workspace. This post covers deploying a persistent Kali Linux container on gpu-1 as an always-on development workstation, accessible via SSH from anywhere on the network.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph GPU1[gpu-1 — i9, 128GB RAM]
     Kali[kali container<br/>kalilinux/kali-rolling]
     SSHD[SSH server<br/>port 2222]

--- a/blog/content/docs/building/19-progressive-delivery/index.md
+++ b/blog/content/docs/building/19-progressive-delivery/index.md
@@ -42,7 +42,7 @@ flowchart LR
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph ArgoRollouts[Argo Rollouts — argo-rollouts namespace]
     Controller[Controller<br/>replica-count canary]
   end

--- a/blog/content/docs/building/22-health-monitoring/index.md
+++ b/blog/content/docs/building/22-health-monitoring/index.md
@@ -26,7 +26,7 @@ Two components join the monitoring namespace alongside VictoriaMetrics and Grafa
 | **Pushgateway** | Heartbeat metric ingestion | Cron scripts push `willikins_heartbeat_last_success_timestamp` after each successful run |
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Monitoring[monitoring namespace]
     VM[VictoriaMetrics]
     BB[Blackbox Exporter]

--- a/blog/content/docs/building/23-health-bridge/index.md
+++ b/blog/content/docs/building/23-health-bridge/index.md
@@ -27,7 +27,7 @@ But the project board — a GitHub Projects v2 board with a custom "Lifecycle" f
 A stateless Go HTTP server sits in the monitoring namespace. Grafana's notification policy routes alerts to it via webhook. The bridge parses each alert, extracts the `github_issue` label (e.g., `willikins#11`), maps the alert severity to a lifecycle state, and updates the GitHub Project item via GraphQL.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Grafana[Grafana Alerting]
     AR[Alert Rules]
     NP[Notification Policy]

--- a/blog/content/docs/building/24-in-cluster-ingress/index.md
+++ b/blog/content/docs/building/24-in-cluster-ingress/index.md
@@ -19,12 +19,13 @@ This post moves the ingress controller inside the cluster: Traefik v3 on the ras
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Internet
     DNS[Pi-hole<br/>*.cluster.derio.net → 192.168.55.220]
   end
   subgraph Cluster[Frank Cluster]
     subgraph Traefik[traefik-system namespace]
+      direction TB
       T[Traefik — raspi-1/raspi-2]
       AC[ACME — Cloudflare DNS-01<br/>*.cluster.derio.net]
       MW[Middlewares<br/>ip-allowlist + security-headers]

--- a/blog/content/docs/building/25-vk-relay/index.md
+++ b/blog/content/docs/building/25-vk-relay/index.md
@@ -19,7 +19,7 @@ VK's architecture solves this with a **relay server** — the local server opens
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Browser[Operator Browser]
     UI[VK Remote UI]
     IDB[IndexedDB<br/>Ed25519 keys]

--- a/blog/content/docs/building/26-vk-remote-self-host/index.md
+++ b/blog/content/docs/building/26-vk-remote-self-host/index.md
@@ -19,7 +19,7 @@ The good news: VK's remote crate already supports self-hosting with local auth. 
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Agent[secure-agent-pod — gpu-1]
     VK[vk-local — port 8081<br/>SQLite workspaces]
   end

--- a/blog/content/docs/building/27-cicd-platform/index.md
+++ b/blog/content/docs/building/27-cicd-platform/index.md
@@ -19,7 +19,7 @@ This post changes that. We deploy a complete CI/CD platform on pc-1: **Gitea** m
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph GitHub
     FR[derio-net/frank]
     AS[agentic-stoa repos]
@@ -251,7 +251,7 @@ It does **not** work when Paperclip AI opens PRs on agentic-stoa repos. Papercli
 ### Architecture (Inverted Slice)
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph GitHub[GitHub — agentic-stoa]
     EV[PR opened/synchronized/reopened]
     PV[Push to main]

--- a/blog/content/docs/building/28-agent-images-sidecar/index.md
+++ b/blog/content/docs/building/28-agent-images-sidecar/index.md
@@ -19,7 +19,7 @@ This post unbakes all of it into three moves: a new `derio-net/agent-images` rep
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph VK[vibe-kanban fork]
     CI1[Fork CI<br/>vk-remote + vk-build]
   end

--- a/blog/content/docs/building/29-ruflo/index.md
+++ b/blog/content/docs/building/29-ruflo/index.md
@@ -19,7 +19,7 @@ This layer adds the opposite. **Ruflo** is the rebrand of ruvnet's `claude-flow`
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Pod[ruflo pod — ruflo-system namespace]
     subgraph Server[ruflo-server]
       RUV[ruvocal SSR<br/>node:24-slim<br/>port 3000]
@@ -34,6 +34,7 @@ flowchart LR
     WS[ruflo-workspace PVC<br/>20Gi — shared]
   end
   subgraph Network
+    direction TB
     WEB[ruflo.cluster.derio.net<br/>Traefik + Authentik]
     SSH[192.168.55.222:22<br/>SSH + Mosh UDP]
     LLM[litellm.litellm.svc:4000<br/>LiteLLM gateway]

--- a/blog/content/docs/building/31-edge-observability/index.md
+++ b/blog/content/docs/building/31-edge-observability/index.md
@@ -19,7 +19,7 @@ This post covers the full edge observability stack: collectors on Hop, backend o
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Hop[Hop — CX23, 4 GB]
     C[Caddy — blog.derio.net<br/>JSON access logs]
     FB[fluent-bit DaemonSet<br/>/var/log/containers → VL]

--- a/blog/content/docs/building/32-automation/index.md
+++ b/blog/content/docs/building/32-automation/index.md
@@ -23,7 +23,7 @@ Ansible has exactly that verb. So this layer — `auto` — is me growing an imp
 ArgoCD installs the awx-operator Helm chart and applies an `AWX` custom resource. That is all ArgoCD manages. Then the *operator* takes over: it reconciles the {{< abbr "CR" >}} into a Deployment for the web pod, the task pod, a StatefulSet for Postgres, migrations Job, Services. None of that is in Git.
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph ArgoCD
     CHART[awx-operator Helm chart]
     CR[AWX custom resource]

--- a/blog/content/docs/building/33-hermes-shell/index.md
+++ b/blog/content/docs/building/33-hermes-shell/index.md
@@ -19,7 +19,7 @@ This post is about handing them back. Nous Research now publishes an official `n
 ## Architecture
 
 ```mermaid
-flowchart LR
+flowchart TD
   subgraph Pod[hermes pod — gpu-1, three containers]
     subgraph Main[hermes — official image]
       GW[hermes gateway run<br/>root → s6 → UID 1000]
@@ -28,6 +28,7 @@ flowchart LR
       SSHD[sshd — key-only, port 22]
     end
     subgraph Hindsight[hindsight sidecar — agent-images]
+      direction TB
       PG[PostgreSQL 18.4<br/>pgvector 0.8.3]
       HA[hindsight-api<br/>127.0.0.1:8888]
       EMB[BAAI/bge-small-en-v1.5<br/>baked model]

--- a/blog/content/docs/operating/06-secrets/index.md
+++ b/blog/content/docs/operating/06-secrets/index.md
@@ -59,7 +59,7 @@ kubectl get clustersecretstore
 ```
 
 ```mermaid
-graph LR
+graph TD
   subgraph BOOT["Bootstrap Layer"]
     S1["SOPS-encrypted<br/>secrets/ files"]
     S1 -->|"sops --decrypt"| INF["Infisical<br/>192.168.55.204:8080"]

--- a/blog/content/docs/operating/08-auth/index.md
+++ b/blog/content/docs/operating/08-auth/index.md
@@ -31,7 +31,7 @@ Authentication is healthy when Authentik at `192.168.55.211:9000` is responding,
 {{< screenshot src="authentik-providers-healthy.png" caption="Authentik admin UI: all cluster OIDC and proxy providers with healthy status" >}}
 
 ```mermaid
-graph LR
+graph TD
   USER["User / Browser"] -->|"https://service.frank.derio.net"| TR["Traefik<br/>Ingress"]
   TR -->|"forward-auth"| FA["forward-auth<br/>middleware"]
   FA -->|"OIDC auth"| AK["Authentik<br/>192.168.55.211:9000"]

--- a/blog/content/docs/operating/11-public-edge/index.md
+++ b/blog/content/docs/operating/11-public-edge/index.md
@@ -39,9 +39,11 @@ graph TB
     end
 
     subgraph hetzner["Hetzner Cloud"]
+        direction TB
         hop["hop-1<br/>CX23 VM<br/>Talos Linux"]
 
         subgraph k8s["Kubernetes"]
+            direction TB
             caddy["Caddy<br/>hostPort 80/443"]
             cs["CrowdSec<br/>LAPI + Bouncer"]
             hs["Headscale<br/>Control Server"]
@@ -56,6 +58,7 @@ graph TB
     end
 
     subgraph mesh["Tailscale Mesh"]
+        direction TB
         laptop["Laptop"]
         raspi["Raspi<br/>Subnet Router"]
         phone["Phone"]

--- a/blog/content/docs/operating/13-workflow-automation/index.md
+++ b/blog/content/docs/operating/13-workflow-automation/index.md
@@ -38,6 +38,7 @@ graph TB
     end
 
     subgraph users["Access"]
+        direction TB
         ui["Web UI<br/>/healthz"]
         api["REST API"]
         agent["Agent Session<br/>Sidecar"]

--- a/blog/content/docs/operating/13-workflow-automation/index.md
+++ b/blog/content/docs/operating/13-workflow-automation/index.md
@@ -25,6 +25,7 @@ graph TB
         n8n ---|"DB connection"| pg
 
         subgraph mounts["Persistent Storage"]
+            direction TB
             config["Config PVC"]
             data["Data PVC"]
         end
@@ -33,6 +34,7 @@ graph TB
     end
 
     subgraph svc["Service Layer"]
+        direction TB
         lb["LoadBalancer Service<br/>External IP"]
         cluster["ClusterIP Service<br/>Internal"]
     end
@@ -51,6 +53,7 @@ graph TB
     n8n -.- agent
 
     subgraph metrics["Observability"]
+        direction TB
         probe["Blackbox Probe<br/>/healthz"]
         met["/metrics endpoint"]
     end

--- a/blog/content/docs/operating/14-secure-agent-pod/index.md
+++ b/blog/content/docs/operating/14-secure-agent-pod/index.md
@@ -29,10 +29,11 @@ source .env_devops   # sets OMNICONFIG + service accounts
 ```mermaid
 flowchart TD
     subgraph "kali container (s6-overlay)"
-        A["s6-svscan (PID 1)"]
-        A --> B["s6-supervise sshd"]
-        A --> C["s6-supervise supercronic"]
-        B --> D["sshd (port 2222)"]
+        direction LR
+        A["s6-svscan<br/>(PID 1)"]
+        A --> B["s6-supervise<br/>sshd"]
+        A --> C["s6-supervise<br/>supercronic"]
+        B --> D["sshd<br/>(port 2222)"]
         C --> E["supercronic"]
         E --> F["session-manager.sh"]
         E --> G["push-heartbeat.sh"]
@@ -40,10 +41,10 @@ flowchart TD
         E --> I["audit-digest.sh"]
     end
     subgraph "vk-local sidecar (tini)"
-        J["vibe-kanban (port 8081)"]
+        J["vibe-kanban<br/>(port 8081)"]
     end
     D -->|TCP:2222| K["ReadinessProbe"]
-    K --> L["LoadBalancer 192.168.55.215:22"]
+    K --> L["LoadBalancer<br/>192.168.55.215:22"]
 ```
 
 Each supervised service runs in signal isolation — a crash in `supercronic` can't take down `sshd`. s6 respawns failed services within ~1s; 5 deaths in 60s triggers a crashloop bail that stops respawning without killing the pod.

--- a/blog/content/docs/operating/15-health-monitoring/index.md
+++ b/blog/content/docs/operating/15-health-monitoring/index.md
@@ -27,7 +27,7 @@ source .env_devops   # sets OMNICONFIG + service accounts
 ## Data Flow
 
 ```mermaid
-flowchart LR
+flowchart TD
     subgraph "Probes & Heartbeats"
         A["Blackbox Exporter<br/>HTTP probes"] --> P[(VictoriaMetrics)]
         B["Cron scripts<br/>Pushgateway"] --> P

--- a/blog/content/docs/operating/17-ingress/index.md
+++ b/blog/content/docs/operating/17-ingress/index.md
@@ -39,12 +39,14 @@ graph TB
 
     subgraph cluster["Frank Cluster"]
         subgraph traefikNS["traefik namespace"]
+            direction TB
             ext["Traefik External<br/>Entrypoint"]
             int["Traefik Internal<br/>Entrypoint"]
             acme["ACME Certificate"]
         end
 
         subgraph routes["IngressRoutes"]
+            direction TB
             r1["ArgoCD Route<br/>→ authentik SSO"]
             r2["App Route<br/>→ Service"]
             r3["Internal Route<br/>→ ClusterIP"]

--- a/blog/content/docs/operating/21-vk-remote/index.md
+++ b/blog/content/docs/operating/21-vk-remote/index.md
@@ -18,7 +18,7 @@ last_updated_commit: https://github.com/derio-net/frank/commit/eff627fb
 This is the operational companion to [VK Remote — Self-Hosting the Kanban Backend]({{< relref "/docs/building/26-vk-remote-self-host" >}}). That post explains the architecture. This one is the day-to-day runbook.
 
 ```mermaid
-graph LR
+graph TD
     subgraph agents["agents namespace"]
         pg["postgres-vk<br/>PostgreSQL<br/>wal_level=logical"]
         electric["electric<br/>ElectricSQL<br/>replication consumer"]

--- a/blog/content/docs/operating/24-ruflo/index.md
+++ b/blog/content/docs/operating/24-ruflo/index.md
@@ -18,7 +18,7 @@ last_updated_commit: https://github.com/derio-net/frank/commit/c4d9305c
 This is the operational companion to [Ruflo]({{< relref "/docs/building/29-ruflo" >}}). That post explains the architecture. This one covers connecting, installing tools, bumping images, and running swarms.
 
 ```mermaid
-graph LR
+graph TD
     subgraph ruflo["ruflo-system namespace"]
         direction LR
         rv["ruflo container<br/>ruvocal chat<br/>port 3000"]

--- a/blog/content/docs/operating/25-frank-papers/index.md
+++ b/blog/content/docs/operating/25-frank-papers/index.md
@@ -18,7 +18,7 @@ last_updated_commit: https://github.com/derio-net/frank/commit/faa3f993
 This is the operational companion to [Building The Frank Papers]({{< relref "/docs/building/30-frank-papers" >}}). That post explains *why* there's a third series and what the dossier gate is for. This one is the cookbook: scaffold, dossier, prose, cover, ship.
 
 ```mermaid
-graph LR
+graph TD
     subgraph repo["Repository"]
         scaffold["blog/content/docs/papers/NN-slug/index.md"]
         dossier["docs/papers-dossiers/NN-slug/dossier.md"]

--- a/blog/content/docs/operating/26-edge-observability/index.md
+++ b/blog/content/docs/operating/26-edge-observability/index.md
@@ -20,7 +20,7 @@ The companion to [Edge Observability]({{< relref "/docs/building/31-edge-observa
 Assumes both `.env` (Frank) and `.env_hop` (Hop) are available. Sourcing the wrong one silently sends commands to the wrong cluster — the single most common mistake.
 
 ```mermaid
-graph LR
+graph TD
     subgraph hop["Hop Edge"]
         caddy["Caddy<br/>access logs"]
         cs_agent["CrowdSec Agent<br/>parses → decides"]

--- a/blog/content/docs/papers/01-heterogeneous-hardware/index.md
+++ b/blog/content/docs/papers/01-heterogeneous-hardware/index.md
@@ -214,6 +214,7 @@ flowchart TD
         A["one image, baked once"]
     end
     subgraph NODES["Physical fleet (N × identical RPi 4)"]
+        direction TB
         P1["raspi-1"]
         P2["raspi-2"]
         P3["raspi-3"]
@@ -285,14 +286,14 @@ fleet at once, a single golden-image rev.
 ```mermaid
 flowchart TD
     subgraph DECL["Declarative (Talos + Omni)"]
-        P1[("patches/phase01-node-config/03-labels-*.yaml")]
+        P1[("patches/phase01-node-config/<br/>03-labels-*.yaml")]
         A["talosctl apply-config per node"]
     end
     subgraph NODES["Physical fleet (7 nodes, 4 hardware classes)"]
-        M1["mini-1/2/3<br/>Intel Ultra 5 / 64GB / iGPU"]
-        G1["gpu-1<br/>i9 / RTX 5070 Ti / 128GB"]
-        PC1["pc-1<br/>Z77 / i5-3570K / 32GB"]
-        R12["raspi-1/2<br/>RPi 4 / ARM / 4GB"]
+        M1["mini-1/2/3<br/>Intel Ultra 5<br/>64GB · iGPU"]
+        G1["gpu-1<br/>i9 · 128GB<br/>RTX 5070 Ti"]
+        PC1["pc-1<br/>Z77 · i5-3570K<br/>32GB"]
+        R12["raspi-1/2<br/>RPi 4 · ARM<br/>4GB"]
     end
     subgraph SCHED["K8s scheduler"]
         NS{{"nodeSelector:<br/>kubernetes.io/hostname<br/>frank/zone, frank/hardware"}}

--- a/blog/content/docs/papers/05-gpu-scheduling/index.md
+++ b/blog/content/docs/papers/05-gpu-scheduling/index.md
@@ -310,6 +310,7 @@ should expect to track upstream tightly.
 ```mermaid
 flowchart TD
     subgraph MG["NVIDIA MIG (hardware partition)"]
+        direction TB
         MIG_MGR["mig-manager (Operator subcomponent)"]
         SLICE1[("MIG slice 1/7 — 5 GB")]
         SLICE2[("MIG slice 2/7 — 5 GB")]

--- a/blog/content/docs/papers/09-secrets-bootstrap/index.md
+++ b/blog/content/docs/papers/09-secrets-bootstrap/index.md
@@ -295,6 +295,7 @@ this is often the right answer.
 ```mermaid
 flowchart TD
     subgraph SEAL["Vault unseal ceremony (manual)"]
+        direction TB
         SK1{"Shamir key share 1"}
         SK2{"Shamir key share 2"}
         SK3{"Shamir key share 3"}

--- a/blog/layouts/_markup/render-codeblock-mermaid.html
+++ b/blog/layouts/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,41 @@
+{{- /* features.mermaid_view — Hextra's mermaid codeblock hook, plus tabindex.
+
+       WHY AN OVERRIDE AT ALL: mermaid-view.css turns this <pre> into a
+       horizontal scroller. WCAG 2.1 §2.1.1 requires a scrollable region to be
+       operable from the keyboard, and a <pre> is not focusable by default — so
+       without `tabindex="0"` the feature would trade a shrunken-but-complete
+       diagram for a full-size one that mouse users can pan and keyboard users
+       cannot. blog-craft already overrides layouts/_markup/render-image.html,
+       so a _markup override is an established pattern here.
+
+       WHY IT LOOKS COPIED: it is. This is Hextra v0.12.1's
+       layouts/_markup/render-codeblock-mermaid.html verbatim (identical in
+       v0.12.3) with one attribute added. Everything else is the theme's
+       contract and must survive byte-for-byte in spirit:
+
+         - role="img" + the i18n aria-label with its "Diagram" fallback —
+           the screen-reader treatment of the diagram;
+         - class="mermaid" — what mermaid.js selects on;
+         - hx:mt-6 — the theme's own spacing, so diagrams sit like every
+           other Hextra site's;
+         - `.Inner | htmlEscape | safeHTML` — changing this pipeline either
+           double-escapes the diagram source or opens an injection path;
+         - `.Page.Store.Set "hasMermaid" true` — the theme's scripts partial
+           reads this to decide whether to load mermaid AT ALL. Dropping it
+           stops diagrams rendering site-wide, and nothing in this file's diff
+           would look like the cause.
+
+       THEREFORE: this file PINS the feature to the theme hook's shape and must
+       be re-checked on every Hextra bump. If upstream changes the markup, this
+       override silently freezes the old version.
+
+       Note the one tension accepted deliberately: a focusable element inside
+       role="img" is unusual. The alternative — an unfocusable scroller — fails
+       WCAG outright. NOT yet verified against a real screen reader: matrix row
+       MMD-6 is the post-merge manual check that closes this. */ -}}
+<div role="img" aria-label="{{ (T "mermaidDiagram") | default "Diagram" }}">
+  <pre class="mermaid hx:mt-6" tabindex="0">
+    {{ .Inner | htmlEscape | safeHTML }}
+  </pre>
+</div>
+{{- .Page.Store.Set "hasMermaid" true -}}

--- a/blog/layouts/partials/custom/head-end.html
+++ b/blog/layouts/partials/custom/head-end.html
@@ -3,14 +3,24 @@
   Loads the fingerprinted custom.css (always — Hextra does NOT auto-load it),
   optional asciinema-player assets (only on pages using the {{< asciinema >}}
   shortcode), the glossary stylesheet (only when features.glossary materialized
-  it), the mermaid initialiser (only when features.mermaid_csp_init materialized
-  it), the read-tracker script (only when features.read_tracker materialized
-  it), and the analytics partial (only when features.analytics materialized it).
+  it), the mermaid-view stylesheet (only when features.mermaid_view
+  materialized it), the mermaid initialiser (only when
+  features.mermaid_csp_init materialized it), the read-tracker script (only
+  when features.read_tracker materialized it), and the analytics partial
+  (only when features.analytics materialized it).
 */ -}}
 {{- /* glossary.css — present only when features.glossary materialized it.
        Deliberately BEFORE custom.css: a blog overrides feature styling in its
        own custom.css, which only works if this loads first. */}}
 {{- with resources.Get "css/glossary.css" }}
+<link rel="stylesheet" href="{{ (. | minify | fingerprint).RelPermalink }}">
+{{- end }}
+{{- /* mermaid-view.css — present only when features.mermaid_view materialized
+       it (default true; a blog sets the flag false to keep prior rendering).
+       Deliberately BEFORE custom.css, same reason as glossary.css above: a
+       blog overrides the frame in its own custom.css, which only works if the
+       feature sheet loads first. */}}
+{{- with resources.Get "css/mermaid-view.css" }}
 <link rel="stylesheet" href="{{ (. | minify | fingerprint).RelPermalink }}">
 {{- end }}
 {{ $customCSS := resources.Get "css/custom.css" | minify | fingerprint }}

--- a/blog/scripts/validate_mermaid.py
+++ b/blog/scripts/validate_mermaid.py
@@ -115,9 +115,7 @@ def _main(argv):
     a = ap.parse_args(argv)
 
     cfg = yaml.safe_load(open(a.config)) or {}
-    if (cfg.get("quality") or {}).get("mermaid_syntax", True) is False:
-        print("mermaid syntax check disabled (quality.mermaid_syntax: false)")
-        return 0
+    gate_enabled = (cfg.get("quality") or {}).get("mermaid_syntax", True) is not False
 
     failed: dict[str, list[str]] = {}
     checked = 0
@@ -131,6 +129,22 @@ def _main(argv):
         fails = validate_file(p, md)
         if fails:
             failed[p] = fails
+
+    if not gate_enabled:
+        # A disabled gate must still SCAN and still be LOUD about it. The
+        # principle, from frank 77e68e37: "a gate nobody runs reports nothing,
+        # including how far behind you are" — that is the FAILURE being fixed,
+        # not the goal. Always exits 0: visible, never build-breaking.
+        total = sum(len(fs) for fs in failed.values())
+        plural = "" if total == 1 else "s"
+        print(f"GATE DISABLED (quality.mermaid_syntax: false) — would report "
+              f"{total} finding{plural} across {checked} file(s) checked",
+              file=sys.stderr)
+        if failed:
+            for fs in failed.values():
+                for x in fs:
+                    print(f"  {x}", file=sys.stderr)
+        return 0
 
     if failed:
         print("MERMAID SYNTAX CHECK FAILED", file=sys.stderr)

--- a/blog/scripts/validate_mermaid_layout.mjs
+++ b/blog/scripts/validate_mermaid_layout.mjs
@@ -1,0 +1,447 @@
+#!/usr/bin/env node
+// validate_mermaid_layout.mjs — the blocking mermaid WIDTH gate (MMD-3).
+//
+// Renders every mermaid diagram in the BUILT site (public/) with the site's
+// own mermaid bundle inside a real headless Chrome, reads each diagram's
+// natural width, and fails the build when one exceeds the budget.
+//
+// Usage:
+//   node scripts/validate_mermaid_layout.mjs --public <site>/public [--max-width 1400]
+//
+//   --public      Hugo's output directory; walked for **/*.html.
+//   --max-width   px budget (default 1400 — ~2x Hextra's 672px content column:
+//                 a diagram needing more than two column-widths of scrolling
+//                 cannot be held in the reader's head). 0 DISABLES the gate:
+//                 diagrams are still counted and listed, loudly, but no
+//                 browser is invoked and the exit code is 0.
+//
+// Exit codes: 0 pass/disabled · 1 over budget or render failure · 2 environment/usage.
+//
+// Per-diagram waiver: a `%% blog-craft: wide-ok — <reason>` comment line in
+// the diagram source (`%%` is a mermaid comment, so it ships invisibly).
+//
+// WHY THIS SHAPE (each point verified during design, 2026-07-28):
+//
+//  - Built HTML, not markdown. Shortcode-emitted diagrams (papers/landscape
+//    quadrantCharts) never appear as fenced blocks — exactly where frank's
+//    real breakage lived (77e68e37: abbr markers injected into quadrantChart
+//    source, missed by every markdown-level check). Findings are reported by
+//    page URL + block index; built HTML has no source line numbers.
+//
+//  - A real browser, not jsdom. Mermaid derives every node's size from text
+//    metrics; under jsdom getBBox/getComputedTextLength do not exist,
+//    getBoundingClientRect() is 0x0, and mermaid.render() throws
+//    `CSSStyleSheet is not defined`. A jsdom "width" would be fiction.
+//    (Syntax checking on jsdom is legitimate — width measurement is not,
+//    which is why this stays a separate tool from the syntax gate.)
+//
+//  - The SITE'S OWN bundle, from public/js/mermaid.*.js. Measuring with any
+//    other mermaid build measures a different site. This is also why the
+//    `mermaid` npm package is not a dependency.
+//
+//  - Zero npm dependencies. Node >= 22 (preinstalled on ubuntu-latest) ships
+//    a global WebSocket, so headless Chrome is driven over raw CDP: no
+//    package.json, no npm install, no supply-chain surface added to any
+//    consumer blog. (It is also why the budget arrives as a flag rather than
+//    being read from .blog-craft.yaml — zero-dep means no YAML parser; the CI
+//    template renders the budget from config at materialization time.)
+//
+//  - Discovery, never a hardcoded browser path. The ubuntu-24.04 image
+//    preinstalls Google Chrome and Chromium but defines NO CHROME_BIN (only
+//    CHROMEWEBDRIVER/EDGEWEBDRIVER/GECKOWEBDRIVER), and ubuntu-latest rolls
+//    to newer images. Resolution order: $CHROME_BIN, then google-chrome,
+//    google-chrome-stable, chromium, chromium-browser on PATH.
+//
+//  - Width is read from the rendered SVG's inline `style="max-width: <n>px"`
+//    — the exact value mermaid writes and mermaid-view.css keys off, so the
+//    gate and the renderer cannot disagree (viewBox width is the fallback).
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { spawn } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const USAGE =
+  "usage: validate_mermaid_layout.mjs --public <dir> [--max-width <px>]  (0 disables the gate)";
+
+function fail(code, msg) {
+  console.error(msg);
+  process.exit(code);
+}
+
+// ------------------------------------------------------------ browser discovery
+
+const PATH_CANDIDATES = [
+  "google-chrome", "google-chrome-stable", "chromium", "chromium-browser",
+];
+
+function isExecutable(p) {
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function whichOnPath(name, envPath) {
+  for (const dir of (envPath || "").split(path.delimiter)) {
+    if (!dir) continue;
+    const p = path.join(dir, name);
+    if (isExecutable(p)) return p;
+  }
+  return null;
+}
+
+function discoverBrowser(env) {
+  const cb = env.CHROME_BIN;
+  if (cb && isExecutable(cb)) return cb;
+  for (const name of PATH_CANDIDATES) {
+    const p = whichOnPath(name, env.PATH);
+    if (p) return p;
+  }
+  fail(2,
+    "mermaid layout gate: no Chrome/Chromium executable found.\n" +
+    `Looked for, in order: $CHROME_BIN${cb ? ` (=${cb}, not an executable file)` : " (unset)"}, ` +
+    PATH_CANDIDATES.join(", ") + " (each resolved on PATH).\n" +
+    "Set CHROME_BIN to a Chrome/Chromium binary, or install one on PATH.\n" +
+    "(ubuntu-24.04 runners preinstall Google Chrome and Chromium but define no\n" +
+    "CHROME_BIN, and ubuntu-latest rolls to newer images — hence discovery over\n" +
+    "a candidate list, never a hardcoded path.)");
+}
+
+// ------------------------------------------------------------------------ main
+
+function parseArgs(argv) {
+  const opts = { public: null, maxWidth: 1400 };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--public") opts.public = argv[++i];
+    else if (a === "--max-width") {
+      const v = Number(argv[++i]);
+      if (!Number.isFinite(v) || v < 0) fail(2, `mermaid layout gate: --max-width must be a non-negative number, got ${argv[i]}\n${USAGE}`);
+      opts.maxWidth = v;
+    } else if (a === "--help" || a === "-h") {
+      console.log(USAGE);
+      process.exit(0);
+    } else fail(2, `mermaid layout gate: unknown argument ${a}\n${USAGE}`);
+  }
+  if (!opts.public) fail(2, `mermaid layout gate: --public is required\n${USAGE}`);
+  return opts;
+}
+
+function* walkHtml(dir) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) yield* walkHtml(p);
+    else if (e.isFile() && e.name.endsWith(".html")) yield p;
+  }
+}
+
+// Built HTML escapes the diagram source (the render hook htmlEscapes .Inner):
+// `-->` arrives as `--&gt;`. Undo that, or every real diagram fails to parse.
+function decodeEntities(s) {
+  return s
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)))
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+// `%%` is a mermaid comment, so the waiver ships invisibly with the diagram.
+const WAIVER_RE = /^\s*%%\s*blog-craft:\s*wide-ok\b/m;
+
+function pageUrl(publicDir, file) {
+  const rel = path.relative(publicDir, file).split(path.sep).join("/");
+  return rel.endsWith("index.html")
+    ? "/" + rel.slice(0, -"index.html".length)
+    : "/" + rel;
+}
+
+// Every <pre class="mermaid"> body in public/**/*.html — the render hook's
+// output AND shortcode-emitted diagrams (papers/landscape quadrantCharts),
+// which never appear as fenced blocks in markdown. Reported by page URL +
+// 1-based block index: built HTML has no source line numbers.
+function extractDiagrams(publicDir) {
+  const diagrams = [];
+  const pages = new Set();
+  for (const file of walkHtml(publicDir)) {
+    const doc = fs.readFileSync(file, "utf8");
+    const page = pageUrl(publicDir, file);
+    let index = 0;
+    for (const m of doc.matchAll(/<pre\b([^>]*)>([\s\S]*?)<\/pre>/gi)) {
+      const cls = /class\s*=\s*"([^"]*)"/i.exec(m[1]);
+      if (!cls || !/(^|\s)mermaid(\s|$)/.test(cls[1])) continue;
+      index += 1;
+      const source = decodeEntities(m[2]).trim();
+      diagrams.push({ page, index, source, waived: WAIVER_RE.test(source) });
+    }
+    if (index > 0) pages.add(page);
+  }
+  return { diagrams, pageCount: pages.size };
+}
+
+function locateBundle(publicDir) {
+  const jsDir = path.join(publicDir, "js");
+  let names = [];
+  try {
+    names = fs.readdirSync(jsDir).filter((n) => /^mermaid\..+\.js$/.test(n));
+  } catch { /* handled below */ }
+  if (names.length === 0) {
+    fail(2,
+      `mermaid layout gate: no mermaid bundle found at ${jsDir}/mermaid.*.js — the\n` +
+      "gate renders with the SITE'S OWN bundle so measured widths match exactly what\n" +
+      "readers see. Build the site first (hugo --minify) on a page with a diagram.");
+  }
+  names.sort();
+  const min = names.find((n) => n.startsWith("mermaid.min."));
+  return path.join(jsDir, min || names[0]);
+}
+
+// ------------------------------------------------- CDP: drive headless Chrome
+//
+// Node >= 22 ships a global WebSocket (undici), which is the whole reason no
+// puppeteer is needed: launch Chrome with --remote-debugging-port=0, read the
+// resolved ws endpoint off stderr, and speak flat-mode CDP directly.
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function withTimeout(promise, ms, what) {
+  let t;
+  const timer = new Promise((_, rej) => {
+    t = setTimeout(() => rej(new Error(`timed out after ${ms}ms: ${what}`)), ms);
+  });
+  return Promise.race([promise, timer]).finally(() => clearTimeout(t));
+}
+
+class Cdp {
+  constructor(url) {
+    this.url = url;
+    this.nextId = 0;
+    this.pending = new Map();
+  }
+
+  async connect(timeoutMs = 15000) {
+    this.ws = new WebSocket(this.url);
+    await withTimeout(new Promise((resolve, reject) => {
+      this.ws.addEventListener("open", resolve, { once: true });
+      this.ws.addEventListener("error", () => reject(new Error(`could not connect to ${this.url}`)), { once: true });
+    }), timeoutMs, "connecting to the DevTools websocket");
+    this.ws.addEventListener("message", (ev) => {
+      let msg;
+      try { msg = JSON.parse(ev.data); } catch { return; }
+      const entry = msg.id !== undefined && this.pending.get(msg.id);
+      if (!entry) return; // CDP events are unsolicited; we poll instead of subscribing
+      this.pending.delete(msg.id);
+      if (msg.error) entry.reject(new Error(`CDP ${entry.method}: ${msg.error.message}`));
+      else entry.resolve(msg.result);
+    });
+  }
+
+  send(method, params = {}, sessionId = undefined, timeoutMs = 30000) {
+    const id = ++this.nextId;
+    const p = new Promise((resolve, reject) => this.pending.set(id, { resolve, reject, method }));
+    this.ws.send(JSON.stringify({ id, method, params, ...(sessionId ? { sessionId } : {}) }));
+    return withTimeout(p, timeoutMs, `CDP ${method}`);
+  }
+
+  close() {
+    try { this.ws?.close(); } catch { /* already gone */ }
+  }
+}
+
+async function launchBrowser(bin, profileDir) {
+  // --no-sandbox --disable-dev-shm-usage: required on CI runners (root user,
+  // tiny /dev/shm). Fresh --user-data-dir: never touch (or lock against) a
+  // real profile. Port 0: let Chrome pick, then read the resolved endpoint.
+  const args = [
+    "--headless", "--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu",
+    `--user-data-dir=${profileDir}`, "--no-first-run", "--no-default-browser-check",
+    "--remote-debugging-port=0", "about:blank",
+  ];
+  const proc = spawn(bin, args, { stdio: ["ignore", "ignore", "pipe"] });
+  const wsUrl = await withTimeout(new Promise((resolve, reject) => {
+    let buf = "";
+    proc.stderr.on("data", (d) => {
+      buf += d;
+      const m = buf.match(/DevTools listening on (ws:\/\/\S+)/);
+      if (m) resolve(m[1]);
+    });
+    proc.on("error", (e) => reject(new Error(`could not launch ${bin}: ${e.message}`)));
+    proc.on("exit", (code) => reject(new Error(`browser exited (code ${code}) before DevTools was ready:\n${buf.slice(-2000)}`)));
+  }), 30000, `waiting for "DevTools listening on ws://…" from ${bin}`);
+  return { proc, wsUrl };
+}
+
+// Runs INSIDE the page. The natural width is the inline
+// `style="max-width: <n>px"` mermaid writes on the rendered svg — the exact
+// value mermaid-view.css keys off — with the viewBox width as fallback.
+function renderExpression(id, source) {
+  return `(async () => {
+    try {
+      const r = await window.mermaid.render(${JSON.stringify(id)}, ${JSON.stringify(source)});
+      const host = document.createElement("div");
+      host.innerHTML = r.svg;
+      document.body.appendChild(host);
+      const svg = host.querySelector("svg");
+      if (!svg) return { error: "mermaid.render produced no <svg>" };
+      const m = /max-width:\\s*([0-9.]+)px/.exec(svg.getAttribute("style") || "");
+      if (m) return { width: parseFloat(m[1]) };
+      const vb = (svg.getAttribute("viewBox") || "").trim().split(/[\\s,]+/);
+      if (vb.length === 4 && isFinite(parseFloat(vb[2]))) return { width: parseFloat(vb[2]) };
+      return { error: "rendered svg has neither an inline max-width nor a viewBox" };
+    } catch (e) {
+      return { error: String((e && e.message) || e) };
+    }
+  })()`;
+}
+
+// Render every diagram in one page that has the site's bundle loaded, and
+// return [{width} | {error}] in input order. One browser, one page, N renders.
+async function measureAll(browserBin, bundlePath, diagrams) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "mermaid-layout-gate-"));
+  const harness = path.join(tmp, "harness.html");
+  fs.writeFileSync(harness,
+    `<!doctype html><html><head><meta charset="utf-8"><script src="${pathToFileURL(bundlePath)}"></script></head><body></body></html>`);
+  let proc, cdp;
+  try {
+    let wsUrl;
+    ({ proc, wsUrl } = await launchBrowser(browserBin, path.join(tmp, "profile")));
+    cdp = new Cdp(wsUrl);
+    await cdp.connect();
+    const { targetId } = await cdp.send("Target.createTarget", { url: pathToFileURL(harness).href });
+    const { sessionId } = await cdp.send("Target.attachToTarget", { targetId, flatten: true });
+
+    // Poll for readiness rather than racing load events we might have missed.
+    const deadline = Date.now() + 20000;
+    for (;;) {
+      const r = await cdp.send("Runtime.evaluate", {
+        expression: "document.readyState === 'complete' && typeof window.mermaid !== 'undefined'",
+        returnByValue: true,
+      }, sessionId);
+      if (r.result?.value === true) break;
+      if (Date.now() > deadline) {
+        throw new Error(`the mermaid bundle (${path.basename(bundlePath)}) never defined window.mermaid in the page`);
+      }
+      await sleep(100);
+    }
+    await cdp.send("Runtime.evaluate", {
+      expression: "window.mermaid.initialize && window.mermaid.initialize({ startOnLoad: false }); true",
+      returnByValue: true,
+    }, sessionId);
+
+    const results = [];
+    for (let i = 0; i < diagrams.length; i++) {
+      const r = await cdp.send("Runtime.evaluate", {
+        expression: renderExpression(`blogcraft-gate-${i}`, diagrams[i].source),
+        awaitPromise: true,
+        returnByValue: true,
+      }, sessionId, 60000);
+      if (r.exceptionDetails) {
+        results.push({ error: r.exceptionDetails.exception?.description || r.exceptionDetails.text || "render evaluation threw" });
+      } else {
+        results.push(r.result?.value ?? { error: "render evaluation returned nothing" });
+      }
+    }
+    return results;
+  } finally {
+    cdp?.close();
+    if (proc && proc.exitCode === null) {
+      proc.kill();
+      // Wait for the exit (bounded) — rmSync racing a still-dying Chrome that
+      // is writing its profile throws ENOTEMPTY.
+      await new Promise((resolve) => {
+        const t = setTimeout(resolve, 3000);
+        proc.once("exit", () => { clearTimeout(t); resolve(); });
+      });
+    }
+    // Best-effort: a leftover tmp dir must never override the gate's verdict.
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* OS-cleaned tmp */ }
+  }
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  let stat;
+  try {
+    stat = fs.statSync(opts.public);
+  } catch { /* handled below */ }
+  if (!stat || !stat.isDirectory()) {
+    fail(2, `mermaid layout gate: public dir not found: ${opts.public} — run \`hugo\` first;\nthis gate measures the BUILT site, not the markdown.`);
+  }
+  const { diagrams, pageCount } = extractDiagrams(opts.public);
+
+  if (opts.maxWidth === 0) {
+    // A disabled gate must still SCAN and still be LOUD about how far behind
+    // it is (frank 77e68e37: "a gate nobody runs reports nothing"). It only
+    // skips the browser: exits 0, never build-breaking.
+    console.error(
+      `GATE DISABLED (quality.mermaid_max_width: 0) — ${diagrams.length} diagram(s) ` +
+      `across ${pageCount} page(s) NOT measured (no browser invoked)`);
+    for (const d of diagrams) {
+      console.error(`  ${d.page} #${d.index}${d.waived ? " (wide-ok waived)" : ""}`);
+    }
+    process.exit(0);
+  }
+
+  if (diagrams.length === 0) {
+    console.log(`MERMAID LAYOUT OK: 0 diagrams under ${opts.public} (no browser invoked)`);
+    process.exit(0);
+  }
+
+  if (typeof WebSocket === "undefined") {
+    // Node 22+ ships a global WebSocket — the whole zero-dependency CDP story.
+    fail(2, `mermaid layout gate: needs Node >= 22 (global WebSocket); this is ${process.version}.`);
+  }
+  const bundle = locateBundle(opts.public);
+  const browser = discoverBrowser(process.env);
+
+  const toMeasure = diagrams.filter((d) => !d.waived);
+  const waived = diagrams.length - toMeasure.length;
+  let results;
+  try {
+    results = await measureAll(browser, bundle, toMeasure);
+  } catch (e) {
+    fail(2, `mermaid layout gate: could not measure: ${e.message}`);
+  }
+
+  const findings = [];
+  let widest = 0;
+  results.forEach((res, i) => {
+    const d = toMeasure[i];
+    if (res.error) {
+      // A diagram that fails to render is an ERROR, not a silent skip — the
+      // gate must not go blind exactly where the site is broken.
+      findings.push(`  ${d.page} #${d.index}: RENDER ERROR — ${res.error}`);
+    } else {
+      const w = Math.round(res.width);
+      widest = Math.max(widest, w);
+      if (w > opts.maxWidth) {
+        findings.push(`  ${d.page} #${d.index}: ${w}px > ${opts.maxWidth}px (${w - opts.maxWidth}px over)`);
+      }
+    }
+  });
+
+  if (findings.length > 0) {
+    console.error(
+      `MERMAID LAYOUT CHECK FAILED — ${findings.length} of ${diagrams.length} diagram(s) ` +
+      `(budget quality.mermaid_max_width: ${opts.maxWidth}px${waived ? `, ${waived} waived` : ""})`);
+    for (const f of findings) console.error(f);
+    console.error(
+      "\n  A diagram wider than the budget cannot be followed by scrolling. Restructure it\n" +
+      "  (flowchart TD is usually far narrower than LR), waive this one with a\n" +
+      "  `%% blog-craft: wide-ok — <reason>` comment in the diagram source, or set\n" +
+      "  `quality.mermaid_max_width: 0` to disable the gate.");
+    process.exit(1);
+  }
+  console.log(
+    `MERMAID LAYOUT OK: ${toMeasure.length} diagram(s) across ${pageCount} page(s) ` +
+    `within ${opts.maxWidth}px (widest ${widest}px${waived ? `, ${waived} waived` : ""})`);
+  process.exit(0);
+}
+
+await main();

--- a/scripts/tests/test_blog_ci_at_repo_root.py
+++ b/scripts/tests/test_blog_ci_at_repo_root.py
@@ -64,6 +64,11 @@ REQUIRED_GATES = [
     "blog/scripts/validate_glossary.py",
     "blog/scripts/validate_mermaid.py",
     "blog/scripts/validate_images.py",
+    # The width gate (blog-craft v0.19.0) measures the BUILT site, so unlike
+    # every gate above it must run after the Hugo build. That ordering is the
+    # reason it is easy to drop: a step appended below `hugo --minify` reads
+    # like a build artifact rather than a gate.
+    "blog/scripts/validate_mermaid_layout.mjs",
 ]
 
 


### PR DESCRIPTION
Adopts blog-craft **v0.19.0** (config schema v5 → v6) and clears the blocking
diagram-width gate it ships.

## Why

Mermaid's `useMaxWidth` shrank every SVG to fit Hextra's **672px** content
column, so a 2139px diagram painted its 14px labels at **4.4px** — identically
on a 4K panel and a laptop, so it was never a wide-screen problem. Diagrams now
render at authored size inside a framed, horizontally scrollable, keyboard-
focusable block.

## Two commits

**1. `chore(repo)` — the resync.** `features.mermaid_view: true`; the scroller
stylesheet; a `render-codeblock-mermaid.html` override adding `tabindex="0"`
(a scroller only a trackpad can reach fails WCAG 2.1 SC 2.1.1); the new width
gate; and `validate_mermaid.py` now reporting what a *disabled* gate would have
found instead of printing a pass-shaped line.

**2. `docs(repo)` — the diagrams.** 35 of 183 were over the 1400px budget
(worst 2394px). **Fixed, not waived** — no `wide-ok` comments, no budget change.
Widest is now **1395px**. Levers, applied by rebuild-and-re-measure after every
change: `LR`→`TD` on 28 diagrams (35→10), `direction TB` on subgraphs of
unconnected peers, `<br/>` label wrapping. Every node, edge and label survives;
only layout direction and line breaks changed.

## Reviewer notes

- **The schema migration was applied BY HAND.** `tools/migrate_config.py`
  round-trips the config through plain PyYAML, deleting every comment and
  re-sorting every key — 298 insertions / 239 deletions for a two-key change,
  including the "Bump AFTER an apply, never before" warning on the key the
  update flow depends on. The hand-edit parses **identical** to the migrator's
  output (asserted before committing) in 9 lines. Filed as blog-craft#73.
- **`blog-ci.yml` conflicted** (frank's copy is deliberately customised: Go
  toolchain for the Hextra module, SHA-pinned actions, `uv` deps, path filters,
  no stub deploy job). Resolved by porting upstream's step **verbatim** rather
  than a paraphrase, so the file now merges clean against the v0.19.0 base —
  re-running `/update` is a 5-NOOP no-op. Its gate-list guard gains the new
  gate.
- **Headroom is 5px** (1395 of 1400). The next diagram edit can tip CI red;
  `quality.mermaid_max_width: 1450` is the pressure valve if that bites.
- **Two mermaid traps documented in commit 2**, both encountered live: a
  subgraph's `direction` is *ignored* when edges cross its boundary (looks
  applied, does nothing), and on a subgraph that is itself an edge **endpoint**
  it backfires (1484 → 2615px).
- **`quality.mermaid_syntax` is deliberately left `false`.** It now reports 50
  findings across 84 files, all one class — and that rule is wrong: it calls
  subgraph-targeting edges "dead on render", while this release's own width gate
  rendered and measured those very diagrams in real Chrome. Filed as
  blog-craft#74. Acting on the backlog would degrade 84 files.

## Verification

- `hugo --minify` — 142 pages
- `MERMAID LAYOUT OK: 183 diagram(s) across 81 page(s) within 1400px (widest 1395px)`
- `pytest scripts/tests/` — 355 passed, 1 xfailed
- papers, glossary and image gates green
- Confirmed live in a browser on `05-gitops`: SVG at its authored 1161px inside
  a 671px column, scroller active (`scrollWidth 1201 > clientWidth 671`),
  `tabindex=0` and `role="img"` intact, and a real **10px** scrollbar where
  macOS overlay scrollbars would paint nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)