### PR TITLE
fix(infer): seed initContainer OOMKilled on first deploy — plus the spike's measurements

### DIFF
--- a/apps/ovms-retrieval/cpu-arm-pod.yaml
+++ b/apps/ovms-retrieval/cpu-arm-pod.yaml
@@ -74,7 +74,22 @@ spec:
         # every start by construction. The gate in the Deployment exists
         # because a PVC survives; this does not.
         - |
-          cp -R /models-src/cpu/. /models/
+          # Per-file copy with a sync between, mirroring the Deployment's seed.
+          # The Deployment's whole-tree `cp -R` was OOMKilled in one second by
+          # dirty-page pressure at a 512Mi limit. This pod writes to an
+          # emptyDir (local disk, fast writeback) rather than a Longhorn
+          # volume, so it is far less exposed — but it is the same shape, and a
+          # control arm that dies on its own seed measures nothing. Bare
+          # `sync`: busybox's applet takes no file operand.
+          cd /models-src/cpu
+          find . -type d | while IFS= read -r d; do
+            mkdir -p "/models/$d"
+          done
+          find . -type f | while IFS= read -r f; do
+            cp "$f" "/models/$f"
+            sync
+          done
+          cd /
           test -f /models/config.json
           echo "cpu-arm: CPU repository seeded"
       securityContext:
@@ -85,10 +100,12 @@ spec:
       resources:
         requests:
           cpu: 100m
-          memory: 128Mi
+          memory: 256Mi
+        # 2Gi for the same reason as the Deployment's seed — see the OOM note
+        # in apps/ovms-retrieval/manifests/deployment.yaml.
         limits:
           cpu: "1"
-          memory: 512Mi
+          memory: 2Gi
       volumeMounts:
         - name: models
           mountPath: /models

--- a/apps/ovms-retrieval/manifests/deployment.yaml
+++ b/apps/ovms-retrieval/manifests/deployment.yaml
@@ -133,7 +133,37 @@ spec:
               # -e` would abort a seed that had in fact copied every byte. The
               # repository is plain files and directories, nothing here needs
               # -p, and ownership comes from fsGroup anyway.
-              cp -R /models-src/gpu/. /models/
+              # Copy FILE BY FILE with a sync after each, rather than one
+              # `cp -R` of the whole tree.
+              #
+              # The tree-at-once form OOMKilled this initContainer in ONE
+              # SECOND on first deploy (exit 137, four restarts). It is not
+              # volume of data over time — it is dirty-page pressure: reads
+              # come off the local overlayfs at NVMe speed while writes go to a
+              # Longhorn network volume, so dirty pages accumulate far faster
+              # than writeback drains them. In cgroup v2 page cache is charged
+              # to the cgroup, and while CLEAN pages are reclaimed under
+              # pressure, DIRTY pages cannot be until written back — so the
+              # cgroup hits its limit and the kernel kills the process.
+              #
+              # Syncing per file bounds the dirty set to the largest single
+              # file (~600 MiB here) instead of the whole ~2.4 GiB repository.
+              # The limit below is headroom over that bound, not the total —
+              # which is what keeps this working if a servable is added later.
+              #
+              # Bare `sync`, not `sync FILE`: GNU coreutils accepts a file
+              # operand, busybox's applet does not, and this image is busybox —
+              # `sync /models/x` would fail there and abort a seed that had
+              # copied every byte, the same shape as the `cp -a` trap above.
+              cd /models-src/gpu
+              find . -type d | while IFS= read -r d; do
+                mkdir -p "/models/$d"
+              done
+              find . -type f | while IFS= read -r f; do
+                cp "$f" "/models/$f"
+                sync
+              done
+              cd /
 
               test -f /models/config.json  # the merged servable list OVMS reads
 
@@ -147,10 +177,15 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 256Mi
+            # 2Gi, not 512Mi: 512Mi OOMKilled this container in one second on
+            # the first real deploy. The bound that matters is the largest
+            # SINGLE file (~600 MiB, given the per-file sync above), not the
+            # ~2.4 GiB repository total — roughly 3x headroom over that, and it
+            # does not need to grow when a servable is added.
             limits:
               cpu: "1"
-              memory: 512Mi
+              memory: 2Gi
           volumeMounts:
             - name: models
               mountPath: /models

--- a/scripts/tests/test_ovms_retrieval_manifests.py
+++ b/scripts/tests/test_ovms_retrieval_manifests.py
@@ -624,11 +624,17 @@ def test_cpu_control_arm_seeds_the_cpu_repository_on_the_same_node():
         for line in "\n".join(init[0].get("command", []) + init[0].get("args", [])).splitlines()
         if not line.lstrip().startswith("#")
     )
-    assert re.search(
-        rf"^\s*cp\s+-R\s+{re.escape(CPU_SEED_SOURCE)}/\.\s+{re.escape(MODELS_MOUNT)}/",
-        script,
-        re.M,
-    ), f"the CPU arm must seed {CPU_SEED_SOURCE}: {script!r}"
+    # Pins the copy ROOT, not the command shape: the seed is a per-file loop
+    # rather than one `cp -R` (see the seed-OOM regression tests at the end of
+    # this file — the whole-tree form OOMKilled the Deployment's seed).
+    assert re.search(rf"^\s*cd\s+{re.escape(CPU_SEED_SOURCE)}\s*$", script, re.M), (
+        f"the CPU arm must establish {CPU_SEED_SOURCE} as its copy root: {script!r}"
+    )
+    assert "sync" in script, (
+        "the CPU arm's seed must sync between files for the same reason the "
+        "Deployment's does — a control arm that dies on its own seed measures "
+        "nothing"
+    )
     assert SEED_SOURCE not in script, (
         "the CPU arm seeds the GPU repository — that measures the GPU and "
         "labels it CPU"

--- a/scripts/tests/test_ovms_retrieval_manifests.py
+++ b/scripts/tests/test_ovms_retrieval_manifests.py
@@ -334,14 +334,16 @@ def test_seed_is_version_gated_by_a_marker_not_seed_if_absent():
     # invisible end to end: OVMS loads both servables on CPU, both probes
     # pass, ArgoCD is green, and the spike's headline number is measured on
     # the CPU while labelled GPU.
+    # The copy is now a per-file loop rather than one `cp -R` (see the
+    # seed-OOM regression tests at the end of this file), so what is pinned
+    # here is the SOURCE, not the command shape: an executable line must
+    # establish /models-src/gpu as the copy root.
     live = _seed_script_live()
-    assert re.search(
-        rf"^\s*cp\s+-R\s+{re.escape(SEED_SOURCE)}/\.\s+{re.escape(MODELS_MOUNT)}/", live, re.M
-    ), (
-        f"no executable `cp -R {SEED_SOURCE}/. {MODELS_MOUNT}/` line in the seed "
-        "script (comments are stripped before this scan). /models-src also holds "
-        "a CPU control arm whose graph.pbtxt names the wrong device — seeding it "
-        "measures the CPU while reporting the GPU"
+    assert re.search(rf"^\s*cd\s+{re.escape(SEED_SOURCE)}\s*$", live, re.M), (
+        f"no executable line establishing {SEED_SOURCE} as the copy root in the "
+        "seed script (comments are stripped before this scan). /models-src also "
+        "holds a CPU control arm whose graph.pbtxt names the wrong device — "
+        "seeding it measures the CPU while reporting the GPU"
     )
     assert "/models-src/cpu" not in live, (
         "the seed script copies the CPU control arm — that repository's "
@@ -745,3 +747,67 @@ def test_prune_can_never_reach_the_model_cache():
             "nothing here needs prune, and leaving it on puts a 20Gi model "
             "cache one mis-sync away from deletion"
         )
+
+
+# ---------------------------------------------------------------------------
+# Seed OOM regression (found live 2026-08-02, first deploy)
+# ---------------------------------------------------------------------------
+#
+# The seed initContainer was OOMKilled in ONE SECOND (exit 137, four restarts)
+# copying the model repository onto its Longhorn PVC. Not volume-over-time —
+# dirty-page pressure: reads come off local overlayfs at NVMe speed, writes go
+# to a network volume, and in cgroup v2 dirty pages cannot be reclaimed until
+# written back, so the cgroup blows its limit almost immediately.
+#
+# Two halves to the fix, and BOTH are load-bearing. Raising the limit alone
+# fixes today's two models and breaks again on a bigger one; syncing alone
+# leaves the ceiling below a single file. These guard both.
+
+
+def _seed_memory_limit_bytes() -> int:
+    raw = str(_seed()["resources"]["limits"]["memory"])
+    units = {"Ki": 1024, "Mi": 1024**2, "Gi": 1024**3, "K": 10**3, "M": 10**6, "G": 10**9}
+    for suffix, mult in sorted(units.items(), key=lambda kv: -len(kv[0])):
+        if raw.endswith(suffix):
+            return int(float(raw[: -len(suffix)]) * mult)
+    return int(raw)
+
+
+def test_seed_memory_limit_clears_the_largest_single_file() -> None:
+    """>= 1Gi. The int8 servables are ~600 MiB each; 512Mi OOMKilled at once."""
+    limit = _seed_memory_limit_bytes()
+    assert limit >= 1024**3, (
+        f"seed-models memory limit is {_seed()['resources']['limits']['memory']}, "
+        "which is at or below the size of a single servable plus slack. 512Mi "
+        "OOMKilled this container in one second on the first real deploy."
+    )
+
+
+def test_seed_syncs_between_files_to_bound_dirty_pages() -> None:
+    """A per-file sync, so the dirty set is one file, not the whole tree."""
+    script = _seed_script_live()
+    assert "sync" in script, (
+        "the seed copy must sync between files — without it the dirty set is "
+        "the entire repository and the cgroup OOMs regardless of the limit"
+    )
+    assert "cp -R /models-src/gpu/. /models/" not in script, (
+        "the whole-tree `cp -R` is what OOMKilled the seed; copy per file "
+        "with a sync between"
+    )
+
+
+def test_seed_sync_takes_no_file_operand() -> None:
+    """busybox's sync applet has no file operand; the final image is busybox.
+
+    `sync /models/x` would fail there and abort a seed that had copied every
+    byte -- the same class of trap as the earlier `cp -a` finding.
+    """
+    import re
+
+    for line in _seed_script_live().splitlines():
+        stripped = line.strip()
+        if re.match(r"^sync\s+\S", stripped):
+            raise AssertionError(
+                f"seed script calls sync with an operand ({stripped!r}); "
+                "busybox sync takes none — use the bare form"
+            )


### PR DESCRIPTION
Follow-up to #748. The seed initContainer **OOMKilled on the first real deploy** — exit 137, four restarts, killed in **one second**. This fixes it, and carries the measurements the spike existed to produce (taken by validating this fix live before asking for a merge).

## The bug

Not volume-over-time. **Dirty-page pressure.**

Reads come off the local overlayfs at NVMe speed; writes go to a Longhorn network volume. Dirty pages accumulate far faster than writeback drains them. cgroup v2 charges page cache to the cgroup, and while *clean* pages are reclaimed under pressure, **dirty pages cannot be reclaimed until written back** — so a 512Mi limit is blown almost instantly. The one-second time-to-kill is the tell: a slow accumulation over a 2.4 GiB copy would have taken far longer.

**Two halves, both load-bearing:**

1. **Copy per file with a `sync` between** — bounds the dirty set to the largest *single* file (~600 MiB) instead of the whole ~2.4 GiB repository.
2. **Raise the limit 512Mi → 2Gi** — headroom over *that bound*, not over the total, so adding a third servable later doesn't require raising it again.

Raising the limit alone would fix today's two models and break on a bigger one. Syncing alone would leave the ceiling below a single file.

Bare `sync`, not `sync FILE`: GNU coreutils accepts a file operand, busybox's applet does not, and this image is busybox — `sync /models/x` would fail there and abort a seed that had copied every byte. Same shape as the `cp -a` trap already documented in #748.

**`cpu-arm-pod.yaml` had the identical bug** (same `cp -R`, same 512Mi) — it was templated from the Deployment before the OOM was known. It writes to an emptyDir so it is far less exposed, but a control arm that dies on its own seed measures nothing. Fixed the same way.

## Guards

Three new regression tests plus two reshaped ones, all **mutation-verified** against the committed fix — mutate, run, confirm failure, revert, confirm clean:

| Mutation | Result |
|---|---|
| limit back to 512Mi | 2 failed |
| drop the per-file `sync` | 1 failed |
| `sync` with a file operand (busybox trap) | 1 failed |
| seed from the CPU repository | 1 failed |

The two reshaped assertions previously pinned the literal `cp -R …` line. They now pin the **copy root** (`cd /models-src/gpu`) instead of the command shape, so they keep their real intent — the GPU repository is the source, never the CPU one — without being coupled to how the copy is spelled.

**Tests: 518 passed.** (The 10 `test_cnc_staging_*` failures are the known `kustomize`-not-on-PATH environment issue; untouched by this branch, green in CI.)

## Validated live before requesting merge

Applied out-of-band with ArgoCD self-heal suspended (root first, then leaf, per the repo's documented recipe), then restored.

- Seed **completed**: `seed-models: rev 1 in place` — where before it was OOMKilled in one second.
- Pod `1/1 Running`; `Available devices for Open VINO: CPU, GPU`.
- `GET /v1/config` — **both servables `AVAILABLE`**.
- Live rerank returns well-separated scores: **0.0395** for the relevant document vs **1.6e-5** for both irrelevant ones (~2400× separation). Not the degenerate pattern that sank the earlier attempt.

### Open finding from #748, now resolved

`/v2/models/<name>/ready` **does** gate on real model state for MediaPipe-graph servables. The evidence is the timing: the pod reached `Running` at 28 s but only `1/1` at 95 s. If that endpoint returned 200 unconditionally the pod would have gone Ready immediately. The probe design holds.

## The measurements

Both arms run byte-identical int8 weights, on the same node, from the same image — differing only in which repository was seeded (`target_device` is baked into `graph.pbtxt` at export).

| Measurement | iGPU | CPU | Ratio |
|---|---|---|---|
| **Rerank, 20 candidates — p50** | **77.3 ms** | 1612.9 ms | **20.9×** |
| Rerank p95 | 87.1 ms | 1702.6 ms | 19.5× |
| Rerank max | 91.1 ms | 1803.5 ms | 19.8× |
| Embeddings batch-32 p50 | 93.2 ms | 1928.0 ms | 20.7× |
| Batch throughput | 343 items/s | 16.6 items/s | 20.7× |
| Single embedding p50 | 28.4 ms | 32.2 ms | 1.1× |
| Embedding dimension | **1024** | 1024 | — |

**The iGPU is worth the DRA plumbing** — decisively, for the batched work that matters. The plan explicitly allowed for the opposite conclusion; it did not happen.

Two things the control arm made visible that the GPU number alone would have hidden:

- **Single-embedding latency is a wash** (28.4 vs 32.2 ms). At batch size 1 the measurement is dominated by request overhead, not compute. Anyone quoting "20× faster" for one-off embedding calls would be wrong.
- **The original 1–5 s/query estimate was, in effect, a CPU estimate.** The CPU arm lands at 1.6 s — inside that range. The iGPU beats it by ~20×.

**Scope of these numbers:** one pod, hostname-pinned to a control-plane node, holding one iGPU via a single ResourceClaim, no other GPU tenant, measured in-cluster. The pin is what makes it repeatable; dropping it or scaling up invalidates the figure rather than extending it. Timing is end-to-end client latency (fresh TCP connection per call, plus client-side JSON parse), not isolated server-side inference.

## Cleanup

All throwaway resources deleted (bench pods, the script ConfigMap, the CPU-arm pod); `resourceclaims` shows only the Deployment's own. Self-heal restored on both root and leaf.

**Note:** with self-heal restored, ArgoCD reverted the Deployment to `main`'s version, so the seed is OOMing again until this merges. That is expected and correct — live and git now agree, and the fix is here rather than as untracked drift on the cluster.

## Still outstanding after this

- Control-plane health across a warm-load window (Test Plan row 7) — not yet captured.
- The requester's own recall benchmark (row 9) — owned by the private repo; not verifiable here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
