### PR TITLE
fix(auth): declare embedded outpost canonical host

### DIFF
--- a/agents/rules/frank-gotchas.md
+++ b/agents/rules/frank-gotchas.md
@@ -71,7 +71,7 @@ One-line reminders only. Each section header points at a per-topic file under `d
 ### Authentik — `docs/runbooks/frank-gotchas/authentik.md`
 - Blueprints mount in WORKER pod via `blueprints.configMaps` — register new ConfigMaps there.
 - Blueprints don't assign providers to embedded outpost — manual Django ORM step (see `frank-argocd.md`).
-- Embedded outpost needs `AUTHENTIK_HOST` env or forward-auth redirects use `0.0.0.0:9000`.
+- Embedded outpost redirects use its persisted `Outpost.config`, not only pod `AUTHENTIK_HOST`; declare both `authentik_host` fields in the cluster proxy blueprint when changing the public Authentik host.
 - API uses Bearer token (not basic auth); 2026.x requires `invalidation_flow` + object-shaped `redirect_uris` + `signing_key` UUID.
 - `global.env` applies to both server + worker (avoids duplication).
 - Forward-auth (`authentik-forwardauth`) matches the request Host against each provider's `external_host` — an unregistered Host (e.g. a `.frank.derio.net` re-front) **404s with `x-powered-by: authentik`**, not a Traefik/backend 404. Fix = add the Host to the blueprint + outpost-assignment step, or drop the middleware for self-authing apps. Full prose: `authentik.md`.

--- a/apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml
+++ b/apps/authentik-extras/manifests/blueprints-cluster-proxy-providers.yaml
@@ -17,6 +17,18 @@ data:
       labels:
         blueprints.goauthentik.io/instantiate: "true"
     entries:
+      # The embedded outpost persists its browser redirect host independently
+      # from the Authentik deployment's AUTHENTIK_HOST environment variable.
+      # Omit providers so blueprint reconciliation preserves manual assignments.
+      - model: authentik_outposts.outpost
+        state: present
+        identifiers:
+          name: authentik Embedded Outpost
+        attrs:
+          config:
+            authentik_host: https://auth.cluster.derio.net
+            authentik_host_browser: https://auth.cluster.derio.net
+
       # Grafana (cluster) proxy provider
       - model: authentik_providers_proxy.proxyprovider
         state: present

--- a/docs/runbooks/frank-gotchas/authentik.md
+++ b/docs/runbooks/frank-gotchas/authentik.md
@@ -31,9 +31,28 @@ Authentik 2026.x requires `invalidation_flow` and `redirect_uris` as a list of o
 
 Saves duplication when an env var needs to be set on both pods.
 
-## Embedded outpost requires `AUTHENTIK_HOST`
+## Embedded outpost host exists in two places
 
-`AUTHENTIK_HOST` env var must be set to the external URL (e.g., `https://auth.frank.derio.net`) — without it, forward-auth redirects use `0.0.0.0:9000`.
+`AUTHENTIK_HOST` must be set on the server and worker deployments, but changing it
+does not rewrite the embedded outpost's database-backed `Outpost.config`. The
+outpost uses its persisted `authentik_host` or `authentik_host_browser` value to
+construct forward-auth browser redirects.
+
+This split surfaced during the 2026-08-01 domain migration: the pods had
+`AUTHENTIK_HOST=https://auth.cluster.derio.net`, while requests to
+`grafana.cluster.derio.net` still redirected to `auth.frank.derio.net`. The
+cluster proxy blueprint now identifies `authentik Embedded Outpost` by name and
+declares only these config fields:
+
+```yaml
+attrs:
+  config:
+    authentik_host: https://auth.cluster.derio.net
+    authentik_host_browser: https://auth.cluster.derio.net
+```
+
+Do not include `providers` in that blueprint entry. Provider assignments are
+managed separately and must survive host changes.
 
 ## Decision (2026-07-12): hermes dashboard drops forward-auth for its own basic-auth
 

--- a/docs/superpowers/journals/debug/2026-08-01-authentik-outpost-canonical-host.md
+++ b/docs/superpowers/journals/debug/2026-08-01-authentik-outpost-canonical-host.md
@@ -1,0 +1,16 @@
+# Journal: 2026-08-01-authentik-outpost-canonical-host
+
+<!-- fr:journal kind=repro scope=debug id=cluster-forward-auth-redirects-legacy-host created=2026-08-01T16:25:44 phase=4 -->
+### cluster-forward-auth-redirects-legacy-host · repro · Cluster forward-auth redirects to legacy Authentik host (phase 4)
+
+After PR #743 deployed, a browser request to https://grafana.cluster.derio.net entered the Grafana (cluster) proxy provider but redirected to https://auth.frank.derio.net/if/flow/default-authentication-flow/. This violates Phase 4's no-non-Omni-frank redirect gate even though the Authentik server and worker deployments both expose AUTHENTIK_HOST=https://auth.cluster.derio.net.
+
+<!-- fr:journal kind=root-cause scope=debug id=embedded-outpost-host-is-persisted created=2026-08-01T16:25:49 phase=4 -->
+### embedded-outpost-host-is-persisted · root-cause · Embedded outpost retains a database-backed authentik_host (phase 4)
+
+Live ORM inspection showed the embedded outpost config still has authentik_host=https://auth.frank.derio.net. Traefik's middleware correctly calls the in-cluster authentik-server Service and the Grafana (cluster) provider correctly owns https://grafana.cluster.derio.net. Updating the pod-level AUTHENTIK_HOST rolls Authentik but does not rewrite the persisted Outpost.config value used to construct browser redirects.
+
+<!-- fr:journal kind=finding scope=debug id=embedded-outpost-host-declared created=2026-08-01T16:31:25 phase=4 state=fixed -->
+### embedded-outpost-host-declared · finding [fixed] · Cluster blueprint declares the embedded outpost browser host (phase 4)
+
+Added an authentik_outposts.outpost entry identified by name that sets only config.authentik_host and config.authentik_host_browser to https://auth.cluster.derio.net. The providers relation is deliberately omitted, so Authentik state=present reconciliation leaves all existing outpost provider assignments unchanged. The failing regression now passes; focused suite 6 passed and full suite 369 passed, 1 xfailed.

--- a/docs/superpowers/plans/2026-07-30--net--frank-derio-net-retire/04.yaml
+++ b/docs/superpowers/plans/2026-07-30--net--frank-derio-net-retire/04.yaml
@@ -34,9 +34,13 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-08-01T16:32:40+00:00'
+      note: 'PR #743 merged as 19a8cd17. All affected Frank apps Synced/Healthy. Live
+        Authentik, ArgoCD, Grafana, n8n, Paperclip, VMProbe, and Hop landing artifacts
+        contain canonical hosts. Browser verification then exposed the separate persisted
+        embedded-outpost host; corrective fix is tracked in the 2026-08-01 authentik-outpost-canonical-host
+        debug journal.'
     P4.T1.S2:
       state: ' '
       ticked_at: null

--- a/scripts/tests/test_frank_domain_retirement.py
+++ b/scripts/tests/test_frank_domain_retirement.py
@@ -235,3 +235,20 @@ def test_cluster_proxy_blueprint_owns_cluster_hosts_during_overlap():
         "https://n8n-01.frank.derio.net",
     }
     assert cluster_hosts.isdisjoint(legacy_hosts)
+
+
+def test_embedded_outpost_uses_cluster_host_without_managing_provider_assignments():
+    entries = _blueprint_entries("blueprints-cluster-proxy-providers.yaml")
+    outpost = next(
+        entry
+        for entry in entries
+        if entry.get("model") == "authentik_outposts.outpost"
+    )
+
+    assert outpost["state"] == "present"
+    assert outpost["identifiers"] == {"name": "authentik Embedded Outpost"}
+    assert outpost["attrs"]["config"] == {
+        "authentik_host": CLUSTER_AUTH_HOST,
+        "authentik_host_browser": CLUSTER_AUTH_HOST,
+    }
+    assert "providers" not in outpost["attrs"]


### PR DESCRIPTION
## Root Cause

After PR #743 deployed, `grafana.cluster.derio.net` entered the correct cluster proxy provider but redirected to `auth.frank.derio.net`. The Authentik server and worker pods both had `AUTHENTIK_HOST=https://auth.cluster.derio.net`, but the embedded outpost retained its independent database-backed `Outpost.config.authentik_host` value.

## Fix

- declare the embedded outpost's `authentik_host` and `authentik_host_browser` as `https://auth.cluster.derio.net` in the cluster proxy blueprint
- deliberately omit `providers`, preserving every existing manual outpost assignment
- add a regression test pinning both canonical host fields and the provider-assignment boundary
- document the two independent Authentik host settings and record the Phase 4 finding

## Failing Test First

The new focused test initially failed with `StopIteration` because no `authentik_outposts.outpost` entry existed. It passes after the blueprint change.

## Verification

- focused domain suite: 6 passed
- full `scripts/tests` suite: 369 passed, 1 xfailed
- Authentik 2026.2 blueprint schema confirms `config` and `providers` are independent fields
- agent configuration validation passed
- plan validation passed with the repository's known minimal-validator fallback warning
- `git diff --check` passed

## Post-Merge Gate

After ArgoCD applies the blueprint, Phase 4 browser checks must confirm cluster forward-auth redirects through `auth.cluster.derio.net` before the eight-hour overlap clock proceeds.
