### PR TITLE
[derio-net/frank] 2026-07-30--net--frank-derio-net-retire · Phase 3/7 · PR 2 - coordinated application cutover to cluster.derio.net

### DIFF
--- a/apps/argocd/values.yaml
+++ b/apps/argocd/values.yaml
@@ -108,10 +108,10 @@ configs:
     # Resource tracking via annotation (avoids conflicts with Helm labels)
     application.resourceTrackingMethod: annotation
     # Authentik OIDC SSO (Phase 13)
-    url: https://argocd.frank.derio.net
+    url: https://argocd.cluster.derio.net
     oidc.config: |
       name: Authentik
-      issuer: https://auth.frank.derio.net/application/o/argocd/
+      issuer: https://auth.cluster.derio.net/application/o/argocd/
       clientID: argocd
       clientSecret: $argocd-oidc-secret:oidc.authentik.clientSecret
       requestedScopes:

--- a/apps/authentik-extras/manifests/blueprints-provider-argocd.yaml
+++ b/apps/authentik-extras/manifests/blueprints-provider-argocd.yaml
@@ -57,4 +57,4 @@ data:
         attrs:
           name: ArgoCD
           provider: !KeyOf provider-argocd
-          meta_launch_url: https://argocd.frank.derio.net
+          meta_launch_url: https://argocd.cluster.derio.net

--- a/apps/authentik-extras/manifests/blueprints-provider-grafana.yaml
+++ b/apps/authentik-extras/manifests/blueprints-provider-grafana.yaml
@@ -52,4 +52,4 @@ data:
         attrs:
           name: Grafana
           provider: !KeyOf provider-grafana
-          meta_launch_url: https://grafana.frank.derio.net
+          meta_launch_url: https://grafana.cluster.derio.net

--- a/apps/authentik-extras/manifests/blueprints-provider-infisical.yaml
+++ b/apps/authentik-extras/manifests/blueprints-provider-infisical.yaml
@@ -52,4 +52,4 @@ data:
         attrs:
           name: Infisical
           provider: !KeyOf provider-infisical
-          meta_launch_url: https://infisical.frank.derio.net
+          meta_launch_url: https://infisical.cluster.derio.net

--- a/apps/authentik/values.yaml
+++ b/apps/authentik/values.yaml
@@ -33,7 +33,7 @@ global:
     # External URL for the embedded proxy outpost to generate correct OAuth redirects.
     # Without this, forward-auth redirects use the container's internal 0.0.0.0:9000.
     - name: AUTHENTIK_HOST
-      value: "https://auth.frank.derio.net"
+      value: "https://auth.cluster.derio.net"
     # PostgreSQL password: the Bitnami subchart uses existingSecret for its own auth,
     # but Authentik server/worker need the password via this env var to connect.
     - name: AUTHENTIK_POSTGRESQL__PASSWORD

--- a/apps/blackbox-exporter/manifests/vmprobe.yaml
+++ b/apps/blackbox-exporter/manifests/vmprobe.yaml
@@ -8,8 +8,8 @@ spec:
     staticConfig:
       targets:
         - http://n8n-01.n8n-01.svc.cluster.local:5678
-        - https://paperclip.frank.derio.net
-        - https://grafana.frank.derio.net
+        - https://paperclip.cluster.derio.net
+        - https://grafana.cluster.derio.net
         - https://blog.derio.net
         # https://www.derio.net is NOT here — it needs a content-asserting module
         # (www-content-probe below), because its edge fallback answers 200 while

--- a/apps/n8n-01/manifests/deployment.yaml
+++ b/apps/n8n-01/manifests/deployment.yaml
@@ -72,7 +72,7 @@ spec:
             - name: N8N_PORT
               value: "5678"
             - name: WEBHOOK_URL
-              value: "https://n8n-01.frank.derio.net/"
+              value: "https://n8n.cluster.derio.net/"
             - name: N8N_SECURE_COOKIE
               value: "false"
             # The stoa workflow's httpRequest node posts to

--- a/apps/paperclip/manifests/configmap.yaml
+++ b/apps/paperclip/manifests/configmap.yaml
@@ -10,14 +10,14 @@ data:
   PAPERCLIP_HOME: "/paperclip"
   PAPERCLIP_DEPLOYMENT_MODE: "authenticated"
   PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
-  PAPERCLIP_PUBLIC_URL: "http://192.168.55.212:3100"
+  PAPERCLIP_PUBLIC_URL: "https://paperclip.cluster.derio.net"
   # private-hostname guard allow-list (enabled for private+authenticated mode):
   # any inbound Host not listed here gets 403'd before the route handler runs.
   # This env var REPLACES (does not extend) the fileConfig server.allowedHostnames,
   # so it must enumerate EVERY host Paperclip is served on:
   #   - paperclip.cluster.derio.net      Traefik IngressRoute (canonical UI domain)
   #   - paperclip.frank.derio.net        legacy domain (still probed by blackbox)
-  #   - 192.168.55.212                   LB IP / PAPERCLIP_PUBLIC_URL host
+  #   - 192.168.55.212                   direct LB IP
   #   - paperclip-lb...svc.cluster.local internal service DNS (live-mirror-sync
   #                                      Tekton Task -> routine-trigger fire, gh #444)
   # envFrom CM change does NOT auto-roll the pod; rollout restart required after sync.

--- a/apps/victoria-metrics/values.yaml
+++ b/apps/victoria-metrics/values.yaml
@@ -182,15 +182,15 @@ grafana:
       optional: true
   grafana.ini:
     server:
-      root_url: https://grafana.frank.derio.net
+      root_url: https://grafana.cluster.derio.net
     auth.generic_oauth:
       enabled: true
       name: Authentik
       client_id: grafana
       client_secret: ${GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}
       scopes: openid profile email groups offline_access
-      auth_url: https://auth.frank.derio.net/application/o/authorize/
-      token_url: https://auth.frank.derio.net/application/o/token/
-      api_url: https://auth.frank.derio.net/application/o/userinfo/
+      auth_url: https://auth.cluster.derio.net/application/o/authorize/
+      token_url: https://auth.cluster.derio.net/application/o/token/
+      api_url: https://auth.cluster.derio.net/application/o/userinfo/
       role_attribute_path: "contains(groups[*], 'root-admins') && 'Admin' || contains(groups[*], 'root-devops') && 'Editor' || 'Viewer'"
       allow_assign_grafana_admin: true

--- a/clusters/hop/apps/landing/manifests/files/index.html
+++ b/clusters/hop/apps/landing/manifests/files/index.html
@@ -18,9 +18,9 @@
   <h2>Services</h2>
   <ul class="services">
     <li><a href="https://headplane.hop.derio.net">Headplane</a> — Mesh management</li>
-    <li><a href="https://argocd.frank.derio.net">ArgoCD</a> — Frank cluster</li>
-    <li><a href="https://grafana.frank.derio.net">Grafana</a> — Monitoring</li>
-    <li><a href="https://longhorn.frank.derio.net">Longhorn</a> — Storage</li>
+    <li><a href="https://argocd.cluster.derio.net">ArgoCD</a> — Frank cluster</li>
+    <li><a href="https://grafana.cluster.derio.net">Grafana</a> — Monitoring</li>
+    <li><a href="https://longhorn.cluster.derio.net">Longhorn</a> — Storage</li>
     <li><a href="https://blog.derio.net/frank">Blog</a> — Frank blog</li>
   </ul>
 </body>

--- a/docs/superpowers/journals/debug/2026-08-01-structured-auth-machine-files.md
+++ b/docs/superpowers/journals/debug/2026-08-01-structured-auth-machine-files.md
@@ -39,3 +39,8 @@ All temporary recovery ConfigPatches are absent. All seven Omni machines remaine
 ### talos-safe-authn-config-fixed · finding [fixed] · Talos-safe structured-auth delivery fixed and tested (phase 2)
 
 Updated the ConfigPatch to write /var/lib/kubernetes/authn-config.yaml with mode 0644 and mount it read-only at /etc/kubernetes/authn-config.yaml inside kube-apiserver. Added regression assertions for distinct host/container paths and non-root readability. Focused suite: 3 passed. Full scripts/tests suite: 359 passed, 8 skipped. Agent and plan validators passed.
+
+<!-- fr:journal kind=finding scope=debug id=structured-auth-control-plane-rollout-complete created=2026-08-01T13:53:12 phase=2 state=fixed -->
+### structured-auth-control-plane-rollout-complete · finding [fixed] · Control-plane-only structured-auth rollout completed (phase 2)
+
+After PRs #741 and #742, Omni ConfigPatch version 9 targeted only frank-control-planes. Omni remained RUNNING Ready 7/7; all three kube-apiserver pods were Running/Ready with exactly one --authentication-config=/etc/kubernetes/authn-config.yaml argument, no legacy --oidc-* arguments, and the /var/lib/kubernetes/authn-config.yaml host file mounted read-only. /readyz and etcd readiness passed. The retained old-issuer token normalized from preferred_username=ak-Kubernetes Agent Access-client_credentials to username=authentik:ak-Kubernetes Agent Access-client_credentials with the same empty claim groups plus TokenReview's system:authenticated group. Omni service-account cluster-admin remained yes. All four worker boot IDs were byte-for-byte unchanged.

--- a/docs/superpowers/plans/2026-07-30--net--frank-derio-net-retire/02.yaml
+++ b/docs/superpowers/plans/2026-07-30--net--frank-derio-net-retire/02.yaml
@@ -50,14 +50,25 @@ state:
       note: authentik-extras Synced/Healthy; live ArgoCD, Grafana, and Infisical providers
         each contain strict old and cluster callbacks.
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-08-01T11:53:25+00:00'
+      note: Applied control-plane-only ConfigPatch version 9 with rollback source
+        a32a343379b5fa9ed405c52229665332672e000c retained. Observer reached Omni RUNNING
+        Ready 7/7; all three kube-apiserver pods Running/Ready; final /readyz and
+        etcd readiness passed without loss of quorum.
     P2.T2.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-08-01T11:53:32+00:00'
+      note: All three API servers have exactly one structured-auth argument, no --oidc-*
+        flags, and the read-only authn-config mount. Retained old token authenticates
+        as authentik:ak-Kubernetes Agent Access-client_credentials with unchanged
+        empty claim groups; Omni service-account remains cluster-admin; all four worker
+        boot IDs are unchanged.
   completion:
-    at: null
-    note: null
+    at: '2026-08-01T12:06:34+00:00'
+    note: 'Dual-issuer control-plane rollout proven after corrective PRs #741 and
+      #742: Omni Ready 7/7, API quorum and readiness healthy, old-token continuity
+      preserved, Omni admin preserved, and workers untouched. Acceptance net-oidc-cutover-continuity
+      remains not-implemented until Phase 4 proves a newly minted auth.cluster.derio.net
+      token.'
     observed_prs: []

--- a/docs/superpowers/plans/2026-07-30--net--frank-derio-net-retire/03.yaml
+++ b/docs/superpowers/plans/2026-07-30--net--frank-derio-net-retire/03.yaml
@@ -31,22 +31,35 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-08-01T11:56:35+00:00'
+      note: 'Added semantic overlap inventory across Authentik, ArgoCD, Grafana, n8n,
+        Paperclip, OIDC launch URLs, feature probes, Hop landing links, and references/access.md.
+        Focused red run: 1 failed, 4 passed at legacy AUTHENTIK_HOST.'
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-08-01T11:56:37+00:00'
+      note: 'Added passing ownership guard: cluster proxy hosts remain exclusively
+        in blueprints-cluster-proxy-providers.yaml; the legacy blueprint is frozen
+        to its four frank.derio.net providers with no duplicate cluster objects.'
     P3.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-08-01T11:57:23+00:00'
+      note: 'Cut canonical consumers to cluster.derio.net: AUTHENTIK_HOST, ArgoCD
+        URL/issuer, Grafana root/OAuth endpoints, n8n WEBHOOK_URL, Paperclip public
+        URL, OIDC app launch URLs, feature probes, Hop landing links, and references/access.md.
+        Focused domain contract: 5 passed; overlap exceptions retained.'
     P3.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-08-01T12:04:40+00:00'
+      note: Focused domain contract 5 passed; full scripts/tests suite 368 passed,
+        1 xfailed; exact Traefik and Authentik manifest client dry-runs passed against
+        the Frank API schema; git diff --check clean; no deleted files; all overlap-only
+        routes, callbacks, issuers, and legacy Paperclip hostname retained.
   completion:
-    at: null
-    note: null
+    at: '2026-08-01T12:04:42+00:00'
+    note: PR 2 implementation is complete and verified offline. Acceptance rows net-cluster-domain-canonical
+      and net-oidc-cutover-continuity remain not-implemented until Phase 4 deploys
+      the cutover, proves browser/OIDC paths and a new cluster-issuer token, and completes
+      the eight-hour old-token overlap.
     observed_prs: []

--- a/references/access.md
+++ b/references/access.md
@@ -7,7 +7,7 @@ workloads.
 ## Pipeline
 
 ```
-Infisical  (UI: https://infisical.frank.derio.net, project: frank-cluster, env: prod)
+Infisical  (UI: https://infisical.cluster.derio.net, project: frank-cluster, env: prod)
    │
    │ ClusterSecretStore 'infisical'   (ESO auth: Universal Auth token)
    ▼

--- a/scripts/tests/test_frank_domain_retirement.py
+++ b/scripts/tests/test_frank_domain_retirement.py
@@ -14,6 +14,7 @@ OLD_ISSUER = "https://auth.frank.derio.net/application/o/k8s-agent/"
 NEW_ISSUER = "https://auth.cluster.derio.net/application/o/k8s-agent/"
 AUTHN_PATH = "/etc/kubernetes/authn-config.yaml"
 AUTHN_HOST_PATH = "/var/lib/kubernetes/authn-config.yaml"
+CLUSTER_AUTH_HOST = "https://auth.cluster.derio.net"
 
 BLUEPRINT_CALLBACKS = {
     "blueprints-provider-argocd.yaml": {
@@ -61,6 +62,10 @@ def _oauth_provider(entries):
         for entry in entries
         if entry.get("model") == "authentik_providers_oauth2.oauth2provider"
     )
+
+
+def _env_value(container, name):
+    return next(item["value"] for item in container["env"] if item["name"] == name)
 
 
 def test_omni_patch_delivers_dual_issuer_authentication_config():
@@ -129,3 +134,104 @@ def test_k8s_agent_contract_stays_callback_free_with_eight_hour_tokens():
     attrs = provider["attrs"]
     assert attrs["redirect_uris"] == []
     assert attrs["access_token_validity"] == "hours=8"
+
+
+def test_overlap_consumers_use_cluster_domain():
+    authentik = yaml.safe_load((REPO / "apps/authentik/values.yaml").read_text())
+    authentik_env = authentik["global"]["env"]
+    authentik_host = next(
+        item["value"] for item in authentik_env if item["name"] == "AUTHENTIK_HOST"
+    )
+    assert authentik_host == CLUSTER_AUTH_HOST
+
+    argocd = yaml.safe_load((REPO / "apps/argocd/values.yaml").read_text())
+    argocd_config = argocd["configs"]["cm"]
+    assert argocd_config["url"] == "https://argocd.cluster.derio.net"
+    assert (
+        f"issuer: {CLUSTER_AUTH_HOST}/application/o/argocd/"
+        in argocd_config["oidc.config"]
+    )
+
+    victoria_metrics = yaml.safe_load(
+        (REPO / "apps/victoria-metrics/values.yaml").read_text()
+    )
+    grafana = victoria_metrics["grafana"]["grafana.ini"]
+    assert grafana["server"]["root_url"] == "https://grafana.cluster.derio.net"
+    oauth = grafana["auth.generic_oauth"]
+    assert oauth["auth_url"] == f"{CLUSTER_AUTH_HOST}/application/o/authorize/"
+    assert oauth["token_url"] == f"{CLUSTER_AUTH_HOST}/application/o/token/"
+    assert oauth["api_url"] == f"{CLUSTER_AUTH_HOST}/application/o/userinfo/"
+
+    n8n = yaml.safe_load((REPO / "apps/n8n-01/manifests/deployment.yaml").read_text())
+    n8n_container = n8n["spec"]["template"]["spec"]["containers"][0]
+    assert _env_value(n8n_container, "WEBHOOK_URL") == "https://n8n.cluster.derio.net/"
+
+    paperclip = yaml.safe_load(
+        (REPO / "apps/paperclip/manifests/configmap.yaml").read_text()
+    )
+    assert (
+        paperclip["data"]["PAPERCLIP_PUBLIC_URL"]
+        == "https://paperclip.cluster.derio.net"
+    )
+    allowed_hosts = paperclip["data"]["PAPERCLIP_ALLOWED_HOSTNAMES"].split(",")
+    assert "paperclip.frank.derio.net" in allowed_hosts
+
+    launch_urls = {
+        "blueprints-provider-argocd.yaml": "https://argocd.cluster.derio.net",
+        "blueprints-provider-grafana.yaml": "https://grafana.cluster.derio.net",
+        "blueprints-provider-infisical.yaml": "https://infisical.cluster.derio.net",
+    }
+    for filename, expected_url in launch_urls.items():
+        application = next(
+            entry
+            for entry in _blueprint_entries(filename)
+            if entry.get("model") == "authentik_core.application"
+        )
+        assert application["attrs"]["meta_launch_url"] == expected_url
+
+    probes = list(
+        yaml.safe_load_all(
+            (REPO / "apps/blackbox-exporter/manifests/vmprobe.yaml").read_text()
+        )
+    )
+    feature_targets = probes[0]["spec"]["targets"]["staticConfig"]["targets"]
+    assert "https://paperclip.cluster.derio.net" in feature_targets
+    assert "https://grafana.cluster.derio.net" in feature_targets
+    assert not any(".frank.derio.net" in target for target in feature_targets)
+
+    landing = (
+        REPO / "clusters/hop/apps/landing/manifests/files/index.html"
+    ).read_text()
+    for host in ("argocd", "grafana", "longhorn"):
+        assert f'https://{host}.cluster.derio.net' in landing
+        assert f'https://{host}.frank.derio.net' not in landing
+
+    access_reference = (REPO / "references/access.md").read_text()
+    assert "https://infisical.cluster.derio.net" in access_reference
+    assert "https://infisical.frank.derio.net" not in access_reference
+
+
+def test_cluster_proxy_blueprint_owns_cluster_hosts_during_overlap():
+    cluster_entries = _blueprint_entries("blueprints-cluster-proxy-providers.yaml")
+    legacy_entries = _blueprint_entries("blueprints-proxy-providers.yaml")
+
+    cluster_hosts = {
+        entry["attrs"]["external_host"]
+        for entry in cluster_entries
+        if entry.get("model") == "authentik_providers_proxy.proxyprovider"
+    }
+    legacy_hosts = {
+        entry["attrs"]["external_host"]
+        for entry in legacy_entries
+        if entry.get("model") == "authentik_providers_proxy.proxyprovider"
+    }
+
+    assert cluster_hosts
+    assert all(host.endswith(".cluster.derio.net") for host in cluster_hosts)
+    assert legacy_hosts == {
+        "https://longhorn.frank.derio.net",
+        "https://hubble.frank.derio.net",
+        "https://sympozium.frank.derio.net",
+        "https://n8n-01.frank.derio.net",
+    }
+    assert cluster_hosts.isdisjoint(legacy_hosts)


### PR DESCRIPTION
## Goal

Cut every active consumer over to `cluster.derio.net` while retaining the dual-issuer and legacy-route overlap needed for the live Phase 4 gate.

## Summary

- switch Authentik, ArgoCD, Grafana, n8n, Paperclip, blackbox probes, Hop landing links, and operator references to canonical cluster hosts
- move ArgoCD, Grafana, and Infisical Authentik launch URLs without removing either callback set
- add an overlap-state contract covering canonical consumers and Authentik proxy-provider ownership
- record the successful Phase 2 structured-auth rollout and complete Phases 2 and 3 in the plan

## Preserved Overlap

- both Kubernetes JWT issuers
- old and cluster OIDC callbacks
- all temporary `*-frank` IngressRoutes
- the four legacy Authentik proxy providers
- the legacy Paperclip allowed hostname
- Omni at `omni.frank.derio.net` and Headscale split DNS

## Verification

- `uv run --frozen pytest scripts/tests/test_frank_domain_retirement.py -q`: 5 passed
- `uv run --frozen pytest scripts/tests -q`: 368 passed, 1 xfailed
- Traefik manifest client dry-run passed against the Frank API schema
- Authentik Extras manifest client dry-run passed against the Frank API schema
- `git diff --check` passed
- no deleted files

## Rollout Boundary

The acceptance rows remain `not-implemented` until Phase 4 deploys this PR, proves browser and OIDC paths, mints and verifies a new `auth.cluster.derio.net` token, and completes the eight-hour old-token overlap.
