### PR TITLE
docs(repo): document the fr write-isolation convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,9 @@ inference, see #461 and derio-net/agent-skills#1).
 
 - Do not edit sensitive files such as `.env_devops`, `.sops.yaml`, or files
   under `.talos/` without explicit user confirmation.
+- This repo is fr-enabled: writes must happen inside an fr-isolation workspace,
+  never the base clone. Read-only work is unaffected. See "Write Isolation (fr)"
+  in `agents/rules/repo-workflows.md` before your first edit.
 - Cluster state should be reproducible from this repo. See
   `agents/rules/repo-principles.md` for the narrow manual-operation exception.
 - Validate agent configuration with `scripts/validate-agent-config.sh`.

--- a/agents/rules/repo-workflows.md
+++ b/agents/rules/repo-workflows.md
@@ -23,6 +23,39 @@ When a deployed layer needs a bugfix or unplanned extension:
 
 Use the layer code in commit messages: `fix(gpu): <description>` or `feat(edge): <description>`.
 
+## Write Isolation (fr)
+
+Frank is fr-enabled, so the `fr-isolation-required` hook **blocks Edit/Write to the base clone**.
+This is not advisory. An agent that edits the main checkout directly is refused at the tool
+layer, before the write lands.
+
+- **Read-only work needs none of this.** Inspect, grep, and run reports against the main
+  checkout as usual.
+- **Every write goes through an fr workspace:**
+
+  ```
+  fr isolation up --branch <branch>                                # devcontainer (default)
+  FR_ISOLATION_TARGET=worktree fr isolation up --branch <branch>   # docker-less host worktree
+  ```
+
+  Use the host variant for doc, rule, and config edits — it is a plain git worktree with no
+  container build. Both agent pods already declare `FR_ISOLATION_TARGET=worktree` globally (see
+  `frank-gotchas.md`), so in-pod sessions get the docker-less path by default.
+- **Workspaces land in `~/.cache/fr/worktrees/frank/<branch>`**, with `/` rewritten as `__` —
+  branch `docs/my-change` becomes `~/.cache/fr/worktrees/frank/docs__my-change`.
+- **A hand-rolled `git worktree add` does not work.** It writes no `.fr-isolation` marker, so
+  the hook rejects it exactly as it rejects the base clone. Only an fr-created workspace
+  validates. This includes the pre-existing worktrees under `.worktrees/` at the repo root:
+  they are ordinary checkouts, not fr workspaces, and writes in them are refused.
+- **The marker is managed for you.** `fr isolation up` writes `.fr-isolation` and excludes it via
+  `.git/info/exclude`. Never commit it, and never hand-write one to satisfy the hook.
+- **Do not run `fr isolation down` as cleanup.** It removes the worktree. Leave the workspace in
+  place once the PR is open.
+
+Frank carries no `.fr-isolation-allow`, so every path in the repo is gated. That is deliberate:
+almost everything here is declarative cluster state, and an allowlist hole would let a write
+reach the cluster without a branch, a PR, or a review.
+
 ## Plan Management Scripts
 
 - `scripts/plan-status.sh` — list all plans with Spec/Archived/Status columns


### PR DESCRIPTION
## What

Documents frank's fr write-isolation convention in frank's own rules.

- **`agents/rules/repo-workflows.md`** — new "Write Isolation (fr)" section. That file is #4 in
  the AGENTS.md load order, so it is read before non-trivial changes.
- **`AGENTS.md`** — one pointer line under "Safety And Enforcement", beside the existing
  sensitive-files and validator lines.

36 insertions, 0 deletions. Nothing existing was reworded.

## Why

Frank has been fr-enabled for a while and said nothing about it:

- `fr isolation` appeared **once** in the entire `agents/` tree — `frank-gotchas.md` line 221,
  in passing, about the `cluster-admin` devcontainer's Omni service-account token.
- `repo-workflows.md` mentioned worktrees **zero** times.
- `AGENTS.md` mentioned isolation **zero** times.

The cost is not hypothetical. I was dispatched into this repo carrying a `.worktrees/`
convention, hand-rolled a worktree there, and found the gate only when an Edit was refused. The
hook taught me the rule because no document did. The next agent — a pod session, the operator's
own, anyone's — pays the same toll until the rule is written down.

## What it states

The hook blocks base-clone writes and is not advisory. Read-only work is unaffected. Writes go
through `fr isolation up --branch <branch>`, with `FR_ISOLATION_TARGET=worktree` as the
docker-less host variant for light/doc work. Workspaces land in
`~/.cache/fr/worktrees/frank/<branch>` with `/` rewritten as `__`. A hand-rolled
`git worktree add` is rejected for want of a `.fr-isolation` marker — **including the existing
`.worktrees/` checkouts at the repo root**, which are ordinary worktrees and are refused for
writes. The marker is written by fr and excluded via `.git/info/exclude`; it must never be
committed or hand-written. `fr isolation down` removes the worktree, so it is not a tidy-up step.

## Proposal: `.fr-isolation-allow` — my recommendation is *near-empty*

No file is added here; per instruction this is the operator's call. My reasoning, for comparison
with willikins' list (`projects/** data/** context/** memory/** staff/** decisions/**
references/** *.local.md session-summaries/**`):

**Willikins and frank are inverses.** Willikins is mostly operator data with a little source, so
a broad allowlist is right there. Frank is mostly declarative cluster state with a little data,
so the same shape would be actively dangerous. Every allowlisted glob here is a path where a
write can reach a live cluster with no branch, no PR, and no review.

**Never allowlist**, and I would say so explicitly if a list is added:

- `apps/`, `patches/`, `clusters/`, `omni/`, `secrets/` — cluster state, the whole point of the
  repo's declarative-only principle.
- `scripts/`, `tests/`, `.githooks/`, `.github/`, `.devcontainer/` — the tooling that gates the
  above; a hole here disables the gates.
- `agents/` — the agent contract itself. Allowlisting it lets an agent rewrite its own rules
  from the base clone. This one is worth naming out loud.
- `blog/` — published output, house-style reviewed.
- `docs/superpowers/` — validated by `validate-plans.sh`, synced by `fr-progress`.
- `docs/runbooks/`, `docs/acceptance/matrix.yaml` — operational source and a CI-gated registry.

**Defensible candidates**, in descending confidence:

```
docs/investigations/**
*.local.md
```

- `docs/investigations/**` — dated incident write-ups (`2026-06-04--stor--raspi-1-memory-wedge-incident.md`
  and friends). Records of what happened, never cluster state, and written under live-incident
  time pressure. That is precisely when isolation friction makes an agent skip the note or fight
  the gate instead of fixing the outage. Strongest case in the repo.
- `*.local.md` — the per-machine override convention; local by definition.

**Deliberately excluded, though arguable** — `docs/audits/`, `docs/patterns/` and
`docs/agentic-discussion/` are also records, but each currently holds one or two considered
documents rather than incident scratch, so they carry no urgency argument and lose nothing by
going through a branch. `.reference-pool/` and `references/` shape published output and access
procedure respectively; both benefit from review.

If the operator wants to start even tighter, `docs/investigations/**` alone would cover the case
that actually bites.

## Verification

- `.githooks/pre-commit` ran automatically; `scripts/validate-agent-config.sh` passed. AGENTS.md
  is one of the files that validator checks, so the rule-registry consistency is machine-checked
  here, not just eyeballed.
- Documentation only. No cluster calls, no builds, no browsers, no `hugo`.

## Relationship to the other open PRs

Independent of #768 and #770 (different files, different topic). Any merge order works.
