### PR TITLE
docs(agents): scope the Mac browser-harness overlay to logged-in sessions

### DIFF
--- a/agents/browser-harness-mac.md
+++ b/agents/browser-harness-mac.md
@@ -9,9 +9,14 @@
 > this Mac (`uname = Darwin` and `brave-clawdia` present). The host-neutral browser-harness rule in
 > `agents/rules/browser-harness.md` loads everywhere and points here for the Mac specifics.
 
-Browser automation uses **browser-harness**, a machine-global skill on `$PATH` (not checked into
-this repo). Source of truth: `~/Developer/browser-harness/SKILL.md`. Invoke as a heredoc; first
-navigation is `new_tab(url)`, not `goto_url`.
+Driving a **real, logged-in** browser uses **browser-harness**, a machine-global skill on `$PATH`
+(not checked into this repo). Source of truth: `~/Developer/browser-harness/SKILL.md`. Invoke as a
+heredoc; first navigation is `new_tab(url)`, not `goto_url`.
+
+**Scope:** local, unauthenticated rendering is exempt. A `hugo server` preview or a
+link/render/quality gate belongs in a disposable headless browser, not in the operator's profile —
+the process-wide CDP exposure described below is precisely why. Full carve-out and rule of thumb:
+"Scope — logged-in sessions, not local rendering" in `agents/rules/browser-harness.md`.
 
 ## Session shape (use the pair)
 


### PR DESCRIPTION
## What

Brings `agents/browser-harness-mac.md` into step with the shared rule as amended by #768.

Two changes, 8 insertions / 3 deletions:

1. **Lede phrasing corrected at source.** "Browser automation uses **browser-harness**" →
   "Driving a **real, logged-in** browser uses **browser-harness**". That opening was the
   contradiction, so it is fixed where it originates rather than patched underneath.
2. **One scope paragraph** deferring to the shared rule for the full carve-out.

## Why

I flagged this drift when delivering #768. That PR narrowed the shared rule
(`agents/rules/browser-harness.md`) to driving a real, logged-in browser and carved out local,
unauthenticated rendering. The Mac overlay carried a near-duplicate lede without the qualifier,
so the two files now disagree.

This is the file where the disagreement costs something. It is injected by frank's SessionStart
adapter only on the macOS workstation, which is exactly the host where the wrong answer drives
the operator's logged-in Brave profile and exposes every profile on port 9222.

## Deliberately minimal

The overlay is the Mac-only *transport* file, so it does not restate the carve-out. In
particular it does **not** duplicate the three reasons: the process-wide CDP exposure is already
documented further down this same file ("**CDP is process-wide.**"), and that existing warning is
cross-referenced instead. The new paragraph points at the shared rule's section by name for the
detail.

## Ordering

The cross-referenced heading, "Scope — logged-in sessions, not local rendering", is introduced by
**#768**. Merge that first so the reference resolves. No file overlap between the two PRs, so
they do not conflict in either order — this is a doc-consistency dependency only.

## Verification

- `.githooks/pre-commit` fired automatically this time and
  `scripts/validate-agent-config.sh` passed. That is the `core.hooksPath` repair landing:
  `git rev-parse --git-path hooks/pre-commit` now resolves to `.githooks/pre-commit` inside the
  fr worktree, where before my #768 commit it silently ran nothing.
- Documentation only. No cluster calls, no builds, no browsers, no `hugo`.
