### PR TITLE
docs(agents): scope browser-harness to logged-in sessions, exempt local rendering

### DIFF
--- a/agents/rules/browser-harness.md
+++ b/agents/rules/browser-harness.md
@@ -7,6 +7,33 @@ with no per-repo configuration.
 - **Source of truth:** `~/Developer/browser-harness/SKILL.md`. Read it before driving the browser.
 - **Invocation:** call `browser-harness` as a heredoc; the first navigation is `new_tab(url)`,
   not `goto_url` (which clobbers the operator's active tab).
+- **Scope:** browser-harness drives a *real, logged-in* browser. Local, unauthenticated
+  rendering is exempt — see the next section.
+
+## Scope — logged-in sessions, not local rendering
+
+Use browser-harness whenever the target needs the operator's identity or cookies:
+
+- Auth-walled cluster UIs: Grafana, ArgoCD, Longhorn, Authentik.
+- Blog screenshots that must show a logged-in view.
+- Anything behind SSO.
+
+**Local, unauthenticated rendering is exempt.** To check a locally-served or public page — a
+`hugo server` preview, a link/render/quality gate, a Lighthouse run — launch a disposable
+headless browser directly (Playwright / Chrome for Testing). Do **not** route that through
+browser-harness. Three reasons:
+
+- The task needs no login, so the operator's logged-in profile buys nothing.
+- browser-harness needs CDP on port 9222, and CDP is **process-wide**: it exposes every profile
+  in that browser, including the operator's personal one, for as long as it runs.
+- Tabs opened in a real profile come back. Session-restore resurrects them on the next launch.
+
+**Rule of thumb:** needs a login → browser-harness. Renders localhost or a public URL →
+headless is correct. If it needs both, prefer browser-harness and close the tabs you opened.
+
+**Tear down either way.** A headless browser left running on the workstation is
+indistinguishable from a leak. Close what you open: `close_tab()` for browser-harness tabs, and
+shut down any headless instance when the check finishes.
 
 ## Transport is injected per environment
 


### PR DESCRIPTION
## What

Adds a scope section to `agents/rules/browser-harness.md`: browser-harness is for driving a
**real, logged-in** browser; local, unauthenticated rendering is exempt and should use a
disposable headless browser instead.

Purely additive (27 insertions, 0 deletions) -- one bullet on the lede's list and one new
section. The existing lede prose and the "Transport is injected per environment" section are
untouched.

`.claude/rules` is a symlink to `../agents/rules`, so this is the single file.

## Why

On 2026-08-15 the operator saw a "Google Chrome for Testing" browser launch on the Mac and
asked who was driving it. An agent working the blog-quality-gate branch (a quality gate over
`blog/content/docs/`) had a local `hugo server` running and launched Chrome for Testing
directly via Playwright to check the rendered pages, instead of going through
`browser-harness`.

It did not go through the harness -- confirmed, not assumed. The `browser-harness` wrapper
self-heals: with nothing serving CDP on port 9222 it runs `brave-clawdia` and blocks until
Brave is up. Brave was not running at all and 9222 was dead, so the wrapper was never invoked.
The wrapper symlink was verified intact, so this was not the known `uv tool upgrade` clobber.

**The agent was right and the rule was wrong.** For a local, unauthenticated Hugo preview a
disposable headless browser is the correct tool. Routing it through Brave-Clawdia would have
been actively worse:

- the page needs no login, so driving the operator's logged-in profile buys nothing;
- it requires CDP on 9222, which is **process-wide** and therefore exposes every Brave profile
  -- the operator's personal `derio` profile included -- for the duration;
- it leaves tabs behind for session-restore to resurrect.

The machine-global rule (`~/.claude/rules/brave-clawdia.md`) already scopes itself correctly,
to driving "a real, logged-in browser". Frank's copy dropped that qualifier. This restores it
and makes the exemption explicit.

## The rule of thumb it establishes

Needs a login -> browser-harness. Renders localhost or a public URL -> headless is correct. If
both, prefer browser-harness and close the tabs you opened.

Tear-down applies either way: a headless browser left running on the workstation is
indistinguishable from a leak.

## Verification

- `scripts/validate-agent-config.sh` -- passed.
- `.githooks/pre-commit` -- run manually, exit 0. Note it did **not** fire automatically:
  `core.hooksPath` in this worktree resolves to the base repo's `.git/hooks`, which has no
  `pre-commit`. Pre-existing condition, unrelated to this change, but worth a look.
- Documentation only. No cluster calls, no builds, no browsers, no `hugo` run.
