### PR TITLE
chore(paperclip): bump to v2026.722.0

### DIFF
--- a/apps/paperclip/manifests/deployment.yaml
+++ b/apps/paperclip/manifests/deployment.yaml
@@ -94,17 +94,18 @@ spec:
       containers:
         - name: paperclip
           # Upstream public image. Pinned by digest-equivalent sha tag.
-          # sha-4c6c0c6 == git tag v2026.626.0 (released 2026-06-26).
-          # v2026.626.0 adds task watchdogs, ask work mode, built-in Hermes
-          # adapter (local + remote gateway), workspace file downloads,
-          # sandbox runtime status in threads, routine date variables,
-          # per-company JWT signing key isolation, Skills Store, and
-          # self-hostable K8s sandbox execution. Tag scheme is upstream's:
-          # only `latest` (master HEAD), `canary`, and `sha-<short>` are
+          # sha-e55d702 == git tag v2026.722.0 (released 2026-07-22).
+          # v2026.722.0 adds run-bound agent secret access (on-demand API
+          # retrieval with audit logging), Windows support for local agents
+          # (ACPX native spawn, no Bash wrapper), Connections v3 foundation
+          # (stable UIDs, AppDefinition catalog, OpenAPI grant routes), plus
+          # two automatic DB migrations. Tag scheme is upstream's: only
+          # `latest` (master HEAD), `canary`, and `sha-<short>` are
           # published — no semver image tags. We pin to the sha for
-          # traceability: v2026.626.0 → commit 4c6c0c6ad048838dda4a67e1aca43aa37a6fcf0d.
-          # Bumped from sha-911a1e8 (v2026.529.0, 2026-05-29).
-          image: ghcr.io/paperclipai/paperclip:sha-4c6c0c6
+          # traceability: v2026.722.0 → commit
+          # e55d702916c4d3ddbcac49b697f879808b160f59.
+          # Bumped from sha-4c6c0c6 (v2026.626.0, 2026-06-26).
+          image: ghcr.io/paperclipai/paperclip:sha-e55d702
           ports:
             - name: http
               containerPort: 3100


### PR DESCRIPTION
Bumps the Paperclip image from `sha-4c6c0c6` (v2026.626.0, 2026-06-26) to `sha-e55d702` (v2026.722.0, 2026-07-22).

Three releases since the deployed version:

---

### v2026.707.0 (2026-07-07)

- **User-specific runtime secrets** — secrets now scopable to individual operators; verification gates runs if required values are absent
- **Work Timeline** — Gantt-style SVG visualisation of agent execution timing and handoffs across the company
- **Custom sandbox images with SSH terminal** — build and configure reusable sandbox images in-browser with embedded SSH for package installation
- **Redesigned environment variables editor** — unified editor for text values, secret references, and sensitive-value warnings across agents, projects, routines, and company envs
- **One-click recovery for diverged work** — recovery card diagnoses branch divergence and offers isolated re-issue resolution
- **Starred resources in sidebar** — pin frequently-accessed projects, agents, and tasks
- Gemini 3.1 Pro model support; optimised issue loading; enhanced command palette project search

---

### v2026.720.0 (2026-07-20)

- **Skill Studio** — three-pane IDE for skill authoring with sandboxed test runs, nested folder organisation, and "My Skills" view
- **Attention Queue & Decisions** — unified surface consolidating all items requiring user input with mobile-friendly decision rows
- **Enhanced search** — filters, sorting, operators, command-palette parity, and a bulk extract endpoint
- **Resilient run execution** — workspace self-healing, quota-aware retries, and improved recovery routing
- **MCP Tool Gateway** (experimental) — governed Model Context Protocol tool connections
- **Built-in Summarizer agent** with summary slots (experimental)
- **Cases** — structured object for releases and documentation (experimental)
- ACP became the default engine for local adapters; design-system convergence with unified tokens and Lucide icon adoption
- **DB migrations** — MCP Tool Gateway, tool access policies, decision-training snapshots, summary slots, audit attribution (automatic, no manual action)

---

### v2026.722.0 (2026-07-22)

- **Run-bound agent secret access** — agents retrieve granted secrets on-demand via `GET /api/agents/me/secrets` with `Cache-Control: no-store` and audit logging; new `access.*` delivery mode
- **Windows support for local agents** — ACPX engine no longer wraps commands in Bash; native spawning on Windows with `.cmd` npm shim preference and symlink fallback-to-copy
- **Connections v3 foundation** — stable connection UIDs, ownership/auth/transport fields, AppDefinition Wave 1 catalog, subject-aware authorization state with OpenAPI grant routes
- `PAPERCLIP_*` env bindings now reach agents (`PAPERCLIP_API_KEY` still rejected; harness-minted tokens mandatory)
- Slash-separated secret names display as nested folder hierarchies; searchable agent picker for secret access grants
- **DB migrations** — Connections v3 schema (`remote_http` renamed to `mcp_remote`), stable UIDs (automatic, no manual action)

> **Upgrade note from v2026.722.0:** `PAPERCLIP_API_KEY` override no longer applies — harness-minted tokens are now mandatory. Verify `apps/paperclip/manifests/configmap.yaml` does not inject this key.

---

## Pre-deploy checklist

- [ ] Snapshot `paperclip-db` PVC (apply a `snapshots.longhorn.io` CR with `spec.createSnapshot: true` and `spec.volume: <pvc-uuid>`)
- [ ] Confirm any new env vars called out in any Upgrade Guide are added to `apps/paperclip/manifests/configmap.yaml`
- [ ] Confirm new DB extensions (if any are required) are pre-created in the `paperclip` database
- [ ] Confirm no breaking config changes from the Upgrade Guides (note v2026.722.0: `PAPERCLIP_API_KEY` override removed — harness-minted tokens are now mandatory)
- [ ] Confirm `imagePullSecret` is still NOT needed (upstream package is public)

---

Generated by the monthly upstream-watcher routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_014srNDFsqLsugX7ENkVybFW)_